### PR TITLE
trim leading whitespace from className

### DIFF
--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -58,7 +58,7 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.state && !this.state.screenType) init();
 
 			let classes = getResolutionClasses();
-			if (this.props.className) classes += ' ' + this.props.className;
+			if (this.props.className) classes += (classes ? ' ' : '') + this.props.className;
 			return <Wrapped {...this.props} className={classes} />;
 		}
 	};


### PR DESCRIPTION
### Issue Resolved / Feature Added

If the wrapped component doesn't already have classNames, you end up with a leading space when providing `className` prop on ResolutionDecorator.
### Resolution

Added a check so that a space is only added if there are existing classNames for the wrapped component.

Enyo-DCO-1.1-Signed-off-by: Dave Freeman dave.freeman@lge.com
