### PR TITLE
ENYO-3815: Picker correctly animates and is back to being absolute positioned

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -107,9 +107,6 @@
 			&.decrementing:before {
 				border-bottom-width: @moon-integer-picker-shadow-width;
 			}
-			.valueWrapper {
-				padding: 0 1ex;
-			}
 			.incrementer,
 			.decrementer {
 				display: block;
@@ -123,7 +120,7 @@
 	}
 
 	&.small .valueWrapper {
-		width: 60px;
+		width: (@moon-spotlight-outset + @moon-icon-size + @moon-spotlight-outset);
 	}
 	&.medium .valueWrapper {
 		width: 180px;
@@ -139,7 +136,7 @@
 			position: relative;
 
 			.item {
-				position: relative;
+				position: absolute;
 				.position(0);
 			}
 		}
@@ -147,6 +144,10 @@
 
 	&.vertical .valueWrapper {
 		display: block;
+
+		.item {
+			margin: 0 @moon-spotlight-outset;
+		}
 	}
 }
 


### PR DESCRIPTION
Adjusted the width of the smallest size to match the minimum size of the icons nearby, which sizes the item to the correct width, which makes absolute positioning safe to use again.