### PR TITLE
Cleanup: Scrollable typo error

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -597,7 +597,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			let {left, top} = this.getPositionForScrollTo(opt);
 
 			if (left !== null || top !== null) {
-				this.start((left !== null) ? left : this.scrollLet, (top !== null) ? top : this.scrollTop, opt.animate);
+				this.start((left !== null) ? left : this.scrollLeft, (top !== null) ? top : this.scrollTop, opt.animate);
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

I found there was one type error. We used `this.scrollLet` instead of `this.scrollLeft`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Renamed `Let` as `Left`

Enyo-DCO-1.1-Signed-off-by: YB Sung (yb.sung@lge.com)