### PR TITLE
ENYO-3953: Let spottable focused elements inside neutral theme…

### DIFF
--- a/packages/moonstone/styles/rules.less
+++ b/packages/moonstone/styles/rules.less
@@ -76,4 +76,8 @@
 	* {
 		color: @moon-neutral-child-text-color;
 	}
+
+	:global(.spottable):focus * {
+		color: inherit;
+	}
 }


### PR DESCRIPTION
…inherit the spotted color.

### Notes

It's possible that with this change, we can drop a `.moon-neutral .button` rule, but to err on the side of caution, I left it untouched.