### PR TITLE
ENYO-3697: Adjust selected indices for locale first day of week

### DIFF
--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -7,11 +7,14 @@
 import {$L} from '@enact/i18n';
 import {coerceArray} from '@enact/core/util';
 import DateFmt from '@enact/i18n/ilib/lib/DateFmt';
+import {forward} from '@enact/core/handle';
 import ilib from '@enact/i18n/ilib/lib/ilib';
 import LocaleInfo from '@enact/i18n/ilib/lib/LocaleInfo';
 import React, {PropTypes} from 'react';
 
 import ExpandableList from '../ExpandableList';
+
+const forwardSelect = forward('onSelect');
 
 /**
  * {@link moonstone/DayPicker.DayPicker} is a component that
@@ -181,12 +184,8 @@ const DayPicker = class extends React.Component {
 	}
 
 	handleSelect = ({selected}) => {
-		const {onSelect} = this.props;
-		if (onSelect) {
-			onSelect({
-				selected: this.adjustSelection(selected, -this.firstDayOfWeek)
-			});
-		}
+		const adjusted = this.adjustSelection(selected, -this.firstDayOfWeek);
+		forwardSelect({selected: adjusted}, this.props);
 	}
 
 	render () {


### PR DESCRIPTION
Adjust the value of selected passed into and out of the ExpandableList
to account for the current locale's firstDayOfWeek to keep a consistent
public API (0 is always Sunday, 6 is always Saturday) but still use
locale-sensitive formatting of the picker.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)