### PR TITLE
Adds back defaultProps

### DIFF
--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -115,6 +115,10 @@ const PickerBase = kind({
 		wrap: React.PropTypes.bool
 	},
 
+	defaultProps: {
+		value: 0
+	},
+
 	computed: {
 		max: ({children}) => children.length - 1,
 		children: ({children}) => React.Children.map(children, (child) => {


### PR DESCRIPTION
### Issue Resolved / Feature Added

The `value` prop needs a default value as it is being passed as the `index` prop for `PickerCore`, which requires `index`. This was removed as part of some `propTypes` and `defaultProps` scrubbing in https://github.com/enyojs/enact/pull/84.
### Resolution

The defaultProp for `value` has been added back.
### Additional Considerations
### Links
### Comments

Issue: PLAT-28039
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
