### PR TITLE
PLAT-28746: ensure computed properties do not individually mutate props

### DIFF
--- a/packages/core/kind/computed.js
+++ b/packages/core/kind/computed.js
@@ -34,12 +34,12 @@ import R from 'ramda';
  */
 const computed = (cfg, props, ...args) => {
 	const keys = Object.keys(cfg);
-
+	const updated = {};
 	for (let i = keys.length - 1; i >= 0; i--) {
-		props[keys[i]] = cfg[keys[i]](props, ...args);
+		updated[keys[i]] = cfg[keys[i]](props, ...args);
 	}
 
-	return props;
+	return Object.assign(props, updated);
 };
 
 // Reducer to chain computed property transformations

--- a/packages/core/kind/tests/computed-specs.js
+++ b/packages/core/kind/tests/computed-specs.js
@@ -48,6 +48,22 @@ describe('computed', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	it('should not leak updated prop values into other computed props', function () {
+		const props = {
+			count: 1
+		};
+		const cfg = {
+			value: ({count}) => count + 5,
+			count: ({count}) => count + 1
+		};
+
+		const updated = computed(cfg, props);
+
+		const expected = 6;
+		const actual = updated.value;
+		expect(actual).to.equal(expected);
+	});
+
 	it('Should work with its documented example - sum', function () {
 		const updated = computed(exampleCfg, exampleProps);
 


### PR DESCRIPTION
Instead of returning the updated value directly into props, we'll drop
them into a temporary object which will merge with props after all
have been evaluated.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
