### PR TITLE
ENYO-3420: Rigby Pickers: 5way Spot becomes Hidden when Button becomes Disabled

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -115,7 +115,7 @@ const ButtonBase = kind({
 		)
 	},
 
-	render: ({children, ...rest}) => {
+	render: ({children, componentRef, ...rest}) => {
 		delete rest.backgroundOpacity;
 		delete rest.minWidth;
 		delete rest.pressed;
@@ -123,7 +123,7 @@ const ButtonBase = kind({
 		delete rest.small;
 
 		return (
-			<button {...rest}>
+			<button {...rest} ref={componentRef}>
 				<div className={css.bg} />
 				<span className={css.client}>{children}</span>
 			</button>

--- a/packages/moonstone/Icon/Icon.js
+++ b/packages/moonstone/Icon/Icon.js
@@ -112,11 +112,11 @@ const IconBase = kind({
 		}
 	},
 
-	render: (props) => {
-		delete props.small;
-		delete props.src;
+	render: ({componentRef, ...rest}) => {
+		delete rest.small;
+		delete rest.src;
 
-		return <div {...props} />;
+		return <div {...rest} ref={componentRef} />;
 	}
 });
 

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -116,9 +116,9 @@ const IconButtonBase = kind({
 		className: ({small, styler}) => styler.append({small})
 	},
 
-	render: ({children, small, src, ...rest}) => {
+	render: ({children, componentRef, small, src, ...rest}) => {
 		return (
-			<Button {...rest} small={small} minWidth={false} marqueeDisabled>
+			<Button {...rest} small={small} minWidth={false} marqueeDisabled componentRef={componentRef}>
 				<Icon small={small} className={css.icon} src={src}>{children}</Icon>
 			</Button>
 		);

--- a/packages/moonstone/Picker/PickerCore.js
+++ b/packages/moonstone/Picker/PickerCore.js
@@ -191,7 +191,7 @@ const PickerCore = class extends React.Component {
 		 */
 		value: steppedNumber,
 
-		/*
+		/**
 		 * Choose a specific size for your picker. `'small'`, `'medium'`, `'large'`, or set to `null` to
 		 * assume auto-sizing. `'small'` is good for numeric pickers, `'medium'` for single or short
 		 * word pickers, `'large'` for maximum-sized pickers.
@@ -201,7 +201,7 @@ const PickerCore = class extends React.Component {
 		 */
 		width: React.PropTypes.oneOf([null, 'small', 'medium', 'large']),
 
-		/*
+		/**
 		 * Should the picker stop incrementing when the picker reaches the last element? Set `wrap`
 		 * to `true` to allow the picker to continue from the opposite end of the list of options.
 		 *
@@ -306,7 +306,9 @@ const PickerCore = class extends React.Component {
 		const {
 			noAnimation,
 			children,
+			decrementerRef,
 			disabled,
+			incrementerRef,
 			index,
 			joined,
 			onMouseUp,
@@ -346,13 +348,13 @@ const PickerCore = class extends React.Component {
 		return (
 			<div {...rest} className={classes} disabled={disabled} onWheel={joined ? this.handleWheel : null}>
 				<span className={css.incrementer} disabled={incrementerDisabled} onClick={handleIncClick} onMouseDown={this.handleIncDown} onMouseUp={onMouseUp}>
-					<ButtonType disabled={incrementerDisabled}>{incrementIcon}</ButtonType>
+					<ButtonType disabled={incrementerDisabled} componentRef={incrementerRef}>{incrementIcon}</ButtonType>
 				</span>
 				<ViewManager arranger={arranger} duration={200} index={index} noAnimation={noAnimation} reverseTransition={this.reverseTransition} className={css.valueWrapper}>
 					{children}
 				</ViewManager>
 				<span className={css.decrementer} disabled={decrementerDisabled} onClick={handleDecClick} onMouseDown={this.handleDecDown} onMouseUp={onMouseUp}>
-					<ButtonType disabled={decrementerDisabled}>{decrementIcon}</ButtonType>
+					<ButtonType disabled={decrementerDisabled} componentRef={decrementerRef}>{decrementIcon}</ButtonType>
 				</span>
 			</div>
 		);

--- a/packages/moonstone/Picker/SpottablePicker.js
+++ b/packages/moonstone/Picker/SpottablePicker.js
@@ -1,5 +1,5 @@
 import hoc from '@enact/core/hoc';
-import {Spottable} from '@enact/spotlight';
+import {Spotlight, Spottable} from '@enact/spotlight';
 import Pressable from '@enact/ui/Pressable';
 import React from 'react';
 
@@ -12,9 +12,25 @@ const SpottablePicker = hoc(null, (config, Wrapped) => {
 			joined: React.PropTypes.bool
 		}
 
+		componentDidUpdate () {
+			if (this.incrementerNode.disabled && !this.decrementerNode.disabled) {
+				Spotlight.focus(this.decrementerNode);
+			} else if (this.decrementerNode.disabled && !this.incrementerNode.disabled) {
+				Spotlight.focus(this.incrementerNode);
+			}
+		}
+
+		getDecrementerNode = (node) => {
+			this.decrementerNode = node;
+		}
+
+		getIncrementerNode = (node) => {
+			this.incrementerNode = node;
+		}
+
 		render () {
 			const Component = this.props.joined ? Joined : Wrapped;
-			return <Component {...this.props} />;
+			return <Component {...this.props} incrementerRef={this.getIncrementerNode} decrementerRef={this.getDecrementerNode} />;
 		}
 	};
 });


### PR DESCRIPTION
### Issue Resolved / Feature Added

When a `SpottablePicker`'s decrementer or incrementer `Buttons` become disabled, `Spotlight` focus is lost.
### Resolution

Force `SpottablePicker` to re-focus the other `Button` if it is also not disabled.
### Additional Considerations

This is definitely Mr. Rightnow instead of Mr. Right.  There is another idea of implementation using styles to make a new state of "disabled but currently spotted for a moment", but it requires a change to `Spotlight` as well.  See link below.  In discussions with @germboy another idea might be to modify the wrapped `PickerBase` to be a `Spotlight` container and perhaps it will correctly re-focus the other `Button`.
### Links

https://jira2.lgsvl.com/browse/ENYO-3420

Enyo-DCO-1.1-Signed-off-by: Dave Freeman dave.freeman@lge.com
