### PR TITLE
ENYO-3827: Fix spotlight key-hold behavior

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight.Spotlight` 5-way behavior where selecting a spottable component may require multiple attempts before performing actions
+
 ## [1.0.0-beta.2] - 2017-01-30
 
 ### Added

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -930,7 +930,7 @@ const Spotlight = (function() {
 	function onKeyUp (evt) {
 		const keyCode = evt.keyCode;
 
-		if (!shouldPreventNavigation() && getDirection(keyCode)) {
+		if (getDirection(keyCode) || isEnter(keyCode)) {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
It sometimes takes multiple presses for spottable components to perform actions. This is most often noticed in a `Panels` or `Popup` scenario.


### Resolution
There is an incorrect spotlight behavior where an `onKeyUp` event may not cause spotlight to flip an internal key-hold flag.

I'm removing the `onKeyUp` check to `shouldPreventNavigation()` before performing actions. This checks the status of spotlight (ensuring it's active and *not* paused) before performing actions. This is needed for most other events/actions (such as `onKeyDown`) but it is not needed here, as any `onKeyUp` event should perform the actions listed - as they simply reset default values. These `onKeyUp` actions should always be performed, as an `onKeyDown` event could ultimately call `Spotlight.pause()` (as it does in `Panels` and `Popup`, where animations are present) and we need the actions in the `onKeyUp` event to happen regardless.

The `_5WayKeyHold` variable should be set to `false` during the `onKeyUp` event if the `keyCode` represents any of the 5-way navigation buttons (up, down, left, right, enter) - as that variable's value is set to `true` due to pressing any of the same 5-way navigation buttons.


### Links
There have been a few historical code changes that initially caused this issue - and even the original code had a slight flaw:
https://github.com/enyojs/enact/commit/96cbc63b6e111d41876b4c89c5b3afc35bb682e5#diff-a002b4a8b41d557d6def26ed13a91d61R933

https://github.com/enyojs/enact/commit/c3761318a803b4f4d759d77d3764f6a0473b88ad
https://github.com/enyojs/enact/commit/f6a9e9e1e7ed8dbe61d64aa7c7721db2b079fca5

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>