### PR TITLE
PLAT-33926: Gain focus properly from another container in VirtualFlexList

### DIFF
--- a/packages/moonstone/VirtualFlexList/VirtualFlexList.js
+++ b/packages/moonstone/VirtualFlexList/VirtualFlexList.js
@@ -21,7 +21,7 @@ import css from './VirtualFlexList.less';
 
 const
 	PositionableVirtualList = Positionable(VirtualListCore),
-	SpotlightPositionableVirtualList = SpotlightContainerDecorator({enterTo: 'default-element'}, Positionable(VirtualListCore));
+	SpotlightPositionableVirtualList = SpotlightContainerDecorator({enterTo: ''}, Positionable(VirtualListCore));
 
 const forwardPositionChange = forward('onPositionChange');
 

--- a/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
+++ b/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
@@ -807,7 +807,7 @@ class VirtualFlexListCore extends Component {
  * @ui
  * @public
  */
-const VirtualFlexListBase = SpotlightContainerDecorator({enterTo: 'default-element'}, Positionable(VirtualFlexListCore));
+const VirtualFlexListBase = SpotlightContainerDecorator({enterTo: ''}, Positionable(VirtualFlexListCore));
 
 export default VirtualFlexListBase;
 export {VirtualFlexListBase};


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: YB Sung (yb.sung@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When moving focus with 5-way key from items to a row header, the last focused item in the header got focus instead of the nearest to the previous focused item in the items.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The default `enterTo` value in `Spotlight` container is not `default-element` but `last-focused`. So the nearest item from the previous item could not get focus. So I changed the value of `enterTo`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

https://jira2.lgsvl.com/browse/PLAT-33926

### Comments
