### PR TITLE
ENYO-3523: Enact CheckboxItem: 'onToggle:[Object]' Fires when Clicking on a Disabled CheckboxItem

### DIFF
--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -124,8 +124,8 @@ const ToggleItemBase = kind({
 
 			return <Icon className={styler.join(css.icon, iconClasses, {checked})}>{icon}</Icon>;
 		},
-		onToggle: ({onToggle, onClick, checked, value}) => {
-			if (onToggle || onClick) {
+		onToggle: ({onToggle, onClick, checked, disabled, value}) => {
+			if (!disabled && (onToggle || onClick)) {
 				return (ev) => {
 					if (onToggle) onToggle({checked: !checked, value});
 					if (onClick) onClick(ev);
@@ -138,10 +138,8 @@ const ToggleItemBase = kind({
 		delete rest.iconClasses;
 		delete rest.inline;
 
-		const handleToggle = rest.disabled ? null : onToggle;
-
 		return (
-			<Item {...rest} onClick={handleToggle}>
+			<Item {...rest} onClick={onToggle}>
 				{icon}
 				{children}
 			</Item>


### PR DESCRIPTION
### Issue Resolved / Feature Added

`ToggleItemBase` was not limiting the onToggle method when it was disabled.
### Resolution

Only use `onToggle` when not disabled.
### Links

https://jira2.lgsvl.com/browse/ENYO-3523

Enyo-DCO-1.1-Signed-off-by: Dave Freeman dave.freeman@lge.com
