### PR TITLE
ENYO-4065: Set webos initial spotlight pointer mode

### DIFF
--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -40,12 +40,18 @@ const SpotlightRootDecorator = hoc((config, Wrapped) => {
 
 		componentWillMount () {
 			if (typeof window === 'object') {
+				const palmSystem = window.PalmSystem;
+
 				Spotlight.initialize();
 				Spotlight.add(spotlightRootContainerName, {
 					selector: '.' + spottableClass,
 					navigableFilter: this.navigableFilter,
 					restrict: 'none'
 				});
+
+				if (palmSystem && palmSystem.cursor) {
+					Spotlight.setPointerMode(palmSystem.cursor.visibility);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
We need to set the initial spotlight pointer mode for apps on webOS devices. Currently app developers need to manually check webOS cursor availability and set pointer mode per app, but we need a way to do this in the framework.


### Resolution
Prior to an application mounting, we initialize spotlight. After initialization, we are able to check the webOS cursor status and set pointer mode accordingly. As for coupling webOS and spotlight code, it seems to make more sense to do this directly in spotlight rather than from the webOS side of things.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>