### PR TITLE
PLAT-35599: Reduce re-render when receiving new data in VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -231,9 +231,9 @@ class VirtualListCore extends Component {
 		}
 	}
 
-	shouldComponentUpdate (nextProps) {
+	shouldComponentUpdate (nextProps, nextState) {
 		if ((this.props.dataSize !== nextProps.dataSize) &&
-			(this.curFirstIndex + this.curNumOfItems) < nextProps.dataSize) {
+			(nextState.firstIndex + nextState.numOfItems) < nextProps.dataSize) {
 			return false;
 		}
 		return true;
@@ -270,9 +270,7 @@ class VirtualListCore extends Component {
 
 	dimensionToExtent = 0
 	threshold = 0
-	curFirstIndex = 0
 	maxFirstIndex = 0
-	curNumOfItems = 0
 	curDataSize = 0
 	cc = []
 	scrollPosition = 0
@@ -387,16 +385,14 @@ class VirtualListCore extends Component {
 			wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (this.state.firstIndex === this.maxFirstIndex));
 
 		this.maxFirstIndex = dataSize - numOfItems;
-		this.curNumOfItems = numOfItems;
 		this.curDataSize = dataSize;
-		this.curFirstIndex = wasFirstIndexMax ? this.maxFirstIndex : Math.min(this.state.firstIndex, this.maxFirstIndex);
 		this.updateFrom = null;
 		this.updateTo = null;
 
 		// reset children
 		this.cc = [];
 
-		this.setState({firstIndex: this.curFirstIndex, numOfItems});
+		this.setState({firstIndex: wasFirstIndexMax ? this.maxFirstIndex : Math.min(this.state.firstIndex, this.maxFirstIndex), numOfItems});
 		this.calculateScrollBounds(props);
 	}
 
@@ -482,7 +478,6 @@ class VirtualListCore extends Component {
 		this.scrollPosition = pos;
 
 		if (firstIndex !== newFirstIndex) {
-			this.curFirstIndex = newFirstIndex;
 			this.setState({firstIndex: newFirstIndex});
 		} else {
 			this.positionItems(this.determineUpdatedNeededIndices());


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Reduced re-render VirtualList when receiving data incrementally from LS2 request.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `shouldComponentUpdate` function for checking whether re-render or not based on dataSize and visible area when changing `dataSize`.
Had to make `curFirstIndex` as holding the recent firstIndex information since setState is async.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
But there is also an inevitable down-side of this approach.
If we wheel while retrieving data incrementally, the scroll performance degraded significantly. We can see from bare eyes that blank or overlapped items frequently.
This is because even if we prevent the rendering caused by changing `dataSize` in the invisible area, We can not avoid calculating scroll bounds according to updated `dataSize` since it is needed from Scrollable for scrolling.
So for keeping the scroll performance good, the app needs to avoid changing `dataSize` frequently.
Please refer to ticket below for more information.

### Links
[//]: # (Related issues, references)
PLAT-35599

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)