### PR TITLE
PLAT-28827, ENYO-3644: Apply marquee to GridListImageItem

### DIFF
--- a/packages/moonstone/VirtualList/GridListImageItem.js
+++ b/packages/moonstone/VirtualList/GridListImageItem.js
@@ -95,7 +95,7 @@ const GridListImageItemBase = kind({
 	},
 
 	computed: {
-		captions: ({caption, subCaption}) => ('' + (caption || null) + (subCaption ? `\n${subCaption}` : null)),
+		captions: ({caption, subCaption}) => ((caption || '') + (subCaption ? `\n${subCaption}` : '')),
 		className: ({selected, styler}) => styler.append({selected})
 	},
 

--- a/packages/moonstone/VirtualList/GridListImageItem.less
+++ b/packages/moonstone/VirtualList/GridListImageItem.less
@@ -66,9 +66,9 @@
 
 	.captions {
 		position: absolute;
-		padding: 0;
 		width: 100%;
 		height: 100%;
+		padding: 0;
 
 		.moon-body-text();
 		text-align: center;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed to start marquee when hover over GridListImageItem.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Defined `MarqueeCaption` for wrapping `caption` and `subCaption` and enlarge the size as big as the item size
- Set `marqueeOn` to 'hover' for starting marquee when hover
- Concatenated `caption` and `subCaption` due to error from `childrenEquals` in utils.js (details in Jira)
- Removed unused CSS classes

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I'd like to separate `<div>` for `caption` and `subCaption` if the error that returns `true` from `childrenEquals` even if the contents of children of Marquee have changed has fixed.

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/PLAT-28827
https://jira2.lgsvl.com/browse/ENYO-3644

### Comments
