### PR TITLE
ENYO-4033: Adjust width of meridiem picker to allow for longer text

### DIFF
--- a/packages/moonstone/TimePicker/TimePickerBase.js
+++ b/packages/moonstone/TimePicker/TimePickerBase.js
@@ -244,7 +244,7 @@ const TimePickerBase = kind({
 							reverse
 							spotlightDisabled={spotlightDisabled}
 							value={meridiem}
-							width="small"
+							width={4}
 							wrap
 						>
 							{meridiems}


### PR DESCRIPTION
This is a hack which relies on the fact that the spacers aren't
working right now. Setting width to a non-zero allows the Picker to
animate and will grow/shrink with the contents. Doing this as the
minimally-invasive change to "make it work" until we can properly fix
both this and the spacer feature of Picker.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)