### PR TITLE
ENYO-3853: Holdable - cancel mouse hold on keypress

### DIFF
--- a/packages/ui/Holdable/Holdable.js
+++ b/packages/ui/Holdable/Holdable.js
@@ -182,8 +182,8 @@ const HoldableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			this.keyEvent = false;
 		}
 
-		componentWillReceiveProps () {
-			if (this.props.disabled) {
+		componentWillReceiveProps (nextProps) {
+			if (nextProps.disabled) {
 				this.endHold();
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
When using Holdable and selecting and holding with the pointer, the hold does not end when a 5-way key is pressed, even though focus changes.


### Resolution
Cancel hold on keypress if there is a `holdJob`.


### Additional Considerations
Works for `IncrementSlider` and regular `Picker` but not joined `Picker` — because in joined `Picker`, `Holdable(PickerButton)` does not receive any keypress events.

### Links
https://jira2.lgsvl.com/browse/ENYO-3853


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com