### PR TITLE
ENYO-3800: Check if children have changed before updating TransitionGroup

### DIFF
--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -5,6 +5,7 @@
 // Using string refs from the source code of ReactTransitionGroup
 /* eslint-disable react/no-string-refs */
 
+import {childrenEquals} from '@enact/core/util';
 import compose from 'ramda/src/compose';
 import eqBy from 'ramda/src/eqBy';
 import findIndex from 'ramda/src/findIndex';
@@ -185,19 +186,22 @@ class TransitionGroup extends React.Component {
 	}
 
 	componentWillReceiveProps (nextProps) {
-		const nextChildMapping = mapChildren(nextProps.children);
-		const prevChildMapping = this.state.children;
-		let children = mergeChildren(nextChildMapping, prevChildMapping);
+		// Avoid an unnecessary setState and reconcileChildren if the children haven't changed
+		if (!childrenEquals(this.props.children, nextProps.children)) {
+			const nextChildMapping = mapChildren(nextProps.children);
+			const prevChildMapping = this.state.children;
+			let children = mergeChildren(nextChildMapping, prevChildMapping);
 
-		// drop children exceeding allowed size
-		const drop = children.length - nextProps.size;
-		const dropped = drop > 0 ? children.splice(drop) : null;
+			// drop children exceeding allowed size
+			const drop = children.length - nextProps.size;
+			const dropped = drop > 0 ? children.splice(drop) : null;
 
-		this.setState({
-			children
-		}, () => {
-			this.reconcileChildren(dropped, prevChildMapping, nextChildMapping);
-		});
+			this.setState({
+				children
+			}, () => {
+				this.reconcileChildren(dropped, prevChildMapping, nextChildMapping);
+			});
+		}
 	}
 
 	reconcileChildren (dropped, prevChildMapping, nextChildMapping) {


### PR DESCRIPTION
Multiple `reconcileChildren` calls within the same update cycle cause
some odd transition behavior where a view can re-transition. Guarding
the call `setState` and thereby `reconcileChildren` avoids this.

May need to investigate moving this logic into a function called by
setState and defer the reconcilation to `componentWillUpdate`. That
requires a bit more investigation but this `childrenEquals()` is likely
useful either way and resolves this bug.

Note that I didn't prevent clicking the breadcrumb. If we want that
behavior, I'd like to handle that under another ticket specific to
that purpose since it's a design choice and not a bug fix.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)