### PR TITLE
ENYO-3734: Fixes initial slider value

### DIFF
--- a/packages/moonstone/Slider/tests/SliderBase-specs.js
+++ b/packages/moonstone/Slider/tests/SliderBase-specs.js
@@ -29,7 +29,7 @@ describe('SliderBase Specs', () => {
 
 	it('Should set min on input', function () {
 		const sliderBase = mount(
-			<SliderBase backgroundPercent={50} min={50} value={50} />
+			<SliderBase min={50} value={50} />
 		);
 
 		const expected = 50;


### PR DESCRIPTION
Issue: ENYO-3734
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When initializing a slider component (`Slider` or `IncrementSlider`) with a non-zero value, the bar and knob do not appear in the correct position.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
A lifecycle method was added to update the UI for `componentDidMount`, to reflect any initialization values.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This issue was masked in Storybook, because the props are set after component mounting, which triggered the `componentWillReceiveProps` lifecycle method. Instead, this issue can be reproduced in rigby's sandbox.

Additionally, I took a look at making a fix in `SliderBar`, but the knob positioning relies on a node reference there anyways.

### Links
[//]: # (Related issues, references)


### Comments
