### PR TITLE
PLAT-27978: Prevent default only when navigating directionally

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -854,7 +854,9 @@ const Spotlight = (function() {
 
 		SpotlightAccelerator.processKey(evt, onAcceleratedKeyDown);
 
-		preventDefault(evt);
+		if (_directions[keyCode]) {
+			preventDefault(evt);
+		}
 	}
 
 	function onMouseOver (evt) {


### PR DESCRIPTION
### Issue Resolved / Feature Added

Calling preventDefault during onKeyDown caused our key-mouse event mapping to fail
### Resolution

We only need to call preventDefault in the case of 4-way directional navigation

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
