### PR TITLE
Adjust locale loader for Chrome status 0 false-errors

### DIFF
--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -6,8 +6,14 @@ import ilibLocale from '../ilib/locale/ilibmanifest.json';
 
 const get = (url, callback) => {
 	if (typeof window === 'object') {
-		xhr({url, sync: true}, (err, resp, body) => {
-			const error = err || resp.statusCode !== 200 && resp.statusCode;
+		let req;
+		xhr({url, sync: true, beforeSend: (r) => (req = r)}, (err, resp, body) => {
+			let error = err || resp.statusCode !== 200 && resp.statusCode;
+			// false failure from chrome and file:// urls
+			if (error && req.status === 0 && req.response.length > 0) {
+				body = req.response;
+				error = false;
+			}
 			const json = error ? null : JSON.parse(body);
 			callback(json, error);
 		});
@@ -18,10 +24,10 @@ const get = (url, callback) => {
 
 function EnyoLoader () {
 	this.base = ilibLocale.path.substring(0, ilibLocale.path.lastIndexOf('/locale'));
-	// TODO: enyo.platform
-	// if (platform.platformName === 'webos') {
-	// 	this.webos = true;
-	// }
+	// TODO: full enyo.platform implementation for improved accuracy
+	if (typeof window === 'object' && typeof window.PalmSystem === 'object') {
+		this.webos = true;
+	}
 }
 
 EnyoLoader.prototype = new Loader();


### PR DESCRIPTION
### Issue Resolved / Feature Added
- Locale loader would fail on webOS builds
- Shared ZoneFiles would not be used.
### Resolution
- XHR library is limited in XHR native object access, so had to add a beforeSend function to get access.
- If the XHR returns status 0 but does have content, we've encounted the Chrome issue when requesting file:// URLs. In this case, use the response and parse the JSON content as a success.
- Additionally, add a basic check for window.PalmSystem as a marker for webOS, so system zonefiles can be used like with Enyo. Can be replaced once a full platform detection module is added to @enact/core.

This is needed for webOS builds to correctly read ilib locale files..

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
