### PR TITLE
ENYO-3741: Picker vertical & small alignment fix

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -41,6 +41,8 @@
 
 	.valueWrapper {
 		overflow: hidden;
+		margin-left: auto;
+		margin-right: auto;
 		vertical-align: bottom;
 		color: inherit;
 	}
@@ -143,13 +145,6 @@
 	&.vertical .valueWrapper {
 		display: block;
 	}
-
-	&.vertical {
-  		&.small .valueWrapper {
-			margin-left: auto;
-			margin-right: auto;
-  		}
-  	}
 }
 
 [data-container-muted='true'] {


### PR DESCRIPTION
### Issue Resolved / Feature Added
When `Picker`/`RangePicker` is set to `vertical` and `small`: picker content is left-aligned
Fix: center align content

### Links
https://jira2.lgsvl.com/browse/ENYO-3741
https://github.com/enyojs/enact/pull/408


### Comments
Reimplementing fix
