### PR TITLE
ENYO-3503: Enact Picker: Truncated Text displays in Small Vertical Orientation

### DIFF
--- a/packages/moonstone/Picker/Picker.less
+++ b/packages/moonstone/Picker/Picker.less
@@ -140,14 +140,6 @@
 				.position(0);
 			}
 		}
-
-		&:not(.large) {
-			.item {
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-			}
-		}
 	}
 
 	&.vertical {


### PR DESCRIPTION
### Issue Resolved / Feature Added

Small `Picker` in vertical orientation did not have correct styling for the valueWrapper.
### Resolution

Added CSS to change styles for vertical `Picker` with `small` width.
### Additional Considerations

Consider that I'm still pretty terrible with CSS.
### Links

https://jira2.lgsvl.com/browse/ENYO-3503

Enyo-DCO-1.1-Signed-off-by: Dave Freeman dave.freeman@lge.com
