### PR TITLE
PLAT-24216: Add application close button

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -94,8 +94,6 @@
 		min-width: @moon-button-small-height;
 		line-height: (@moon-button-small-height - (2 * @moon-button-border-width));
 		padding: 0 @moon-button-small-h-padding;
-		position: relative;
-		overflow: visible;
 
 		&.minWidth {
 			min-width: @moon-button-small-min-width;

--- a/packages/moonstone/Panels/ActivityPanels.js
+++ b/packages/moonstone/Panels/ActivityPanels.js
@@ -1,6 +1,6 @@
 import {ActivityArranger} from './Arrangers';
 import BreadcrumbDecorator from './BreadcrumbDecorator';
-import Viewport from './Viewport';
+import PanelsBase from './Panels';
 
 /**
 * An instance of Panels in which the Panel uses the entire viewable screen with a single breadcrumb
@@ -16,7 +16,7 @@ const ActivityPanels = BreadcrumbDecorator({
 	props: {
 		arranger: ActivityArranger
 	}
-}, Viewport);
+}, PanelsBase);
 
 export default ActivityPanels;
 export {ActivityPanels};

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -1,0 +1,47 @@
+import kind from '@enact/core/kind';
+import React from 'react';
+
+import IconButton from '../IconButton';
+
+import css from './ApplicationCloseButton.less';
+
+/**
+ * An {@link module:@enact/moonstone/IconButton~IconButton} with `closex` icon. It is used in
+ * {@link module:@enact/moonstone/Panels~Panels} positioned at top right corner.
+ * `onApplicationClose` callback function should be specified to close your app. The recommended
+ * action to take with the event is `window.close()`, but you may also want to also do operations
+ * like save user work or close database connections.
+ *
+ * @class ApplicationCloseButton
+ * @private
+ */
+const ApplicationCloseButton = kind({
+	propTypes: {
+		/**
+		 * A function to run when app close button is clicked
+		 *
+		 * @type {Function}
+		 */
+		onApplicationClose: React.PropTypes.func
+	},
+
+	styles: {
+		css,
+		className: 'applicationCloseButton'
+	},
+
+	render: ({onApplicationClose, ...rest}) => {
+		return (
+			<IconButton
+				{...rest}
+				small
+				backgroundOpacity="transparent"
+				onClick={onApplicationClose}
+			>
+				closex
+			</IconButton>
+		);
+	}
+});
+
+export default ApplicationCloseButton;

--- a/packages/moonstone/Panels/ApplicationCloseButton.less
+++ b/packages/moonstone/Panels/ApplicationCloseButton.less
@@ -1,0 +1,10 @@
+@import '~@enact/ui/styles/mixins.less';
+@import '../styles/variables.less';
+
+.applicationCloseButton {
+	position: absolute;
+	top: (@moon-app-keepout + @moon-spotlight-outset);
+	.position-start-end(auto, @moon-spotlight-outset * 2);
+	z-index: 1;
+	margin: 0;
+}

--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -1,3 +1,5 @@
+@import '~@enact/ui/styles/mixins.less';
+
 @import '../styles/variables.less';
 @import '../styles/text.less';
 
@@ -18,6 +20,10 @@
 	// .titleAbove {
 	// 	.moon-super-header-text();
 	// }
+
+	:global(.hasCloseButton) & {
+		.padding-start-end(0, @moon-spotlight-outset + @moon-icon-button-small-size + @moon-spotlight-outset);
+	}
 
 	.title {
 		.moon-header-text();

--- a/packages/moonstone/Panels/Panel.less
+++ b/packages/moonstone/Panels/Panel.less
@@ -21,4 +21,3 @@
 	z-index: 1;
 	flex: 1
 }
-

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -1,6 +1,15 @@
+/**
+ * Exports the {@link module:@enact/moonstone/Panels~Panels} and {@link module:@enact/moonstone/Panels~PanelBase}
+ * components. The default export is {@link module:@enact/moonstone/Panels~PanelsBase}.
+ *
+ * @module @enact/moonstone/Panels
+ */
+
 import kind from '@enact/core/kind';
+import {shape} from '@enact/ui/ViewManager';
 import React from 'react';
 
+import ApplicationCloseButton from './ApplicationCloseButton';
 import Viewport from './Viewport';
 
 import css from './Panels.less';
@@ -13,20 +22,87 @@ import css from './Panels.less';
 const PanelsBase = kind({
 	name: 'Panels',
 
-	propTypes: Viewport.propTypes,
+	propTypes: {
+		/**
+		 * Set of functions that control how the panels are transitioned into and out of the
+		 * viewport
+		 *
+		 * @type {Arranger}
+		 */
+		arranger: shape,
+
+		/**
+		 * Panels to be rendered
+		 *
+		 * @type {Panel}
+		 */
+		children: React.PropTypes.node,
+
+		/**
+		 * Index of the active panel
+		 *
+		 * @type {Number}
+		 * @default 0
+		 */
+		index: React.PropTypes.number,
+
+		/**
+		 * Disable panel transitions
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 */
+		noAnimation: React.PropTypes.bool,
+
+		/**
+		 * When `true`, application close button does not show on the top right corner
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 */
+		noCloseButton: React.PropTypes.bool,
+
+		/**
+		 * A function to run when app close button is clicked
+		 * @type {Function}
+		 */
+		onApplicationClose: React.PropTypes.func
+	},
+
+	defaultProps: {
+		noCloseButton: false
+	},
 
 	styles: {
 		css,
 		className: 'panels enact-fit'
 	},
 
-	render: ({noAnimation, arranger, children, index, ...rest}) => (
-		<div {...rest}>
-			<Viewport noAnimation={noAnimation} arranger={arranger} index={index}>
-				{children}
-			</Viewport>
-		</div>
-	)
+	computed: {
+		className: ({noCloseButton, styler}) => styler.join({
+			hasCloseButton: !noCloseButton
+		}),
+		applicationCloseButton: ({noCloseButton, onApplicationClose}) => {
+			if (!noCloseButton) {
+				return (
+					<ApplicationCloseButton onApplicationClose={onApplicationClose} />
+				);
+			}
+		}
+	},
+
+	render: ({noAnimation, arranger, children, index, applicationCloseButton, ...rest}) => {
+		delete rest.noCloseButton;
+		delete rest.onApplicationClose;
+		return (
+			<div {...rest}>
+				{applicationCloseButton}
+				<Viewport noAnimation={noAnimation} arranger={arranger} index={index}>
+					{children}
+				</Viewport>
+			</div>
+		);
+	}
 });
 
 export default PanelsBase;

--- a/packages/moonstone/Panels/Panels.less
+++ b/packages/moonstone/Panels/Panels.less
@@ -56,7 +56,7 @@
 			direction: rtl;
 		}
 	}
-
+	
 	// TODO: Application Close Button Support
 	// &:not(.first) {
 	// 	.moon-application-close-button {

--- a/packages/moonstone/Panels/tests/Panels-specs.js
+++ b/packages/moonstone/Panels/tests/Panels-specs.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+
+import Panels from '../Panels';
+
+describe('Panels Specs', () => {
+
+	it('should render application close button when \'noCloseButton\' is not specified', function () {
+		const panels = mount(
+			<Panels />
+		);
+
+		const applicationCloseButton = panels.find('IconButton');
+		const expected = 1;
+		const actual = applicationCloseButton.length;
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should not render application close button when \'noCloseButton\' is set to true', function () {
+		const panels = mount(
+			<Panels noCloseButton />
+		);
+
+		const applicationCloseButton = panels.find('IconButton');
+		const expected = 0;
+		const actual = applicationCloseButton.length;
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should call onApplicationClose when application close button is clicked', function () {
+		const handleAppClose = sinon.spy();
+		const subject = mount(
+			<Panels onApplicationClose={handleAppClose} />
+		);
+
+		subject.find('IconButton').simulate('click');
+
+		const expected = true;
+		const actual = handleAppClose.calledOnce;
+
+		expect(expected).to.equal(actual);
+	});
+
+});

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -6,6 +6,17 @@
 	will-change: transform;
 }
 
+// Applies RTL-compatible start and end position to a selector
+.position-start-end (@start, @end) {
+	left: @start;
+	right: @end;
+
+	:global(.enact-locale-right-to-left) & {
+		left: @end;
+		right: @start;
+	}
+}
+
 // Applies RTL-compatible start and end margins to a selector
 .margin-start-end (@start, @end) {
 	margin-left: @start;


### PR DESCRIPTION
### Issue Resolved / Feature Added

Add application close button
### Resolution
- Provides `onApplicationClose` to handle close
- `Panels` can either show or hide application close button
- Added `Panels` tests for application close button
### Additional Considerations
- `style={{'position': 'absolute'}}` is applied to `IconButton` as `applicationCloseButton` class is not added last
- Application close button is not to be used outside the context of `Panels`. Hence it's not exported nor modularized
- If we do modularize, there's a CSS specificity issue where `Button.less` sets `position: relative` in `.button.small` class.
### Links

[PLAT-24216](https://jira2.lgsvl.com/browse/PLAT-24216)
### Comments
- No tooltip needed
