### PR TITLE
ENYO-3759: Force restart of synced marquees on prop change

### DIFF
--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -211,6 +211,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				overflow: 'ellipsis'
 			};
 			this.sync = false;
+			this.forceRestartMarquee = false;
 
 			this.invalidateMetrics();
 		}
@@ -243,6 +244,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.shouldStartMarquee()) {
 				this.startAnimation(this.props.marqueeDelay);
 			}
+			this.forceRestartMarquee = false;
 		}
 
 		componentWillUnmount () {
@@ -287,7 +289,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 */
 		shouldStartMarquee () {
 			return (
-				!this.sync && (
+				// restart un-synced marquees or marqueeOn="render" synced marquees that were
+				// cancelled due to a prop change
+				(!this.sync || this.forceRestartMarquee) && (
 					this.props.marqueeOn === 'render' ||
 					(this.isFocused && this.props.marqueeOn === 'focus') ||
 					(this.isHovered && this.props.marqueeOn === 'hover')
@@ -446,6 +450,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 */
 		cancelAnimation = () => {
 			if (this.sync) {
+				this.forceRestartMarquee = true;
 				this.context.cancel(this);
 			}
 


### PR DESCRIPTION
The cause here is that `sync` -ed Marquees do not restart (`shouldStartMarquee()` returns false when sync is true) when updating because they need to wait for the controller to queue them to start. So when you update a marquee prop, it calls `cancelAnimation` which stops all the synced Marquees but they don't restart because they're synced. I think we'll have to add a forced restart flag for those two conditions in `componentWillReceiveProps` that call `cancelAnimation`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)