### PR TITLE
Plat-28121-Madala-Created a qa-sample for SimplePicker with one item

### DIFF
--- a/packages/sampler/stories/qa-stories/Picker.js
+++ b/packages/sampler/stories/qa-stories/Picker.js
@@ -1,10 +1,10 @@
 import Picker, {PickerBase} from '@enact/moonstone/Picker';
-import Pickable from '@enact/ui/Pickable';
+import Changeable from '@enact/ui/Changeable';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {withKnobs, text, boolean, select} from '@kadira/storybook-addon-knobs';
 
-const StatefulPicker = Pickable(Picker);
+const StatefulPicker = Changeable(Picker);
 StatefulPicker.propTypes = Object.assign({}, PickerBase.propTypes, StatefulPicker.propTypes);
 StatefulPicker.defaultProps = Object.assign({}, PickerBase.defaultProps, StatefulPicker.defaultProps);
 StatefulPicker.displayName = 'Picker';


### PR DESCRIPTION
### Issue Resolved / Feature Added

Created a qa-sample for SimplePicker with one item
### Resolution

From Stephen's analysis on PLAT-27719:
When there's only one item in SimplePicker, wrap:true enables arrows on both ends. This is very unusual UX, but apps had to manually switch wrap: false when number of children is one. (com.webos.app.connectionwizard/src/views/input/universalControl/Test.js)
Hence, created a qa-sample that proves out that this use case will still work with our new picker.
### Additional Considerations
### Links

https://jira2.lgsvl.com/browse/PLAT-28121
### Comments

Enyo-DCO-1.1-Signed-off-by:Madala Satyanarayana madala.satyanarayana@lge.com
