### PR TITLE
ENYO-3602: Fixes reversed ordering of padding

### DIFF
--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -70,11 +70,11 @@
 	}
 
 	.iconEnd {
-		.padding-start-end(0, 9px);
+		.padding-start-end(18px, 0);
 	}
 
 	.iconStart {
-		.padding-start-end(9px, 0);
+		.padding-start-end(0, 18px);
 	}
 
 	// RIGBY NOTE: multiline is a NOT YET IMPLEMENTED feature that combines <input> and <textarea>


### PR DESCRIPTION
### Issue Resolved / Feature Added

The padding values for the start and end icons were reversed during a merge commit (https://github.com/enyojs/enact/commit/bfb7d6ddc95ea7fba3ef1e557618e7e94de503ba).
### Resolution

The padding values have been corrected.
### Additional Considerations

Additionally, I increased the value from `9px` to `18px` as this seemed to work better for some of the icons that have a harder edge (i.e. `arrowhookright`, `plug`) and seemed to work better in general, visually. Let me know if there are objections and we can tweak this setting as necessary. In Enyo Moonstone, the icons are effectively flush with the value text, but we had not supported a start icon, and the ellipsis added some padding.
### Links

https://github.com/enyojs/enact/pull/125
### Comments

Issue: ENYO-3602
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
