### PR TITLE
ENYO-3588: Corrected button colors for Picker.

### DIFF
--- a/packages/moonstone/Picker/Picker.less
+++ b/packages/moonstone/Picker/Picker.less
@@ -56,7 +56,6 @@
 	}
 
 	&.joined {
-		background-color: @moon-button-background-color;
 		color: @moon-button-text-color;
 		margin: 0 @moon-spotlight-outset;
 

--- a/packages/moonstone/Picker/PickerCore.js
+++ b/packages/moonstone/Picker/PickerCore.js
@@ -32,6 +32,8 @@ const jobNames = {
 const emulateMouseEventsTimeout = 175;
 
 // Components
+const TransparentIconButton = (props) => <IconButton {...props} backgroundOpacity="transparent" />;
+
 const PickerCore = class extends React.Component {
 	static displayName = 'PickerCore'
 
@@ -327,7 +329,7 @@ const PickerCore = class extends React.Component {
 		delete rest.value;
 		delete rest.wrap;
 
-		const ButtonType = joined ? Icon : IconButton;
+		const ButtonType = joined ? Icon : TransparentIconButton;
 		const incrementIcon = selectIncIcon(this.props);
 		const decrementIcon = selectDecIcon(this.props);
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
1. Joined Picker shouldn't have a background in normal-state.
2. Picker's buttons had a background color whey they shouldn't.
### Resolution
1. It doesn't
2. They don't
### Comments

Just a small change. Easy to test.
