### PR TITLE
ENYO-3741: Picker fix Incorrect alignment with small width && vertical

### DIFF
--- a/packages/moonstone/Picker/Picker.less
+++ b/packages/moonstone/Picker/Picker.less
@@ -143,6 +143,12 @@
 	&.vertical .valueWrapper {
 		display: block;
 	}
+
+	&.vertical {
+		&.small .valueWrapper {
+			width: inherit;
+		}
+	}
 }
 
 [data-container-muted='true'] {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Picker Incorrect alignment with small width && vertical


### Resolution
Set the width to inherit for `valueWrapper` when picker is both vertical and small.


### Links
https://jira2.lgsvl.com/browse/ENYO-3741


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com