### PR TITLE
ENYO-3598:  Add Non Latin font change for Button and Picker

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -101,6 +101,10 @@
 		}
 
 		.moon-taparea(@moon-button-small-height);
+
+		:global(.enact-locale-non-latin) & {
+			.enact-locale-non-latin .moon-small-button-text;
+		}
 	}
 
 	&.translucent .bg {
@@ -171,5 +175,9 @@
 				background-color: @moon-neutral-button-disabled-bg-color;
 			}
 		}
+	}
+
+	:global(.enact-locale-non-latin) & {
+		.enact-locale-non-latin .moon-large-button-text;
 	}
 }

--- a/packages/moonstone/Picker/Picker.less
+++ b/packages/moonstone/Picker/Picker.less
@@ -104,6 +104,10 @@
 			background-color: @moon-spotlight-border-color;
 			color: @moon-spotlight-text-color;
 		}
+
+		:global(.enact-locale-non-latin) & {
+			.enact-locale-non-latin .moon-picker-text;
+		}
 	}
 
 	&:not(.joined) {
@@ -113,6 +117,10 @@
 			height: @moon-button-height;
 			line-height: @moon-button-height;
 			max-width: 300px;
+
+			:global(.enact-locale-non-latin) & {
+				.enact-locale-non-latin .moon-picker-text;
+			}
 		}
 	}
 

--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -161,6 +161,7 @@
 	// Light weighted classes
 	.moon-body-text,
 	.moon-superscript,
+	.moon-picker-text,
 	.moon-pre-text {
 		font-family: @moon-non-latin-font-family-light;
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
ENYO-3598: Enact Locale: Font Does Not Toggle on Buttons and Pickers


### Resolution
Added to enact-locale-non-latin css for button and picker.


### Additional Considerations
This will also reflect in the variants of Button and Picker.


### Links
https://jira2.lgsvl.com/browse/ENYO-3598


### Comments
Enyo-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)
