### PR TITLE
ENYO-3898: Storybook: Add the Disabled Knob

### DIFF
--- a/packages/sampler/stories/moonstone-stories/BodyText.js
+++ b/packages/sampler/stories/moonstone-stories/BodyText.js
@@ -13,6 +13,7 @@ storiesOf('BodyText')
 		() => (
 			<BodyText
 				centered={nullify(boolean('centered', false))}
+				disabled={nullify(boolean('disabled', false))}
 			>
 				{text('children', 'This is Body Text')}
 			</BodyText>

--- a/packages/sampler/stories/moonstone-stories/Dialog.js
+++ b/packages/sampler/stories/moonstone-stories/Dialog.js
@@ -24,7 +24,7 @@ storiesOf('Dialog')
 					<title>{text('title', 'Hello Dialog')}</title>
 					<titleBelow>{text('titleBelow', 'This is an organized dialog')}</titleBelow>
 					<span>This dialog has content in it and can be very useful for organizing information
-					for the user.</span>
+				for the user.</span>
 					<buttons>
 						<Button>Ok</Button>
 						<Button>Nevermind</Button>

--- a/packages/sampler/stories/moonstone-stories/Divider.js
+++ b/packages/sampler/stories/moonstone-stories/Divider.js
@@ -1,7 +1,9 @@
 import Divider from '@enact/moonstone/Divider';
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {withKnobs, text} from '@kadira/storybook-addon-knobs';
+import {boolean, text, withKnobs} from '@kadira/storybook-addon-knobs';
+
+import nullify from '../../src/utils/nullify.js';
 
 storiesOf('Divider')
 	.addDecorator(withKnobs)
@@ -9,7 +11,9 @@ storiesOf('Divider')
 		' ',
 		'Basic usage of divider',
 		() => (
-			<Divider>
+			<Divider
+				disabled={nullify(boolean('disabled', false))}
+			>
 				{text('children', 'divider text')}
 			</Divider>
 		)

--- a/packages/sampler/stories/moonstone-stories/Group.js
+++ b/packages/sampler/stories/moonstone-stories/Group.js
@@ -30,13 +30,14 @@ storiesOf('Group')
 		() => (
 			<Group
 				childComponent={getComponent(select('childComponent', Object.keys(prop.children), 'CheckboxItem'))}
+				defaultSelected={0}
 				itemProps={{
+					disabled: boolean('itemProps-disabled', false),
 					inline: boolean('ItemProps-Inline', false)
 				}}
+				onSelect={action('onSelect')}
 				select={select('select', ['single', 'radio', 'multiple'], 'radio')}
 				selectedProp="selected"
-				defaultSelected={0}
-				onSelect={action('onSelect')}
 			>
 				{['Item 1', 'Item 2', 'Item 3']}
 			</Group>

--- a/packages/sampler/stories/moonstone-stories/Icon.js
+++ b/packages/sampler/stories/moonstone-stories/Icon.js
@@ -5,6 +5,8 @@ import React from 'react';
 import {storiesOf} from '@kadira/storybook';
 import {withKnobs, boolean, select, text} from '@kadira/storybook-addon-knobs';
 
+import nullify from '../../src/utils/nullify.js';
+
 // import icons
 import fwd from '../../images/icon-fwd-btn.png';
 import play from '../../images/icon-play-btn.png';
@@ -18,6 +20,7 @@ storiesOf('Icon')
 		() => (
 			<div>
 				<Icon
+					disabled={nullify(boolean('disabled', false))}
 					small={boolean('small', false)}
 				>
 					{select('src', ['', fwd, play, rew], '') + select('icon', ['', ...iconNames], 'plus') + text('custom icon', '')}

--- a/packages/sampler/stories/moonstone-stories/Image.js
+++ b/packages/sampler/stories/moonstone-stories/Image.js
@@ -1,7 +1,9 @@
 import Image from '@enact/moonstone/Image';
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {withKnobs, select} from '@kadira/storybook-addon-knobs';
+import {boolean, select, withKnobs} from '@kadira/storybook-addon-knobs';
+
+import nullify from '../../src/utils/nullify.js';
 
 const src = {
 	'hd': 'http://lorempixel.com/128/128/city/1/',
@@ -15,6 +17,10 @@ storiesOf('Image')
 		' ',
 		'The basic Image',
 		() => (
-			<Image src={src} sizing={select('sizing', ['fill', 'fit', 'none'], 'fill')} />
+			<Image
+				disabled={nullify(boolean('disabled', false))}
+				sizing={select('sizing', ['fill', 'fit', 'none'], 'fill')}
+				src={src}
+			/>
 		)
 	);

--- a/packages/sampler/stories/moonstone-stories/Notification.js
+++ b/packages/sampler/stories/moonstone-stories/Notification.js
@@ -4,6 +4,8 @@ import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {withKnobs, boolean, text} from '@kadira/storybook-addon-knobs';
 
+import nullify from '../../src/utils/nullify.js';
+
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('Notification', NotificationBase, Notification);
@@ -15,9 +17,10 @@ storiesOf('Notification')
 		'Basic usage of Notification',
 		() => (
 			<Notification
-				open={boolean('open', true)}
+				disabled={nullify(boolean('disabled', false))}
 				noAutoDismiss={boolean('noAutoDismiss', false)}
 				onClose={action('onClose')}
+				open={boolean('open', true)}
 			>
 				<span>{text('message', 'Notification has content in it and can be very useful for organizing information for the user.')}</span>
 				<buttons>

--- a/packages/sampler/stories/moonstone-stories/Popup.js
+++ b/packages/sampler/stories/moonstone-stories/Popup.js
@@ -2,7 +2,9 @@ import Popup, {PopupBase} from '@enact/moonstone/Popup';
 import BodyText from '@enact/moonstone/BodyText';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, boolean, text, select} from '@kadira/storybook-addon-knobs';
+import {boolean, select, text, withKnobs} from '@kadira/storybook-addon-knobs';
+
+import nullify from '../../src/utils/nullify.js';
 
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
@@ -16,10 +18,11 @@ storiesOf('Popup')
 		() => (
 			<div>
 				<Popup
-					open={boolean('open', false)}
+					disabled={nullify(boolean('disabled', false))}
 					noAnimation={boolean('noAnimation', false)}
 					noAutoDismiss={boolean('noAutoDismiss', false)}
 					onClose={action('onClose')}
+					open={boolean('open', false)}
 					showCloseButton={boolean('showCloseButton', false)}
 					spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], 'self-only')}
 				>

--- a/packages/sampler/stories/moonstone-stories/Scroller.js
+++ b/packages/sampler/stories/moonstone-stories/Scroller.js
@@ -2,7 +2,9 @@ import ri from '@enact/ui/resolution';
 import Scroller, {ScrollerBase} from '@enact/moonstone/Scroller';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, select} from '@kadira/storybook-addon-knobs';
+import {boolean, select, withKnobs} from '@kadira/storybook-addon-knobs';
+
+import nullify from '../../src/utils/nullify.js';
 
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
@@ -32,22 +34,26 @@ storiesOf('Scroller')
 	.addWithInfo(
 		' ',
 		'Basic usage of Scroller',
-		() => (
-			<Scroller
-				horizontal={select('horizontal', prop.horizontal, 'auto')}
-				onScrollStart={action('onScrollStart')}
-				onScrollStop={action('onScrollStop')}
-				style={style.scroller}
-				vertical={select('vertical', prop.vertical, 'auto')}
-			>
-				<div style={style.content}>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
-					Aenean id blandit nunc. Donec lacinia nisi vitae mi dictum, eget pulvinar nunc tincidunt. Integer vehicula tempus rutrum. Sed efficitur neque in arcu dignissim cursus.
-					<div style={style.bottom}>
-						Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
+		() => {
+			const disabled = boolean('disabled', false);
+			return (
+				<Scroller
+					disabled={disabled}
+					horizontal={disabled ? 'hidden' : select('horizontal', prop.horizontal, 'auto')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					style={style.scroller}
+					vertical={disabled ? 'hidden' : select('vertical', prop.vertical, 'auto')}
+				>
+					<div style={style.content}>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
+						Aenean id blandit nunc. Donec lacinia nisi vitae mi dictum, eget pulvinar nunc tincidunt. Integer vehicula tempus rutrum. Sed efficitur neque in arcu dignissim cursus.
+						<div style={style.bottom}>
+							Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
+						</div>
 					</div>
-				</div>
-			</Scroller>
-		),
+				</Scroller>
+			)
+		},
 		{propTables: [Config]}
 	);

--- a/packages/sampler/stories/moonstone-stories/TooltipDecorator.js
+++ b/packages/sampler/stories/moonstone-stories/TooltipDecorator.js
@@ -1,7 +1,7 @@
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {withKnobs, boolean, number, select, text} from '@kadira/storybook-addon-knobs';
+import {boolean, number, select, text, withKnobs} from '@kadira/storybook-addon-knobs';
 
 import nullify from '../../src/utils/nullify.js';
 
@@ -32,6 +32,7 @@ storiesOf('TooltipDecorator')
 		() => (
 			<div style={{textAlign: 'center'}}>
 				<Button
+					disabled={nullify(boolean('disabled', false))}
 					tooltipDelay={number('tooltipDelay', 500)}
 					tooltipText={text('tooltipText', 'tooltip!')}
 					tooltipPosition={select('tooltipPosition', prop.tooltipPosition, 'above')}

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -3,7 +3,7 @@ import IconButton from '@enact/moonstone/IconButton';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, boolean, number, select, text} from '@kadira/storybook-addon-knobs';
+import {boolean, number, select, text, withKnobs} from '@kadira/storybook-addon-knobs';
 
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 

--- a/packages/sampler/stories/moonstone-stories/VirtualFlexList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualFlexList.js
@@ -3,7 +3,7 @@ import Item from '@enact/moonstone/Item';
 import VirtualFlexList from '@enact/moonstone/VirtualFlexList';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, number} from '@kadira/storybook-addon-knobs';
+import {boolean, number, withKnobs} from '@kadira/storybook-addon-knobs';
 
 const
 	channelWidth = ri.scale(420),

--- a/packages/sampler/stories/moonstone-stories/VirtualGridList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualGridList.js
@@ -4,7 +4,7 @@ import {VirtualListCore} from '@enact/moonstone/VirtualList/VirtualListBase';
 import GridListImageItem from '@enact/moonstone/VirtualList/GridListImageItem';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, number, select} from '@kadira/storybook-addon-knobs';
+import {number, select, withKnobs} from '@kadira/storybook-addon-knobs';
 
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -4,7 +4,7 @@ import Item from '@enact/moonstone/Item';
 import {VirtualListCore} from '@enact/moonstone/VirtualList/VirtualListBase';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
-import {withKnobs, number} from '@kadira/storybook-addon-knobs';
+import {number, withKnobs} from '@kadira/storybook-addon-knobs';
 
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Adds a `disabled` knob for `Divider`, `Group`, `Icon`, `Image`, and `Tooltip` stories.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Some other components in the issue did not receive a `disabled` knob.

### Links
[//]: # (Related issues, references)
ENYO-3898

Enact-DCO-1.0-Signed-off-by: Dave Freeman dave.freeman@lge.com