### PR TITLE
ENYO-3865: Enact Dialog-Unable to 5way Navigate when Mouse Pointer Hovers Button

### DIFF
--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -336,6 +336,8 @@ class Popup extends React.Component {
 			ev.preventDefault();
 			// stop propagation to prevent default spotlight behavior
 			ev.stopPropagation();
+			// set the pointer mode to false on keydown.
+			Spotlight.setPointerMode(false);
 
 			// if focus has changed
 			if (Spotlight.move(direction)) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix Unable to 5way Navigate when Mouse Pointer Hovers Button in Enact Dialog.


### Resolution
Add `Spotlight.setPointerMode(false);` for the `handleKeyDown` in Popup . Without this `_pointerMode` will be always true even after the key down and `focusElement` in Spotlight will return without any operation.



### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
ENYO-3865


### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)