### PR TITLE
ENYO-4106 : Accessibility: Exit button needs to set aria-label

### DIFF
--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -1,3 +1,4 @@
+import $L from '@enact/i18n/$L';
 import kind from '@enact/core/kind';
 import React from 'react';
 
@@ -37,6 +38,7 @@ const ApplicationCloseButton = kind({
 		return (
 			<IconButton
 				{...rest}
+				aria-label={$L('Exit app')}
 				small
 				backgroundOpacity="transparent"
 				onClick={onApplicationClose}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ApplicationCloseButton doesn't read 'Exit App'

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `aria-label=$L('Exit app')`

### Note
Enyo ApplicationCloseButton add aria-label only when `autoShow` is false for tooltip but I don't see any other Enact component which import ApplicationCloseButton but Panels

Enyo-DCO-1.1-Signed-off-by: Seungho Park <seunghoh.park@lge.com>
