### PR TITLE
PLAT-37712: Added support for large text on Item

### DIFF
--- a/packages/moonstone/Item/Item.less
+++ b/packages/moonstone/Item/Item.less
@@ -19,6 +19,11 @@
 		box-sizing: border-box;
 	}
 
+	.moon-custom-text({
+		font-size: @moon-item-font-size-large;
+		line-height: @moon-item-line-height-large;
+	});
+
 	// Apply to the content area to tell it to expand to the available width of the container
 	.content {
 		flex: 1 1 auto;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -190,8 +190,10 @@
 // Items
 // ---------------------------------------
 @moon-item-height: 60px;
+@moon-item-height-large: 72px;
 @moon-item-vertical-padding: 3px;
 @moon-item-line-height: @moon-item-height - (@moon-item-vertical-padding * 2);
+@moon-item-line-height-large: @moon-item-height-large - (@moon-item-vertical-padding * 2);
 @moon-item-indent: 36px;
 
 // ToggleButton


### PR DESCRIPTION
This includes support for the following derivatives of item:
toggle item, switch item, selectable item, radio item, item overlay, checkbox item

### Additional Considerations
While this does add new text size support to the above items, it only partially addresses the expandable-class of `LabeledItem` based components. This support will come in an additional PR, dependent on this one.