### PR TITLE
PLAT-27530: shouldComponentUpdate usage in ViewManager

### DIFF
--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -84,8 +84,7 @@ class View extends React.Component {
 			return false;
 		}
 
-		// since state is checked above, we can just check props for equality
-		return !shallowEqual(this.props, nextProps);
+		return true;
 	}
 
 	componentWillReceiveProps (nextProps) {

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -117,15 +117,6 @@ class ViewManager extends React.Component {
 		index: 0
 	}
 
-	shouldComponentUpdate (nextProps) {
-		// update when the index changes or the children change
-		if (this.props.index !== nextProps.index) {
-			return true;
-		} else {
-			return !childrenEquals(this.props.children, nextProps.children);
-		}
-	}
-
 	componentWillReceiveProps (nextProps) {
 		this.previousIndex = this.props.index;
 		this.checkReverse(nextProps);


### PR DESCRIPTION
Some healthy discussion on React's GH on this topic. https://github.com/facebook/react/issues/2517

My short conclusion is that there isn't a solution in React right now for allowing intermediate controls to return false from shouldComponentUpdate if children of those controls might need to update as a result of a context change. In the case of i18n, this is effectively a deal breaker since $L will be used all over the place.

I think our approach for now needs to be a conservative use of shouldComponentUpdate within framework components and only return false when the code specifically controls it (e.g. @enact/core/ViewManager/View stores a state value for transition step that need not cause a re-render because the transition update is handled in a rAF).

To align with this, I'm removing a bit of code from ViewManager that was too aggressively returning false.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
