### PR TITLE
Key-Value usage of $L returns '[object Object]' in non-localized scenarios

### DIFF
--- a/packages/i18n/src/$L.js
+++ b/packages/i18n/src/$L.js
@@ -41,17 +41,13 @@ function createResBundle (locale) {
  * @returns {ilib.IString} The translated string
  */
 function toIString (str) {
-	if (typeof window === 'object') {
-		const rb = getResBundle();
-		const isObject = typeof str === 'object';
-		if (rb) {
-			return isObject ? rb.getString(str.value, str.key) : rb.getString(str);
-		}
-
-		return new IString(isObject ? str.value : str);
+	const rb = getResBundle();
+	const isObject = typeof str === 'object';
+	if (rb) {
+		return isObject ? rb.getString(str.value, str.key) : rb.getString(str);
 	}
 
-	return String(str);
+	return new IString(isObject ? str.value : str);
 }
 
 /**
@@ -62,11 +58,7 @@ function toIString (str) {
  * @returns {String} The translated string.
  */
 function $L (str) {
-	if (typeof window === 'object') {
-		return String(toIString(str));
-	}
-
-	return String(str);
+	return String(toIString(str));
 }
 
 /**


### PR DESCRIPTION
### Issue Resolved / Feature Added
* In a locale-less environment (snapshot or prerender prior to app loading), the output from key-value objects is `[object Object]`

### Resolution
* Since we already guard XHR, we can remove `window` guards around `$L()`
* When the argument to `$L()` is an object the fallback should be able to return obj.value.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>