### PR TITLE
PLAT-32281 i18n: Investigate multiple loads 

### DIFF
--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -60,7 +60,8 @@ const IntlHoc = hoc((config, Wrapped) => {
 
 		constructor (props) {
 			super(props);
-			const locale = props.locale && props.locale !== ilib.locale ? updateLocale(props.locale) : ilib.locale;
+			const ilibLocale = ilib.getLocale();
+			const locale = props.locale && props.locale !== ilibLocale ? updateLocale(props.locale) : ilibLocale;
 
 			this.state = {
 				locale: locale

--- a/packages/i18n/src/locale.js
+++ b/packages/i18n/src/locale.js
@@ -109,11 +109,9 @@ function getI18nClasses () {
  * @returns {undefined}
  */
 const updateLocale = function (locale) {
-	// if there is a new locale, blow away the cache to force it to reload the manifest files for the new app
-	if (typeof locale !== 'undefined' && locale !== ilib.locale && ilib._load) {
-		// eslint-disable-next-line no-undefined
-		ilib._load.manifest = undefined;
-	}
+	// blow away the cache to force it to reload the manifest files for the new app
+	// eslint-disable-next-line no-undefined
+	if (ilib._load) ilib._load.manifest = undefined;
 	// ilib handles falsy values and automatically uses local locale when encountered which
 	// is expected and desired
 	ilib.setLocale(locale);


### PR DESCRIPTION
Added check so i18nDecorator and locale.js would only updateLocale when there is a new locale

### Issue Resolved / Feature Added
i18n: Investigate multiple loads.


### Resolution
Looks like `i18nDecorator` was calling `updateLocale` in it's constructor, which causes and ajax request. The locale is already set to pull from the system when we load up i18n the first time so we don't need to update anything or send for a request unless we explicitly need to change locales.

### Additional Considerations
I also made changes in `locale.js`. Currently if theres a call to `updateLocale` it will automatically make another ajax call whether the locale is new or not. So I've adjusted it to only update when there is a new locale to prevent unnecessary ajax calls. This may not be necessary for apps since there's a fix in `i18nDecorator`, but I left it in if somebody wants to use it outside of `i18nDecorator`.

### Links
https://jira2.lgsvl.com/browse/PLAT-32281

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com