### PR TITLE
PLAT-38424: Add data-transitioning to ViewManager during transition

### DIFF
--- a/packages/moonstone/Panels/Arrangers.js
+++ b/packages/moonstone/Panels/Arrangers.js
@@ -73,6 +73,18 @@ const offsetForBreadcrumbs = ({node}) => {
 	}
 };
 
+// Adds the data-clip attribute to allow clipping when transitioning between non-zero panels
+// CSS is enforced by Panels.less
+const clipForBreadcrumbs = ({from, node, percent, to}) => {
+	const viewport = node.parentNode;
+	if (to === 0 || from === 0 || percent === 0 || percent === 1) {
+		// remove clip when moving to or from the first panel and when a transition is completing
+		delete viewport.dataset.clip;
+	} else {
+		viewport.dataset.clip = 'true';
+	}
+};
+
 /**
  * Arranger that slides panels in from the right and out to the left allowing space for the single
  * breadcrumb when `to` index is greater than zero.
@@ -81,7 +93,7 @@ const offsetForBreadcrumbs = ({node}) => {
  * @private
  */
 export const ActivityArranger = {
-	enter: compose(panelEnter, reverse(offsetForBreadcrumbs)),
+	enter: compose(panelEnter, reverse(offsetForBreadcrumbs), clipForBreadcrumbs),
 	leave: compose(panelLeave, offsetForBreadcrumbs),
 	// Need a stay arrangement in case the initial index for ActivityPanels is > 0 so the panel is
 	// correctly offset for the breadcrumbs.

--- a/packages/moonstone/Panels/Panels.less
+++ b/packages/moonstone/Panels/Panels.less
@@ -104,27 +104,14 @@
 	}
 
 	.viewport {
-		-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-
-		// Using transition only so that we can delay it for non-zero indices. See comment below.
-		transition: clip-path linear 0ms, -webkit-clip-path linear 0ms;
+		&[data-clip] {
+			-webkit-clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
+			clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
+		}
 
 		> :not([data-index='0']) {
 			padding-left: 0;
 			width: calc(~"100% - " @moon-breadcrumb-width);
-		}
-	}
-
-	&:not([data-index='0']) {
-		.viewport {
-			-webkit-clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
-			clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
-
-			// This delay matches the duration on Viewport's ViewManager. The effect is to defer
-			// setting the clip-path until the panel animation completes but only when changing to
-			// a non-zero index so that it is removed immediately when changing to the first panel.
-			transition-delay: 250ms;
 		}
 	}
 


### PR DESCRIPTION
* Directly mutate the root node of TransitionGroup to add the `data-transitioning` property which can be used to limit CSS to either only
during transition (`[data-transitioning]`) or only not during transition (`:not([data-transitioning])`).

* Modifies the CSS rules of Panels to only apply `clip-path` when transitioning.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)