### PR TITLE
ENYO-3768: Add keymap for VirtualList and VirtualFlexList

### DIFF
--- a/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
+++ b/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
@@ -6,6 +6,7 @@
 
 import React, {Component, PropTypes} from 'react';
 
+import {is} from '@enact/core/keymap';
 import {Spotlight, SpotlightContainerDecorator} from '@enact/spotlight';
 
 import Positionable from './Positionable';
@@ -14,10 +15,10 @@ const
 	dataContainerDisabledAttribute = 'data-container-disabled',
 	dataContainerIdAttribute = 'data-container-id',
 	dataIndexAttribute = 'data-index',
-	keyLeft	 = 37,
-	keyUp	 = 38,
-	keyRight = 39,
-	keyDown	 = 40;
+	isDown = is('down'),
+	isLeft = is('left'),
+	isRight = is('right'),
+	isUp = is('up');
 
 /**
  * The shape for {@link moonstone/VirtualFlexList.dataSize}
@@ -688,10 +689,10 @@ class VirtualFlexListCore extends Component {
 		let isSelfOnly = false;
 
 		if (this.props.flexAxis === 'row') {
-			if (keyCode === keyUp && canMoveBackward || keyCode === keyDown && canMoveForward) {
+			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
 				isSelfOnly = true;
 			}
-		} else if (keyCode === keyLeft && canMoveBackward || keyCode === keyRight && canMoveForward) {
+		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
 			isSelfOnly = true;
 		}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,6 +7,7 @@
 
 import React, {Component, PropTypes} from 'react';
 
+import {is} from '@enact/core/keymap';
 import {Spotlight, SpotlightContainerDecorator} from '@enact/spotlight';
 import {contextTypes} from '@enact/i18n/I18nDecorator';
 
@@ -15,10 +16,10 @@ import {dataIndexAttribute, Scrollable} from '../Scroller/Scrollable';
 const
 	dataContainerMutedAttribute = 'data-container-muted',
 	dataContainerIdAttribute = 'data-container-id',
-	keyLeft	 = 37,
-	keyUp	 = 38,
-	keyRight = 39,
-	keyDown	 = 40,
+	isDown = is('down'),
+	isLeft = is('left'),
+	isRight = is('right'),
+	isUp = is('up'),
 	nop = () => {};
 
 /**
@@ -624,10 +625,10 @@ class VirtualListCore extends Component {
 		let isSelfOnly = false;
 
 		if (isPrimaryDirectionVertical) {
-			if (keyCode === keyUp && canMoveBackward || keyCode === keyDown && canMoveForward) {
+			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
 				isSelfOnly = true;
 			}
-		} else if (keyCode === keyLeft && canMoveBackward || keyCode === keyRight && canMoveForward) {
+		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
 			isSelfOnly = true;
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Needed to apply `@enact/core/keymap` to `VirtualList` and `VirtualFlexList`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I replaced 
```
keyLeft	 = 37
keyUp	 = 38
keyRight = 39
keyDown	 = 40
```
with
```
isDown = is('down')
isLeft = is('left')
isRight = is('right')
isUp = is('up')
```

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3768

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)