### PR TITLE
Fix invoking false onSuccess callback

### DIFF
--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -73,8 +73,10 @@ export default class LS2Request {
 			};
 		}
 
-		if ((parsedMsg.errorCode || parsedMsg.returnValue === false) && onFailure) {
-			onFailure(parsedMsg);
+		if ((parsedMsg.errorCode || parsedMsg.returnValue === false)) {
+			if (onFailure) {
+				onFailure(parsedMsg);
+			}
 		} else if (onSuccess) {
 			onSuccess(parsedMsg);
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Prevent `onSuccess` being invoked when `returnValue` is `false` and `onFailure` not specified

### Comments

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
