### PR TITLE
ENYO-3978: Spotlight hold fix

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -813,18 +813,10 @@ const Spotlight = (function () {
 		const currentContainerId = last(currentContainerIds);
 
 		if (currentContainerId !== nextContainerId) {
-			const dataIndexAttribute = 'data-index';
-			let focusedItemIndex = null;
-
-			if (currentFocusedElement) {
-				focusedItemIndex = currentFocusedElement.getAttribute(dataIndexAttribute);
-			}
-
-			if (_5WayKeyHold && focusedItemIndex) {
-				return false;
-			}
-
 			if (nextContainerIds.indexOf(currentContainerId) < 0) {
+				if (_5WayKeyHold) {
+					return false;
+				}
 				const result = gotoLeaveFor(difference(currentContainerIds, nextContainerIds), direction);
 
 				if (result) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
5-way hold stops navigating at ExpandableList

### Resolution
Only cancel `Spotlight` hold when the next element has a different `containerId` and `currentFocusedElement` has `data-index`.


### Additional Considerations
This fix assumes that spottable items in `ExpandableList`/`Group` have `data-index` and the spottable items outside or next container does not.


### Links
ENYO-3978


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com