### PR TITLE
Added missing dependencies that were lost in migration

### DIFF
--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -37,12 +37,14 @@
     "enyo-config": "enyojs/enyo-config#test-suite"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "eases": "^1.0.8",
     "enact-core": "^1.0.0-alpha.1",
     "enact-i18n": "^1.0.0-alpha.1",
     "enact-spotlight": "^1.0.0-alpha.1",
     "enact-ui": "^1.0.0-alpha.1",
     "invariant": "^2.2.1",
+    "ramda": "^0.22.1",
     "react": "^15.3.1",
     "warning": "^3.0.0"
   }

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -28,6 +28,7 @@
     "enyo-config": "enyojs/enyo-config"
   },
   "dependencies": {
+    "ramda": "^0.22.1",
     "react": "^15.3.1"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "enact-core": "1.0.0-alpha.1",
+    "ramda": "^0.22.1",
     "react-dom": "^15.3.1",
     "recompose": "^0.20.2",
     "warning": "^3.0.0"


### PR DESCRIPTION
### Issue Resolved / Feature Added

Tests were failing because `ramda` wasn't included in certain libraries.
### Resolution

Added `ramda` to the packages that use `ramda` and did not have it in their dependencies. 

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
