### PR TITLE
Simplifies ExpandableInput sample

### DIFF
--- a/packages/sampler/stories/moonstone-stories/ExpandableInput.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandableInput.js
@@ -1,57 +1,18 @@
 import {ExpandableInput as ExpInput, ExpandableInputBase} from '@enact/moonstone/ExpandableInput';
-import {forward} from '@enact/core/handle';
+import Changeable from '@enact/ui/Changeable';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {withKnobs, boolean, text} from '@kadira/storybook-addon-knobs';
 
-class ExpandableInput extends React.Component {
-	constructor (props) {
-		super(props);
-		this.state = {
-			open: false
-		};
-		this.forwardOnChange = forward('onChange');
-		this.forwardOnOpen = forward('onOpen');
-		this.forwardOnClose = forward('onClose');
-	}
-
-	handleSelect = (ev) => {
-		this.setState({
-			value: ev.value
-		});
-		this.forwardOnChange(ev, this.props);
-	}
-
-	handleOpen = (ev) => {
-		this.setState({
-			open: true
-		});
-		this.forwardOnOpen(ev, this.props);
-	}
-
-	handleClose = (ev) => {
-		this.setState({
-			open: false
-		});
-		this.forwardOnClose(ev, this.props);
-	}
-
-	render () {
-		return (
-			<ExpInput
-				{...this.props}
-				value={this.state.value}
-				open={this.state.open}
-				onOpen={this.handleOpen}
-				onClose={this.handleClose}
-				onChange={this.handleSelect}
-			/>
-		);
-	}
-}
+const ExpandableInput = Changeable({mutable: true}, ExpInput);
 
 ExpandableInput.propTypes = Object.assign({}, ExpInput.propTypes, ExpandableInputBase.propTypes);
 ExpandableInput.defaultProps = Object.assign({}, ExpInput.defaultProps, ExpandableInputBase.defaultProps);
+
+delete ExpandableInput.propTypes.onInputChange;
+delete ExpandableInput.propTypes.defaultOpen;
+delete ExpandableInput.defaultProps.onInputChange;
+delete ExpandableInput.defaultProps.defaultOpen;
 
 storiesOf('ExpandableInput')
 	.addDecorator(withKnobs)
@@ -61,12 +22,13 @@ storiesOf('ExpandableInput')
 		() => (
 			<ExpandableInput
 				disabled={boolean('disabled', false)}
-				noneText={text('noneText', 'nothing selected')}
+				noneText={text('noneText', 'nothing inputted')}
 				onChange={action('onChange')}
 				onClose={action('onClose')}
 				onOpen={action('onOpen')}
 				open={boolean('open', false)}
 				title={text('title', 'title')}
+				value={text('value', '')}
 			/>
 		)
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The `open` knob wasn't functioning.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Realized that the sample could be greatly simplified, in addition to having the `open` knob function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>