### PR TITLE
ENYO-3744: Fix ExpandableInput value not saved on clicking the title

### DIFF
--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -125,6 +125,10 @@ class ExpandableInputBase extends React.Component {
 		// if the contained <input> has focus, prevent onClicks so that clicking on the LabeledItem
 		// doesn't open the expandable immediately after blurring the <input> closed it.
 		if (ev.currentTarget.contains(document.activeElement)) {
+			if (this.props.open) {
+				const {onChange, value} = this.props;
+				onChange({value});
+			}
 			ev.preventDefault();
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix ExpandableInput value not saved on clicking the title

### Resolution
added onChange to handleMouseDown.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3744

### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)