### PR TITLE
PLAT-29450: Enact UI library missing invariant in dependencies

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "react": "~15.3.2",
     "react-dom": "~15.3.1",
     "recompose": "~0.20.2",
-    "warning": "~3.0.0"
+    "warning": "~3.0.0",
+    "invariant": "~2.2.1"
   }
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added

Adds invariant to the ui library's package.json
### Resolution

Without it, can cause builds to fail in certain scenarios
Uses same version of invariant as moonstone

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
