### PR TITLE
Fixed the storybook background plugin.

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -49,8 +49,8 @@ const FullscreenBase = kind({
 	)
 });
 
-const Moonstone = MoonstoneDecorator(PanelsBase);
-const MoonstoneFullscreen = MoonstoneDecorator(FullscreenBase);
+const Moonstone = MoonstoneDecorator({overlay: true}, PanelsBase);
+const MoonstoneFullscreen = MoonstoneDecorator({overlay: true}, FullscreenBase);
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
@@ -17,9 +17,6 @@
 }
 
 .moonstone {
-	// This sets moonstone's root background color to transparent so the background-addon bg can shine through.
-	background-color: transparent;
-
 	.description {
 		margin: 0 @moon-spotlight-outset 1em;
 


### PR DESCRIPTION
Backgrounds for storybook don't work. This corrects that by using the new `overlay` config option.