### PR TITLE
Fires events for ExpandableList sample

### DIFF
--- a/packages/sampler/stories/moonstone-stories/ExpandableList.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandableList.js
@@ -1,6 +1,7 @@
 import {ExpandableList as ExpList, ExpandableListBase} from '@enact/moonstone/ExpandableList';
+import {forward} from '@enact/core/handle';
 import React from 'react';
-import {storiesOf} from '@kadira/storybook';
+import {storiesOf, action} from '@kadira/storybook';
 import {withKnobs, boolean, text} from '@kadira/storybook-addon-knobs';
 
 class ExpandableList extends React.Component {
@@ -9,24 +10,30 @@ class ExpandableList extends React.Component {
 		this.state = {
 			open: false
 		};
+		this.forwardOnChange = forward('onChange');
+		this.forwardOnOpen = forward('onOpen');
+		this.forwardOnClose = forward('onClose');
 	}
 
-	handleChange = ({value}) => {
+	handleChange = (ev) => {
 		this.setState({
-			value: value
+			value: ev.value
 		});
+		this.forwardOnChange(ev, this.props);
 	}
 
-	handleOpen = () => {
+	handleOpen = (ev) => {
 		this.setState({
 			'open': true
 		});
+		this.forwardOnOpen(ev, this.props);
 	};
 
-	handleClose = () => {
+	handleClose = (ev) => {
 		this.setState({
 			'open': false
 		});
+		this.forwardOnClose(ev, this.props);
 	};
 
 	render () {
@@ -54,6 +61,9 @@ storiesOf('ExpandableList')
 		'Basic usage of ExpandableList',
 		() => (
 			<ExpandableList
+				onChange={action('onChange')}
+				onClose={action('onClose')}
+				onOpen={action('onOpen')}
 				title={text('title', 'title')}
 				noneText={text('noneText', 'nothing selected')}
 				disabled={boolean('disabled', false)}


### PR DESCRIPTION
### Issue Resolved / Feature Added

The various `ExpandableList` events (`onChange`, `onClose`, `onOpen`) were not being fired in the sampler.
### Resolution

Because we are wrapping the expandable component in a stateful component, we were handling the events directly inside this wrapping component, effectively consuming the events. We utilize the `forward` feature from `@enact/core` in order to execute the externally specified event handlers.
### Additional Considerations

This adds some additional complexity to the sample, but only for the wrapping component, and does not affect the sample source.
### Links
### Comments

Issue: ENYO-3513
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
