### PR TITLE
Added shouldComponentUpdate to ViewManager with a new preventUpdate prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 - Spotlight stops at container boundaries when 5-way key held down
 - Several issues related to spotting controls in edge cases
-- Joined picker now has correct animation onMouseWheel. 
 
 
 ## [1.0.0-alpha.2] - 2016-10-21

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -21,6 +21,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 this module. When authoring components and importing mixins, only the local mixins need to be
 imported, as they already import the general mixins.
 
+### Fixed
+
+- Joined picker so that it now has correct animation when using the mouse wheel.
+
 ## [1.0.0-alpha.3] - 2016-11-8
 
 ### Added

--- a/packages/moonstone/Picker/PickerCore.js
+++ b/packages/moonstone/Picker/PickerCore.js
@@ -6,8 +6,8 @@
  */
 
 import * as jobs from '@enact/core/jobs';
-import {SlideLeftArranger, SlideTopArranger, ViewManager} from '@enact/ui/ViewManager';
 import {childrenEquals} from '@enact/core/util';
+import {SlideLeftArranger, SlideTopArranger, ViewManager} from '@enact/ui/ViewManager';
 import R from 'ramda';
 import React from 'react';
 import shouldUpdate from 'recompose/shouldUpdate';


### PR DESCRIPTION
### Issue Resolved / Feature Added
Enact DatePicker: Wheeling Down Causes Value to Rotate Down then Unexpectedly Up


### Resolution
~~Adjusted timeout from 175ms to 400ms because it was causing a stutter in the animation.~~
After searching the root cause a little bit more, it looks like there is some sort of race/timing condition. Looks like Picker has a pressed state that causes a rerender after the value has changed. This also causes the ViewManager to trigger a render rerender aswell. This gives the effect of the animation going two ways down and then up.

### Additional Considerations
I tested it working smoothly on M16 and on chrome w/CPU throttling, but I'm not sure how it will fair on something like M2. I think it should work fine, but it might be worth checking out.


### Links
https://jira2.lgsvl.com/browse/ENYO-3651

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
