### PR TITLE
PLAT-29939: Prevent changing focus while in pointer mode

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -634,12 +634,12 @@ const Spotlight = (function() {
 		return lastFocusedElement;
 	}
 
-	function focusElement (elem, containerId, pointer) {
+	function focusElement (elem, containerId, fromPointer) {
 		if (!elem) {
 			return false;
 		}
 
-		if ((_pointerMode && !pointer)) {
+		if ((_pointerMode && !fromPointer)) {
 			_containers[containerId].lastFocusedElement = elem;
 			return false;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Spotlight needed a way to prevent programatically changing focus while in pointer mode.


### Additional Considerations
Within the `focusElement` method, we are able to determine whether we should prevent focus changes. I should note that I added an extra argument that will allow focus changes to occur while in pointer mode - if the method was in fact called by a pointer event (`onMouseOver`). Looking through the code changes, you'll see the the removal of the 3rd argument in various places that would identify the `direction` of the focus change. This was old code from spatial-navigation that apparently never was cleaned up. Its purpose was solely to be included in synthetic focus-events that we have removed from enact. So those arguments were not needed anymore.

When we prevent focus changes while in pointer mode, we are saving the requested element as the `lastFocused` element for the specified container. Spotlight will use this upon resuming 5-way navigation.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>