### PR TITLE
Switches panel type

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -3,7 +3,7 @@
 import kind from '@enact/core/kind';
 import React, {PropTypes} from 'react';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
-import {ActivityPanels as Panels, Panel, Header} from '@enact/moonstone/Panels';
+import {Panels, Panel, Header} from '@enact/moonstone/Panels';
 import {select} from '@kadira/storybook-addon-knobs';
 
 import css from './MoonstoneEnvironment.less';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There were some side effects with `clip-path` in `ActivityPanels` and Chrome 55.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We can probably just use standard `Panels` anyways, so switching to that for the samples.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Didn't notice any side effects to this. Potentially, could be hiding the Chrome 55 bug by doing this.

### Links
[//]: # (Related issues, references)


### Comments
