### PR TITLE
Added description text to aid in locale selection

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -48,16 +48,18 @@ const Moonstone = MoonstoneDecorator(PanelsBase);
 const MoonstoneFullscreen = MoonstoneDecorator(FullscreenBase);
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
-const locales = [
-	'en-US',
-	'ko-KR',
-	'th-TH ',
-	'ar-SA',
-	'ur-PK',
-	'zh-Hant-HK',
-	'ja-JP',
-	'en-JP'
-];
+const locales = {
+	'local': 'local',
+	'en-US': 'en-US - US English',
+	'ko-KR': 'ko-KR - Korean',
+	'es-ES': 'es-ES - Spanish, with alternate weekends',
+	'th-TH': 'th-TH - Thai, with tall characters',
+	'ar-SA': 'ar-SA - Arabic, RTL and standard font',
+	'ur-PK': 'ur-PK - Urdu, RTL and custom Urdu font',
+	'zh-Hant-HK': 'zh-Hant-HK - Traditional Chinese, custom Hant font',
+	'ja-JP': 'ja-JP - Japanese, custom Japanese font',
+	'en-JP': 'en-JP - English, custom Japanese font',
+};
 
 // NOTE: Knobs cannot set locale in fullscreen mode. This allows the locale to
 // be taken from the URL.
@@ -80,7 +82,6 @@ const getLocaleFromURL = () => {
 };
 
 const StorybookDecorator = (story, config) => {
-
 	const sample = story();
 	return (
 		<Moonstone


### PR DESCRIPTION
### Feature Added

Including description text in the locale picker knob helps developers understand _why_ a locale should be tested. Some locales use different fonts, some have a different alignment, some use different ilib settings and this helps clarify that.
