### PR TITLE
PLAT-29037: Perf > Reuse React elements to reduce JS heap memory

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -172,8 +172,8 @@ class VirtualListCore extends Component {
 	curDataSize = 0
 	cc = []
 	scrollPosition = 0
-	updateFrom = 0
-	updateTo = 0
+	updateFrom = null
+	updateTo = null
 
 	containerRef = null
 	wrapperRef = null
@@ -319,8 +319,8 @@ class VirtualListCore extends Component {
 
 		this.maxFirstIndex = dataSize - numOfItems;
 		this.curDataSize = dataSize;
-		this.updateFrom = 0;
-		this.updateTo = 0;
+		this.updateFrom = null;
+		this.updateTo = null;
 
 		this.setState({firstIndex: Math.min(this.state.firstIndex, this.maxFirstIndex), numOfItems});
 		this.calculateScrollBounds(props);
@@ -489,7 +489,7 @@ class VirtualListCore extends Component {
 		// positioning items
 		for (let i = updateFrom, j = updateFrom % dimensionToExtent; i < updateTo; i++) {
 
-			if ((!this.updateFrom && !this.updateTo) || (this.updateFrom > i) || (this.updateTo <= i)) {
+			if (this.updateFrom === null || this.updateTo === null || this.updateFrom > i || this.updateTo <= i) {
 				this.applyStyleToNewNode(i, width, height, primaryPosition, secondaryPosition);
 			} else {
 				this.applyStyleToExistingNode(i, width, height, primaryPosition, secondaryPosition);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is the bottleneck to enhance list scroll performance related with JS heap memory usage because we did reuse DOM elements but we did not reuse React elements.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Instead of removing all React elements ( `this.cc.length = 0` ) when rendering VirtualList, I tried to reuse most of them and to create only new VirtualDOMs. By doing it, we could enhance significant list scroll performance.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I only considered the VirtualList in `develop` branch.  I need to consider the VirtualList for VirtualVariableList later.

### Links
[//]: # (Related issues, references)

This PR is one the PRs for https://jira2.lgsvl.com/browse/PLAT-29037 story.

### Comments

N / A

Enyo-DCO-1.1-Signed-off-by: YB Sung (yb.sung@lge.com)