### PR TITLE
ENYO-3579: Defer ViewManager children reconciliation

### DIFF
--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -132,14 +132,16 @@ class TransitionGroup extends React.Component {
 
 		// drop children exceeding allowed size
 		const drop = children.length - nextProps.size;
-		let dropped = null;
-		if (drop > 0) {
-			[dropped, children] = R.splitAt(drop, children);
-		}
+		const dropped = drop > 0 ? children.splice(drop) : null;
 
-		// cache the new set of children
-		this.setState({children});
+		this.setState({
+			children
+		}, () => {
+			this.reconcileChildren(dropped, prevChildMapping, nextChildMapping);
+		});
+	}
 
+	reconcileChildren (dropped, prevChildMapping, nextChildMapping) {
 		// mark any new child as entering
 		nextChildMapping.forEach(child => {
 			const key = child.key;
@@ -174,9 +176,7 @@ class TransitionGroup extends React.Component {
 				delete this.currentlyTransitioningKeys[child.key];
 			});
 		}
-	}
 
-	componentDidUpdate () {
 		// once the component has been updated, start the enter transition for new children,
 		const keysToEnter = this.keysToEnter;
 		this.keysToEnter = [];
@@ -191,7 +191,6 @@ class TransitionGroup extends React.Component {
 		const keysToLeave = this.keysToLeave;
 		this.keysToLeave = [];
 		keysToLeave.forEach(this.performLeave);
-
 	}
 
 	performAppear = (key) => {


### PR DESCRIPTION
If new props came in before a prior setState re-rendered, the stateful
members (e.g. this.keysToLeave) could get out of sync with the actual
children that were present. This was further compounded by the change
to prepend new children on merge (by ENYO-3558) which didn't update the
drop logic which assumed the new children were appended.

The resolution is to move all the reconciliation into the setState
callback so we're updating the stateful members in sync with
this.state.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
