### PR TITLE
PLAT-30345: Handles container entrance and exit

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -1,3 +1,4 @@
+import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import React from 'react';
 
@@ -5,6 +6,9 @@ import Spotlight from './spotlight';
 import {spottableClass} from './spottable';
 
 const spotlightDefaultClass = 'spottable-default';
+
+const enterEvent = 'onMouseEnter';
+const leaveEvent = 'onMouseLeave';
 
 const defaultConfig = {
 	/**
@@ -63,6 +67,9 @@ const defaultConfig = {
  * @returns {Function} SpotlightContainerDecorator
  */
 const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
+	const forwardMouseEnter = forward(enterEvent);
+	const forwardMouseLeave = forward(leaveEvent);
+
 	return class extends React.Component {
 		constructor (props) {
 			super(props);
@@ -98,11 +105,23 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			Spotlight.remove(this.state.containerId);
 		}
 
+		handleMouseEnter = (ev) => {
+			Spotlight.setActiveContainer(this.state.containerId);
+			forwardMouseEnter(ev, this.props);
+		}
+
+		handleMouseLeave = (ev) => {
+			Spotlight.setActiveContainer(null);
+			forwardMouseLeave(ev, this.props);
+		}
+
 		render () {
 			const containerId = this.state.containerId,
 				props = Object.assign({}, this.props);
 
 			props['data-container-id'] = containerId;
+			props[enterEvent] = this.handleMouseEnter;
+			props[leaveEvent] = this.handleMouseLeave;
 
 			return <Wrapped {...props} />;
 		}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -958,7 +958,7 @@ const Spotlight = (function() {
 				if (!_pause) {
 					if (getCurrent()) {
 						SpotlightAccelerator.processKey(evt, onAcceleratedKeyDown);
-					} else if (!spotNextFromPoint(direction, {x: _pointerX, y: _pointerY}, spotlightRootContainerName)) {
+					} else if (!spotNextFromPoint(direction, {x: _pointerX, y: _pointerY}, _lastContainerId)) {
 						Spotlight.focus(getContainerLastFocusedElement(_lastContainerId));
 					}
 					_5WayKeyHold = true;
@@ -1219,6 +1219,17 @@ const Spotlight = (function() {
 			} else {
 				_defaultContainerId = containerId;
 			}
+		},
+
+		/**
+		 * Sets the currently active container.
+		 *
+		 * @param {String} [containerId] The id of the currently active container. If this is not
+		 *	provided, the root container is set as the currently active container.
+		 * @public
+		 */
+		setActiveContainer: function (containerId) {
+			_lastContainerId = containerId || spotlightRootContainerName;
 		},
 
 		/**


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was an issue raised in https://github.com/enyojs/enact/pull/187 about intra-container navigation

>A side effect of this is that having the pointer inside a container and then pressing 5-way will not necessarily spot what is closest within that container. One way to alleviate this would be to handle mouseenter and mouseleave events, but it adds some additional heft and more event handling that we were trying to avoid, and assumes we don't have overlapping containers (which we might be able to safely assume for how we're using Spotlight containers).

Originally, I had wanted to avoid modifying the container logic too much and wanted to revisit this issue later, as containers can overlap and rely on focus of internal elements to update the active container. With the way Spotlight is utilized, we are generally assuming non-overlapping containers, and the focusing of internal elements can actually augment the proposed changes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We are now handling the `mouseenter` and `mouseleave` events for containers, and updating the active container appropriately (defaults to the root container if a falsy container id is passed).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Note that this does not properly handle the case where we have switched to 5-way mode and the pointer is subsequently "woken up" and appears in a different container - the active container will not be updated and pressing a 5-way key may not necessarily spot the nearest item in the container whose bounds the pointer appears within. This seems to be a rare enough (and non-blocking) case to note and move forward from, for now.

### Links
[//]: # (Related issues, references)


### Comments

Issue: PLAT-30345
Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>