### PR TITLE
ENYO-3787: Check 'center' anchor type in RTL adjustment.

### DIFF
--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -200,12 +200,12 @@ const TooltipDecorator = hoc((config, Wrapped) => {
 		}
 
 		adjustAnchor (arrowAnchor, tooltipDirection, overflow) {
-			if (this.context.rtl && arrowAnchor !== 'center' && (tooltipDirection === 'above' || tooltipDirection === 'below')) {
-				arrowAnchor = arrowAnchor === 'left' ? 'right' : 'left';
-			}
-
-			// Flip sideways for 'above' and 'below' if it overflows to the sides
 			if (tooltipDirection === 'above' || tooltipDirection === 'below') {
+				if (this.context.rtl && arrowAnchor !== 'center') {
+					arrowAnchor = arrowAnchor === 'left' ? 'right' : 'left';
+				}
+
+				// Flip sideways if it overflows to the sides
 				if (overflow.isOverRight) {
 					arrowAnchor = 'left';
 				} else if (overflow.isOverLeft) {


### PR DESCRIPTION

### Issue Resolved / Feature Added
When locale set to RTL, tooltip type change from 'above center' to 'above left'


### Resolution
Insert check condition in adjust anchor function


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
http://jira2.lgsvl.com/browse/ENYO-3783


### Comments

Enact-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>