### PR TITLE
ENYO-3817: Prevent blurring input when clicking the decorator

### DIFF
--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -139,7 +139,9 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 						this.focusDecorator(ev.currentTarget);
 						ev.stopPropagation();
 					}
-				} if (!this.state.focused === 'input') {	// Blurring decorator but not focusing input
+				} else if (!ev.currentTarget.contains(ev.relatedTarget)) {
+					// Blurring decorator but not focusing input
+					forwardBlur(ev, this.props);
 					this.blur();
 				}
 			} else if (this.state.focused === 'input' && this.state.node === ev.target) {


### PR DESCRIPTION
Prevent the blur from propagating when clicking on the decorator when
the input was focused and allow it to be refocused on update.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)