### PR TITLE
ENYO-3417: Slider Knob Does Not Expand on Press

### DIFF
--- a/packages/moonstone/Slider/Slider.less
+++ b/packages/moonstone/Slider/Slider.less
@@ -12,8 +12,7 @@
 		}
 		.knob {
 			background-color: @moon-slider-spotlight-knob-color;
-			border: @moon-button-border-width solid @moon-slider-spotlight-knob-color;
-			border-style: inherit;
+			border-width: 0; // Setting the border-width:0 removes the border and lets the background fill the entire size that was previously cropped off by the border.
 		}
 	}
 
@@ -51,7 +50,7 @@
 		border: @moon-button-border-width solid transparent;
 		box-sizing: border-box;
 		will-change: transform;
-		-webkit-background-clip: padding;
+		background-clip: padding-box;
 	}
 
 	.input {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Slider knob does not expands on Press Stops

### Resolution
On pressed css class border color changed to match the knob color as well as in knob class background clipped to have the expand effect

### Additional Considerations
The component is tested with samples and is working fine.

### Links
https://jira2.lgsvl.com/browse/ENYO-3417

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)