### PR TITLE
Added knob to add scroller for taller samples

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -4,7 +4,7 @@ import kind from '@enact/core/kind';
 import React, {PropTypes} from 'react';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {Panels, Panel, Header} from '@enact/moonstone/Panels';
-import {select} from '@kadira/storybook-addon-knobs';
+import {select, boolean} from '@kadira/storybook-addon-knobs';
 
 import css from './MoonstoneEnvironment.less';
 
@@ -29,7 +29,7 @@ const PanelsBase = kind({
 	render: ({children, title, description, ...rest}) => (
 		<div {...rest}>
 			<Panels onApplicationClose={reloadPage}>
-				<Panel>
+				<Panel style={boolean('Scroll On', false) ? {overflow: 'auto'} : null}>
 					<Header type="compact" title={title} preserveCase />
 					<div className={css.description}>
 						<p>{description}</p>


### PR DESCRIPTION
### Issue Resolved / Feature Added
VideoPlayer by default was too big for the sampler, which made it hard to view the controls.


### Resolution
Added a knob for `Scroll On` so the user can scroll if the sample is too big (e.g VideoPlayer)


### Additional Considerations
Looks like there's a problem with storybook or the knobs plugin. When you toggle this one and off the knob will disappear but it will set the correct scroller. It seems to also affect the locale knob. 

### Links
ENYO-3765

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com