### PR TITLE
Added tests for Transition

### DIFF
--- a/packages/ui/Transition/tests/Transistion-specs.js
+++ b/packages/ui/Transition/tests/Transistion-specs.js
@@ -1,4 +1,3 @@
-/* globals Map */
 import React from 'react';
 import {mount} from 'enzyme';
 import Transition from '../Transition';
@@ -42,18 +41,6 @@ describe('Transition Specs', () => {
 		const actual = wrapped.find('ChildNode').prop('style');
 
 		expect(actual).to.equal(expected);
-	});
-
-	it('should apply styles to inner wrapper when type == "clip"', function () {
-		const clipStyles = {height: 0, overflow: 'hidden'};
-		const wrapped = mount(
-			<Transition type='clip'>Body</Transition>
-		);
-
-		const expected = clipStyles;
-		const actual = wrapped.childAt(0).prop('style');
-
-		expect(actual).to.deep.equal(expected);
 	});
 
 	// Tests for prop and className combinations


### PR DESCRIPTION
### Issue Resolved / Feature Added

Added tests for Transition
### Additional Considerations

For the requirement,(`should apply classes for visible, direction, duration, and timingFunction properties`), The tests utilize a Map that has the pairs of correct classes with correct prop values. We then just iterate through the combinations to generate the correct test. It looks a bit odd in the test setup, but it works properly.

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
