### PR TITLE
ENYO-4081: Darken neutral theme button colors

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -223,8 +223,12 @@
 			background-color: fade(@moon-neutral-button-bg-color, @moon-button-translucent-opacity);
 		}
 
-		&.transparent .bg {
-			background-color: transparent;
+		&.transparent {
+			color: @moon-neutral-button-bg-color;
+
+			.bg {
+				background-color: transparent;
+			}
 		}
 
 		* {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` text color when used on a neutral (light) background in some cases
+- `moonstone/Popup` background opacity
 
 ## [1.0.0] - 2017-03-31
 

--- a/packages/moonstone/Notification/Notification.less
+++ b/packages/moonstone/Notification/Notification.less
@@ -10,7 +10,6 @@
 	max-width: 978px;
 	text-align: center;
 	border-radius: @moon-notification-border-radius;
-	background-color: fade(@moon-neutral-bg-color, @moon-notification-background-opacity);
 	-webkit-transform: translateY(-324px) translate3d(-50%, 50%, 0);
 	-moz-transform:    translateY(-324px) translate3d(-50%, 50%, 0);
 	-ms-transform:     translateY(-324px) translate3d(-50%, 50%, 0);

--- a/packages/moonstone/Popup/Popup.less
+++ b/packages/moonstone/Popup/Popup.less
@@ -26,6 +26,10 @@
 		.padding-start-end(@padding-h, @moon-icon-button-small-size + @moon-spotlight-outset);
 	}
 
+	&:global(.moon-neutral) {
+		background-color: fade(@moon-neutral-bg-color, @moon-neutral-popup-background-opacity);
+	}
+
 	:global(.enact-locale-right-to-left) & {
 		.closeButton {
 			right: auto;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -16,10 +16,11 @@
 @moon-neutral-scroller-icon: url(../images/LightTheme_Icons/scroller_icon.png);
 @moon-neutral-border-color: @moon-dark-gray;
 @moon-neutral-icon-color: @moon-dark-gray;
-@moon-neutral-button-text-color: @moon-dark-gray;
-@moon-neutral-button-bg-color: @moon-white;
-@moon-neutral-button-disabled-text-color: @moon-dark-gray;
-@moon-neutral-button-disabled-bg-color: @moon-white;
+@moon-neutral-button-text-color: @moon-white;
+@moon-neutral-button-bg-color: #686868;
+@moon-neutral-button-disabled-text-color: #cdcdcd;
+@moon-neutral-button-disabled-bg-color: #686868;
+@moon-neutral-popup-background-opacity: 95%;
 @moon-neutral-thumb-bg-color: rgba(50, 50, 50, 0.8);
 @moon-neutral-slider-knob-bg-color: @moon-white;
 @moon-neutral-slider-spotlight-bar-color: @moon-spotlight-color;
@@ -301,7 +302,6 @@
 @moon-notification-font-family: "MuseoSans";
 @moon-notification-font-weight: 500;
 @moon-notification-font-style: normal;
-@moon-notification-background-opacity: 95%;
 @moon-notification-border-opacity: 30%;
 @moon-notification-border-width: 6px;
 @moon-notification-border-radius: 15px;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Assign dark button colors for neutral theme (e.g. Popup, Dialog, Notification) to match enyo 2.6.4 style
- Add background opacity of 95% for `Popup`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- It's highly unlikely to use transparent button on a neutral theme background, but `color` needs to be assigned for text to appear correctly

### Links
[//]: # (Related issues, references)
ENYO-4081
https://github.com/enyojs/moonstone/pull/2870

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>