### PR TITLE
Added sample support for using custom icon strings (dingbat fonts)

### DIFF
--- a/packages/sampler/stories/moonstone-stories/Icon.js
+++ b/packages/sampler/stories/moonstone-stories/Icon.js
@@ -1,7 +1,7 @@
 import {Icon, icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {withKnobs, boolean, select} from '@kadira/storybook-addon-knobs';
+import {withKnobs, boolean, select, text} from '@kadira/storybook-addon-knobs';
 
 // import icons
 import fwd from '../../images/icon-fwd-btn.png';
@@ -20,7 +20,7 @@ storiesOf('Icon')
 				small={boolean('small')}
 				src={select('src', ['', fwd, play, rew], '')}
 			>
-				{select('icon', ['', ...iconNames], 'plus')}
+				{select('icon', ['', ...iconNames], 'plus') + text('custom icon', '')}
 			</Icon>
 		)
 	);

--- a/packages/sampler/stories/moonstone-stories/IconButton.js
+++ b/packages/sampler/stories/moonstone-stories/IconButton.js
@@ -2,7 +2,7 @@ import IconButton, {IconButtonBase} from '@enact/moonstone/IconButton';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, boolean, select} from '@kadira/storybook-addon-knobs';
+import {withKnobs, boolean, select, text} from '@kadira/storybook-addon-knobs';
 
 // import icons
 import fwd from '../../images/icon-fwd-btn.png';
@@ -34,7 +34,7 @@ storiesOf('IconButton')
 				small={boolean('small')}
 				src={select('src', ['', fwd, play, rew], '')}
 			>
-				{select('icon', ['', ...iconNames], 'play')}
+				{select('icon', ['', ...iconNames], 'play') + text('custom icon', '')}
 			</IconButton>
 		)
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
One can now add custom icons to the Icon and IconButton samples which allow the usage of Hex (`\uXXX`) HTML Entity (`&#XXX;`) and Octal (`0xXXX`) codes for icons. This lets developers see how to use the Dingbat font, which includes most icons outside of our Moonstone set.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>