### PR TITLE
Added fullBleed to Header

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Image` component
+- `fullBleed` prop to `moonstone/Panels/Header`. When `true`, the header content is indented and the header lines are removed.
 
 ### Changed
 

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -33,6 +33,15 @@ const HeaderBase = kind({
 		]),
 
 		/**
+		 * When `true`, the header content is indented and the header lines are removed.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		fullBleed: React.PropTypes.bool,
+
+		/**
 		 * When true, the case of the [`title`]{@link module:moonstone/Header~Header#title} will
 		 * remain unchanged.
 		 * Uses [Uppercase HOC]{@link module:@enact/i18n/Uppercase~Uppercase} and mirrors the
@@ -82,6 +91,7 @@ const HeaderBase = kind({
 	},
 
 	defaultProps: {
+		fullBleed: false,
 		preserveCase: false,
 		// titleAbove: '00',
 		type: 'standard'
@@ -93,10 +103,12 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({type, styler}) => styler.append(type)
+		className: ({fullBleed, type, styler}) => styler.append({fullBleed},type)
 	},
 
-	render: ({children, preserveCase, styler, subTitleBelow, title, titleAbove, titleBelow, type, ...rest}) => {
+	render: ({children, preserveCase, subTitleBelow, title, titleAbove, titleBelow, type, ...rest}) => {
+		delete rest.fullBleed;
+
 		switch (type) {
 			case 'compact': return (
 				<header {...rest}>

--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -136,4 +136,9 @@
 			background-color: fade(cyan, @alpha);
 		}
 	}
+
+	&.fullBleed {
+		padding: 0 @moon-header-indent-width @moon-spotlight-outset;
+		border: 0;
+	}
 }

--- a/packages/moonstone/Panels/tests/Header-specs.js
+++ b/packages/moonstone/Panels/tests/Header-specs.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import Header from '../Header';
+import css from '../Header.less';
 
 describe('Header Specs', () => {
 
@@ -13,6 +14,19 @@ describe('Header Specs', () => {
 
 		const expected = msg.toUpperCase();
 		const actual = header.text();
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should have fullBleed class applied', function () {
+		const header = mount(
+			<Header fullBleed>
+				<title>Header</title>
+			</Header>
+		);
+
+		const expected = true;
+		const actual = header.find('header').hasClass(css.fullBleed);
 
 		expect(actual).to.equal(expected);
 	});

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -147,6 +147,7 @@
 @moon-header-title-subtitle-gap: 36px;
 @moon-header-border-top-width: 3px;
 @moon-header-border-bottom-width: 6px;
+@moon-header-indent-width: 18px;
 
 // Button
 // ---------------------------------------


### PR DESCRIPTION
### Issue Resolved / Feature Added

Header needs option to hide dividers
### Resolution

Added fullBleed prop. When it's set to `true` then the default `border` and `padding` will be overridden.
### Additional Considerations

Also removed `styler` from render `props` because it's not needed.
### Links

https://jira2.lgsvl.com/browse/ENYO-3606

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
