### PR TITLE
ENYO-3779: Enact Button(RTL): Short Text Does Not Center inside Butto…

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -75,6 +75,7 @@
 
 	.marquee {
 		flex-grow: 1;
+		text-align: center;
 	}
 
 	.client {


### PR DESCRIPTION
…n of RTL Layout

### Issue Resolved / Feature Added
Enact Button(RTL): Short Text Does Not Center inside Button of RTL Layout

### Resolution
- Added css in Button.less 'text-align: center'
### Additional Considerations
non

### Links
https://jira2.lgsvl.com/browse/ENYO-3779

### Comments
Enyo-DCO-1.1-Signed-off-by:Richa Shaurbh richa.shaurbh@lge.com