### PR TITLE
ENYO-3673: apply hidden overlay rules when item is disabled

### DIFF
--- a/packages/moonstone/Item/Overlay.less
+++ b/packages/moonstone/Item/Overlay.less
@@ -25,7 +25,10 @@
 		}
 	}
 
-	&:global(.spottable):not(:focus) .overlay.hidden {
-		display: none;
+	&:global(.spottable):not(:focus),
+	&[disabled] {
+		.overlay.hidden {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
Previously, the hidden class was only applied when the component was
spottable but not focused. Disabled components do not receive the
spottable class so the overlays were always hidden. No longer!

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)