### PR TITLE
Add background plugin support to sampler

### DIFF
--- a/packages/sampler/.qa-storybook/addons.js
+++ b/packages/sampler/.qa-storybook/addons.js
@@ -1,3 +1,3 @@
 import '@kadira/storybook/addons';
-//import 'react-storybook-addon-backgrounds/register';
+import 'react-storybook-addon-backgrounds/register';
 import '@kadira/storybook-addon-knobs/register';

--- a/packages/sampler/.qa-storybook/config.js
+++ b/packages/sampler/.qa-storybook/config.js
@@ -1,25 +1,24 @@
 import {configure, setAddon, addDecorator} from '@kadira/storybook';
 import infoAddon from '@kadira/react-storybook-addon-info';
 import {withKnobs} from '@kadira/storybook-addon-knobs';
-//import backgrounds from 'react-storybook-addon-backgrounds';
+import backgrounds from 'react-storybook-addon-backgrounds';
 import Moonstone from '../src/MoonstoneEnvironment';
-const req = require.context('../stories/qa-stories', true, /.js$/)
+const req = require.context('../stories/qa-stories', true, /.js$/);
 
 addDecorator(Moonstone);
 addDecorator(withKnobs);
-/* Disabling until background works.  TODO: Re-enable import here and in addons.js.
 addDecorator(backgrounds([
-	{name: 'black', value: '#000000'},
+	{name: 'black', value: '#000000', default: true},
+	{name: 'white', value: '#ffffff'},
 	{name: 'dark image', value: 'darkgray url("http://lorempixel.com/720/480/abstract/2/") no-repeat center/cover'},
 	{name: 'light image', value: 'lightgray url("http://lorempixel.com/720/480/cats/9/") no-repeat center/cover'},
 	{name: 'random image', value: 'gray url("http://lorempixel.com/720/480/") no-repeat center/cover'}
 ]));
-*/
 
 setAddon(infoAddon);
 
 function loadStories () {
-	req.keys().forEach((filename) => req(filename))
+	req.keys().forEach((filename) => req(filename));
 }
 
 configure(loadStories, module);

--- a/packages/sampler/.storybook/addons.js
+++ b/packages/sampler/.storybook/addons.js
@@ -1,3 +1,3 @@
 import '@kadira/storybook/addons';
-//import 'react-storybook-addon-backgrounds/register';
+import 'react-storybook-addon-backgrounds/register';
 import '@kadira/storybook-addon-knobs/register';

--- a/packages/sampler/.storybook/config.js
+++ b/packages/sampler/.storybook/config.js
@@ -1,10 +1,10 @@
 import {configure, setAddon, addDecorator} from '@kadira/storybook';
 import infoAddon from '@kadira/react-storybook-addon-info';
 import {withKnobs} from '@kadira/storybook-addon-knobs';
-//import backgrounds from 'react-storybook-addon-backgrounds';
 import perf from 'react-addons-perf';
+import backgrounds from 'react-storybook-addon-backgrounds';
 import Moonstone from '../src/MoonstoneEnvironment';
-const req = require.context('../stories/moonstone-stories', true, /.js$/)
+const req = require.context('../stories/moonstone-stories', true, /.js$/);
 
 if (typeof window === 'object') {
 	window.ReactPerf = perf;
@@ -12,19 +12,18 @@ if (typeof window === 'object') {
 
 addDecorator(Moonstone);
 addDecorator(withKnobs);
-/* Disabling until background works.  TODO: Re-enable import here and in addons.js.
 addDecorator(backgrounds([
-	{name: 'black', value: '#000000'},
+	{name: 'black', value: '#000000', default: true},
+	{name: 'white', value: '#ffffff'},
 	{name: 'dark image', value: 'darkgray url("http://lorempixel.com/720/480/abstract/2/") no-repeat center/cover'},
 	{name: 'light image', value: 'lightgray url("http://lorempixel.com/720/480/cats/9/") no-repeat center/cover'},
 	{name: 'random image', value: 'gray url("http://lorempixel.com/720/480/") no-repeat center/cover'}
 ]));
-*/
 
 setAddon(infoAddon);
 
 function loadStories () {
-	req.keys().forEach((filename) => req(filename))
+	req.keys().forEach((filename) => req(filename));
 }
 
 configure(loadStories, module);

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
@@ -12,9 +12,8 @@
 }
 
 .moonstone {
-	// Restore the line below when backgrounds addon accepts images and allows a user-specified default background.
-	// It sets moonstone's root background color to transparent so the background-addon bg can shine through.
-	// background-color: transparent;
+	// This sets moonstone's root background color to transparent so the background-addon bg can shine through.
+	background-color: transparent;
 
 	.description {
 		margin: 0 @moon-spotlight-outset 1em;


### PR DESCRIPTION
### Issue Resolved / Feature Added

With storybook background plugin updated, removed the commented code to re-enable backgrounds which support default black, a light background, and several colors of background images for testing.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
