### PR TITLE
ENYO-4051: Input large size

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -133,7 +133,7 @@
 	}
 
 	&.small .valueWrapper {
-		width: (@moon-spotlight-outset + @moon-icon-size + @moon-spotlight-outset);
+		width: (@moon-icon-size + @moon-spotlight-outset*3);
 	}
 	&.medium .valueWrapper {
 		width: 180px;
@@ -163,10 +163,10 @@
 		}
 
 		.item {
-			padding: 0 @moon-spotlight-outset;
+			margin: 0 @moon-spotlight-outset;
 
 			:global(.enact-text-large) & {
-				padding: 0;
+				margin: 0;
 			}
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
- [x] Large text size should display in the input field when set to large text.

### Resolution
- Add `moon-custom-text-size` with `font-size-large` for `Input`.

### Links
ENYO-4051


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
