### PR TITLE
PLAT-38837: Fixed wrong calculation of scroll position in Scroller

### DIFF
--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -149,7 +149,7 @@ class ScrollerBase extends Component {
 			if (this.context.rtl && newItemLeft > clientWidth) {
 				// For RTL, and if the `focusedItem` is bigger than `this.scrollBounds.clientWidth`, keep
 				// the scroller to the right.
-				this.scrollPos.left -= newitemLeft;
+				this.scrollPos.left -= newItemLeft;
 			} else if (newItemLeft + itemWidth > (clientWidth + currentScrollLeft) && itemWidth < clientWidth) {
 				// If focus is moved to an element outside of view area (to the right), scroller will move
 				// to the right just enough to show the current `focusedItem`. This does not apply to


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed wrong calculation of scroll position in Scroller
Scroller is using offset values when it calculates scroll position onFocus. If a scroller has an item that has 'position: absolute' property, current code will give the wrong position to scroll.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed using offset values to using `getBoundingClientRect` values

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-38837

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)