### PR TITLE
ENYO-3664: Fix item size is not changed

### DIFF
--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -42,7 +42,7 @@ storiesOf('VirtualList')
 		' ',
 		'Basic usage of VirtualList',
 		() => {
-			const itemSize = ri.scale(number('item.size', 72));
+			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<VirtualList
 					data={items}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The spotlight size does not change depending on the item size.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Item has fixed height style value, so item height is not changed.
I applied item size value to height style of Item.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This PR branch is based on https://jira2.lgsvl.com/browse/PLAT-31256.

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3664

### Comments

Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>