### PR TITLE
ENYO-3524 - add initial Marquee support to Button

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -11,6 +11,8 @@ import {Spottable} from '@enact/spotlight';
 import Pressable from '@enact/ui/Pressable';
 import React, {PropTypes} from 'react';
 
+import Marquee from '../Marquee';
+
 import css from './Button.less';
 
 /**
@@ -125,7 +127,7 @@ const ButtonBase = kind({
 		return (
 			<button {...rest}>
 				<div className={css.bg} />
-				<span className={css.client}>{children}</span>
+				<Marquee className={css.client}>{children}</Marquee>
 			</button>
 		);
 	}

--- a/packages/sampler/stories/moonstone-stories/Button.js
+++ b/packages/sampler/stories/moonstone-stories/Button.js
@@ -1,7 +1,7 @@
 import Button, {ButtonBase} from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, boolean, select} from '@kadira/storybook-addon-knobs';
+import {withKnobs, boolean, select, text} from '@kadira/storybook-addon-knobs';
 
 Button.propTypes = Object.assign({}, ButtonBase.propTypes, Button.propTypes);
 Button.defaultProps = Object.assign({}, ButtonBase.defaultProps, Button.defaultProps);
@@ -26,8 +26,7 @@ storiesOf('Button')
 				preserveCase={boolean('preserveCase')}
 				selected={boolean('selected')}
 				small={boolean('small')}
-			>
-				Click Me
-			</Button>
+				children={text('children', 'Click Me')}
+			/>
 		)
 	);


### PR DESCRIPTION
May need to revisit when the full implementation of Marquee lands but
the current impl correctly clamps the text to prevent layout issues.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
