### PR TITLE
Set default visibility of scrollbars to false

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -18,6 +18,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ProgressBar` properties `progress` and `backgroundProgress` to accept a number between 0 and 1.
 - `moonstone/Slider` and `moonstone/IncrementSlider` property `backgroundPercent` to `backgroundProgress` which now accepts a number between 0 and 1
 - `moonstone/Slider` to not ignore `value` prop when it is the same as the previous value
+- `moonstone/Scrollable` to not display scrollbar controls by default.
 
 ### Removed
 

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -189,8 +189,8 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			super(props);
 
 			this.state = {
-				isHorizontalScrollbarVisible: true,
-				isVerticalScrollbarVisible: true
+				isHorizontalScrollbarVisible: false,
+				isVerticalScrollbarVisible: false
 			};
 
 			this.initChildRef = this.initRef('childRef');


### PR DESCRIPTION
### Issue Resolved / Feature Added
When an app using Scroller is prerendered you'll see scrollbar controls even at first even if they don't need to be shown.

### Resolution
I set them both to false, after discussion this morning. So now scroller controls will show up after everything is interactive and won't show on very first paints.


### Additional Considerations
We could make this a prop to scrollable and let the developer decide, but I'm not sure we want to rely on developers to so these sorts of things.


### Links
https://jira2.lgsvl.com/browse/ENYO-3752

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com