### PR TITLE
added max width of 100% to ToggleItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Changed
 
 - `moonstone/Divider`'s `children` property is now optional
+- `moonstone/ToggleItem`'s `inline` now has a `max-width` of `240px`
 
 
 ## [1.0.0-alpha.2] - 2016-10-21

--- a/packages/moonstone/ToggleItem/ToggleItem.less
+++ b/packages/moonstone/ToggleItem/ToggleItem.less
@@ -10,6 +10,8 @@
 
 	&.inline {
 		display: inline-flex;
+		max-width: 240px;
+		box-sizing: border-box;
 	}
 
 	.icon {


### PR DESCRIPTION
### Issue Resolved / Feature Added

Enact RadioItem: Inline's Long Text Bleeds Out of Viewport
### Resolution

When `display` is `inline-flex` it's width just keeps growing when we add content. Added `max-width: 100%` to ToggleItem so it would never grow beyond it's container.
### Links

https://jira2.lgsvl.com/browse/ENYO-3607

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
