### PR TITLE
Use develop branch of enact-dev for travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "node"
 sudo: false
 install:
-    - npm install -g enyojs/enact-dev
+    - npm install -g enyojs/enact-dev#develop
     - npm install
     - npm run bootstrap
 script:


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Tests continue failing on travis due to using master branch of enact-dev

### Resolution
* Use `develop` branch of enact-dev in travis at least until beta.1 when the test tools fiox merges into master.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
