### PR TITLE
PLAT-27521: Ensure we can use locale switching with pre-rendering/snapshot

### DIFF
--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -1,3 +1,5 @@
+/* global XMLHttpRequest */
+
 import xhr from 'xhr';
 
 import Loader from '../ilib/lib/Loader';
@@ -5,7 +7,8 @@ import ZoneInfoFile from './zoneinfo';
 import ilibLocale from '../ilib/locale/ilibmanifest.json';
 
 const get = (url, callback) => {
-	if (typeof window === 'object') {
+	if (typeof XMLHttpRequest !== 'undefined') {
+		xhr.XMLHttpRequest = XMLHttpRequest || xhr.XMLHttpRequest;
 		let req;
 		xhr({url, sync: true, beforeSend: (r) => (req = r)}, (err, resp, body) => {
 			let error = err || resp.statusCode !== 200 && resp.statusCode;


### PR DESCRIPTION
### Issue Resolved / Feature Added
* During snapshot, `xhr` library's XMLHttpRequest object is set as undefined by circumstance. This causes runtime ilib locale loading to fail
* No way to pre-render for specific locales

### Resolution
* Limit guard scope to `XMLHttpRequest` itself so the code will run in NodeJS only if a global `XMLHttpRequest` polyfill has been set (as would be done in multi-locale prerendering). This additionally will still guard against snapshot as intended.
* Set the `xhr` library's `XMLHttpRequest` value to the global value at runtime

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>