### PR TITLE
PLAT-29860: Guard inline platform-check code against window object

### DIFF
--- a/packages/webos/platform/platform.js
+++ b/packages/webos/platform/platform.js
@@ -10,7 +10,7 @@
 */
 const platform = {};
 
-if (window.PalmSystem) {
+if (typeof window === 'object' && window.PalmSystem) {
 	if (window.navigator.userAgent.indexOf('SmartWatch') > -1) {
 		platform.watch = true;
 	} else if ((window.navigator.userAgent.indexOf('SmartTV') > -1) || (window.navigator.userAgent.indexOf('Large Screen') > -1)) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Usage of webOS platform check were failing on node-based execution


### Resolution
* Guards inline platform-check code against window object.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
