### PR TITLE
PLAT-29235:Create samples for Spinner

### DIFF
--- a/packages/sampler/stories/moonstone-stories/Spinner.js
+++ b/packages/sampler/stories/moonstone-stories/Spinner.js
@@ -10,11 +10,11 @@ storiesOf('Spinner')
 		'Basic usage of Spinner',
 		() => (
 			<Spinner
-				transparent={boolean('transparent')}
-				middle={boolean('middle')}
-				center={boolean('center')}
+				transparent={boolean('transparent', false)}
+				middle={boolean('middle', false)}
+				center={boolean('center', false)}
 			>
-				{text('children', '')}
+				{text('content', '')}
 			</Spinner>
 		)
 	);

--- a/packages/sampler/stories/qa-stories/Spinner.js
+++ b/packages/sampler/stories/qa-stories/Spinner.js
@@ -24,9 +24,9 @@ storiesOf('Spinner')
 		() => (
 			<div style={style.spinnerDiv}>
 				<Spinner
-					transparent={boolean('transparent')}
-					middle={boolean('middle')}
-					center={boolean('center')}
+					transparent={boolean('transparent', false)}
+					middle={boolean('middle', false)}
+					center={boolean('center', false)}
 				>
 					{text('content', prop.longText)}
 				</Spinner>
@@ -39,9 +39,9 @@ storiesOf('Spinner')
 		() => (
 			<div style={style.spinnerDiv}>
 				<Spinner
-					transparent={boolean('transparent')}
-					middle={boolean('middle')}
-					center={boolean('center')}
+					transparent={boolean('transparent', false)}
+					middle={boolean('middle', false)}
+					center={boolean('center', false)}
 				>
 					<Icon>hollowstar</Icon>
 					<Icon>star</Icon>
@@ -56,9 +56,9 @@ storiesOf('Spinner')
 		() => (
 			<div style={style.spinnerDiv}>
 				<Spinner
-					transparent={boolean('transparent')}
-					middle={boolean('middle')}
-					center={boolean('center')}
+					transparent={boolean('transparent', false)}
+					middle={boolean('middle', false)}
+					center={boolean('center', false)}
 				>
 					{text('content', prop.longText)}
 					<Icon>hollowstar</Icon>
@@ -73,9 +73,9 @@ storiesOf('Spinner')
 		() => (
 			<div style={style.spinnerDiv}>
 				<Spinner
-					transparent={boolean('transparent')}
-					middle={boolean('middle')}
-					center={boolean('center')}
+					transparent={boolean('transparent', false)}
+					middle={boolean('middle', false)}
+					center={boolean('center', false)}
 				>
 					<Icon>hollowstar</Icon>
 					<Icon>star</Icon>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Created QA edge test cases for Spinner Component

### Resolution
- spinner with long content
- spinner with components inside before text
- spinner with components inside after text
- spinner with components inside before and after text
- spinner centered horizontally and vertically
- spinnner centered only horizontally
 
### Additional Considerations
In case of long content, after text last component inside the spinner is always coming in new line. 

### Links
https://jira2.lgsvl.com/browse/PLAT-29235

### Comments
Enyo-DCO-1.1-Signed-off-by:Richa Shaurbh richa.shaurbh@lge.com