### PR TITLE
ENYO-4101: Prevent re-focus of Expandable children

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableContainer.js
+++ b/packages/moonstone/ExpandableItem/ExpandableContainer.js
@@ -60,16 +60,18 @@ const ExpandableContainerBase = class extends React.Component {
 	}
 
 	highlightContents = () => {
-		if (this.containerNode.contains(document.activeElement)) {
+		const current = Spotlight.getCurrent();
+		if (this.containerNode.contains(current)) {
 			const contents = this.containerNode.querySelector('[data-expandable-container]');
-			if (contents && !contents.contains(document.activeElement) && !this.props.noAutoFocus) {
+			if (contents && !this.props.noAutoFocus && !contents.contains(current)) {
 				Spotlight.focus(contents.dataset.containerId);
 			}
 		}
 	}
 
 	highlightLabeledItem = () => {
-		if (this.containerNode.contains(document.activeElement)) {
+		const current = Spotlight.getCurrent();
+		if (this.containerNode.contains(current)) {
 			Spotlight.focus(this.props['data-container-id']);
 		}
 	}


### PR DESCRIPTION
Add condition check Expandable children has already focused.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ExpandableContainer make children be focused when Expandable is opened. However, ExpandableContainer also triggers onTransition event callback when the child is animated like changing the value of picker. Then, re-focus event is called in ExpandableContainer even if children already has focused.
In the case of DatePicker / TimePicker, TV reads hint message when picker value is changed because of this reason.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If the current focused item is in contents container, it means that Expandable children have focus, so I prevented re-focus by adding this condition. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4101

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>