### PR TITLE
ENYO-3850: Fixed VirtualGridList to show dynamically added items

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -394,7 +394,8 @@ class VirtualListCore extends Component {
 		const
 			{dataSize, overhang} = props,
 			{dimensionToExtent, primary} = this,
-			numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang));
+			numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
+			wasFirstIndexMax = (this.maxFirstIndex && (this.state.firstIndex === this.maxFirstIndex));
 
 		this.maxFirstIndex = dataSize - numOfItems;
 		this.curDataSize = dataSize;
@@ -404,7 +405,7 @@ class VirtualListCore extends Component {
 		// reset children
 		this.cc = [];
 
-		this.setState({firstIndex: Math.min(this.state.firstIndex, this.maxFirstIndex), numOfItems});
+		this.setState({firstIndex: wasFirstIndexMax ? this.maxFirstIndex : Math.min(this.state.firstIndex, this.maxFirstIndex), numOfItems});
 		this.calculateScrollBounds(props);
 	}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed VirtualGridList to show dynamically added items when the list scrolled to the bottom
The current issue is that if an item added when the list positioned at the bottom, the list does not show the added item.
What happened here is that after VirtualList got new `dataSize` prop, it will call updateStatesAndBounds.
In this function, we choose a min value between current `firstIndex` and `maxFirstIndex` as new `firstIndex`. But if `firstIndex` is `maxFirstIndex`, `firstIndex` won't be changed since updated `maxFirstIndex` would be always bigger than `firstIndex`. This makes this issue.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a condition that if current `firstIndex` is the max, VL will choose updated `maxFirstIndex` as its new `firstIndex`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The paging controls won't be enabled automatically when adding items. It will be fixed when this PR(https://github.com/enyojs/enact/pull/542) merged.

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-3850

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)