### PR TITLE
ENYO-3556: Marquee Stops when MarqueeDelay is Set to Zero

### DIFF
--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -433,7 +433,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		resetAnimation = () => {
-			let marqueeResetDelay = Math.max(40, this.props.marqueeResetDelay);
+			const marqueeResetDelay = Math.max(40, this.props.marqueeResetDelay);
 			this.setTimeout(this.restartAnimation, marqueeResetDelay);
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Marquee Stops when MarqueeDelay is Set to Zero


### Resolution
While translate using CSS if the translation starts without any delay, this may cause issues as the browser preventing the transition for optimization. The solution is to have minDelay before resetting.

### Additional Considerations
minDelay is set 40 as when tested, 30 was the minimum requirement so as a safer side gave 40 to minDelay

### Links
https://jira2.lgsvl.com/browse/ENYO-3556

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)