### PR TITLE
PLAT-29441: SpotlightRootDecorator accessing window before mount

### DIFF
--- a/packages/spotlight/src/root.js
+++ b/packages/spotlight/src/root.js
@@ -30,12 +30,14 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillMount () {
-			Spotlight.initialize();
-			Spotlight.add(spotlightRootContainerName, {
-				selector: '.' + spottableClass,
-				navigableFilter: this.navigableFilter,
-				restrict: 'none'
-			});
+			if (typeof window === 'object') {
+				Spotlight.initialize();
+				Spotlight.add(spotlightRootContainerName, {
+					selector: '.' + spottableClass,
+					navigableFilter: this.navigableFilter,
+					restrict: 'none'
+				});
+			}
 		}
 
 		componentDidMount () {


### PR DESCRIPTION
### Issue Resolved / Feature Added

Added a window object existence check before SpotlightRootDecorator attempts to initialize Spotlight.
### Resolution

Can't assume window exists before component mountings; breaks prerender/isomorphic usage.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
