### PR TITLE
ENYO-3701: Reset item nodes when a list should be re-rendered.

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -309,6 +309,9 @@ class VirtualListCore extends Component {
 		this.state.firstIndex = 0;
 		// eslint-disable-next-line react/no-direct-mutation-state
 		this.state.numOfItems = 0;
+
+		// reset children
+		this.cc = [];
 	}
 
 	updateStatesAndBounds (props) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
An issue is that items of a grid list is displayed abnormally when a `direction` prop is changed from `'vertical'` to '`horizontal'`.
In detail, large items and small items are displayed together, but large items are only normal items.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When a list should be re-rendered due to metrics change, item nodes also should be cleared but the code is missing.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3701

### Comments

When a list should be re-rendered due to metrics changed,


Enyo-DCO-1.1-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)