### PR TITLE
ENYO-3927: Updated `fullBleed` style to match current design needs.

### DIFF
--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -142,7 +142,13 @@
 	}
 
 	&.fullBleed {
-		padding: 0 @moon-header-indent-width @moon-spotlight-outset;
-		border: 0;
+		border-top-width: 0;
+		border-color: @moon-header-full-bleed-border-color;
+		color: @moon-header-full-bleed-text-color;
+
+		.titleBelow,
+		.subTitleBelow {
+			color: @moon-header-title-below-full-bleed-text-color;
+		}
 	}
 }

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -26,8 +26,11 @@
 @moon-divider-text-color:             @moon-text-color;
 @moon-sup-header-text-color:          @moon-text-color;
 @moon-header-text-color:              #ccc;
+@moon-header-full-bleed-text-color:   #f5f5f5;
+@moon-header-title-below-full-bleed-text-color: @moon-light-gray;
 @moon-header-border-color:            #505050;
 @moon-header-bottom-border-color:     #404040;
+@moon-header-full-bleed-border-color: fade(@moon-white, 25%);
 @moon-body-text-color:                @moon-text-color;
 @moon-spotlight-text-color:           @moon-white;
 @moon-spotlight-background-color:     @moon-accent;


### PR DESCRIPTION
Also, addresses ENYO-4011 by changing the border locations and colors for `fullBleed` mode (when an image or non-black background is being used).

### Comments
A white with a 25% opacity, when over a black background, results in the same color as Moonstone's current standard opaque light gray bottom border.