### PR TITLE
ENYO-3852: minor refactoring of updateScrollbars()

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -673,16 +673,18 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		}
 
 		updateScrollbars = () => {
-			const {isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state;
-			const bounds = this.getScrollBounds();
+			const
+				{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
+				bounds = this.getScrollBounds();
 
 			// determine if we should hide or show any scrollbars
-			const canScrollHorizontally = this.canScrollHorizontally(bounds);
-			const canScrollVertically = this.canScrollVertically(bounds);
-			const isVisibilityChanged = (
-				isHorizontalScrollbarVisible !== canScrollHorizontally ||
-				isVerticalScrollbarVisible !== canScrollVertically
-			);
+			const
+				canScrollHorizontally = this.canScrollHorizontally(bounds),
+				canScrollVertically = this.canScrollVertically(bounds),
+				isVisibilityChanged = (
+					isHorizontalScrollbarVisible !== canScrollHorizontally ||
+					isVerticalScrollbarVisible !== canScrollVertically
+				);
 
 			if (isVisibilityChanged) {
 				// one or both scrollbars have changed visibility


### PR DESCRIPTION
* Removes optional boolean arg. Flags, particularly optional ones, to methods are generally bad for readability because it's often not obvious what the flag means. The usage was okay in this case because the variable passed in `componentDidUpdate` was descriptive but I've eliminated it to avoid future confusion (e.g. `updateScrollbars(true)` -- what does `true` mean?!?)

* Updated it to *either* update state *or* notify scrollbars of the new bounds. No need to notify scrollbars immediately after calling `setState()` because that will trigger a re-render, which will invoke `componentWillUpdate`, which will call `updateScrollbars`, which will then notify the scrollbars with the updated bounds. 

* Added a bit of inline docs

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)