### PR TITLE
ENYO-3596: Picker: Font face changes when joined

### DIFF
--- a/packages/moonstone/Picker/Picker.less
+++ b/packages/moonstone/Picker/Picker.less
@@ -65,8 +65,6 @@
 		}
 
 		.valueWrapper {
-			.moon-large-button-text();
-
 			height: @moon-button-height;
 			line-height: @moon-button-height;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added

`Picker` font face changes between joined and unjoined modes.
### Resolution

Remove the rule that applies large Moonstone `Button` text styles.
### Additional Considerations

Is this a change from original UX?
### Links

https://jira2.lgsvl.com/browse/ENYO-3596

Enyo-DCO-1.1-Signed-off-by: Dave Freeman dave.freeman@lge.com
