### PR TITLE
PLAT-3677: Image does not receive immediate spotlight

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -13,6 +13,7 @@ import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
 import React, {Component, PropTypes} from 'react';
 import ri from '@enact/ui/resolution';
+import Spotlight from '@enact/Spotlight';
 
 import css from './Scrollable.less';
 import ScrollAnimator from './ScrollAnimator';
@@ -432,6 +433,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					isVertical = this.canScrollVertically(bounds),
 					delta = this.wheel(e, isHorizontal, isVertical);
 
+				Spotlight.setPointerMode(false);
 				window.document.activeElement.blur();
 				this.childRef.setContainerDisabled(true);
 				this.scrollToAccumulatedTarget(delta, isHorizontal, isVertical);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The Image in VirtualGridList does not receive immediate Spotlight when trying to move a point after scrolling with "wheel" event

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I forced to turn off pointer mode in Spotlight when wheeling. (Technically it is still pointer mode in device). By doing, Spotlight forced to give the image spotlight focus immediately when trying to move because it's the way when it was not pointer mode in Spotlight and a "move" event generated.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-3677

### Comments
