### PR TITLE
PLAT-32097: Font definitions don’t get stamped into every module.

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
@@ -5,4 +5,5 @@
 @import '~@enact/ui/styles/core.less';
 
 // Moonstone Rules
+@import '../styles/fonts.less';
 @import '../styles/rules.less';

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -1,6 +1,5 @@
 // Variables
 //
-@import './fonts.less';
 @import './colors.less';
 
 // App


### PR DESCRIPTION
### Issue Resolved / Feature Added
It turns out that our font-face definitions were getting included into every module that used or referenced `variables.less`.


### Resolution
Let's get rid of that and only have it included in `MoonstoneDecorator`'s LESS file


### Additional Considerations
To verify this, look at the current `develop` branch in Sampler. Navigate to the iframe with our components rendered in it, locate the `<head>` section, swivel down the arrows for almost any one of the generated `<style>` tags, and you'll be confronted by a wall of `@font-face blah blah blah` rules.

The new approach includes this just once in one place (the way it ought to be done)
![BOOM](http://m.memegen.com/mb6dvq.jpg)
👍 👍 👍 👍 👍 👍 👍 👍 👍 👍 👍 👍 👍 