### PR TITLE
PLAT-37706: Add legacy support for old Moonstone Font metadata

### DIFF
--- a/packages/moonstone/styles/fonts.less
+++ b/packages/moonstone/styles/fonts.less
@@ -16,7 +16,7 @@
 @font-system-src-non-latin-light:  local("LG Display-Light");
 @font-system-src-non-latin-bold:   local("LG Display-Regular");
 
-@font-system-src-moonstone-icons:  local("Moonstone"), url("../fonts/Moonstone.ttf") format("truetype");
+@font-system-src-moonstone-icons:  local("Moonstone"), local("Moonstone "), url("../fonts/Moonstone.ttf") format("truetype");
 @font-system-src-lg-icons:         local("LG Display_Dingbat");
 
 


### PR DESCRIPTION
This adds a fallback font name that includes the legacy version of the font.