### PR TITLE
PLAT-28827, ENYO-3644: Apply MarqueeController to GridListImageItem

### DIFF
--- a/packages/moonstone/VirtualList/GridListImageItem.js
+++ b/packages/moonstone/VirtualList/GridListImageItem.js
@@ -12,7 +12,6 @@ import {Spottable} from '@enact/spotlight';
 
 import Icon from '../Icon';
 import {Image} from '../Image';
-import {ItemBase} from '../Item';
 import {MarqueeController, MarqueeText} from '../Marquee';
 
 import css from './GridListImageItem.less';
@@ -103,9 +102,7 @@ const GridListImageItemBase = kind({
 
 		return (
 			<Controller {...rest}>
-				<MarqueeText marqueeOn="hover" className={css.image}>
-					<Image src={source} placeholder={defaultPlaceholder} />
-				</MarqueeText>
+				<Image className={css.image} src={source} placeholder={defaultPlaceholder} />
 				{
 					selectionOverlayShowing ? (
 						<div className={css.overlayContainer}>

--- a/packages/moonstone/VirtualList/GridListImageItem.less
+++ b/packages/moonstone/VirtualList/GridListImageItem.less
@@ -26,11 +26,6 @@
 		width: 100%;
 		height: 100%;
 		margin: 0;
-		div {
-			width: 100%;
-			height: 100%;
-			margin: 0;
-		}
 	}
 
 	.overlayComponent {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Fixed to start marquee when hover over GridListImageItem.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Apply `MarqueeController` and `MarqueeText` to GridListImageItem
- Set `marqueeOn` to 'hover' for starting marquee when hovering an item
- Removed unused CSS classes

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

There are 2 issues related with `MarqueeController` and `MarqueeDecorator`.
1. If hovering the short text which width is smaller than a `GridListImageItem` width with 'MarqueeController', there are no marquee animation in the other texts.

Step>
* Run storybook sample and select VirtualList.VirtualGridList
* Hover the image or the caption ( Item 000 ) of the first item
* Actual result : There is no marquee animation with the sub-caption ( SubItem 000 )
* Expected result : The sub caption should animate

2. With Moonstone marquee parity, long texts should animate continuously. But with 'MarqueeController`, the texts animate just one time. 

Step>
* Run storybook sample and select VirtualList.VirtualGridList
* Hover the sub-caption ( SubItem 000 ) of the first item
* Actual result : The sub-caption animates just one time
* Expected result :  The sub-caption should animate continuously

### Links
[//]: # (Related issues, references)

https://jira2.lgsvl.com/browse/PLAT-28827
https://jira2.lgsvl.com/browse/ENYO-3644

### Comments

We implemented marquee support in GridListImageItem again to use `MarqueeController`. The previous PR is https://github.com/enyojs/enact/pull/270.

Enyo-DCO-1.1-Signed-off-by: YB Sung (yb.sung@lge.com)