### PR TITLE
PLAT-30729: Support React 15.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,9 +28,9 @@
     "extends": "enact/strict"
   },
   "dependencies": {
-    "react": "~15.3.2",
-    "react-addons-update": "~15.3.2",
-    "react-dom": "~15.3.2",
+    "react": "~15.4.0",
+    "react-addons-update": "~15.4.0",
+    "react-dom": "~15.4.0",
     "ramda": "~0.22.1",
     "classnames": "~2.2.5"
   }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.3",
-    "react": "~15.3.2",
-    "react-dom": "~15.3.2",
+    "react": "~15.4.0",
+    "react-dom": "~15.4.0",
     "ramda": "~0.22.1",
     "xhr": "~2.2.2"
   }

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -36,7 +36,7 @@
     "@enact/ui": "^1.0.0-alpha.3",
     "invariant": "~2.2.1",
     "ramda": "~0.22.1",
-    "react": "~15.3.1",
+    "react": "~15.4.0",
     "recompose": "~0.20.2",
     "warning": "~3.0.0"
   }

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -48,9 +48,9 @@
     "@kadira/react-storybook-addon-info": "~3.2.1",
     "@kadira/storybook": "~2.20.1",
     "@kadira/storybook-addon-knobs": "~1.2.3",
-    "react": "~15.3.2",
-    "react-addons-perf": "~15.3.2",
-    "react-dom": "~15.3.2",
+    "react": "~15.4.0",
+    "react-addons-perf": "~15.4.0",
+    "react-dom": "~15.4.0",
     "react-storybook-addon-backgrounds": "~0.0.4"
   }
 }

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.3",
     "ramda": "~0.22.1",
-    "react": "~15.3.1"
+    "react": "~15.4.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@enact/core": "^1.0.0-alpha.3",
     "ramda": "~0.22.1",
-    "react": "~15.3.2",
-    "react-dom": "~15.3.1",
+    "react": "~15.4.0",
+    "react-dom": "~15.4.0",
     "recompose": "~0.20.2",
     "warning": "~3.0.0",
     "invariant": "~2.2.1"


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Outdated version of React/ReactDOM in dependencies could lead to multiple copies of libraries if App used current release app-level.

### Resolution
* Updates React package dependencies to 15.4.0

### Additional Considerations
* Should go in with https://github.com/enyojs/enact-dev/pull/25

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>