### PR TITLE
PLAT-28977: validate that text is still visible when marquee stops

### DIFF
--- a/packages/sampler/stories/qa-stories/Components/MarqueeStartStop/MarqueeStartStop.js
+++ b/packages/sampler/stories/qa-stories/Components/MarqueeStartStop/MarqueeStartStop.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {MarqueeText} from '@enact/moonstone/Marquee';
+import Button from '@enact/moonstone/Button';
+
+const MarqueeStartStop = class extends React.Component {
+	static displayName: 'MarqueeStartStop'
+
+	constructor (props) {
+		super(props);
+	}
+
+	startMarquee = () => {
+		this.node.startAnimation();
+	}
+
+	stopMarquee = () => {
+		this.node.cancelAnimation();
+	}
+
+	getNode = (node) => {
+		this.node = node;
+	}
+
+	render () {
+		return (
+			<div>
+				<MarqueeText ref={this.getNode} style={{width: '400px'}}>
+					The quick brown fox jumped over the lazy dog.  The bean bird flies at sundown.
+				</MarqueeText>
+				<Button onClick={this.startMarquee}>Start</Button>
+				<Button onClick={this.stopMarquee}>Stop</Button>
+			</div>
+		);
+	}
+};
+
+export default MarqueeStartStop;
+export {MarqueeStartStop as MarqueeStartStop};

--- a/packages/sampler/stories/qa-stories/Components/MarqueeStartStop/package.json
+++ b/packages/sampler/stories/qa-stories/Components/MarqueeStartStop/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "MarqueeStartStop.js"
+}

--- a/packages/sampler/stories/qa-stories/Marquee.js
+++ b/packages/sampler/stories/qa-stories/Marquee.js
@@ -1,4 +1,5 @@
 import {MarqueeController, MarqueeText} from '@enact/moonstone/Marquee';
+import MarqueeStartStop from './Components/MarqueeStartStop';
 import Item from '@enact/moonstone/Item';
 import {Spottable} from '@enact/spotlight';
 import React from 'react';
@@ -132,5 +133,13 @@ storiesOf('Marquee')
 					{LTR[0]}
 				</MarqueeText>
 			</SpottableDiv>
+		)
+	)
+
+	.addWithInfo(
+		'Start Stop',
+		() => (
+			<MarqueeStartStop>
+			</MarqueeStartStop>
 		)
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
Validate that text is still visible when marquee stops

### Resolution
Created a Marquee Component with start & stop buttons to start and stop the marquee

### Additional Considerations
The new MarqueeStartStop component is used to create the sample

### Links
https://jira2.lgsvl.com/browse/PLAT-28977

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)