### PR TITLE
ENYO-4132: Unable to open popup.

### DIFF
--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -300,8 +300,12 @@ class Transition extends React.Component {
 		const {visible} = this.props;
 		const {initialHeight, renderState} = this.state;
 
-		// Checking that something changed that wasn't the visibility or the initialHeight state or checking if component should be visible but doesn't have a height
-		if ((visible === prevProps.visible && initialHeight === prevState.initialHeight && renderState !== TRANSITION_STATE.INIT) || (initialHeight == null && visible)) {
+		// Checking that something changed that wasn't the visibility
+		// or the initialHeight state or checking if component should be visible but doesn't have a height
+		if ((visible === prevProps.visible &&
+			initialHeight === prevState.initialHeight &&
+			renderState !== TRANSITION_STATE.INIT) ||
+			(initialHeight == null && visible)) {
 			this.measureInner();
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Popup was broken when we added idle to transition.


### Resolution
Adding back measuring inside `transition` when a transition that's supposed to be visible is called.


### Links
ENYO-4132

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com