### PR TITLE
ENYO-3690: filter strings out of date/time formats for picker ordering

### DIFF
--- a/packages/moonstone/DatePicker/DatePickerController.js
+++ b/packages/moonstone/DatePicker/DatePickerController.js
@@ -151,7 +151,10 @@ const DatePickerController = class extends React.Component {
 				useNative: false
 			});
 
-			this.order = this.dateFormat.getTemplate().match(/([mdy]+)/ig).map(s => s[0].toLowerCase());
+			this.order = this.dateFormat.getTemplate()
+				.replace(/'.*?'/g, '')
+				.match(/([mdy]+)/ig)
+				.map(s => s[0].toLowerCase());
 		}
 	}
 

--- a/packages/moonstone/TimePicker/TimePickerController.js
+++ b/packages/moonstone/TimePicker/TimePickerController.js
@@ -210,7 +210,10 @@ const TimePickerController = class extends React.Component {
 			this.meridiemEnabled = clockPref === '12';
 
 			const filter = this.meridiemEnabled ? includeMeridiem : excludeMeridiem;
-			this.order = this.timeFormat.getTemplate().match(filter).map(s => s[0].toLowerCase());
+			this.order = this.timeFormat.getTemplate()
+				.replace(/'.*?'/g, '')
+				.match(filter)
+				.map(s => s[0].toLowerCase());
 
 			const timeFormat = {
 				type: 'time',


### PR DESCRIPTION
The prior regex would match the contents of strings (e.g. 'de' for
es-ES) as a date component causing duplicate children in DatePicker.
Need to filter them out so we are only using date component strings and
not text.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)