### PR TITLE
ENYO-3775: Directly applied RTL on the title component.

### DIFF
--- a/packages/moonstone/LabeledItem/LabeledItem.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.less
@@ -24,6 +24,10 @@
 		.icon {
 			margin-bottom: 0;
 		}
+
+		:global(.enact-locale-right-to-left) & {
+			direction: rtl;
+		}
 	}
 
 	// Text


### PR DESCRIPTION
The title isn’t receiving the correct direction because it’s wrapped inside a marquee. The Marquee can’t assign a direction because it can’t easily determine whether the content is RTL or LTR, so it applies nothing, which means the RTL content inside that has the `inherit` direction, inherits the wrong direction: LTR. Forcibly setting RTL corrects this and matches the other correctly RTL’d marquees around it.
This also corrects Marqueeing of RTL content to flow in the expected direction.