### PR TITLE
ENYO-3600: ExpandableItem icons are missing

### DIFF
--- a/packages/moonstone/ExpandableItem/Expandable.less
+++ b/packages/moonstone/ExpandableItem/Expandable.less
@@ -3,39 +3,32 @@
 @import '../styles/variables.less';
 
 .expandableItem {
-	display: inline-block;
-
-	.item {
-		display: block;
-		min-width: auto;
-	}
 
 	.header {
-		display: inline-block;
-		padding-right: @moon-spotlight-outset + 30px;
-		position: relative;
+		display: inline-flex;
+		padding-right: @moon-expandable-icon-large-padding;
 
 		&:after {
 			position: absolute;
-			top: @moon-spotlight-outset - 12px;
-			right: @moon-spotlight-outset + 1px;
+			top: @moon-spotlight-outset - @moon-icon-margin;
+			right: @moon-expandable-icon-position;
 			font-family: @moon-icon-font-family;
 			font-size: @moon-expandable-caret-icon-font-size;
 			content: @moon-expandable-close-caret-icon;
 
 			:global(.enact-locale-right-to-left) & {
-				left: @moon-spotlight-outset + 1px;
+				left: @moon-expandable-icon-position;
 				right: initial;
 			}
 		}
 
-		&[open]:after {
-			content: @moon-expandable-open-caret-icon;
-		}
-
 		:global(.enact-locale-right-to-left) & {
-			padding-left: @moon-spotlight-outset + 30px;
-			padding-right: @moon-spotlight-outset;
+			padding-left: @moon-expandable-icon-large-padding;
+			padding-right: @moon-expandable-icon-small-padding;
 		}
+	}
+
+	&.open .header:after {
+		content: @moon-expandable-open-caret-icon;
 	}
 }

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -11,13 +11,12 @@ import kind from '@enact/core/kind';
 import React, {PropTypes} from 'react';
 
 import LabeledItem from '../LabeledItem';
-
+import Item, {ItemOverlay} from '../Item';
 import Expandable from './Expandable';
 import ExpandableContainer from './ExpandableContainer';
+import ExpandableTransitionContainer from './ExpandableTransitionContainer';
 
 import css from './Expandable.less';
-
-import ExpandableTransitionContainer from './ExpandableTransitionContainer';
 
 /**
  * {@link moonstone/ExpandableItem.ExpandableItem} is a stateless component that
@@ -142,7 +141,8 @@ const ExpandableItemBase = kind({
 				return open ? onClose : onOpen;
 			}
 		},
-		open: ({disabled, open}) => open && !disabled
+		open: ({disabled, open}) => open && !disabled,
+		className: ({open, styler}) => styler.append({open})
 	},
 
 	render: ({children, disabled, handleOpen, label, open, title, ...rest}) => {
@@ -156,19 +156,14 @@ const ExpandableItemBase = kind({
 
 		return (
 			<ExpandableContainer {...rest} disabled={disabled} open={open}>
-				<LabeledItem
-					className={css.item}
-					disabled={disabled}
-					label={label}
-					onClick={handleOpen}
-				>
-					<div
+				<ItemOverlay onClick={handleOpen}>
+					<Item
 						className={css.header}
-						open={open}
-					>
-						{title}
-					</div>
-				</LabeledItem>
+					>{title}</Item>
+					<LabeledItem
+						label={label}
+					/>
+				</ItemOverlay>
 				<ExpandableTransitionContainer data-container-disabled={!open} data-expandable-container visible={open} duration="short" type="clip">
 					{children}
 				</ExpandableTransitionContainer>

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -276,6 +276,9 @@
 @moon-expandable-open-caret-icon: "\0EFFEE";
 @moon-expandable-close-caret-icon: "\0EFFED";
 @moon-expandable-caret-icon-font-size: 48px;
+@moon-expandable-icon-small-padding: @moon-spotlight-outset;
+@moon-expandable-icon-large-padding: @moon-spotlight-outset + 30px;
+@moon-expandable-icon-position: @moon-spotlight-outset + 1;
 
 // ContextualPopup
 // ---------------------------------------


### PR DESCRIPTION
### Issue Resolved / Feature Added
Icons are missing in ExpandableItem component


### Resolution
The icons were not implemented in ExpandableItem component to show the open and close state.
Now icon component is added to ExpandableItem component. 
arraowsmallup will show on open state and arrowsmalldown will show on close state.

### Additional Considerations
The component is tested with samples and is working fine.
Unit testing couldn't completed as enact test start was  not working

### Links
https://jira2.lgsvl.com/browse/ENYO-3600

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)
