### PR TITLE
ENYO-3726: Updates ToggleItem to use updated ItemOverlay autoHide prop

### DIFF
--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -161,7 +161,7 @@ const ToggleItemBase = kind({
 		delete rest.value;
 
 		return (
-			<ItemOverlay {...rest} onClick={onToggle} autoHide="no">
+			<ItemOverlay {...rest} onClick={onToggle}>
 				{iconBefore}
 				{children}
 				{iconAfter}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The `autoHide` API for `OverlayDecorator` was modified and the "no" value was removed. `ToggleItem` was explicitly passing the now-invalid value of "no."

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`ToggleItem` has been updated to not pass any value for `autoHide`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://github.com/enyojs/enact/pull/324

### Comments

Issue: ENYO-3726
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>