### PR TITLE
PLAT-30344: Support Babel __BROWSER__ expression plugin for simplified/readable browser environment detection.

### DIFF
--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -67,7 +67,7 @@ const IntlHoc = hoc((config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			if (typeof window === 'object') {
+			if (__BROWSER__) {
 				on('languagechange', this.handleLocaleChange, window);
 			}
 		}
@@ -79,7 +79,7 @@ const IntlHoc = hoc((config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			if (typeof window === 'object') {
+			if (__BROWSER__) {
 				off('languagechange', this.handleLocaleChange, window);
 			}
 		}

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -28,7 +28,7 @@ const get = (url, callback) => {
 function EnyoLoader () {
 	this.base = ilibLocale.path.substring(0, ilibLocale.path.lastIndexOf('/locale'));
 	// TODO: full enyo.platform implementation for improved accuracy
-	if (typeof window === 'object' && typeof window.PalmSystem === 'object') {
+	if (__BROWSER__ && typeof window.PalmSystem === 'object') {
 		this.webos = true;
 	}
 }

--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -26,7 +26,7 @@ import {updateLocale} from './locale';
 
 ilib.setLoaderCallback(new Loader());
 
-if (typeof window === 'object' && typeof window.UILocale !== 'undefined') {
+if (__BROWSER__ && typeof window.UILocale !== 'undefined') {
 	// this is a hack until GF-1581 is fixed
 	ilib.setLocale(window.UILocale);
 }

--- a/packages/moonstone/DatePicker/DatePickerController.js
+++ b/packages/moonstone/DatePicker/DatePickerController.js
@@ -141,7 +141,7 @@ const DatePickerController = class extends React.Component {
 	initI18n () {
 		const locale = ilib.getLocale();
 
-		if (this.locale !== locale && typeof window === 'object') {
+		if (this.locale !== locale && __BROWSER__) {
 			this.locale = locale;
 
 			this.dateFormat = new DateFmt({

--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -111,7 +111,7 @@ const DayPicker = class extends React.Component {
 
 	initIlib () {
 		const locale = ilib.getLocale();
-		if (this.locale !== locale && typeof window === 'object') {
+		if (this.locale !== locale && __BROWSER__) {
 			this.locale = locale;
 
 			const df = new DateFmt({length: 'full'});

--- a/packages/moonstone/Panels/AlwaysViewingPanels.js
+++ b/packages/moonstone/Panels/AlwaysViewingPanels.js
@@ -28,7 +28,7 @@ const calcMax = R.memoize((viewportWidth, width) => Math.floor(viewportWidth / 2
 const AlwaysViewingPanels = BreadcrumbDecorator({
 	className: 'panels alwaysViewing enact-fit',
 	max: () => {
-		if (typeof window === 'object') {
+		if (__BROWSER__) {
 			return calcMax(window.innerWidth, breadcrumbWidth);
 		}
 	},

--- a/packages/moonstone/Scroller/ScrollAnimator.js
+++ b/packages/moonstone/Scroller/ScrollAnimator.js
@@ -43,9 +43,9 @@ const
 
 	// These guards probably aren't necessary because there shouldn't be any scrolling occurring
 	// in isomorphic mode.
-	rAF = (typeof window === 'object') ? window.requestAnimationFrame : function () {},
-	cAF = (typeof window === 'object') ? window.cancelAnimationFrame : function () {},
-	perf = (typeof window === 'object') ? window.performance : {};
+	rAF = (__BROWSER__) ? window.requestAnimationFrame : function () {},
+	cAF = (__BROWSER__) ? window.cancelAnimationFrame : function () {},
+	perf = (__BROWSER__) ? window.performance : {};
 
 /**
  * {@link moonstone/Scroller/ScrollAnimator.ScrollAnimator} is the class

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -19,14 +19,14 @@ import css from './Scrollable.less';
 const
 	calcVelocity = (d, dt) => (d && dt) ? d / dt : 0,
 	nop = () => {},
-	perf = (typeof window === 'object') ? window.performance : {},
+	perf = (__BROWSER__) ? window.performance : {},
 	holdTime = 50,
 	scrollWheelMultiplier = 5,
 	pixelPerLine = ri.scale(40) * scrollWheelMultiplier,
 	pixelPerScrollbarBtn = ri.scale(100),
 	epsilon = 1,
 	// spotlight
-	doc = (typeof window === 'object') ? window.document : {},
+	doc = (__BROWSER__) ? window.document : {},
 	spotlightAnimationDuration = 500;
 
 /**

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -52,7 +52,7 @@ const
 	selectPrevIcon = selectIcon(true),
 	selectNextIcon = selectIcon(false),
 	// spotlight
-	doc = (typeof window === 'object') ? window.document : {};
+	doc = (__BROWSER__) ? window.document : {};
 
 /**
  * {@link moonstone/Scroller/Scrollbar.Scrollbar} is a Scrollbar with Moonstone styling.

--- a/packages/moonstone/TimePicker/TimePickerController.js
+++ b/packages/moonstone/TimePicker/TimePickerController.js
@@ -180,7 +180,7 @@ const TimePickerController = class extends React.Component {
 	initI18n () {
 		const locale = ilib.getLocale();
 
-		if (this.locale !== locale && typeof window === 'object') {
+		if (this.locale !== locale && __BROWSER__) {
 			this.locale = locale;
 
 			const format = {

--- a/packages/sampler/.qa-storybook/.babelrc
+++ b/packages/sampler/.qa-storybook/.babelrc
@@ -1,6 +1,6 @@
 {
 	"presets": ["es2015", "stage-0", "react"],
-	"plugins": ["dev-expression"],
+	"plugins": ["browser-expression", "dev-expression"],
 	"env": {
 		"production": {
 			"plugins": ["transform-react-inline-elements","transform-react-constant-elements"]

--- a/packages/sampler/.storybook/.babelrc
+++ b/packages/sampler/.storybook/.babelrc
@@ -1,6 +1,6 @@
 {
 	"presets": ["es2015", "stage-0", "react"],
-	"plugins": ["dev-expression"],
+	"plugins": ["browser-expression", "dev-expression"],
 	"env": {
 		"production": {
 			"plugins": ["transform-react-inline-elements","transform-react-constant-elements"]

--- a/packages/sampler/.storybook/config.js
+++ b/packages/sampler/.storybook/config.js
@@ -2,7 +2,7 @@ import perf from 'react-addons-perf';
 import configure from '../src/configure';
 const stories = require.context('../stories/moonstone-stories', true, /.js$/);
 
-if (typeof window === 'object') {
+if (__BROWSER__) {
 	window.ReactPerf = perf;
 }
 

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "babel-core": "6.14.0",
     "babel-loader": "6.2.5",
+    "babel-plugin-browser-expression": "github:enyojs/babel-plugin-browser-expression#0.1.0",
     "babel-plugin-dev-expression": "0.2.1",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-inline-elements": "6.8.0",

--- a/packages/spotlight/src/root.js
+++ b/packages/spotlight/src/root.js
@@ -30,7 +30,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillMount () {
-			if (typeof window === 'object') {
+			if (__BROWSER__) {
 				Spotlight.initialize();
 				Spotlight.add(spotlightRootContainerName, {
 					selector: '.' + spottableClass,

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -132,7 +132,7 @@ const Spotlight = (function() {
 		const matchedNodes = (this.parentNode || this.document).querySelectorAll(selector);
 		return [].slice.call(matchedNodes).indexOf(this) >= 0;
 	};
-	if (typeof window === 'object') {
+	if (__BROWSER__) {
 		elementMatchesSelector = window.Element.prototype.matches
 			|| window.Element.prototype.matchesSelector
 			|| window.Element.prototype.mozMatchesSelector

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -11,8 +11,8 @@ let baseScreen,
 	screenTypes = [{
 		name: 'standard',
 		pxPerRem: 16,
-		width: (typeof window === 'object') ? window.innerWidth : 1920,
-		height: (typeof window === 'object') ? window.innerHeight : 1080,
+		width: (__BROWSER__) ? window.innerWidth : 1920,
+		height: (__BROWSER__) ? window.innerHeight : 1080,
 		aspectRatioName: 'standard',
 		base: true
 	}],	// Assign one sane type in case defineScreenTypes is never run.
@@ -102,8 +102,8 @@ function defineScreenTypes (types) {
  */
 function getScreenType (rez) {
 	rez = rez || {
-		height: (typeof window === 'object') ? window.innerHeight : 1080,
-		width: (typeof window === 'object') ? window.innerWidth : 1920
+		height: (__BROWSER__) ? window.innerHeight : 1080,
+		width: (__BROWSER__) ? window.innerWidth : 1920
 	};
 
 	const types = screenTypes;
@@ -171,7 +171,7 @@ function calculateFontSize (type) {
  * @returns {null} n/a
  */
 function updateBaseFontSize (size) {
-	if (typeof window === 'object') {
+	if (__BROWSER__) {
 		document.documentElement.style.fontSize = size;
 	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Using `typeof window === 'object'` is clunky and affects readability of sourcecode

### Resolution
* Uses `__BROWSER__` where necessary for Babel-level code simplification in sourcecode. Transpiled code to be published will have `__BROWSER__` resolved to `typeof window !== 'undefined'`
* Updates Sampler to support babel-plugin-browser-expression

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
