### PR TITLE
ENYO-3908: Picker button fix for spottable and disabled when pressed

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -164,6 +164,17 @@
 		}
 	}
 
+	// Disable animation for Picker button spottable and disabled.
+	&:global(.spottableDisabled) {
+		&.pressed,
+		&:global(.spottable):active {
+			.bg {
+				-webkit-animation-name: none;
+				animation-name: none;
+			}
+		}
+	}
+
 	// 'Selected' state
 	&.selected {
 		.bg {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Picker button: the disabled pink translucent spot should not animate on pointer click.

### Resolution
Thanks to Blake: added css class to disable animation for Picker button spottable and disabled.

### Links
https://jira2.lgsvl.com/browse/ENYO-3908


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com