### PR TITLE
ENYO-3516_Enact IncrementSlider Knob Does Not Set to the Changed Min …

### DIFF
--- a/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
+++ b/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
@@ -169,9 +169,16 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillReceiveProps (nextProps) {
-			if (nextProps.value !== this.props.value || nextProps.max < this.state.value || nextProps.min > this.state.value) {
-				this.updateValue(clamp(nextProps.min, nextProps.max, nextProps.value));
+			if (nextProps.value !== this.props.value) {
+				this.updateValue(clamp(this.props.min, this.props.max, nextProps.value));
 			}
+		}
+
+		shouldComponentUpdate(nextProps) {
+			if (nextProps.max < this.state.value || nextProps.min > this.state.value) {
+				return false;
+			}
+			return true;
 		}
 
 		onChange = (value) => {


### PR DESCRIPTION
### Issue Resolved / Feature Added
 In Enact IncrementSlider Knob Does Not Set to the Changed Min Value.

### Resolution
- If IncrementSlider propType min > value and max < value we are updating value but remains stationary
### Additional Considerations
non

### Links
https://jira2.lgsvl.com/browse/ENYO-3516

### Comments
Enyo-DCO-1.1-Signed-off-by:Richa Shaurbh richa.shaurbh@lge.com