### PR TITLE
Using forceDirection

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -12,7 +12,7 @@
 	border-radius: @button-width;
 	vertical-align: bottom;
 	position: relative;
-	direction: inherit;
+	direction: ltr;
 	text-align: center;
 	margin-left: @moon-spotlight-outset;
 	margin-right: @moon-spotlight-outset;
@@ -147,22 +147,6 @@
 
 		.item {
 			margin: 0 @moon-spotlight-outset;
-		}
-	}
-
-	:global(.enact-locale-right-to-left) & {
-		&.horizontal {
-			.incrementer,
-			.decrementer {
-				transform: scaleX(-1);
-			}
-		}
-
-		&.joined &.horizontal {
-			.incrementer,
-			.decrementer {
-				transform: scaleX(-1);
-			}
 		}
 	}
 }

--- a/packages/moonstone/internal/Picker/PickerItem.js
+++ b/packages/moonstone/internal/Picker/PickerItem.js
@@ -17,7 +17,7 @@ const PickerItemBase = kind({
 		* @type {Node}
 		* @public
 		*/
-		children: React.PropTypes.node.isRequired
+		children: React.PropTypes.node
 	},
 
 	styles: {
@@ -26,19 +26,11 @@ const PickerItemBase = kind({
 	},
 
 	computed: {
-		clientStyle: ({children}) => {
-			let direction = isRtlText(children) ? 'rtl' : 'ltr';
-
-			const style = {
-				direction
-			};
-
-			return style;
-		}
+		forceDirection: ({children}) => isRtlText(children) ? 'rtl' : 'ltr'
 	},
 
-	render: ({clientStyle, ...props}) => (
-		<MarqueeText {...props} style={clientStyle} marqueeCentered />
+	render: (props) => (
+		<MarqueeText {...props} marqueeCentered />
 	)
 });
 


### PR DESCRIPTION
Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com

### Issue Resolved / Feature Added
My comment requested to use `forceDirection`, you are still applying the `direction` to the `style` prop. So I'm making a PR to show how `forceDirection` works.

### Resolution
Use `forceDirection` prop.


### Additional Considerations
You don't have to change any of the `CSS`.  The `CSS` here is the exact same as the `develop` branch. All you need to do is use `forceDirection` on `MarqueeText` and the sample will work without any other changes.

You can compare it to `develop` here at https://github.com/enyojs/enact/compare/ENYO-3886-derektor


### Links
https://jira2.lgsvl.com/browse/ENYO-3886

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com
