### PR TITLE
PLAT-35478: a11y support for Image and Spinner

### DIFF
--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -99,7 +99,7 @@ const ImageBase = kind({
 		delete rest.sizing;
 
 		return (
-			<div {...rest} style={{...style, backgroundImage: bgImage}} />
+			<div role="img" {...rest} style={{...style, backgroundImage: bgImage}} />
 		);
 	}
 });

--- a/packages/moonstone/Image/tests/Image-specs.js
+++ b/packages/moonstone/Image/tests/Image-specs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import Image from '../Image';
 import css from '../Image.less';
 
@@ -43,4 +43,15 @@ describe('Image Specs', () => {
 		expect(actual).to.equal(expected);
 	});
 
+
+	it('should set role to img by default', function () {
+		const image = shallow(
+			<Image src={src} sizing="fit" />
+		);
+
+		const expected = 'img';
+		const actual = image.prop('role');
+
+		expect(actual).to.equal(expected);
+	});
 });

--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -88,7 +88,7 @@ const SpinnerBase = kind({
 		delete rest.transparent;
 
 		return (
-			<div {...rest}>
+			<div aria-live="off" role="alert" {...rest}>
 				<div className={css.ballDecorator}>
 					<div className={`${css.ball} ${css.ball1}`} />
 					<div className={`${css.ball} ${css.ball2}`} />

--- a/packages/moonstone/Spinner/tests/Spinner-specs.js
+++ b/packages/moonstone/Spinner/tests/Spinner-specs.js
@@ -77,4 +77,26 @@ describe('Spinner Specs', () => {
 
 		expect(actual).to.equal(expected);
 	});
+
+	it('should set role to alert by default', function () {
+		const spinner = shallow(
+			<Spinner />
+		);
+
+		const expected = 'alert';
+		const actual = spinner.prop('role');
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should set aria-live to off by default', function () {
+		const spinner = shallow(
+			<Spinner />
+		);
+
+		const expected = 'off';
+		const actual = spinner.prop('aria-live');
+
+		expect(actual).to.equal(expected);
+	});
 });


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added a11y support for Image and Spinner

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Image
- Set `role` to `img`

Spinner
- Set `role` to `alert`
- Set `aria-live` to `off`


### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/PLAT-35478



Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)