### PR TITLE
ENYO-3826: Unable to Set Index Order in Enact Picker QA sample

### DIFF
--- a/packages/sampler/stories/qa-stories/components/PickerAddRemove/PickerAddRemove.js
+++ b/packages/sampler/stories/qa-stories/components/PickerAddRemove/PickerAddRemove.js
@@ -47,7 +47,7 @@ class PickerAddRemove extends React.Component {
 	handleAddReplace = () => {
 		const children = this.state.children,
 			index = this.index,
-			value = this.value || 'sample' + this.index,
+			value = this.value || 'sample' + index,
 			newChild = {};
 
 		newChild[index] = value;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Steps To Reproduce: 
1. http://nebula.lgsvl.com/enyojs/enact-qa-sampler/develop/
2. Picker > with item add/remove
3. In the 'index' input, input '0'
In the 'value' input '0' 
and click on the 'Add' button. 
4. In the 'index' input, input '5'
In the 'value' input '5' 
and click on the 'Add' button. 
5. In the 'index' input, input '3'
In the 'value' input '3' 
and click on the 'Add' button.
Expected Result: Index 3 should display ahead of Index 5.
Actual Result: Index 5 unexpectedly displays ahead of Index 3.
NOTE: Adding additional indexes after the steps above, work as expected.

### Resolution
Replace children array with map.
Using an object map automatically sorts the indices for children.

### Additional Considerations
In the QA sample:
- Adding a value to existing index will replace the value for that index.
- Calling `this.setState()` in `PickerAddRemove` won't update the currently shown value of the `statefulPicker`.

### Links
https://jira2.lgsvl.com/browse/ENYO-3826
