### PR TITLE
ENYO-3573: Adds translucent checkmark when spotted

### DIFF
--- a/packages/moonstone/CheckboxItem/CheckboxItem.js
+++ b/packages/moonstone/CheckboxItem/CheckboxItem.js
@@ -18,7 +18,7 @@ const CheckboxItemBase = kind({
 		children: PropTypes.string.isRequired,
 
 		/**
-		 * Applies a "checked" visual state to the checkbox item.
+		 * When `true`, a "checked" visual effect is applied to the button.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -27,7 +27,7 @@ const CheckboxItemBase = kind({
 		checked: PropTypes.bool,
 
 		/**
-		 * Applies a disabled visual state to the checkbox item.
+		 * When `true`, applies a disabled style and the control becomes non-interactive.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -36,7 +36,7 @@ const CheckboxItemBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
-		 * Applies inline styling to the checkbox item.
+		 * When `true`, an inline visual effect is applied to the button.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -78,10 +78,7 @@ const CheckboxItemBase = kind({
 	},
 
 	computed: {
-		iconClasses: ({checked, styler}) => styler.join(
-			css.icon,
-			{checked}
-		)
+		iconClasses: ({checked}) => !checked ? css.translucent : null
 	},
 
 	render: (props) => (

--- a/packages/moonstone/CheckboxItem/CheckboxItem.less
+++ b/packages/moonstone/CheckboxItem/CheckboxItem.less
@@ -1,2 +1,11 @@
 // CheckboxItem.less
 //
+
+.checkboxItem {
+	&:global(.spottable):focus {
+		.translucent {
+			visibility: visible;
+			opacity: 0.3;
+		}
+	}
+}

--- a/packages/moonstone/SelectableItem/SelectableItem.less
+++ b/packages/moonstone/SelectableItem/SelectableItem.less
@@ -11,9 +11,9 @@
 		line-height: @dot-size;
 		color: @moon-accent;
 
-	    margin-top: -4px;
-	    margin-bottom: 0;
-	    .margin-start-end(0, @moon-toggle-item-icon-margin);
+		margin-top: -4px;
+		margin-bottom: 0;
+		.margin-start-end(0, @moon-toggle-item-icon-margin);
 
 		&:not(.checked) {
 			display: none;

--- a/packages/moonstone/ToggleItem/ToggleItem.less
+++ b/packages/moonstone/ToggleItem/ToggleItem.less
@@ -5,24 +5,24 @@
 @import '../styles/variables.less';
 
 .toggleItem {
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 
-    &.inline {
-        display: inline-flex;
-    }
+	&.inline {
+		display: inline-flex;
+	}
 
-    .icon {
-        margin-top: 0;
-        margin-bottom: 0;
-        .margin-start-end(0, @moon-toggle-item-icon-margin);
-        
-        &:not(.checked) {
-            visibility: hidden;
-        }
-    }
+	.icon {
+		margin-top: 0;
+		margin-bottom: 0;
+		.margin-start-end(0, @moon-toggle-item-icon-margin);
 
-    .content {
-        flex-grow: 1;
-    }
+		&:not(.checked) {
+			visibility: hidden;
+		}
+	}
+
+	.content {
+		flex-grow: 1;
+	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added

The checkmark for `CheckboxItem` should be translucent when the component is spotted, as opposed to not being visible at all.
### Resolution

A rule was added to `ToggleItem`'s styling to support this visual cue. Also, made some fixes to convert spaces back to tabs.
### Additional Considerations

I'd be curious if there's a better way to implement this styling. The `&:global(.spottable):focus` selector has to be applied to `toggleItem` because focus does not cascade and is specific to the element. I also had to add a `translucent` class selector as not all the components that utilize `ToggleItem` have this visual styling.
### Links
### Comments

Issue: ENYO-3573
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
