### PR TITLE
PLAT-31354: Add a passthrough for perf.now to return Date.now in non-browser environments.

### DIFF
--- a/packages/moonstone/Scroller/ScrollAnimator.js
+++ b/packages/moonstone/Scroller/ScrollAnimator.js
@@ -45,7 +45,7 @@ const
 	// in isomorphic mode.
 	rAF = (typeof window === 'object') ? window.requestAnimationFrame : function () {},
 	cAF = (typeof window === 'object') ? window.cancelAnimationFrame : function () {},
-	perf = (typeof window === 'object') ? window.performance : {};
+	perf = (typeof window === 'object') ? window.performance : {now: Date.now};
 
 /**
  * {@link moonstone/Scroller/ScrollAnimator.ScrollAnimator} is the class

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -19,7 +19,7 @@ import css from './Scrollable.less';
 const
 	calcVelocity = (d, dt) => (d && dt) ? d / dt : 0,
 	nop = () => {},
-	perf = (typeof window === 'object') ? window.performance : {},
+	perf = (typeof window === 'object') ? window.performance : {now: Date.now},
 	holdTime = 50,
 	scrollWheelMultiplier = 5,
 	pixelPerLine = ri.scale(40) * scrollWheelMultiplier,

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -53,7 +53,7 @@ const
 	selectNextIcon = selectIcon(false),
 	// spotlight
 	doc = (typeof window === 'object') ? window.document : {},
-	perf = (typeof window === 'object') ? window.performance : {};
+	perf = (typeof window === 'object') ? window.performance : {now: Date.now};
 
 /**
  * {@link moonstone/Scroller/Scrollbar.Scrollbar} is a Scrollbar with Moonstone styling.


### PR DESCRIPTION
### Issue Resolved / Feature Added
Scroller-related code was using an empty object in lieu of `window.performance`. This cause isomorphic failure when it was calling `perf.now()`


### Resolution
*Add a passthrough returning environment-neutral `Date.now` for non-browser environments

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
