### PR TITLE
ENYO-4107: Only add placeholder to aria-label when value is not set

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -187,7 +187,7 @@ const InputBase = kind({
 
 	computed: {
 		'aria-label': ({placeholder, type, value}) => {
-			const title = value == null ? placeholder : '';
+			const title = (value == null || value === '') ? placeholder : '';
 			return calcAriaLabel(title, type, value);
 		},
 		className: ({focused, styler}) => styler.append({focused}),


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)