### PR TITLE
ENYO-3483: Re: Add holdable to paging control button of Scrollbar

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualGridList` to be scrolled by page when navigating with a 5-way direction key
 - `moonstone/Scroller`, `moonstone/VirtualList`, `moonstone/VirtualGridList`, and `moonstone/Scrollable` to no longer respond to mouse down/move/up events
 - `moonstone/VirtualList` to mute its container instead of disabling it during scroll events
+- `moonstone/VirtualList`, `moonstone/VirtualGridList`, and `moonstone/Scroller` to continue scrolling when holding down the paging controls
 
 ### Fixed
 

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -10,7 +10,7 @@ import IconButton from '../IconButton';
 
 import css from './Scrollbar.less';
 
-const HoldableIconButton = Holdable(IconButton);
+const HoldableIconButton = Holdable({endHold: 'onLeave'}, IconButton);
 
 const
 	verticalProperties = {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
List does not scroll on long press hold

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We apply holdable HoC to paging control button.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

~**Holdable PR (https://github.com/enyojs/enact/pull/277) should be merged before this PR.**~
~This PR included Holdable PR using cherry-pick.~

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3483

### Comments

@kbs12e created the https://github.com/enyojs/enact/pull/362 PR for ENYO-3483. But there were several cherry-picked commits from https://github.com/enyojs/enact/pull/277. So I created this PR again.
This PR depends on https://github.com/enyojs/enact/pull/277 PR. But that PR was merged into `develop`.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>