### PR TITLE
ENYO-4042: Focused Input css fix

### DIFF
--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -90,6 +90,7 @@
 	// which should highlight the border
 	&.noDecorator:active,
 	&:global(.spottable):focus {
+		color: @moon-input-font-color;
 		border-color: @moon-spotlight-border-color;
 		background-color: @moon-input-decorator-bg-color;
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Focused `Input` now shows text. 


### Resolution
Change font color to `@moon-input-font-color` so it's different from background-color


### Links
ENYO-4042


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
