### PR TITLE
ENYO-3740: Enable to move to 0 when it's not scrollable

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -551,10 +551,14 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					if (canScrollHorizontally) {
 						// We need '!=' to check if opt.potision.x is null or undefined
 						left = opt.position.x != null ? opt.position.x : this.scrollLeft;
+					} else {
+						left = 0;
 					}
 					if (canScrollVertically) {
 						// We need '!=' to check if opt.potision.y is null or undefined
 						top = opt.position.y != null ? opt.position.y : this.scrollTop;
+					} else {
+						top = 0;
 					}
 				} else if (typeof opt.align === 'string') {
 					if (canScrollHorizontally) {


### PR DESCRIPTION
To fix top of viewport gets truncated when dataSize is changed to a small value
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed top of viewport gets truncated when dataSize is changed to a small value

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The problem of seeing truncated viewport when dataSize is changed to a small value was that while updating `scrollBounds` information due to dataSize changing, VirtualList called `scrollTo` method in Scrollable to sync current scrollPosition based on updated `scrollBounds` but in the method, we had a guard code for when Scrollable has no scrollability and due to this guard code, we couldn't move to 0 position. To remedy this, we added making left or top value to 0 when Scrollable has no scrollability. If Scrollable cannot scroll vertically, maxTop would be 0 and in horizontal case, maxLeft would be 0. So making scrollLeft and scrollTop values to 0 in no scrollability would be no issue.


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3740

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)