### PR TITLE
ENYO-4037: onHide not triggering when popup hides

### DIFF
--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -213,6 +213,14 @@ class Popup extends React.Component {
 		onClose: PropTypes.func,
 
 		/**
+		 * A function to be run after transition for hiding is finished.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onHide: PropTypes.func,
+
+		/**
 		 * A function to be run when a key-down action is invoked by the user.
 		 *
 		 * @type {Function}


### PR DESCRIPTION
### Issue Resolved / Feature Added
`props.onHide` was not firing when popup was hiding.

### Resolution
just needed to forward `onHide`.

### Testing
To test this add `onHide` to the popup sample and make it trigger a `console.log` or some function. Originally I tried to do an action, but since you have to trigger with knobs the logger didn't seem to work.

### Links
ENYO-4037

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com