### PR TITLE
ENYO-3886-In Picker RTL text in RTL Locale coming as LTR Text

### DIFF
--- a/packages/moonstone/internal/Picker/PickerItem.js
+++ b/packages/moonstone/internal/Picker/PickerItem.js
@@ -17,16 +17,7 @@ const PickerItemBase = kind({
 		 * @type {Node|Node[]}
 		 * @public
 		 */
-		children: React.PropTypes.node,
-
-
-		/**
-		 * Forces the `direction` Picker list. Valid values are `rtl` and `ltr`. This includes non-text elements as well.
-		 *
-		 * @type {String}
-		 * @public
-		 */
-		forceDirection: React.PropTypes.oneOf(['rtl', 'ltr'])
+		children: React.PropTypes.node
 	},
 
 	styles: {


### PR DESCRIPTION
Issue Resolved / Feature Added

In Picker RTL text in RTL Locale coming as LTR Text

Resolution

Edited default direction based on RTL text and locale

Additional Considerations

In marquee default direction is inherit from locale(RTL/LTR) but in the Picker default direction inherit take CSS from direct parent which is always LTR for increment/decrement icon instead of locale(RTL/LTR). 
So In picker RTL text also shown as LTR text.

Links

https://jira2.lgsvl.com/browse/ENYO-3886

Comments

Enyo-DCO-1.1-Signed-off-by:Richa Shaurbh richa.shaurbh@lge.com