### PR TITLE
ENYO-3950: Highlight InputDecorator in ExpandableInput when clicked

### DIFF
--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -86,7 +86,9 @@
 		border-radius: 12px;
 	}
 
-	// RIGBY NOTE: Complex focus scenarios are broken at the moment
+	// For ExpandableInput, the decorator will not receive focus but it can be activated by clicking
+	// which should highlight the border
+	&.noDecorator:active,
 	&:global(.spottable):focus {
 		border-color: @moon-spotlight-border-color;
 		background-color: @moon-input-decorator-bg-color;

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -4,6 +4,8 @@ import {is} from '@enact/core/keymap';
 import React from 'react';
 import {Spotlight, Spottable} from '@enact/spotlight';
 
+import css from './Input.less';
+
 const preventSpotlightNavigation = (ev) => {
 	ev.nativeEvent.stopImmediatePropagation();
 };
@@ -258,6 +260,15 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			forwardKeyDown(ev, this.props);
 		}
 
+		calcClassName () {
+			const {className, noDecorator} = this.props;
+			if (noDecorator) {
+				return className ? css.noDecorator + ' ' + className : css.noDecorator;
+			}
+
+			return className;
+		}
+
 		render () {
 			const props = Object.assign({}, this.props);
 			delete props.noDecorator;
@@ -265,6 +276,7 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			return (
 				<Component
 					{...props}
+					className={this.calcClassName()}
 					focused={this.state.focused === 'input'}
 					onBlur={this.onBlur}
 					onClick={this.onClick}


### PR DESCRIPTION
* Added a CSS class for `noDecorator` mode
* Added a selector on the hightlight ring ruleset for that class

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)