### PR TITLE
Setup the sampler to use the ApplicationCloseButton to reload storybook cleanly.

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -8,6 +8,11 @@ import {select} from '@kadira/storybook-addon-knobs';
 
 import css from './MoonstoneEnvironment.less';
 
+const reloadPage = () => {
+	const {protocol, host} = window.location;
+	window.parent.location.href = protocol + '//' + host;
+};
+
 const PanelsBase = kind({
 	name: 'MoonstoneEnvironment',
 
@@ -23,7 +28,7 @@ const PanelsBase = kind({
 
 	render: ({children, title, description, ...rest}) => (
 		<div {...rest}>
-			<Panels>
+			<Panels onApplicationClose={reloadPage}>
 				<Panel>
 					<Header type="compact" title={title} preserveCase />
 					<div className={css.description}>


### PR DESCRIPTION
This is more elaborate than `window.reload()` to avoid re-using possibly unclean knob data.

Thi greatly helps when developing/testing on the TV so you can forcibly reload Storybook to a clean slate, without interacting with the dev console (which is currently broken).