### PR TITLE
ENYO-4076: Maintain scrollable DOM structure

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -867,13 +867,11 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			delete props.verticalScrollbar;
 
 			return (
-				(isHorizontalScrollbarVisible || isVerticalScrollbarVisible) ? (
-					<div ref={this.initContainerRef} className={scrollableClasses} style={style}>
-						{vscrollbar}
-						{hscrollbar}
-						<Wrapped {...props} {...this.eventHandlers} ref={this.initChildRef} cbScrollTo={this.scrollTo} className={css.container} />
-					</div>
-				) : <Wrapped {...props} {...this.eventHandlers} cbScrollTo={this.scrollTo} className={scrollableClasses} ref={this.initChildRef} style={style} />
+				<div ref={this.initContainerRef} className={scrollableClasses} style={style}>
+					{vscrollbar}
+					{hscrollbar}
+					<Wrapped {...props} {...this.eventHandlers} ref={this.initChildRef} cbScrollTo={this.scrollTo} className={css.container} />
+				</div>
 			);
 		}
 	};


### PR DESCRIPTION
In the current code, the first pass it renders just Wrapped. Second pass, it renders the wrapper + scrollbars + Wrapped. The DOM hierarchy changes when it detects it needs scrollbars so React can’t reuse the DOM nodes; the tree changed too much.

Proposing we change it to the same structure in either case which uses an extra DOM node but saves re-creating all the children.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)