### PR TITLE
ENYO:3788-Popup Unexpectedly Switches Left/Right Direction

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -260,13 +260,13 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		adjustDirection () {
-			if (this.overflow.isOverTop && this.adjustedDirection === 'up') {
+			if (this.overflow.isOverTop && !this.overflow.isOverBottom && this.adjustedDirection === 'up') {
 				this.adjustedDirection = 'down';
-			} else if (this.overflow.isOverBottom && this.adjustedDirection === 'down') {
+			} else if (this.overflow.isOverBottom && !this.overflow.isOverTop && this.adjustedDirection === 'down') {
 				this.adjustedDirection = 'up';
-			} else if (this.overflow.isOverLeft && this.adjustedDirection === 'left') {
+			} else if (this.overflow.isOverLeft && !this.overflow.isOverRight && this.adjustedDirection === 'left') {
 				this.adjustedDirection = 'right';
-			} else if (this.overflow.isOverRight && this.adjustedDirection === 'right') {
+			} else if (this.overflow.isOverRight && !this.overflow.isOverLeft && this.adjustedDirection === 'right') {
 				this.adjustedDirection = 'left';
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Enact QA ContextualPopup: Popup Unexpectedly Switches Left/Right Direction

### Resolution
The issue is because of the adjustDirection() in the ContextualPopupDecorator where the adjustedDirection= 'left' and not have enough 'left' space for popup, it will set adjustedDirection= 'right', so the popup moves to right side, same case of right direction. ultimate result is switching between the directions.

One more checking, when the adjustedDirection= 'left' and overflow in left side , then check for !this.overflow.isOverRight then only move to right direction will solve the issue

### Additional Considerations
The checking of opposite direction also implemented for all direction cases

### Links
https://jira2.lgsvl.com/browse/ENYO-3788

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)