### PR TITLE
Added exception for eslint to match new mocha env

### DIFF
--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -1,3 +1,5 @@
+/* eslint no-shadow: ["error", { "allow": ["context"] }]*/
+
 import computed from './computed';
 import defaultProps from './defaultProps';
 import name from './name';

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -1,3 +1,5 @@
+/* eslint no-shadow: ["error", { "allow": ["context"] }] */
+
 import xhr from 'xhr';
 
 import Loader from '../ilib/lib/Loader';
@@ -217,4 +219,3 @@ EnyoLoader.prototype.isAvailable = function (_root, path) {
 
 export default EnyoLoader;
 export {EnyoLoader as Loader};
-


### PR DESCRIPTION
### Issue Resolved / Feature Added

Adding new environment to eslint for mocha variables. It adds `context` which we use in a few places.
### Resolution

Added eslint exceptions to files that were throwing an eslint no shadow error.

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
