### PR TITLE
Add guard to mousemove

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 - `spotlight.Spotlight` behavior to follow container config rules when navigating between containers
 - `spotlight.Spotlight` behavior to not set focus on spottable components animating past the pointer when not in pointer-mode
 - `spotlight.Spotlight` 5-way behavior where selecting a spottable component may require multiple attempts before performing actions
+- `spotlight.Spotlight` to not unfocus elements on scroll
 
 ## [1.0.0-beta.2] - 2017-01-30
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -1008,6 +1008,11 @@ const Spotlight = (function() {
 	}
 
 	function onMouseMove (evt) {
+		// Chrome emits mousemove on scroll, but client coordinates do not change.
+		if (!_pointerMode && (evt.clientX === _pointerX) && (evt.clientY === _pointerY)) {
+			return;
+		}
+
 		_pointerMode = true;
 
 		// cache last-known pointer coordinates


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When scrolling occurs, the spotted element would be unspotted. The cause was Chrome sending
a `mousemove` event despite the mouse not moving. Added a guard to prevent switching to pointer
mode if the client mouse position did not change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The guard should have minimal impact on spotlight performance

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-3820

### Comments
