### PR TITLE
Slider: Restores default value

### DIFF
--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -148,7 +148,7 @@ const SliderBase = kind({
 		onChange: () => {}, // needed to ensure the base input element is mutable if no change handler is provided
 		pressed: false,
 		step: 1,
-		value: 50,
+		value: 0,
 		vertical: false
 	},
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The default value of `Slider` was unintentionally changed from `0` to `50`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The default value has been reset back to `0`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>