### PR TITLE
ENYO-4033-4049-4050: CSS fixes for Time Picker

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -36,7 +36,6 @@
 
 		.moon-custom-text({
 			font-size: @moon-item-font-size-large;
-			height: @moon-button-height-large;
 			line-height: @moon-button-height-large;
 		});
 	}
@@ -95,6 +94,11 @@
 		}
 
 		&.horizontal {
+			.moon-custom-text({
+				font-size: @moon-item-font-size-large;
+				height: @moon-button-height-large;
+				line-height: @moon-button-height-large;
+			});
 			&.incrementing:before {
 				border-right-width: @moon-integer-picker-shadow-width;
 			}
@@ -129,7 +133,7 @@
 	}
 
 	&.small .valueWrapper {
-		width: (@moon-spotlight-outset + @moon-icon-size + @moon-spotlight-outset);
+		width: (@moon-icon-size + @moon-spotlight-outset*3);
 	}
 	&.medium .valueWrapper {
 		width: 180px;
@@ -154,8 +158,16 @@
 	&.vertical .valueWrapper {
 		display: block;
 
+		:global(.enact-text-large) & {
+			padding: 0 @moon-spotlight-outset;
+		}
+
 		.item {
 			margin: 0 @moon-spotlight-outset;
+
+			:global(.enact-text-large) & {
+				margin: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
- [x] Large size text should aligned centered in the meridien Picker.
- [x] Large size Hour and Minute values should display.
- [x] The meridien picker should display two Korean characters when in Korean.

### Resolution
Move large text picker css rules to more specific areas. Also added a bit more space for Korean letters.

### Links
ENYO-4050
ENYO-4049
ENYO-4033

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
