### PR TITLE
Fixes Transition animations

### DIFF
--- a/packages/ui/Transition/Transition.less
+++ b/packages/ui/Transition/Transition.less
@@ -6,7 +6,7 @@
 	overflow: hidden;
 }
 .transition {
-	transition-property: transform;
+	transition-property: height, opacity, transform;
 
 	&.slide {
 		.enact-composite();


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Regression from https://github.com/enyojs/enact/pull/349. We were restricting the properties that would fire an `onTransitionEnd` event as there were some false positives when handling this event in `Popup`. Missed the fact we need some additional properties here to properly account for all the transitions.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `height` and `opacity` to the set of `transition-property` values.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This is the direct fix - would be curious if we want to approach this differently, taking into account the issues with `Popup`, or :shipit: for now...

### Links
[//]: # (Related issues, references)


### Comments

Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>