### PR TITLE
PLAT-28826: Fix scrollbar's button change issue.

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -504,16 +504,14 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		}
 
 		scroll = (left, top, skipPositionContainer = false) => {
-			const {scrollLeft, scrollTop} = this;
-
-			if (left !== scrollLeft) {
+			if (left !== this.scrollLeft) {
 				this.setScrollLeft(left);
 			}
-			if (top !== scrollTop) {
+			if (top !== this.scrollTop) {
 				this.setScrollTop(top);
 			}
 
-			this.childRef.setScrollPosition(scrollLeft, scrollTop, this.dirHorizontal, this.dirVertical, skipPositionContainer);
+			this.childRef.setScrollPosition(this.scrollLeft, this.scrollTop, this.dirHorizontal, this.dirVertical, skipPositionContainer);
 			this.doScrolling();
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added

Each Item's position is calculated using animation, so very small value could set to each item after animation. We expect scrollTop position is zero when the first item has spotlight focus, but item's transform value is a very small number. ( e.g. 0.013923479e-9 ).
### Resolution

We can ignore scroll if a very small number is translated in the item.
### Additional Considerations
### Links

https://jira2.lgsvl.com/browse/PLAT-28826
### Comments

Scrollbar button is changed to enable state though VirtualList doesn't
scroll.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
