### PR TITLE
Remove unneeded webos-meta-loader dependency

### DIFF
--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -44,7 +44,6 @@
     "less-loader": "2.2.3",
     "resolution-independence": "0.0.3",
     "style-loader": "0.13.1",
-    "webos-meta-loader": "enyojs/webos-meta-loader",
     "webos-meta-webpack-plugin": "github:enyojs/webos-meta-webpack-plugin",
     "webpack": "1.13.2"
   },


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
