### PR TITLE
ENYO-3479: remove invalid handle() test

### DIFF
--- a/packages/core/handle/tests/handle-specs.js
+++ b/packages/core/handle/tests/handle-specs.js
@@ -118,18 +118,6 @@ describe('handle', () => {
 		expect(handler.calledOnce).to.equal(true);
 	});
 
-	it('should only call handler for specified which', function () {
-		const which = 1;
-		const handler = sinon.spy();
-		const callback = handle(forWhich(which), handler);
-
-		callback(makeEvent());
-		expect(handler.calledOnce).to.equal(false);
-
-		callback(makeEvent({which}));
-		expect(handler.calledOnce).to.equal(true);
-	});
-
 	it('should only call handler for specified prop', function () {
 		const prop = 'index';
 		const value = 0;


### PR DESCRIPTION
Missed removing this test when the feature was removed from ENYO-3479

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
