### PR TITLE
ENYO-3611: force auto overflow for sampler

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
@@ -13,6 +13,7 @@
 
 [data-reactroot] {
 	overflow: auto !important;
+	transition: none !important;
 }
 
 .moonstone {


### PR DESCRIPTION
Another CSS hack to make storybook behave. This will require us to
implement our own scroller within MoonstoneEnvironment when we need
that feature.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)