### PR TITLE
ENYO-3676: Add FocusManager for Panels

### DIFF
--- a/packages/moonstone/Panels/ActivityPanels.js
+++ b/packages/moonstone/Panels/ActivityPanels.js
@@ -15,7 +15,8 @@ const ActivityPanels = BreadcrumbDecorator({
 	className: 'panels activity enact-fit',
 	max: 1,
 	props: {
-		arranger: ActivityArranger
+		arranger: ActivityArranger,
+		noFocusManager: true
 	}
 }, PanelsBase);
 

--- a/packages/moonstone/Panels/BreadcrumbDecorator.js
+++ b/packages/moonstone/Panels/BreadcrumbDecorator.js
@@ -7,6 +7,7 @@ import React from 'react';
 
 import Breadcrumb from './Breadcrumb';
 import BreadcrumbArranger from './BreadcrumbArranger';
+import FocusManager from './FocusManager';
 import IndexedBreadcrumbs from './IndexedBreadcrumbs';
 
 import css from './Panels.less';
@@ -148,7 +149,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			);
 
 			return (
-				<div className={className}>
+				<FocusManager className={className} index={index}>
 					<ViewManager
 						noAnimation={noAnimation}
 						arranger={BreadcrumbArranger}
@@ -163,7 +164,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					<Wrapped {...rest} noAnimation={noAnimation} index={index} {...config.props}>
 						{children}
 					</Wrapped>
-				</div>
+				</FocusManager>
 			);
 		}
 	});

--- a/packages/moonstone/Panels/FocusManager.js
+++ b/packages/moonstone/Panels/FocusManager.js
@@ -1,0 +1,54 @@
+import Spotlight, {spottableClass} from '@enact/spotlight';
+import React, {PropTypes} from 'react';
+
+/**
+ * The focus manager for a set of Panels
+ *
+ * @class FocusManager
+ * @private
+ */
+class FocusManagerBase extends React.Component {
+	static displayName = 'FocusManager';
+
+	static propTypes = {
+		/**
+		 * Index of the active panel
+		 *
+		 * @type {Number}
+		 * @default 0
+		 */
+		index: PropTypes.number
+	}
+
+	componentDidUpdate (prevProps) {
+		if (prevProps.index !== this.props.index && this.node.contains(document.activeElement)) {
+			const spotlightClass = '.' + spottableClass;
+			const activePanel = this.node.querySelector('article');
+
+			// we prioritize what area to spot next. if spottable controls are available in the active panel, we
+			// want to spot the content (`<section>`) first, followed by any spottable control in the panel
+			// itself (including possible `<Header>` controls), followed by any spottable control contained within
+			// the panel decorators - including possible breadcrumbs or an existing `noCloseButton`.
+			const spottable = activePanel.querySelector('section ' + spotlightClass) || activePanel.querySelector(spotlightClass) || this.node.querySelector(spotlightClass);
+			if (spottable) {
+				Spotlight.focus(spottable);
+			}
+		}
+	}
+
+	getNode = (node) => {
+		this.node = node;
+	}
+
+	render () {
+		const props = Object.assign({}, this.props);
+		delete props.index;
+
+		return (
+			<div {...props} ref={this.getNode} />
+		);
+	}
+}
+
+export default FocusManagerBase;
+export {FocusManagerBase as FocusManager};

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -10,6 +10,7 @@ import React from 'react';
 import {shape} from '@enact/ui/ViewManager';
 
 import ApplicationCloseButton from './ApplicationCloseButton';
+import FocusManager from './FocusManager';
 import Viewport from './Viewport';
 
 import css from './Panels.less';
@@ -64,6 +65,14 @@ const PanelsBase = kind({
 		noCloseButton: React.PropTypes.bool,
 
 		/**
+		 * When `true`, panels will not be wrapped with a focus manager component
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 */
+		noFocusManager: React.PropTypes.bool,
+
+		/**
 		 * A function to run when app close button is clicked
 		 * @type {Function}
 		 */
@@ -71,7 +80,8 @@ const PanelsBase = kind({
 	},
 
 	defaultProps: {
-		noCloseButton: false
+		noCloseButton: false,
+		noFocusManager: false
 	},
 
 	styles: {
@@ -89,19 +99,27 @@ const PanelsBase = kind({
 					<ApplicationCloseButton onApplicationClose={onApplicationClose} />
 				);
 			}
+		},
+		wrapperComponent: (noFocusManager) => {
+			return noFocusManager ? FocusManager : 'div';
 		}
 	},
 
-	render: ({noAnimation, arranger, children, index, applicationCloseButton, ...rest}) => {
+	render: ({noAnimation, arranger, children, index, applicationCloseButton, noFocusManager, wrapperComponent: Component, ...rest}) => {
 		delete rest.noCloseButton;
 		delete rest.onApplicationClose;
+
+		if (!noFocusManager) {
+			rest.index = index;
+		}
+
 		return (
-			<div {...rest}>
+			<Component {...rest}>
 				{applicationCloseButton}
 				<Viewport noAnimation={noAnimation} arranger={arranger} index={index}>
 					{children}
 				</Viewport>
-			</div>
+			</Component>
 		);
 	}
 });

--- a/packages/spotlight/index.js
+++ b/packages/spotlight/index.js
@@ -1,7 +1,7 @@
 import {Spotlight} from './src/spotlight';
 import {SpotlightRootDecorator} from './src/root';
 import {SpotlightContainerDecorator, spotlightDefaultClass} from './src/container';
-import {Spottable} from './src/spottable';
+import {Spottable, spottableClass} from './src/spottable';
 
 export default Spotlight;
-export {Spotlight, SpotlightRootDecorator, SpotlightContainerDecorator, Spottable, spotlightDefaultClass};
+export {Spotlight, SpotlightRootDecorator, SpotlightContainerDecorator, Spottable, spotlightDefaultClass, spottableClass};


### PR DESCRIPTION
### Issue Resolved / Feature Added
Added a FocusManager module for Panels, that enables us to maintain focus after a panel change has taken place. 

### Additional Considerations
Ideally, we'd pause/freeze spotlight during a transition to ensure navigation does not change unexpectedly. Panels currently cannot make use of `onTransitionEnd` events, so we are unable to properly determine when a panel transition has ended in order to resume spotlight. That being said, we're simply changing focus after the `Panels` component updates. We may have to revisit focusing post-transition in the future.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
