### PR TITLE
ENYO-3648: Removes unnecessary background style

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.less
+++ b/packages/moonstone/Scroller/Scrollable.less
@@ -14,7 +14,6 @@
 		background: inherit;
 		overflow: hidden;
 	}
-	background: black;
 	.padding-start-end(0, @moon-icon-button-small-size + @moon-spotlight-outset);
 
 	padding-bottom:  @moon-icon-button-small-size + @moon-spotlight-outset;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When setting a background for any sort of component that utilizes `Scrollable`, the background does not appear through the component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We have removed the explicit setting of the black background color for `Scrollable`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Issue: ENYO-3648
Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>