### PR TITLE
ENYO-3781: Enact VideoPlayer: Long Title Does Not Marquee

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.less
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.less
@@ -42,6 +42,7 @@
 					flex-grow: 1;
 					color: @moon-video-player-title-color;
 					opacity: 1;
+					overflow: hidden;
 					.margin-start-end(0, @moon-spotlight-outset);
 
 					&.hidden {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added `overflow: hidden;` to `.titleFrame` class. (thanks @Djspaceg !) 

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3781

### Comments

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)