### PR TITLE
Includes resources for tests

### DIFF
--- a/packages/moonstone/karma.conf.js
+++ b/packages/moonstone/karma.conf.js
@@ -2,6 +2,12 @@
 var config = require('enyo-config');
 
 module.exports = config.karma({
+	files: [
+		{pattern: 'resources/*.json', watched: true, served: true, included: false}
+	],
+	proxies: {
+		'/resources/': '/base/resources/'
+	},
 	ri: {
 		baseSize: 24
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added

The tests on Travis were failing because there was excessive output due to warnings about missing `i18n` resources, which is now a dependency of Marquee.
### Resolution

We have an existing `ilibmanifest.json` but it was not being loaded by the test runner. The karma config has been updated to include json files from the `resources` directory.
### Additional Considerations
### Links
### Comments

Issue: ENYO-3563
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
