### PR TITLE
ENYO-3536: Fix Input behavior on TV

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -137,6 +137,12 @@ class InputBase extends React.Component {
 		this.inputNode = node;
 	}
 
+	handleDecoratorClick = (e) => {
+		if (e.target.getAttribute('data-input-decorator') === 'true') {
+			this.inputNode.focus();
+		}
+	}
+
 	spotlightMove = (direction) => {
 		if (!Spotlight.move(direction)) {
 			this.inputNode.blur();
@@ -167,11 +173,11 @@ class InputBase extends React.Component {
 		delete rest.dismissOnEnter;
 
 		return (
-			<label {...containerProps} disabled={disabled} className={decoratorClasses} tabIndex={tabIndex} onKeyDown={onKeyDown} onFocus={onFocus} >
+			<div {...containerProps} data-input-decorator disabled={disabled} className={decoratorClasses} tabIndex={tabIndex} onKeyDown={onKeyDown} onFocus={onFocus} onClick={this.handleDecoratorClick}>
 				{firstIcon}
 				<PlainInput {...rest} decorated disabled={disabled} spotlightDisabled={!spotlightDisabled} onKeyDown={this.inputKeyDown} inputRef={this.getInputNode} />
 				{lastIcon}
-			</label>
+			</div>
 		);
 	}
 }

--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -35,7 +35,7 @@
 		color: @moon-input-placeholder-color;
 	});
 
-	&:focus {
+	&:global(.spottable):focus {
 		cursor: text;
 		color: @moon-input-font-color;
 		background-color: inherit;
@@ -86,9 +86,8 @@
 	}
 
 	// RIGBY NOTE: Complex focus scenarios are broken at the moment
-	&:focus {
+	&:global(.spottable):focus {
 		border-color: @moon-spotlight-border-color;
-		// color: @moon-spotlight-text-color;
 		background-color: @moon-input-decorator-bg-color;
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added

A TV-specific issue resolved: When you use spotlight to 5-way navigate to an `Input`, it will
- automatically set focus to the decorated `<input>` tag instead of the decorator `<label>` tag
- trap spotlight within the `Input`, making it impossible to 5-way navigate away
### Resolution

I've discovered that our TVs display an unusual behavior regarding `<label>` tags. If a `<label>` is spottable (able to be focused), the TV will not issue an `onFocus` event - even though it works across browsers. More specifically, it will issue the event, if there is another spottable/focus-enabled control inside the `<label>` (e.g. `<input>`) - however, the event target will be returned as the input, not the label - even if the label is the only thing gaining focus. This is why enact `Input` doesn't work correctly on TVs. To remedy this, I've replaced the `<label>` tag with a `<div>` and added the necessary compatibility/features.
### Links
- https://www.w3.org/TR/html401/interact/forms.html#h-17.9.1
- http://stackoverflow.com/a/27568825/1569595

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
