### PR TITLE
ENYO-3716: Set active to container to parent container on mouse out

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -190,7 +190,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleMouseLeave = (ev) => {
-			const parentContainer = ev.currentTarget.closest('[data-container-id]');
+			const parentContainer = ev.currentTarget.parentNode.closest('[data-container-id]');
 			const activeContainer = parentContainer ? parentContainer.dataset.containerId : null;
 			Spotlight.setActiveContainer(activeContainer);
 			forwardMouseLeave(ev, this.props);


### PR DESCRIPTION
The last container was being reset to the root when leaving any
container (the Expandable contents in this case) instead of being reset
to the next container up the tree.

The proposed solution walks up the DOM tree to find the next container
and sets that (or null if none was found) as the active container when
leaving a container.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)