### PR TITLE
PLAT-23245: Stop spotlight 5-way nav at container borders when holding

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -90,6 +90,14 @@ const Spotlight = (function() {
 	let _duringFocusChange = false;
 
 	/**
+	 * Whether a 5-way directional key is being held.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 */
+	let _5WayKeyHold = false;
+
+	/**
 	 * Whether Spotlight is in pointer mode (as opposed to 5-way mode).
 	 *
 	 * @type {Boolean}
@@ -792,6 +800,9 @@ const Spotlight = (function() {
 			let nextContainerId = getContainerId(next);
 
 			if (currentContainerId !== nextContainerId) {
+				if (_5WayKeyHold) {
+					return false;
+				}
 				let result = gotoLeaveFor(currentContainerId, direction);
 				if (result) {
 					return true;
@@ -861,6 +872,7 @@ const Spotlight = (function() {
 		}
 
 		SpotlightAccelerator.reset();
+		_5WayKeyHold = false;
 	}
 
 	function onKeyDown(evt) {
@@ -889,6 +901,7 @@ const Spotlight = (function() {
 				_pointerMode = false;
 				if (isPointerHideTimestampExpired()) {
 					SpotlightAccelerator.processKey(evt, onAcceleratedKeyDown);
+					_5WayKeyHold = true;
 				}
 				break;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added

Added a feature that enables spotlight 5-way navigation to stop changing focus during a hold when focus reaches a container border.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
