### PR TITLE
PLAT-29229: Create samples for Divider Component

### DIFF
--- a/packages/sampler/stories/qa-stories/Divider.js
+++ b/packages/sampler/stories/qa-stories/Divider.js
@@ -1,0 +1,28 @@
+import Divider from '@enact/moonstone/Divider';
+import React from 'react';
+import {storiesOf} from '@kadira/storybook';
+import {withKnobs, text, select} from '@kadira/storybook-addon-knobs';
+
+const prop = {
+	tallText: {'नरेंद्र मोदी': 'नरेंद्र मोदी', 'ฟิ้  ไั  ஒ  து': 'ฟิ้  ไั  ஒ  து', 'ÃÑÕÂÊÎÔÛÄËÏÖÜŸ': 'ÃÑÕÂÊÎÔÛÄËÏÖÜŸ'}
+};
+
+storiesOf('Divider')
+	.addDecorator(withKnobs)
+	.addWithInfo(
+		'Long Text',
+		() => (
+			<Divider>
+				{text('children', 'This long text is for the marquee test in divider component. This long text is for the marquee test in divider component. This long text is for the marquee test in divider component.')}
+			</Divider>
+		)
+	)
+
+	.addWithInfo(
+		'Tall Text',
+		() => (
+			<Divider>
+				{select('children', prop.tallText, 'नरेंद्र मोदी')}
+			</Divider>
+		)
+	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
Created QA edge test cases for Divider Component

### Resolution
* LongText - Divider created with long text to test the marquee
* TallText - Divider created with tall strings

### Additional Considerations
This is the initail push to find the edge cases in Divider component.

### Links
https://jira2.lgsvl.com/browse/PLAT-29229

### Comments

Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)

