### PR TITLE
PLAT-36932: Add factory support to IconButton

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -19,160 +19,199 @@ import {TooltipDecorator} from '../TooltipDecorator';
 import componentCss from './Button.less';
 
 /**
- * {@link moonstone/Button.ButtonBase} is a stateless Button with Moonstone styling
- * applied. In most circumstances, you will want to use the Pressable and Spottable version:
- * {@link moonstone/Button.Button}
- *
- * @class ButtonBase
- * @memberof moonstone/Button
- * @ui
- * @public
- */
-const ButtonBaseFactory = factory({css: componentCss}, ({css}) => kind({
-	name: 'Button',
-
-	propTypes: /** @lends moonstone/Button.ButtonBase.prototype */ {
-		children: PropTypes.node.isRequired,
-
-		/**
-		 * The background-color opacity of this button; valid values are `'opaque'`, `'translucent'`,
-		 * and `'transparent'`.
-		 *
-		 * @type {String}
-		 * @default 'opaque'
-		 * @public
-		 */
-		backgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'transparent']),
-
-		/**
-		 * When `true`, the [button]{@glossary button} is shown as disabled and does not
-		 * generate `onClick` [events]{@glossary event}.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		disabled: PropTypes.bool,
-
-		/**
-		 * A boolean parameter affecting the minimum width of the button. When `true`,
-		 * the minimum width will be set to 180px (or 130px if [small]{@link moonstone/Button.Button#small}
-		 * is `true`). If `false`, the minimum width will be set to the current value of
-		 * `@moon-button-height` (thus forcing the button to be no smaller than a circle with
-		 * diameter `@moon-button-height`).
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		minWidth: PropTypes.bool,
-
-		/**
-		 * When `true`, a pressed visual effect is applied to the button
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		pressed: PropTypes.bool,
-
-		/**
-		 * When `true`, a selected visual effect is applied to the button
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		selected: PropTypes.bool,
-
-		/**
-		 * A boolean parameter affecting the size of the button. If `true`, the
-		 * button's diameter will be set to 60px. However, the button's tap target
-		 * will still have a diameter of 78px, with an invisible DOM element
-		 * wrapping the small button to provide the larger tap zone.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		small: PropTypes.bool
-	},
-
-	defaultProps: {
-		backgroundOpacity: 'opaque',
-		disabled: false,
-		minWidth: true,
-		pressed: false,
-		selected: false,
-		small: false
-	},
-
-	styles: {
-		css: {
-			...componentCss,
-			/*
-			 * Allowed CSS Class Overrides
-			 *
-			 * * .bg	The background of the button, used on a child of button.
-			 * * .selected	The selected state of the button, applied to the base element.
-			 */
-			bg: css.bg,
-			selected: css.selected
-		},
-		className: 'button'
-	},
-
-	computed: {
-		className: ({backgroundOpacity, minWidth, pressed, selected, small, styler}) => styler.append(
-			{pressed, small, minWidth, selected},
-			backgroundOpacity
-		)
-	},
-
-	handlers: {
-		onClick: handle(
-			forProp('disabled', false),
-			forward('onClick')
-		)
-	},
-
-	render: ({children, ...rest}) => {
-		delete rest.backgroundOpacity;
-		delete rest.minWidth;
-		delete rest.pressed;
-		delete rest.selected;
-		delete rest.small;
-
-		return (
-			<div role="button" {...rest}>
-				<div className={css.bg} />
-				<div className={css.client}>{children}</div>
-			</div>
-		);
-	}
-}));
-
-/**
- * {@link moonstone/Button.Button} is a Button with Moonstone styling, Spottable and
- * Pressable applied.  If the Button's child component is text, it will be uppercased unless
- * `preserveCase` is set.
+ * {@link moonstone/Button.ButtonBaseFactory} is Factory wrapper around {@link moonstone/Button.ButtonBase}
+ * that allows overriding certain classes at design time. The following are properties of the `css`
+ * member of the argument to the factory.
  *
  * Usage:
  * ```
- * <Button>Press me!</Button>
+ * import css from './CustomButton.less';
+ * import {ButtonFactory} from '@enact/moonstone/Button';
+ * const Button = ButtonFactory({
+ *     css: {
+ *         bg: css.bg,
+ *         selected: css.selected
+ *     }
+ * });
  * ```
  *
- * @class Button
+ * @class ButtonBaseFactory
  * @memberof moonstone/Button
- * @mixes i18n/Uppercase.Uppercase
- * @mixes moonstone/TooltipDecorator.TooltipDecorator
- * @mixes spotlight.Spottable
- * @mixes ui/Pressable.Pressable
- * @ui
+ * @factory
+ * @public
+ */
+const ButtonBaseFactory = factory({css: componentCss}, ({css}) =>
+
+	/**
+	 * {@link moonstone/Button.ButtonBase} is a stateless Button with Moonstone styling
+	 * applied. In most circumstances, you will want to use the Pressable and Spottable version:
+	 * {@link moonstone/Button.Button}
+	 *
+	 * @class ButtonBase
+	 * @memberof moonstone/Button
+	 * @ui
+	 * @public
+	 */
+	kind({
+		name: 'Button',
+
+		propTypes: /** @lends moonstone/Button.ButtonBase.prototype */ {
+			children: PropTypes.node.isRequired,
+
+			/**
+			 * The background-color opacity of this button; valid values are `'opaque'`, `'translucent'`,
+			 * and `'transparent'`.
+			 *
+			 * @type {String}
+			 * @default 'opaque'
+			 * @public
+			 */
+			backgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'transparent']),
+
+			/**
+			 * When `true`, the [button]{@glossary button} is shown as disabled and does not
+			 * generate `onClick` [events]{@glossary event}.
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @public
+			 */
+			disabled: PropTypes.bool,
+
+			/**
+			 * A boolean parameter affecting the minimum width of the button. When `true`,
+			 * the minimum width will be set to 180px (or 130px if [small]{@link moonstone/Button.Button#small}
+			 * is `true`). If `false`, the minimum width will be set to the current value of
+			 * `@moon-button-height` (thus forcing the button to be no smaller than a circle with
+			 * diameter `@moon-button-height`).
+			 *
+			 * @type {Boolean}
+			 * @default true
+			 * @public
+			 */
+			minWidth: PropTypes.bool,
+
+			/**
+			 * When `true`, a pressed visual effect is applied to the button
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @public
+			 */
+			pressed: PropTypes.bool,
+
+			/**
+			 * When `true`, a selected visual effect is applied to the button
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @public
+			 */
+			selected: PropTypes.bool,
+
+			/**
+			 * A boolean parameter affecting the size of the button. If `true`, the
+			 * button's diameter will be set to 60px. However, the button's tap target
+			 * will still have a diameter of 78px, with an invisible DOM element
+			 * wrapping the small button to provide the larger tap zone.
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @public
+			 */
+			small: PropTypes.bool
+		},
+
+		defaultProps: {
+			backgroundOpacity: 'opaque',
+			disabled: false,
+			minWidth: true,
+			pressed: false,
+			selected: false,
+			small: false
+		},
+
+		styles: {
+			css: /** @lends moonstone/Button.ButtonBaseFactory.prototype */ {
+				...componentCss,
+				/**
+				 * Classes to apply to the background of the button, used on a child of button
+				 * @type {String}
+				 * @public
+				 */
+				bg: css.bg,
+
+				/**
+				 * Classes to apply to the selected state of the button, applied to the base element
+				 * @type {String}
+				 * @public
+				 */
+				selected: css.selected
+			},
+			className: 'button'
+		},
+
+		computed: {
+			className: ({backgroundOpacity, minWidth, pressed, selected, small, styler}) => styler.append(
+				{pressed, small, minWidth, selected},
+				backgroundOpacity
+			)
+		},
+
+		handlers: {
+			onClick: handle(
+				forProp('disabled', false),
+				forward('onClick')
+			)
+		},
+
+		render: ({children, ...rest}) => {
+			delete rest.backgroundOpacity;
+			delete rest.minWidth;
+			delete rest.pressed;
+			delete rest.selected;
+			delete rest.small;
+
+			return (
+				<div role="button" {...rest}>
+					<div className={css.bg} />
+					<div className={css.client}>{children}</div>
+				</div>
+			);
+		}
+	})
+);
+
+/**
+ * {@link moonstone/Button.ButtonFactory} is Factory wrapper around {@link moonstone/Button.Button}
+ * that allows overriding certain classes at design time. See {@link moonstone/Button.ButtonBaseFactory}.
+ *
+ * @class ButtonFactory
+ * @memberof moonstone/Button
+ * @factory
  * @public
  */
 const ButtonFactory = factory(css => {
 	const Base = ButtonBaseFactory(css);
+	/**
+	 * {@link moonstone/Button.Button} is a Button with Moonstone styling, Spottable and
+	 * Pressable applied.  If the Button's child component is text, it will be uppercased unless
+	 * `preserveCase` is set.
+	 *
+	 * Usage:
+	 * ```
+	 * <Button>Press me!</Button>
+	 * ```
+	 *
+	 * @class Button
+	 * @memberof moonstone/Button
+	 * @mixes i18n/Uppercase.Uppercase
+	 * @mixes moonstone/TooltipDecorator.TooltipDecorator
+	 * @mixes spotlight.Spottable
+	 * @mixes ui/Pressable.Pressable
+	 * @ui
+	 * @public
+	 */
 	return Uppercase(
 		TooltipDecorator(
 			MarqueeDecorator(

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -17,24 +17,34 @@ import componentCss from './IconButton.less';
 const OptimizedIcon = onlyUpdateForKeys(['small', 'children'])(Icon);
 
 /**
- * {@link moonstone/IconButton.IconButton} is a {@link moonstone/Icon.Icon} that acts like a button.
- * You may specify an image or a font-based icon by setting the children to either the path to the
- * image or a string from the [IconList]{@link moonstone/Icon.IconList}.
+ * {@link moonstone/IconButton.IconButtonFactory} is Factory wrapper around
+ * {@link moonstone/IconButton.IconButton} that allows overriding certain classes of the base
+ * `Button` component at design time. See {@link moonstone/Button.ButtonBaseFactory}.
  *
- * Usage:
- * ```
- * <IconButton onClick={handleClick} small>
- *     plus
- * </IconButton>
- * ```
- *
- * @class IconButton
+ * @class IconButtonFactory
  * @memberof moonstone/IconButton
- * @ui
+ * @factory
  * @public
  */
 const IconButtonBaseFactory = factory({css: componentCss}, ({css}) => {
 	const Button = ButtonFactory({css});
+	/**
+	 * {@link moonstone/IconButton.IconButton} is a {@link moonstone/Icon.Icon} that acts like a button.
+	 * You may specify an image or a font-based icon by setting the children to either the path to the
+	 * image or a string from the [IconList]{@link moonstone/Icon.IconList}.
+	 *
+	 * Usage:
+	 * ```
+	 * <IconButton onClick={handleClick} small>
+	 *     plus
+	 * </IconButton>
+	 * ```
+	 *
+	 * @class IconButton
+	 * @memberof moonstone/IconButton
+	 * @ui
+	 * @public
+	 */
 	return kind({
 		name: 'IconButton',
 


### PR DESCRIPTION
To test/verify, add a `.bg` class to IconButton.less or anything that uses IconButtonFactory and assign a background color.
```
.bg {
	background-color: cyan;
}
```
The color will appear on buttons which are not also translucent or transparent.