### PR TITLE
Reset text direction appropriately

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -12,7 +12,6 @@
 	border-radius: @button-width;
 	vertical-align: bottom;
 	position: relative;
-	direction: ltr;
 	text-align: center;
 	margin-left: @moon-spotlight-outset;
 	margin-right: @moon-spotlight-outset;
@@ -49,9 +48,6 @@
 		margin-right: auto;
 		vertical-align: bottom;
 		color: inherit;
-		:global(.enact-locale-right-to-left) & {
-			direction: rtl;
-		}
 	}
 
 	.incrementer,
@@ -68,6 +64,10 @@
 
 	&.horizontal {
 		display: inline-flex;
+
+		:global(.enact-locale-right-to-left) & {
+			flex-direction: row-reverse;
+		}
 
 		.incrementer {
 			order: 3;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
RTL text in picker in RTL language was treated as LTR

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Picker forced its contents to be LTR (so the buttons appear in the right order, I believe).
I added code to force the value area back to RTL when in RTL.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-3886

### Comments
