### PR TITLE
PLAT-28697: Supports default spotlight element in a container

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,6 +4,15 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Added
+
+- `spotlightDefaultClass` to `@enact/spotlight` export. Applying this class to an item in a
+	container will cause it to be the default spotted item in that container.
+
+### Changed
+
+- Spotlight containers now default to focus last selected item when gaining focus.
+
 ## [1.0.0-alpha.2] - 2016-10-21
 
 This version includes a lot of refactoring from the previous release. Developers need to switch to the new enact-dev command-line tool.

--- a/packages/spotlight/index.js
+++ b/packages/spotlight/index.js
@@ -1,8 +1,8 @@
 import {Spotlight} from './src/spotlight';
 import {SpotlightRootDecorator} from './src/root';
-import {SpotlightContainerDecorator} from './src/container';
+import {SpotlightContainerDecorator, spotlightDefaultClass} from './src/container';
 import {SpotlightFocusableDecorator} from './src/focusable';
 import {Spottable} from './src/spottable';
 
 export default Spotlight;
-export {Spotlight, SpotlightRootDecorator, SpotlightContainerDecorator, Spottable, SpotlightFocusableDecorator};
+export {Spotlight, SpotlightRootDecorator, SpotlightContainerDecorator, Spottable, SpotlightFocusableDecorator, spotlightDefaultClass};

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -4,15 +4,26 @@ import React from 'react';
 import Spotlight from './spotlight';
 import {spottableClass} from './spottable';
 
+const spotlightDefaultClass = 'spottable-default';
+
 const defaultConfig = {
+	/**
+	 * The selector for the default spottable element within the container.
+	 *
+	 * @type {String}
+	 * @default '.spottable-default'
+	 * @public
+	 */
+	defaultElement: `.${spotlightDefaultClass}`,
+
 	/**
 	 * Directs which component receives focus when gaining focus from another container.
 	 *
 	 * @type {String}
-	 * @default ''
+	 * @default 'last-focused'
 	 * @public
 	 */
-	enterTo: '',
+	enterTo: 'last-focused',
 
 	/**
 	 * Restricts or prioritizes navigation when focus attempts to leave the container.
@@ -31,6 +42,20 @@ const defaultConfig = {
  * @example
  *	const DefaultContainer = SpotlightContainerDecorator(Component);
  *	const SelfRestrictedContainer = SpotlightContainerDecorator({restrict: 'self-only'}, Component);
+ *
+ * To specify a default element to spot in a container, utilize the `spotlightDefaultClass`.
+ *
+ * @example
+ *	import {SpotlightContainerDecorator, spotlightDefaultClass} from '@enact/spotlight';
+ *	const ContainerComponent = SpotlightContainerDecorator(Component);
+ *	const View = kind({
+ *		render: () => {
+ *			<ContainerComponent>
+ *				<SpottableComponent>foo</SpottableComponent>
+ *				<SpottableComponent className={spotlightDefaultClass}>spot me first</SpottableComponent>
+ *			</ContainerComponent>
+ *		}
+ *	});
  *
  * @param  {Object} defaultConfig Set of default configuration parameters
  * @param  {Function} Higher-order component
@@ -85,4 +110,4 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 });
 
 export default SpotlightContainerDecorator;
-export {SpotlightContainerDecorator};
+export {SpotlightContainerDecorator, spotlightDefaultClass};


### PR DESCRIPTION
### Issue Resolved / Feature Added

There are scenarios where the default element in a Spotlight container needs to be specified, rather than relying on the standard nearest-neighbor logic.
### Resolution

Considered a few different approaches, but decided to stick with the facilities provided by spatial-navigation. We specify a class for the default element and export this for use by components that wish to specify a default element.
### Additional Considerations

I also decided to change the default value of `enterTo` to `last-focused` instead of the empty string, as this aligns with Enyo and covers a majority of cases. This allows for the default element to be focused upon initial entry, and then the last focused element to be focused on subsequent entries, which matches the behavior we expected from Enyo. This is also easily configurable if needed.
### Links

Relies on the container fix in https://github.com/enyojs/enact/pull/145.
### Comments

Issue: PLAT-28697
Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
