### PR TITLE
ENYO-3631: Add first item focus on spotlight open for expandable items

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableContainer.js
+++ b/packages/moonstone/ExpandableItem/ExpandableContainer.js
@@ -27,12 +27,20 @@ const ExpandableContainerBase = class extends React.Component {
 	componentDidUpdate (prevProps) {
 		if (!this.props.open && prevProps.open) {
 			this.highlightLabeledItem();
+		} else if (!prevProps.open && this.props.open) {
+			this.highlightDrawerItem();
 		}
 	}
 
 	highlightLabeledItem = () => {
 		if (this.containerNode.contains(document.activeElement)) {
 			Spotlight.focus(this.props['data-container-id']);
+		}
+	}
+
+	highlightDrawerItem = () => {
+		if (this.containerNode.contains(document.activeElement)) {
+			Spotlight.move('down');
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
DatePicker: Month Picker Does Not Receive Spotlight via 5way Selection

### Resolution
Added Spotlight down when the expandable item opens


### Additional Considerations
Expandable item close on spotlight select of date picker component is not implemented and is reported in ENYO-3630.
Even the date/month/year picker on enter is not changing the values


### Links
https://jira2.lgsvl.com/browse/ENYO-3631


### Comments
Enyo-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)
