### PR TITLE
ENYO-3624: fixed not firing onScrollStart via 5way navigation

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -346,7 +346,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					doc.activeElement.blur();
 					this.childRef.setContainerDisabled(true);
 					this.isScrollAnimationTargetAccumulated = false;
-					this.start(target.targetX, target.targetY, true, target.duration);
+					this.start(target.targetX, target.targetY, true, true, target.duration);
 				}
 			}
 		}
@@ -370,7 +370,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				const pos = this.childRef.calculatePositionOnFocus(index);
 				if (pos) {
 					if (pos.left !== this.scrollLeft || pos.top !== this.scrollTop) {
-						this.start(pos.left, pos.top, (spotlightAnimationDuration > 0), spotlightAnimationDuration);
+						this.start(pos.left, pos.top, (spotlightAnimationDuration > 0), false, spotlightAnimationDuration);
 					}
 					this.lastFocusedItem = item;
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed not firing `onScrollStart` when navigation with 5way key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
set `silent` parameter of `start` function to `false`.

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3624

### Comments

Enyo-DCO-1.1-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)