### PR TITLE
PLAT-30019: Update Enact's in-editor eslint config entries to use enact/strict

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   },
   "dependencies": {
     "react": "~15.3.2",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -31,7 +31,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   },
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.2",

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   },
   "dependencies": {
     "classnames": "~2.2.5",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -16,7 +16,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   },
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   },
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.2",

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -23,6 +23,6 @@
     }
   },
   "eslintConfig": {
-    "extends": "enact-internal"
+    "extends": "enact/strict"
   }
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
- Update Enact's in-editor eslint config entries to use enact/strict

### Resolution
- While enact-internal still exists (and is at parity with enact/strict), we want to migrate now to avoid any developer confusion.

### Additional Considerations
- Requires the following merged first:
https://github.com/enyojs/enact-dev/pull/16
https://github.com/enyojs/eslint-config-enact/pull/12
https://github.com/enyojs/eslint-config-enact-internal/pull/2

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>