### PR TITLE
ENYO-3608: Fix how Focusable sets Spotlight Focus

### DIFF
--- a/packages/moonstone/Input/InputDecorator.js
+++ b/packages/moonstone/Input/InputDecorator.js
@@ -1,0 +1,73 @@
+/**
+ * Exports the {@link module:@enact/moonstone/Input/InputDecorator~InputDecorator} component.
+ *
+ * @module @enact/moonstone/Input/InputDecorator
+ */
+
+import kind from '@enact/core/kind';
+import {Spottable} from '@enact/spotlight';
+import React, {PropTypes} from 'react';
+
+import css from './Input.less';
+
+/**
+ * {@link module:@enact/moonstone/Input/InputDecorator~InputDecorator} is a control that provides input styling. Any controls
+ * in the InputDecorator will appear to be inside an area styled as an input. Usually,
+ * an InputDecorator surrounds a {@link module:@enact/moonstone/Input~Input}:
+ *
+ * @class InputDecorator
+ * @ui
+ * @public
+ */
+const InputDecoratorBase = kind({
+	name: 'InputDecoratorBase',
+
+	propTypes: {
+		/**
+		 * The method to run when the decorator mounts, giving a reference to the dom.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		decoratorRef: PropTypes.func,
+
+		/**
+		 * Applies a disabled visual state to the input decorator.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		disabled: PropTypes.bool
+	},
+
+	defaultProps: {
+		disabled: false
+	},
+
+	styles: {
+		css,
+		className: 'decorator'
+	},
+
+	computed: {
+		className: ({disabled, styler}) => styler.append({disabled})
+	},
+
+	render: ({decoratorRef, ...rest}) => (
+		<div {...rest} ref={decoratorRef} />
+	)
+});
+
+const InputDecorator = Spottable({emulateMouse: false}, kind({
+	name: 'InputDecorator',
+
+	render: (props) => {
+		return (
+			<InputDecoratorBase {...props} />
+		);
+	}
+}));
+
+export default InputDecorator;
+export {InputDecorator, InputDecoratorBase};

--- a/packages/moonstone/Input/PlainInput.js
+++ b/packages/moonstone/Input/PlainInput.js
@@ -48,8 +48,6 @@ const PlainInput = Spottable(kind({
 	name: 'PlainInput',
 
 	render: (props) => {
-		delete props.spotlightDisabled;
-
 		return (
 			<PlainInputBase {...props} />
 		);

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Changed
 
 - Spotlight containers now default to focus last selected item when gaining focus.
+- Removed `decorated` prop from `@enact/spotlight/focusable` as this relationship is managed
+	implicitly by the component decorated by `@enact/spotlight/focusable`.
 
 ## [1.0.0-alpha.2] - 2016-10-21
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -856,7 +856,7 @@ const Spotlight = (function() {
 			return;
 		}
 
-		if (!spotNext(_directions[evt.keyCode], currentFocusedElement, currentContainerId)) {
+		if (_directions[evt.keyCode] && !spotNext(_directions[evt.keyCode], currentFocusedElement, currentContainerId)) {
 			focusElement(currentFocusedElement, currentContainerId)
 		}
 	}

--- a/packages/spotlight/src/spottable.js
+++ b/packages/spotlight/src/spottable.js
@@ -2,7 +2,6 @@ import {kind, hoc} from '@enact/core';
 import React from 'react';
 
 const spottableClass = 'spottable';
-const decoratedProp = 'data-spot-decorated';
 
 const ENTER_KEY = 13;
 const REMOTE_OK_KEY = 16777221;
@@ -72,15 +71,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => kind({
 
 	propTypes: {
 		/**
-		 * Whether or not the component is decorated by another spottable component.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		decorated: React.PropTypes.bool,
-
-		/**
 		 * Whether or not the component is in a disabled state.
 		 *
 		 * @type {Boolean}
@@ -110,10 +100,11 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => kind({
 		onKeyUp: forwardEnter('onKeyUp', 'onMouseUp')
 	},
 
-	render: ({classes, className, decorated, ...rest}) => {
+	render: ({classes, className, ...rest}) => {
 		const spottable = !rest.disabled && !rest.spotlightDisabled;
 		let tabIndex = rest.tabIndex;
-		rest[decoratedProp] = decorated;
+
+		delete rest.spotlightDisabled;
 
 		if (tabIndex == null && spottable) {
 			tabIndex = -1;
@@ -130,4 +121,4 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => kind({
 }));
 
 export default Spottable;
-export {Spottable, spottableClass, decoratedProp};
+export {Spottable, spottableClass};


### PR DESCRIPTION
### Issue Resolved / Feature Added
Focusable can set/change focus incorrectly when a focusable component updates due to a decorated control being blurred


### Resolution
The major change proposed is the removal of spotlight containers for focusable components. We should be more declarative about which elements receive focus within `Focusable`. We are able to provide refs to `Input` and `InputDecorator` dom elements directly to `Focusable` via a ref to the `Focusable` instance.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>