### PR TITLE
Corrected className usage for PickerItem

### DIFF
--- a/packages/moonstone/Picker/PickerItem.js
+++ b/packages/moonstone/Picker/PickerItem.js
@@ -8,11 +8,11 @@ const PickerItem = kind({
 
 	styles: {
 		css,
-		classes: 'item'
+		className: 'item'
 	},
 
-	render: ({children, classes, ...rest}) => (
-		<div {...rest} className={classes}>
+	render: ({children, ...rest}) => (
+		<div {...rest}>
 			{children}
 		</div>
 	)


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
