### PR TITLE
ENYO-3774: Fix containers as they relate to Popup-ContextualPopup

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -232,6 +232,7 @@ const ButtonFactory = factory(css => {
 				{className: componentCss.marquee},
 				Pressable(
 					Spottable(
+						{selectionKeyUpDelay: 200},
 						Base
 					)
 				)

--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -146,8 +146,7 @@
 
 	// Button-non-disabled rules
 	&:not([disabled]) {
-		&.pressed,
-		&:global(.spottable):active {
+		&.pressed {
 			.bg {
 				-webkit-animation-name: expand;
 				animation-name: expand;
@@ -155,6 +154,12 @@
 		}
 
 		&:global(.spottable):focus {
+			&:active {
+				.bg {
+					-webkit-animation-name: expand;
+					animation-name: expand;
+				}
+			}
 			background-color: transparent;
 
 			.bg {

--- a/packages/moonstone/Button/tests/Button-specs.js
+++ b/packages/moonstone/Button/tests/Button-specs.js
@@ -70,6 +70,7 @@ describe('Button', () => {
 				<Button onClick={handleClick}>I am a disabled Button</Button>
 			);
 
+			subject.simulate('focus');
 			subject.simulate('click');
 
 			const expected = true;
@@ -84,6 +85,7 @@ describe('Button', () => {
 				<Button disabled onClick={handleClick}>I am a disabled Button</Button>
 			);
 
+			subject.simulate('focus');
 			subject.simulate('click');
 
 			const expected = false;

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Popup.Popup` and `moonstone/ContextualPopupDecorator.ContextualPopupDecorator` navigation behavior
 - `moonstone/Panels.Panel` behavior for setting focus after render
 - `moonstone/VirtualList.VirtualGridList` showing empty items when items are continuously added dynamically
 - `moonstone/Picker` to marquee on focus once again

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -364,13 +364,17 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		spotActivator = (activator) => {
+			Spotlight.setActiveContainer(null, this.state.containerId);
 			if (!Spotlight.focus(activator)) {
 				Spotlight.focus();
 			}
 		}
 
 		spotPopupContent = () => {
-			Spotlight.focus(this.state.containerId);
+			const {containerId} = this.state;
+			if (!Spotlight.focus(containerId)) {
+				Spotlight.setActiveContainer(containerId);
+			}
 		}
 
 		render () {

--- a/packages/moonstone/ExpandablePicker/tests/ExpandablePicker-specs.js
+++ b/packages/moonstone/ExpandablePicker/tests/ExpandablePicker-specs.js
@@ -13,7 +13,8 @@ describe('ExpandablePicker Specs', () => {
 			</ExpandablePicker>
 		);
 
-		const checkButton = expandablePicker.find('Icon').last();
+		const checkButton = expandablePicker.find('IconButton').last();
+		checkButton.simulate('focus');
 		checkButton.simulate('click');
 
 		const expected = false;
@@ -32,6 +33,7 @@ describe('ExpandablePicker Specs', () => {
 		);
 
 		const checkButton = expandablePicker.find('IconButton').last();
+		checkButton.simulate('focus');
 		checkButton.simulate('click');
 
 		const expected = value;
@@ -50,6 +52,7 @@ describe('ExpandablePicker Specs', () => {
 		);
 
 		const checkButton = expandablePicker.find('IconButton').last();
+		checkButton.simulate('focus');
 		checkButton.simulate('click');
 
 		const expected = value;

--- a/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
+++ b/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
@@ -15,7 +15,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.decrementButton}`).simulate('click');
+		const decrementButton = incrementSlider.find(`.${css.decrementButton}`);
+		decrementButton.simulate('focus');
+		decrementButton.simulate('click');
 
 		const expected = value - 1;
 		const actual = handleChange.args[0][0].value;
@@ -33,7 +35,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.incrementButton}`).simulate('click');
+		const incrementButton = incrementSlider.find(`.${css.incrementButton}`);
+		incrementButton.simulate('focus');
+		incrementButton.simulate('click');
 
 		const expected = value + 1;
 		const actual = handleChange.args[0][0].value;
@@ -51,7 +55,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.incrementButton}`).simulate('click');
+		const incrementButton = incrementSlider.find(`.${css.incrementButton}`);
+		incrementButton.simulate('focus');
+		incrementButton.simulate('click');
 
 		const expected = true;
 		const actual = handleChange.calledOnce;
@@ -115,7 +121,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.incrementButton}`).simulate('click');
+		const incrementButton = incrementSlider.find(`.${css.incrementButton}`);
+		incrementButton.simulate('focus');
+		incrementButton.simulate('click');
 
 		const expected = true;
 		const actual = handleIncrement.calledOnce;
@@ -133,7 +141,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.incrementButton}`).simulate('click');
+		const incrementButton = incrementSlider.find(`.${css.incrementButton}`);
+		incrementButton.simulate('focus');
+		incrementButton.simulate('click');
 
 		const expected = false;
 		const actual = handleIncrement.called;
@@ -151,7 +161,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.decrementButton}`).simulate('click');
+		const decrementButton = incrementSlider.find(`.${css.decrementButton}`);
+		decrementButton.simulate('focus');
+		decrementButton.simulate('click');
 
 		const expected = true;
 		const actual = handleDecrement.calledOnce;
@@ -169,7 +181,9 @@ describe('IncrementSlider Specs', () => {
 			/>
 		);
 
-		incrementSlider.find(`.${css.decrementButton}`).simulate('click');
+		const decrementButton = incrementSlider.find(`.${css.decrementButton}`);
+		decrementButton.simulate('focus');
+		decrementButton.simulate('click');
 
 		const expected = false;
 		const actual = handleDecrement.called;

--- a/packages/moonstone/Input/tests/Input-specs.js
+++ b/packages/moonstone/Input/tests/Input-specs.js
@@ -151,6 +151,7 @@ describe('Input Specs', () => {
 			<Input />
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click');
 
 		const expected = true;
@@ -166,6 +167,7 @@ describe('Input Specs', () => {
 			<Input />
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click');
 		subject.unmount();
 

--- a/packages/moonstone/Panels/tests/Breadcrumb-specs.js
+++ b/packages/moonstone/Panels/tests/Breadcrumb-specs.js
@@ -11,6 +11,7 @@ describe('Breadcrumb', () => {
 			<Breadcrumb index={3} onSelect={handleSelect} />
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click', {});
 
 		const expected = 3;
@@ -26,6 +27,7 @@ describe('Breadcrumb', () => {
 			<Breadcrumb index={3} onClick={handleClick} onSelect={handleSelect} />
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click', {});
 
 		const expected = true;

--- a/packages/moonstone/Panels/tests/IndexedBreadcrumbs-specs.js
+++ b/packages/moonstone/Panels/tests/IndexedBreadcrumbs-specs.js
@@ -47,7 +47,9 @@ describe('IndexedBreadcrumbs', () => {
 			</nav>
 		);
 
-		subject.find('Breadcrumb').simulate('click', {});
+		const breadcrumb = subject.find('Breadcrumb');
+		breadcrumb.simulate('focus');
+		breadcrumb.simulate('click', {});
 
 		const expected = true;
 		const actual = handleClick.calledOnce;

--- a/packages/moonstone/Panels/tests/Panels-specs.js
+++ b/packages/moonstone/Panels/tests/Panels-specs.js
@@ -36,7 +36,9 @@ describe('Panels Specs', () => {
 			<Panels onApplicationClose={handleAppClose} />
 		);
 
-		subject.find('IconButton').simulate('click');
+		const button = subject.find('IconButton');
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = true;
 		const actual = handleAppClose.calledOnce;

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -323,11 +323,13 @@ class Popup extends React.Component {
 	}
 
 	componentWillUnmount () {
-		Spotlight.remove(this.state.containerId);
+		const {containerId} = this.state;
 		if (this.props.open) {
 			off('click', this.handleClick);
 			off('keydown', this.handleKeyDown);
+			Spotlight.setActiveContainer(null, containerId);
 		}
+		Spotlight.remove(this.state.containerId);
 	}
 
 	handleFloatingLayerOpen = () => {

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -6,21 +6,29 @@
  */
 
 import $L from '@enact/i18n/$L';
+import {is} from '@enact/core/keymap';
+import {on, off} from '@enact/core/dispatcher';
 import FloatingLayer from '@enact/ui/FloatingLayer';
 import kind from '@enact/core/kind';
 import React, {PropTypes} from 'react';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import {spottableClass} from '@enact/spotlight/Spottable';
 import Transition from '@enact/ui/Transition';
 
 import IconButton from '../IconButton';
 
 import css from './Popup.less';
 
+const isUp = is('up');
 const TransitionContainer = SpotlightContainerDecorator({preserveId: true}, Transition);
 
 const getContainerNode = (containerId) => {
 	return document.querySelector(`[data-container-id='${containerId}']`);
+};
+
+const getContainerSpottables = (containerId) => {
+	return document.querySelectorAll(`[data-container-id='${containerId}'] .${spottableClass}`);
 };
 
 /**
@@ -275,6 +283,13 @@ class Popup extends React.Component {
 		};
 	}
 
+	componentDidMount () {
+		if (this.props.open) {
+			on('click', this.handleClick);
+			on('keydown', this.handleKeyDown);
+		}
+	}
+
 	componentWillReceiveProps (nextProps) {
 		if (!this.props.open && nextProps.open) {
 			this.setState({
@@ -296,8 +311,12 @@ class Popup extends React.Component {
 			if (!this.props.noAnimation) {
 				Spotlight.pause();
 			} else if (this.props.open) {
+				on('click', this.handleClick);
+				on('keydown', this.handleKeyDown);
 				this.spotPopupContent();
 			} else if (prevProps.open) {
+				off('click', this.handleClick);
+				off('keydown', this.handleKeyDown);
 				this.spotActivator(prevState.activator);
 			}
 		}
@@ -305,6 +324,10 @@ class Popup extends React.Component {
 
 	componentWillUnmount () {
 		Spotlight.remove(this.state.containerId);
+		if (this.props.open) {
+			off('click', this.handleClick);
+			off('keydown', this.handleKeyDown);
+		}
 	}
 
 	handleFloatingLayerOpen = () => {
@@ -315,25 +338,48 @@ class Popup extends React.Component {
 		}
 	}
 
+	handleClick = (ev) => {
+		const {noAutoDismiss, onClose, scrimType, spotlightRestrict} = this.props;
+
+		// to account for a specific edge-case in which all of the following conditions are met, we need a way
+		// to close the popup via the pointer - by clicking outside the bounds of the popup
+		if (onClose &&
+				noAutoDismiss &&
+				scrimType === 'none' &&
+				spotlightRestrict !== 'self-only' &&
+				!getContainerSpottables(this.state.containerId).length) {
+			const spottable = ev.target.closest(`.${spottableClass}`);
+
+			onClose(ev);
+			if (spottable) {
+				// explicitly turn off pointer-mode so focus can be programmatically changed
+				Spotlight.setPointerMode(false);
+				Spotlight.focus(spottable);
+			}
+		}
+	}
+
 	handleKeyDown = (ev) => {
-		const {onClose, onKeyDown} = this.props;
-		const direction = getDirection(ev.keyCode);
-		let containerNode;
+		const {onClose, onKeyDown, spotlightRestrict} = this.props;
+		const keyCode = ev.keyCode;
+		const direction = getDirection(keyCode);
+		const spottables = getContainerSpottables(this.state.containerId).length;
 
-		if (direction) {
-			// prevent default page scrolling
-			ev.preventDefault();
-			// stop propagation to prevent default spotlight behavior
-			ev.stopPropagation();
+		if (direction && onClose) {
+			let focusChanged;
 
-			// if focus has changed
-			if (Spotlight.move(direction)) {
-				containerNode = getContainerNode(this.state.containerId);
+			if (spottables && Spotlight.getCurrent() && spotlightRestrict !== 'self-only') {
+				focusChanged = Spotlight.move(direction);
+			}
 
-				// if current focus is not within the popup's container, issue the `onClose` event
-				if (!containerNode.contains(document.activeElement) && onClose) {
-					onClose(ev);
-				}
+			if (!spottables || (focusChanged === false && isUp(keyCode))) {
+				// prevent default page scrolling
+				ev.preventDefault();
+				// stop propagation to prevent default spotlight behavior
+				ev.stopPropagation();
+				// explicitly turn off pointer-mode so focus can be programmatically changed
+				Spotlight.setPointerMode(false);
+				onClose(ev);
 			}
 		}
 
@@ -354,28 +400,58 @@ class Popup extends React.Component {
 			Spotlight.resume();
 
 			if (this.props.open) {
+				on('click', this.handleClick);
+				on('keydown', this.handleKeyDown);
 				this.spotPopupContent();
 			} else {
+				off('click', this.handleClick);
+				off('keydown', this.handleKeyDown);
 				this.spotActivator(this.state.activator);
 			}
 		}
 	}
 
 	spotActivator = (activator) => {
-		const activeElement = document.activeElement;
-		const containerNode = getContainerNode(this.state.containerId);
+		const current = Spotlight.getCurrent();
+		const {containerId} = this.state;
+		const containerNode = getContainerNode(containerId);
 
-		if ((activeElement === document.body || (containerNode && containerNode.contains(activeElement))) && !Spotlight.focus(activator)) {
-			Spotlight.focus();
+		// if the currently-spotted control doesn't exist or is wrapped by the popup's container, we
+		// know it's safe to change focus
+		if (!current || (containerNode && containerNode.contains(current))) {
+			Spotlight.setActiveContainer(null, containerId);
+			// attempt to set focus to the activator, if available
+			if (!Spotlight.focus(activator)) {
+				Spotlight.focus();
+			}
 		}
 	}
 
 	spotPopupContent = () => {
-		Spotlight.focus(this.state.containerId);
+		const {containerId} = this.state;
+		if (!Spotlight.focus(containerId)) {
+			const current = Spotlight.getCurrent();
+
+			// In cases where the container contains no spottable controls or we're in pointer-mode, focus
+			// cannot inherently set the active container or blur the active control, so we must do that
+			// here. We don't explicitly turn off pointer-mode, as we don't want to spot controls in the
+			// popup if it opened due to a pointer action.
+			if (current) {
+				current.blur();
+			}
+			Spotlight.setActiveContainer(containerId);
+		}
 	}
 
 	render () {
 		const {noAutoDismiss, onClose, scrimType, ...rest} = this.props;
+
+		// We override the specified `spotlightRestrict` value because using `'self-only'` allows us to
+		// a) lock spotlight within the popup when using pointer-mode to hover or click spottable controls
+		// outside the popup and b) after switching from pointer to 5-way mode, give default focus to the
+		// popup instead of any spottable controls that may be nearest to the pointer, if they are outside
+		// the popup. We still use the specified `spotlightRestrict` value in the internal navigation logic.
+		delete rest.spotlightRestrict;
 
 		return (
 			<FloatingLayer
@@ -394,7 +470,7 @@ class Popup extends React.Component {
 					open={this.state.popupOpen}
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
-					onKeyDown={this.handleKeyDown}
+					spotlightRestrict="self-only"
 				/>
 			</FloatingLayer>
 		);

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -284,7 +284,7 @@ class Popup extends React.Component {
 	}
 
 	componentDidMount () {
-		if (this.props.open) {
+		if (this.props.open && this.props.noAnimation) {
 			on('click', this.handleClick);
 			on('keydown', this.handleKeyDown);
 		}

--- a/packages/moonstone/RangePicker/tests/RangePicker-specs.js
+++ b/packages/moonstone/RangePicker/tests/RangePicker-specs.js
@@ -24,6 +24,7 @@ describe('RangePicker Specs', () => {
 		);
 
 		const button = picker.find(`.${css.incrementer}`);
+		button.simulate('focus');
 		button.simulate('click');
 		const expected = '11';
 		const actual = picker.find('PickerItem').text();
@@ -39,6 +40,7 @@ describe('RangePicker Specs', () => {
 		);
 
 		const button = picker.find(`.${css.decrementer}`);
+		button.simulate('focus');
 		button.simulate('click');
 		const expected = '9';
 		const actual = picker.find('PickerItem').text();

--- a/packages/moonstone/ToggleItem/tests/ToggleItem-specs.js
+++ b/packages/moonstone/ToggleItem/tests/ToggleItem-specs.js
@@ -15,6 +15,7 @@ describe('ToggleItem Specs', () => {
 			</ToggleItemBase>
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click');
 
 		const expected = true;
@@ -31,6 +32,7 @@ describe('ToggleItem Specs', () => {
 			</ToggleItemBase>
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click');
 
 		const expected = true;
@@ -47,6 +49,7 @@ describe('ToggleItem Specs', () => {
 			</ToggleItemBase>
 		);
 
+		subject.simulate('focus');
 		subject.simulate('click');
 
 		const expected = true;

--- a/packages/moonstone/internal/Picker/tests/Picker-specs.js
+++ b/packages/moonstone/internal/Picker/tests/Picker-specs.js
@@ -24,7 +24,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} min={-1} max={1} value={0} index={0} />
 		);
 
-		picker.find(`.${css.incrementer}`).simulate('click');
+		const button = picker.find(`.${css.incrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = 1;
 		const actual = handleChange.args[0][0].value;
@@ -38,7 +40,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} min={-1} max={1} value={0} index={0} />
 		);
 
-		picker.find(`.${css.decrementer}`).simulate('click');
+		const button = picker.find(`.${css.decrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = -1;
 		const actual = handleChange.args[0][0].value;
@@ -52,7 +56,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} disabled min={0} max={0} value={0} index={0} />
 		);
 
-		picker.find(`.${css.incrementer}`).simulate('click');
+		const button = picker.find(`.${css.incrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = false;
 		const actual = handleChange.called;
@@ -66,7 +72,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} wrap min={-1} max={0} value={0} index={0} />
 		);
 
-		picker.find(`.${css.incrementer}`).simulate('click');
+		const button = picker.find(`.${css.incrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = -1;
 		const actual = handleChange.args[0][0].value;
@@ -80,7 +88,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} wrap min={0} max={1} value={0} index={0} />
 		);
 
-		picker.find(`.${css.decrementer}`).simulate('click');
+		const button = picker.find(`.${css.decrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = 1;
 		const actual = handleChange.args[0][0].value;
@@ -96,6 +106,7 @@ describe('Picker Specs', function () {
 		const button = picker.find(`.${css.incrementer}`);
 
 		const expected = 3;
+		button.simulate('focus');
 		button.simulate('click');
 		const actual = handleChange.args[0][0].value;
 
@@ -110,6 +121,7 @@ describe('Picker Specs', function () {
 		const button = picker.find(`.${css.decrementer}`);
 
 		const expected = 0;
+		button.simulate('focus');
 		button.simulate('click');
 		const actual = handleChange.args[0][0].value;
 
@@ -122,7 +134,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} wrap step={3} min={0} max={3} value={3} index={0} />
 		);
 
-		picker.find(`.${css.incrementer}`).simulate('click');
+		const button = picker.find(`.${css.incrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = 0;
 		const actual = handleChange.args[0][0].value;
@@ -136,7 +150,9 @@ describe('Picker Specs', function () {
 			<Picker onChange={handleChange} wrap step={3} min={0} max={9} value={0} index={0} />
 		);
 
-		picker.find(`.${css.decrementer}`).simulate('click');
+		const button = picker.find(`.${css.decrementer}`);
+		button.simulate('focus');
+		button.simulate('click');
 
 		const expected = 9;
 		const actual = handleChange.args[0][0].value;

--- a/packages/sampler/stories/qa-stories/Spotlight.js
+++ b/packages/sampler/stories/qa-stories/Spotlight.js
@@ -133,6 +133,7 @@ class PopupFocusTest extends React.Component {
 		noAnimation: React.PropTypes.bool,
 		noAutoDismiss: React.PropTypes.bool,
 		scrimType: React.PropTypes.oneOf(['transparent', 'translucent', 'none']),
+		showCloseButton: React.PropTypes.bool,
 		spotlightRestrict: React.PropTypes.oneOf(['none', 'self-first', 'self-only'])
 	}
 
@@ -140,6 +141,7 @@ class PopupFocusTest extends React.Component {
 		noAnimation: false,
 		noAutoDismiss: false,
 		scrimType: 'translucent',
+		showCloseButton: false,
 		spotlightRestrict: 'self-only'
 	}
 
@@ -159,7 +161,7 @@ class PopupFocusTest extends React.Component {
 	}
 
 	render () {
-		const {noAnimation, noAutoDismiss, scrimType, spotlightRestrict} = this.props;
+		const {noAnimation, noAutoDismiss, scrimType, showCloseButton, spotlightRestrict} = this.props;
 
 		return (
 			<div>
@@ -169,6 +171,9 @@ class PopupFocusTest extends React.Component {
 					Focus should return to the button used to originally open the popup. Verify this
 					behavior for each of the buttons.
 				</p>
+				<p>
+					Use the knobs to verify 5-way behavior under different Popup configurations.
+				</p>
 				<Button onClick={this.handleOpenPopup}>Open Popup</Button>
 				<Button onClick={this.handleOpenPopup}>Open Popup</Button>
 				<Popup
@@ -177,7 +182,7 @@ class PopupFocusTest extends React.Component {
 					onClose={this.handleClosePopup}
 					open={this.state.popupOpen}
 					scrimType={scrimType}
-					showCloseButton
+					showCloseButton={showCloseButton}
 					spotlightRestrict={spotlightRestrict}
 				>
 					<div>This is a Popup</div>
@@ -306,12 +311,13 @@ storiesOf('Spotlight')
 		)
 	)
 	.addWithInfo(
-		'Popup Focus Targets',
+		'Popup',
 		() => (
 			<PopupFocusTest
 				noAnimation={boolean('noAnimation', false)}
 				noAutoDismiss={boolean('noAutoDismiss', false)}
 				scrimType={select('scrimType', ['none', 'transparent', 'translucent'], 'translucent')}
+				showCloseButton={boolean('showCloseButton', true)}
 				spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], 'self-only')}
 			/>
 		)

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,9 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-`spotlight.Spotlight` behavior to properly save the last-focused element for nested containers
+- `spotlight/Spotlight` setting the correct active container when calling `focus(containerId)`
+- `spotlight/Spotlight` behavior to follow the various container config rules when navigating between nested containers
+- `spotlight/Spotlight` behavior to properly save the last-focused element for nested containers
 
 ### Removed
 

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -206,9 +206,11 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleMouseLeave = (ev) => {
-			const parentContainer = ev.currentTarget.parentNode.closest('[data-container-id]');
-			const activeContainer = parentContainer ? parentContainer.dataset.containerId : null;
-			Spotlight.setActiveContainer(activeContainer);
+			if (this.props.spotlightRestrict !== 'self-only') {
+				const parentContainer = ev.currentTarget.parentNode.closest('[data-container-id]');
+				const activeContainer = parentContainer ? parentContainer.dataset.containerId : null;
+				Spotlight.setActiveContainer(activeContainer, this.state.id);
+			}
 			forwardMouseLeave(ev, this.props);
 		}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -1427,7 +1427,8 @@ const Spotlight = (function () {
 				identifier = containerId;
 			}
 
-			const lastSpotlightModal = _containers.get(_lastContainerId).restrict === 'self-only';
+			const lastConfig = _containers.get(_lastContainerId);
+			const lastSpotlightModal = lastConfig && lastConfig.restrict === 'self-only';
 
 			// the current active container is requesting the change, or...
 			if (identifier === _lastContainerId ||

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -602,32 +602,28 @@ const Spotlight = (function () {
 		return true;
 	}
 
-	function getContainerId (elem) {
-		const containers = [..._containers.keys()];
-
-		for (let i = containers.length; i-- > 0;) {
-			const id = containers[i];
-			const config = _containers.get(id);
-			if (!config.selectorDisabled && matchSelector(elem, config.selector)) {
-				return id;
-			}
-		}
-	}
-
-	// returns an array of ids for containers that wrap the element, in order of outer-to-inner, with
+	// returns an object of container data for the supplied element, consisting of 2 properties:
+	// `containerIds` - array of ids for containers that wrap the element, in order of outer-to-inner, with
 	// the last array item being the immediate container id of the element.
+	// `activeContainerId` - id of the container that serves as the active container of the element. Usually
+	// this will be the immediate container id of the element, except in nested container cases where this value
+	// will be the nearest parent container that uses a `restrict` config value of `'self-only'`, if available.
 	function getContainerIds (elem) {
 		const containerIds = [..._containers.keys()];
 		const matches = [];
+		let activeContainerId;
 
 		for (let i = 0, containers = containerIds.length; i < containers; ++i) {
 			const id = containerIds[i];
 			const config = _containers.get(id);
 			if (!config.selectorDisabled && matchSelector(elem, config.selector)) {
 				matches.push(id);
+				if (config.restrict === 'self-only') {
+					activeContainerId = id;
+				}
 			}
 		}
-		return matches;
+		return {containerIds: matches, activeContainerId: activeContainerId || last(matches)};
 	}
 
 	function getContainerNavigableElements (containerId) {
@@ -664,7 +660,7 @@ const Spotlight = (function () {
 		}
 	}
 
-	function focusElement (elem, containerIds, fromPointer) {
+	function focusElement (elem, containerIds, activeContainerId, fromPointer) {
 		if (!elem) {
 			return false;
 		}
@@ -681,7 +677,7 @@ const Spotlight = (function () {
 				currentFocusedElement.blur();
 			}
 			elem.focus();
-			focusChanged(elem, containerIds);
+			focusChanged(elem, containerIds, activeContainerId);
 		};
 
 		if (_duringFocusChange) {
@@ -705,18 +701,18 @@ const Spotlight = (function () {
 
 		_duringFocusChange = false;
 
-		focusChanged(elem, containerIds);
+		focusChanged(elem, containerIds, activeContainerId);
 		return true;
 	}
 
-	function focusChanged (elem, containerIds) {
+	function focusChanged (elem, containerIds, activeContainerId) {
 		if (!containerIds || !containerIds.length) {
-			containerIds = getContainerIds(elem);
+			[containerIds, activeContainerId] = getContainerIds(elem);
 		}
 		const containerId = last(containerIds);
 		if (containerId) {
 			setContainerLastFocusedElement(elem, containerIds);
-			_lastContainerId = containerId;
+			_lastContainerId = activeContainerId;
 		}
 	}
 
@@ -731,9 +727,9 @@ const Spotlight = (function () {
 		} else {
 			let next = parseSelector(selector)[0];
 			if (next) {
-				const nextContainerIds = getContainerIds(next);
-				if (isNavigable(next, last(nextContainerIds))) {
-					return focusElement(next, nextContainerIds);
+				const {containerIds, activeContainerId} = getContainerIds(next);
+				if (isNavigable(next, last(containerIds))) {
+					return focusElement(next, containerIds, activeContainerId);
 				}
 			}
 		}
@@ -773,7 +769,8 @@ const Spotlight = (function () {
 			}
 
 			if (next) {
-				return focusElement(next, range);
+				const {containerIds, activeContainerId} = getContainerIds(next);
+				return focusElement(next, containerIds, activeContainerId);
 			}
 		}
 
@@ -793,9 +790,9 @@ const Spotlight = (function () {
 				return focusExtendedSelector(next);
 			}
 
-			const nextContainerIds = getContainerIds(next);
-			if (isNavigable(next, last(nextContainerIds))) {
-				return focusElement(next, nextContainerIds);
+			const {containerIds, activeContainerId} = getContainerIds(next);
+			if (isNavigable(next, last(containerIds))) {
+				return focusElement(next, containerIds, activeContainerId);
 			}
 		}
 		return false;
@@ -813,8 +810,8 @@ const Spotlight = (function () {
 	}
 
 	function focusNext (next, direction, currentContainerId, currentFocusedElement) {
-		const nextContainerIds = getContainerIds(next);
-		const nextContainerId = last(nextContainerIds);
+		const {containerIds, activeContainerId} = getContainerIds(next);
+		const nextContainerId = last(containerIds);
 
 		if (currentContainerId !== nextContainerId) {
 			if (_5WayKeyHold) {
@@ -843,7 +840,7 @@ const Spotlight = (function () {
 			}
 		}
 
-		return focusElement(next, nextContainerIds);
+		return focusElement(next, containerIds, activeContainerId);
 	}
 
 	function spotNextFromPoint (direction, position, containerId) {
@@ -879,7 +876,7 @@ const Spotlight = (function () {
 		return false;
 	}
 
-	function spotNext (direction, currentFocusedElement, currentContainerId) {
+	function spotNext (direction, currentFocusedElement, currentContainerId, currentActiveContainerId) {
 		const extSelector = currentFocusedElement.getAttribute('data-spot-' + direction);
 		if (typeof extSelector === 'string') {
 			if (extSelector === '' || !focusExtendedSelector(extSelector)) {
@@ -890,10 +887,11 @@ const Spotlight = (function () {
 
 		const {allNavigableElements, containerNavigableElements} = getNavigableElements();
 		const config = extend({}, GlobalConfig, _containers.get(currentContainerId));
+		const useActiveContainer = currentContainerId !== currentActiveContainerId;
 		let next;
 
-		if (config.restrict === 'self-only' || config.restrict === 'self-first') {
-			let currentContainerNavigableElements = containerNavigableElements[currentContainerId];
+		if (useActiveContainer || config.restrict === 'self-only' || config.restrict === 'self-first') {
+			const currentContainerNavigableElements = containerNavigableElements[currentContainerId];
 
 			next = navigate(
 				currentFocusedElement,
@@ -902,13 +900,22 @@ const Spotlight = (function () {
 				config
 			);
 
-			if (!next && config.restrict === 'self-first') {
-				next = navigate(
-					currentFocusedElement,
-					direction,
-					exclude(allNavigableElements, currentContainerNavigableElements),
-					config
-				);
+			if (!next) {
+				if (useActiveContainer) {
+					next = navigate(
+						currentFocusedElement,
+						direction,
+						exclude(containerNavigableElements[currentActiveContainerId], currentFocusedElement),
+						extend({}, GlobalConfig, _containers.get(currentActiveContainerId))
+					);
+				} else if (config.restrict === 'self-first') {
+					next = navigate(
+						currentFocusedElement,
+						direction,
+						exclude(allNavigableElements, currentContainerNavigableElements),
+						config
+					);
+				}
 			}
 		} else {
 			next = navigate(
@@ -964,14 +971,14 @@ const Spotlight = (function () {
 			}
 		}
 
-		const currentContainerIds = getContainerIds(currentFocusedElement);
-		const currentContainerId = last(currentContainerIds);
+		const {containerIds, activeContainerId} = getContainerIds(currentFocusedElement);
+		const currentContainerId = last(containerIds);
 		if (!currentContainerId) {
 			return;
 		}
 
-		if (direction && !spotNext(direction, currentFocusedElement, currentContainerId) && currentFocusedElement !== document.activeElement) {
-			focusElement(currentFocusedElement, currentContainerIds);
+		if (direction && !spotNext(direction, currentFocusedElement, currentContainerId, activeContainerId) && currentFocusedElement !== document.activeElement) {
+			focusElement(currentFocusedElement, containerIds, activeContainerId);
 		}
 	}
 
@@ -1036,8 +1043,13 @@ const Spotlight = (function () {
 		const target = getNavigableTarget(evt.target); // account for child controls
 
 		if (target && target !== getCurrent()) { // moving over a focusable element
-			focusElement(target, getContainerIds(target), true);
-			preventDefault(evt);
+			const spotlightModal = _containers.get(_lastContainerId).restrict === 'self-only';
+
+			if (!spotlightModal || (spotlightModal && isNavigable(target, _lastContainerId, true))) {
+				const {containerIds, activeContainerId} = getContainerIds(target);
+				focusElement(target, containerIds, activeContainerId, true);
+				preventDefault(evt);
+			}
 		}
 	}
 
@@ -1074,8 +1086,13 @@ const Spotlight = (function () {
 				// we are moving over a non-focusable element, so we force a blur to occur
 				current.blur();
 			} else if (target && (!current || target !== current)) {
-				// we are moving over a focusable element, so we set focus to the target
-				focusElement(target, getContainerIds(target), true);
+				const spotlightModal = _containers.get(_lastContainerId).restrict === 'self-only';
+
+				if (!spotlightModal || (spotlightModal && isNavigable(target, _lastContainerId, true))) {
+					const {containerIds, activeContainerId} = getContainerIds(target);
+					// we are moving over a focusable element, so we set focus to the target
+					focusElement(target, containerIds, activeContainerId, true);
+				}
 			}
 		}
 	}
@@ -1159,14 +1176,15 @@ const Spotlight = (function () {
 		 * @public
 		 */
 		set: function () {
-			let containerId, config;
+			let containerId, config, existingConfig;
 
 			if (typeof arguments[0] === 'object') {
 				config = arguments[0];
 			} else if (typeof arguments[0] === 'string' && typeof arguments[1] === 'object') {
 				containerId = arguments[0];
 				config = arguments[1];
-				if (!_containers.get(containerId)) {
+				existingConfig = _containers.get(containerId);
+				if (!existingConfig) {
 					throw new Error('Container "' + containerId + '" doesn\'t exist!');
 				}
 			} else {
@@ -1174,18 +1192,18 @@ const Spotlight = (function () {
 			}
 
 			for (let key in config) {
-				const validKey = typeof GlobalConfig[key] !== 'undefined';
-
-				if (!containerId && validKey && typeof config[key] !== 'undefined') {
-					GlobalConfig[key] = config[key];
-				} else if (containerId && !validKey) {
-					delete config[key];
+				if (typeof GlobalConfig[key] !== 'undefined') {
+					if (containerId) {
+						existingConfig[key] = config[key];
+					} else if (typeof config[key] !== 'undefined') {
+						GlobalConfig[key] = config[key];
+					}
 				}
 			}
 
 			if (containerId) {
 				// remove "undefined" items
-				_containers.set(containerId, extend({}, config));
+				_containers.set(containerId, extend({}, existingConfig));
 			}
 		},
 
@@ -1334,10 +1352,9 @@ const Spotlight = (function () {
 					result = focusExtendedSelector(elem);
 				}
 			} else {
-				const nextContainerIds = getContainerIds(elem);
-				const nextContainerId = last(nextContainerIds);
-				if (isNavigable(elem, nextContainerId)) {
-					result = focusElement(elem, nextContainerIds);
+				const {containerIds, activeContainerId} = getContainerIds(elem);
+				if (isNavigable(elem, last(containerIds))) {
+					result = focusElement(elem, containerIds, activeContainerId);
 				}
 			}
 
@@ -1358,24 +1375,23 @@ const Spotlight = (function () {
 		 * @public
 		 */
 		move: function (direction, selector) {
-			let elem, containerId;
-
 			direction = direction.toLowerCase();
 			if (!_reverseDirections[direction]) {
 				return false;
 			}
 
-			elem = selector ? parseSelector(selector)[0] : getCurrent();
+			const elem = selector ? parseSelector(selector)[0] : getCurrent();
 			if (!elem) {
 				return false;
 			}
 
-			containerId = getContainerId(elem);
+			const {containerIds, activeContainerId} = getContainerIds(elem);
+			const containerId = last(containerIds);
 			if (!containerId) {
 				return false;
 			}
 
-			return spotNext(direction, elem, containerId);
+			return spotNext(direction, elem, containerId, activeContainerId);
 		},
 
 		/**
@@ -1402,10 +1418,33 @@ const Spotlight = (function () {
 		 * @memberof spotlight.Spotlight.prototype
 		 * @param {String} [containerId] The id of the currently active container. If this is not
 		 *	provided, the root container is set as the currently active container.
+		 * @param {String} [identifier] The id of the container requesting the change. If this is
+		 *	not provided, the provided `containerId` parameter is set as the identifier.
 		 * @public
 		 */
-		setActiveContainer: function (containerId) {
-			_lastContainerId = containerId || spotlightRootContainerName;
+		setActiveContainer: function (containerId, identifier) {
+			if (containerId && !identifier) {
+				identifier = containerId;
+			}
+
+			const lastSpotlightModal = _containers.get(_lastContainerId).restrict === 'self-only';
+
+			// the current active container is requesting the change, or...
+			if (identifier === _lastContainerId ||
+					// there's a request to change to a specified `containerId` and...
+					(containerId &&
+						// the requested container is not active and...
+						containerId !== _lastContainerId &&
+						// the active container uses a `restrict: 'self-only'` config rule and..
+						lastSpotlightModal &&
+						// the requested container also uses a `restrict: 'self-only'` config rule and..
+						_containers.get(containerId).restrict === 'self-only' &&
+						// the actve container also wraps/contains the requested container
+						(document.querySelector(`[data-container-id='${_lastContainerId}']`) || document).contains(document.querySelector(`[data-container-id='${containerId}']`) || document)) ||
+					// the current active container's config rules will allow focus to move outside its boundaries
+					!lastSpotlightModal) {
+				_lastContainerId = containerId || spotlightRootContainerName;
+			}
 		},
 
 		/**


### PR DESCRIPTION
### Issue Resolved / Feature Added
This PR resolves issues related to spotlight-navigation using `Popup` and `ContextualPopup`. There are some underling spotlight container changes that were needed in order to add this functionality.


### Resolution
This PR introduces spotlight behavior that allows/denies navigation based on an active container `_lastContainerId`. Measures are taken to only change the active container under specific scenarios. Also, spottable components can no longer be spotted via a pointer if they exist outside of a container using a `restrict: 'self-only'` container config.

In these cases we naturally prevent forwarding click events, since the component isn't spotted/active. A byproduct of this is - in our test suite when attempting to call `component.simulate('click')`. The click event isn't being forwarded because the component isn't spotted, unless you to call `component.simulate('focus')` first.


### Additional Considerations
There are some edge-case scenarios to keep in mind when dealing with 5-way behavior in `Popup`. Behaviors can be dictated by the following individual (or combination of) props:
`noAutoDismiss`, `scrimType`, `spotlightRestrict`, then behavior is further affected if the `Popup` contains (or does not contain) spottable components.


### Links
There are a series of in-progress PRs that this PR was dependent upon in order to work. The following PRs were incorporated into this fix:
ENYO-3864 - https://github.com/enyojs/enact/pull/594
ENYO-3987 - https://github.com/enyojs/enact/pull/605
ENYO-3970 - https://github.com/enyojs/enact/pull/599
ENYO-3905 - https://github.com/enyojs/enact/pull/600

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>