### PR TITLE
PLAT-26616: Create unit tests for CheckboxItem

### DIFF
--- a/packages/moonstone/CheckboxItem/tests/CheckboxItem-specs.js
+++ b/packages/moonstone/CheckboxItem/tests/CheckboxItem-specs.js
@@ -1,21 +1,20 @@
 
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import CheckboxItem from '../CheckboxItem';
 
 describe('CheckboxItem Specs', () => {
 
 	it('should always use the check icon', function () {
 
-		const checkbox = mount(
+		const checkbox = shallow(
 			<CheckboxItem>
 				Checkbox
 			</CheckboxItem>
 		);
-		const checkboxIcon = checkbox.text().split('').shift();
 
-		const expected = checkboxIcon;
-		const actual = '✓';
+		const expected = 'check';
+		const actual = checkbox.prop('icon');
 
 		expect(actual).to.equal(expected);
 	});


### PR DESCRIPTION
### Issue Resolved / Feature Added
 add CheckboxItem test

### Additional Considerations
CheckboxItem doesn't expect an `iconClass` prop, so I am not sure if 

> "should generate custom iconClasses"

 is within the scope of CheckboxItem; although ToggleItem does take `iconClass`.


### Links
https://jira2.lgsvl.com/browse/PLAT-26616


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com