### PR TITLE
ENYO-4001: CSS fix for unspottable Video Player controls

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.less
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.less
@@ -289,7 +289,7 @@
 							pointer-events: none;
 
 							.moreControls {
-								pointer-events: all;
+								pointer-events: auto;
 							}
 						}
 						.mediaControls,


### PR DESCRIPTION
### Issue Resolved / Feature Added
Able to focus to `leftComponent` `Button` via cursor when showing more controls.

### Resolution
Apply `pointer-event: none;` to `.centerComponents .more` when showing more controls. Also specify `pointer-event: all;` to `.moreControls` to enable click events back to the visible buttons.


### Links
ENYO-4001


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com