### PR TITLE
Added Storybook Addon Options

### DIFF
--- a/packages/sampler/.qa-storybook/config.js
+++ b/packages/sampler/.qa-storybook/config.js
@@ -1,4 +1,16 @@
 import configure from '../src/configure';
+import { setOptions } from '@kadira/storybook-addon-options';
+
 const stories = require.context('../stories/qa-stories', true, /.js$/);
+
+setOptions({
+	name: 'ENACT SAMPLER',
+	url: 'http://nebula.lgsvl.com/enyojs/enact-docs/develop/',
+	goFullScreen: false,
+	showLeftPanel: true,
+	showDownPanel: true,
+	showSearchBox: false,
+	downPanelInRight: false,
+});
 
 configure(stories, module);

--- a/packages/sampler/.storybook/config.js
+++ b/packages/sampler/.storybook/config.js
@@ -1,9 +1,21 @@
 import perf from 'react-addons-perf';
 import configure from '../src/configure';
+import { setOptions } from '@kadira/storybook-addon-options';
+
 const stories = require.context('../stories/moonstone-stories', true, /.js$/);
 
 if (typeof window === 'object') {
 	window.ReactPerf = perf;
 }
+
+setOptions({
+	name: 'ENACT SAMPLER',
+	url: 'http://nebula.lgsvl.com/enyojs/enact-docs/develop/',
+	goFullScreen: false,
+	showLeftPanel: true,
+	showDownPanel: true,
+	showSearchBox: false,
+	downPanelInRight: false,
+});
 
 configure(stories, module);

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -48,6 +48,7 @@
     "@kadira/react-storybook-addon-info": "~3.3.0",
     "@kadira/storybook": "~2.34.0",
     "@kadira/storybook-addon-knobs": "~1.7.1",
+    "@kadira/storybook-addon-options": "^1.0.1",
     "react": "~15.4.0",
     "react-addons-perf": "~15.4.0",
     "react-dom": "~15.4.0",

--- a/packages/sampler/src/addons.js
+++ b/packages/sampler/src/addons.js
@@ -1,3 +1,5 @@
 import '@kadira/storybook/addons';
 import 'react-storybook-addon-backgrounds/register';
 import '@kadira/storybook-addon-knobs/register';
+import '@kadira/storybook-addon-options/register';
+


### PR DESCRIPTION
### Issue Resolved / Feature Added
Enact Sampler is not customized to link to our sites. 


### Resolution
Added [storybook-addon-options](https://github.com/storybooks/storybook-addon-options). This allows us to customize the text and link.

### Additional Considerations
Remember to run `npm run bootstrap` to install the new addon.

### Links
https://jira2.lgsvl.com/browse/PLAT-34142

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com