### PR TITLE
use console-snoop instead of enyo-console-spy

### DIFF
--- a/packages/core/dispatcher/tests/dispatcher-specs.js
+++ b/packages/core/dispatcher/tests/dispatcher-specs.js
@@ -1,7 +1,7 @@
 /* global CustomEvent */
 
 import sinon from 'sinon';
-import {restoreErrorAndWarnings, watchErrorAndWarnings} from 'enyo-console-spy';
+import {restoreErrorAndWarnings, watchErrorAndWarnings} from 'console-snoop';
 
 import {off, on, once} from '../dispatcher';
 


### PR DESCRIPTION
Intentionally omitting the package.json dependency for now to avoid any
inadvertent impacts with the version provided by the dev tooling.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)