### PR TITLE
ENYO-3701: (Additional Fix) Reset item nodes when a list should be re-rendered.

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -309,9 +309,6 @@ class VirtualListCore extends Component {
 		this.state.firstIndex = 0;
 		// eslint-disable-next-line react/no-direct-mutation-state
 		this.state.numOfItems = 0;
-
-		// reset children
-		this.cc = [];
 	}
 
 	updateStatesAndBounds (props) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Even after applying #309, if the size of data is decreased, unnecessary DOM nodes are still remaining.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reset child DOM nodes in `updateStatesAndBounds` instead of `calculateMetrics` to cover the issue as well as an issue in #309.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3701

### Comments
