### PR TITLE
PLAT-30286: Change LTR Layout of VirtualList Sample to Support Locale

### DIFF
--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -20,8 +20,7 @@ const
 
 			color: 'white',
 			fontSize: ri.scale(40) + 'px',
-			lineHeight: ri.scale(70) + 'px',
-			textAlign: 'center'
+			lineHeight: ri.scale(70) + 'px'
 		},
 		listHeight: {
 			height: ri.scale(550) + 'px'


### PR DESCRIPTION
### Issue Resolved / Feature Added
Currently, the VirtualList Sample displays Centered in LTR locale and displays Right aligned in RTL locale. 
So, when the storybook setting is LTR, it should be on the Left aligned.

### Resolution
Change the LTR locale layout to Left aligned.


### Links
https://jira2.lgsvl.com/browse/PLAT-30286


### Comments
Enyo-DCO-1.1-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)