### PR TITLE
PLAT-35312: Investigate and implement caching of ilib locale data

### DIFF
--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -25,14 +25,11 @@ const get = (url, callback) => {
 	}
 };
 
-const iLibBase = (typeof ILIB_BASE_PATH !== 'undefined') ?
-		ILIB_BASE_PATH : 'node_modules/@enact/i18n/ilib/locale';
-const iLibResources = (typeof ILIB_RESOURCES_PATH !== 'undefined') ?
-		ILIB_RESOURCES_PATH : 'resources';
+const iLibBase = ILIB_BASE_PATH;
+const iLibResources = ILIB_RESOURCES_PATH;
 const cachePrefix = 'ENACT-ILIB-';
 const cacheKey = cachePrefix + 'CACHE-ID';
-const cacheID = (typeof ILIB_CACHE_ID !== 'undefined') ?
-		ILIB_CACHE_ID : null;
+const cacheID = ILIB_CACHE_ID;
 
 function EnyoLoader () {
 	this.base = iLibBase;
@@ -165,7 +162,7 @@ EnyoLoader.prototype._storeFilesCache = function (paths, data) {
 };
 
 EnyoLoader.prototype._validateCache = function () {
-	if (typeof window !== 'undefined' && window.localStorage) {
+	if (typeof window !== 'undefined' && window.localStoragez) {
 		let activeID = window.localStorage.getItem(cacheKey);
 		if (activeID !== cacheID) {
 			for (let i = 0; i < window.localStorage.length; i++) {


### PR DESCRIPTION
### Requires
https://github.com/enyojs/ilib-webpack-plugin/pull/1
https://github.com/enyojs/enact-dev/pull/46

### Issue Resolved / Feature Added
* Switch from ilib-loader usage of iLib to an ILibPlugin.
* Cache iLib fetched data to improve launch times.

### Resolution
* Uses global constants (will fallbacks) to allow ILibPlugin to rewrite and dynamically configure iLib as desired.
* Caches to localeStorage as needed.

### Additional Considerations
* Cache is reset whenever locale is different for requested files and entirely reset when compilation-set unique cache ID has changed.
* Cache on webOS apps is separate per-app, so no issues there either.

### Links
* https://jira2.lgsvl.com/browse/PLAT-35312

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>