### PR TITLE
PLAT-38483: Update minimum size for scroll thumb

### DIFF
--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -28,7 +28,7 @@ const
 		thumbClass: css.scrollerHthumb
 	},
 	nop = () => {},
-	minThumbSize = ri.scale(20),
+	minThumbSize = 20,
 	prepareButton = (isPrev) => (isVertical, rtl) => {
 		let direction;
 
@@ -238,7 +238,7 @@ class ScrollbarBase extends Component {
 	calculateMetrics () {
 		this.thumbSize = this.thumbRef[this.scrollbarInfo.sizeProperty];
 		this.trackSize = this.containerRef[this.scrollbarInfo.sizeProperty];
-		this.minThumbSizeRatio = minThumbSize / this.trackSize;
+		this.minThumbSizeRatio = ri.scale(minThumbSize) / this.trackSize;
 	}
 
 	initRef (prop) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Need to update minimum size for scroll thumb
Fixed ri.scale was not applied properly
- **Allow minThumbSize to change when resolution is changed** ( (Parity) Moonstone fixed minThumbSize to 20px)

### Resolution
- Update minThumbSize (4->20)
- Modify minimum size to be calculated after componentDidMount

### Links
PLAT-38483

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo jung (baekwoo.jung@lge.com)