### PR TITLE
ENYO-3796: Remove the cache of the platform name to allow transition between sna…

### DIFF
--- a/packages/i18n/src/locale.js
+++ b/packages/i18n/src/locale.js
@@ -112,6 +112,8 @@ const updateLocale = function (locale) {
 	// blow away the cache to force it to reload the manifest files for the new app
 	// eslint-disable-next-line no-undefined
 	if (ilib._load) ilib._load.manifest = undefined;
+	// remove the cache of the platform name to allow transition between snapshot and browser
+	delete ilib._platform;
 	// ilib handles falsy values and automatically uses local locale when encountered which
 	// is expected and desired
 	ilib.setLocale(locale);


### PR DESCRIPTION
…pshot and browser

### Issue Resolved / Feature Added
* Platform name not being reset when locale data is reloaded. Causes iLib to think it's running in nodejs rather than browser when started via snapshot.


### Resolution
* Removes the `_platform` string property cache as part of `updateLocale()`

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>