### PR TITLE
PLAT-37370: Apply missed code and remove unnecessary code

### DIFF
--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -651,7 +651,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				containerNode.addEventListener('wheel', this.onWheel);
 			}
 			// FIXME `onScroll` doesn't work on the v8 snapshot.
-			containerNode.addEventListener('scroll', this.onScroll, {capture: true, passive: true});
+			containerNode.addEventListener('scroll', this.onScroll, {capture: true});
 			// FIXME `onFocus` doesn't work on the v8 snapshot.
 			containerNode.addEventListener('focus', this.onFocus, {capture: true});
 			// FIXME `onMouseOver` doesn't work on the v8 snapshot.


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When #666 is merged, native components are still under developing and modified code is also meaningful to native components. So the same modification is applied to native components.

In native components, `passive` option was added to 'scroll' event handler, but it takes no effect at all. `passive` option is removed.




### Links
[//]: # (Related issues, references)
PLAT-37370

### Comments
`passive` option works for wheel event and touch events. In our native components, we use wheel event handler but we cannot set `passive` since `preventDefault` can be called in some cases.

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)