### PR TITLE
ENYO:3556-Marquee Stops when MarqueeDelay is Set to Zero

### DIFF
--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -398,6 +398,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		resetAnimation = () => {
+			// without a mimimum delay, a marquee can fail to restart if the values of `marqueeDelay`
+			// and `marqueeResetDelay` are both very low values (such as 0). This appears to be a quirk
+			// due to running a series of callbacks through `setTimeout` methods at a low value (0).
 			const minDelay = 100;
 			this.setTimeout(this.restartAnimation, this.props.marqueeResetDelay + minDelay);
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Marquee Stops when MarqueeDelay is Set to Zero


### Resolution
While translate using CSS if the translation starts without any delay, this may cause issues as the browser preventing the transition for optimization. The solution is to force a redraw before apply the transition again.

### Additional Considerations
The component is tested with samples and is working fine.

### Links
https://jira2.lgsvl.com/browse/ENYO-3556

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)