### PR TITLE
ENYO-3782: Add stay arrangement for ActivityPanels

### DIFF
--- a/packages/moonstone/Panels/Arrangers.js
+++ b/packages/moonstone/Panels/Arrangers.js
@@ -82,5 +82,8 @@ const offsetForBreadcrumbs = ({node}) => {
  */
 export const ActivityArranger = {
 	enter: compose(panelEnter, reverse(offsetForBreadcrumbs)),
-	leave: compose(panelLeave, offsetForBreadcrumbs)
+	leave: compose(panelLeave, offsetForBreadcrumbs),
+	// Need a stay arrangement in case the initial index for ActivityPanels is > 0 so the panel is
+	// correctly offset for the breadcrumbs.
+	stay: offsetForBreadcrumbs
 };


### PR DESCRIPTION
Only need to account for breadcrumb positioning and not panel
positioning because stay is only used on appear so a panel doesn't need
to transition from one place in the viewport to another in the
viewport (like a Breadcrumb does).

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)