### PR TITLE
Prevents onWillTransition event from unnecessarily firing

### DIFF
--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -236,7 +236,9 @@ class TransitionGroup extends React.Component {
 			});
 		}
 
-		forwardOnWillTransition(null, this.props);
+		if (this.keysToEnter.length) {
+			forwardOnWillTransition(null, this.props);
+		}
 
 		// once the component has been updated, start the enter transition for new children,
 		const keysToEnter = this.keysToEnter;


### PR DESCRIPTION
Issue: ENYO-3747
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>

### Issue Resolved / Feature Added
Spotlight was at times being paused when there was no panels transition taking place - effectively making 5-way impossible when changing knob values in our samples.
