### PR TITLE
Added TestHelpers Folder in ui and moonstone with PropTypeChecker.

### DIFF
--- a/packages/moonstone/TestHelpers/PropTypeChecker-specs.js
+++ b/packages/moonstone/TestHelpers/PropTypeChecker-specs.js
@@ -1,0 +1,21 @@
+/* global console beforeEach afterEach*/
+/* eslint no-console: ["error", { allow: ["error"] }] */
+
+import {
+	watchErrorAndWarnings,
+	filterErrorAndWarnings,
+	restoreErrorAndWarnings
+} from 'enyo-console-spy';
+
+beforeEach(watchErrorAndWarnings);
+
+afterEach(function (done) {
+	const actual = filterErrorAndWarnings(/(Invalid prop|Failed prop type|Unknown prop)/);
+	const expected = 0;
+	restoreErrorAndWarnings();
+	if (actual.length > expected) {
+		console.error(`PropType Failure: ${this.currentTest.parent.title} at "${this.currentTest.title}"`);
+	}
+	done();
+	expect(actual).to.have.length(expected);
+});

--- a/packages/ui/TestHelpers/PropTypeChecker-specs.js
+++ b/packages/ui/TestHelpers/PropTypeChecker-specs.js
@@ -1,0 +1,21 @@
+/* global console beforeEach afterEach*/
+/* eslint no-console: ["error", { allow: ["error"] }] */
+
+import {
+	watchErrorAndWarnings,
+	filterErrorAndWarnings,
+	restoreErrorAndWarnings
+} from 'enyo-console-spy';
+
+beforeEach(watchErrorAndWarnings);
+
+afterEach(function (done) {
+	const actual = filterErrorAndWarnings(/(Invalid prop|Failed prop type|Unknown prop)/);
+	const expected = 0;
+	restoreErrorAndWarnings();
+	if (actual.length > expected) {
+		console.error(`PropType Failure: ${this.currentTest.parent.title} at "${this.currentTest.title}"`);
+	}
+	done();
+	expect(actual).to.have.length(expected);
+});


### PR DESCRIPTION
### Issue Resolved / Feature Added

Currently, tests don't fail we have PropType warnings. Added PropTypeChecker to make PropType warnings fail tests.
### Resolution

Added PropTypeChecker to be run before and after each test. It will check for any console.errors that are caused by the test. If the error matches 'Invalid prop|Failed prop type|Unknown prop'. then it will return the error.

A typical error would something look like this:

```
ERROR: 'Warning: Failed prop type: Required prop `children` was not specified in `Icon`.
    in Icon (created by ToggleItem)
    in ToggleItem (created by Unknown)
    in Unknown'
ERROR: 'PropType Failure: ToggleItem Specs at "should create a <label> tag with an <input> child"'
PhantomJS 2.1.1 (Mac OS X 0.0.0)  "after each" hook FAILED
```
### Additional Considerations

`beforeEach` and `afterEach` are run outside of  a describe block so they can work on all tests , but it has some issues.  We will now run extra tests in the output.

Example of 80 of 78 tests run:

```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 80 of 78 (6 FAILED) (skipped 2) (0.617 secs / 0.563 secs)
```

This does get the correct failures, it just oddly outputs them.
### Links

Related:
https://medium.com/about-codecademy/proptypes-validation-in-react-karma-683c7d52abe#.3667lav2n

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
