### PR TITLE
ENYO-3970: Send emulated click events on keyup instead of keypress

### DIFF
--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -196,6 +196,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (onSpotlightUp && is('up', keyCode)) {
 				onSpotlightUp(ev);
 			}
+
+			return true;
 		}
 
 		handle = handle.bind(this)


### PR DESCRIPTION
Since keypress events may be generated after keydown but before keyup
*and* the first keypress event will not have its repeat member set to
true, this moves the press => click emulation to the keyup to ensure
we receive the keyup/mouseup event before the click event.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)