### PR TITLE
ENYO-3620: Panels className prop is overwritten

### DIFF
--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -79,7 +79,7 @@ const PanelsBase = kind({
 	},
 
 	computed: {
-		className: ({noCloseButton, styler}) => styler.join({
+		className: ({noCloseButton, styler}) => styler.append({
 			hasCloseButton: !noCloseButton
 		}),
 		applicationCloseButton: ({noCloseButton, onApplicationClose}) => {


### PR DESCRIPTION
### Issue Resolved 
Panels overrides the provided className prop

### Resolution
Append the provided className and the computed className

### Comments

Enyo-DCO-1.1-Signed-off-by: Alan Stice (alan.stice@lge.com)