### PR TITLE
ENYO-3951: Toggle switch retains its color regardless of spottable state

### DIFF
--- a/packages/moonstone/Switch/Switch.less
+++ b/packages/moonstone/Switch/Switch.less
@@ -29,6 +29,10 @@
 		line-height: inherit;
 		margin: 0;
 		vertical-align: top;	// The TV incorrectly positions the icon too low without this
+
+		:global(.spottable):focus & {
+			color: @moon-checkbox-toggle-switch-color;
+		}
 	}
 	&.selected {
 		background-color: @moon-checkbox-toggle-switch-selected-bg-color;
@@ -36,6 +40,10 @@
 		.icon {
 			left: (@moon-toggleswitch-width - @moon-toggleswitch-height);
 			color: @moon-checkbox-toggle-switch-selected-color;
+
+			:global(.spottable):focus & {
+				color: @moon-checkbox-toggle-switch-selected-color;
+			}
 		}
 	}
 	&[disabled] {


### PR DESCRIPTION
Straightforward commit. A parent having spotlight focus no longer affects the colors of the circle icon.