### PR TITLE
Fix Input Spotlight Behavior

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -55,7 +55,7 @@ class InputBase extends React.Component {
 	}
 
 	spotlightMove = (direction) => {
-		if(!Spotlight.move(direction)) {
+		if (!Spotlight.move(direction)) {
 			this.inputNode.blur();
 		}
 	}
@@ -75,7 +75,7 @@ class InputBase extends React.Component {
 		const firstIcon = icon('iconStart', this.props, iconClasses),
 			lastIcon = icon('iconEnd', this.props, iconClasses);
 		const containerProps = {};
-		
+
 		if (spotlightDisabled) {
 			containerProps['data-container-id'] = rest['data-container-id'];
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added

This fixes an issue where the input component - upon being enabled to type, by gaining focus via the `<enter>` key- could not return to its previous, unfocused state when no other spottable components exist in the 5-way direction pressed.
### Resolution

`Spotlight.move()` returns `false` if no other spottable components exist in the 5-way direction pressed. We can use this to determine if we need to call `blur()` on the input.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
