### PR TITLE
ENYO-3759: Enact QA Marquee: Changing Speed causes Synchronized Marquee Not to Restart

### DIFF
--- a/packages/moonstone/Marquee/MarqueeController.js
+++ b/packages/moonstone/Marquee/MarqueeController.js
@@ -181,7 +181,7 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		/*
+		/**
 		 * Handler for the focus event
 		 */
 		handleFocus = (ev) => {
@@ -189,7 +189,7 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 			forwardFocus(ev, this.props);
 		}
 
-		/*
+		/**
 		 * Handler for the blur event
 		 */
 		handleBlur = (ev) => {

--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -236,6 +236,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.cancelAnimation();
 			} else if (next.marqueeOn !== marqueeOn || next.marqueeDisabled !== marqueeDisabled || next.marqueeSpeed !== marqueeSpeed) {
 				this.cancelAnimation();
+				if (next.marqueeSpeed !== marqueeSpeed && this.sync) {
+					this.startAnimation(this.props.marqueeDelay);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
restart synchronized marquee if marqueeDelay is changed

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I tried various combinations of `stop()`/`start()` (with and without context scope) and other decorator methods like `restartAnimation` but this is the only thing that works...mostly, see below.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In some tests, going back to the original value (60 is the default) resulted in none of the marquees animating.  Changing to the test value (600) again or any other value causes them to start, and then back to the default starts working.

Question: would it be better to handle this in `MarqueeController` instead and the preferred way to do that?


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3759


Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)