### PR TITLE
PLAT-40178: position items with 'transform' for native lists

### DIFF
--- a/packages/moonstone/VirtualList/ListItemNative.less
+++ b/packages/moonstone/VirtualList/ListItemNative.less
@@ -1,7 +1,0 @@
-.listItem {
-	position: absolute;
-	overflow: hidden;
-	width: 100%;
-
-	will-change: left, top;
-}

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -15,7 +15,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import {dataIndexAttribute, ScrollableNative} from '../Scroller/ScrollableNative';
 
 import css from './VirtualListBaseNative.less';
-import cssItem from './ListItemNative.less';
+import cssItem from './ListItem.less';
 
 const
 	dataContainerMutedAttribute = 'data-container-muted',
@@ -175,8 +175,6 @@ class VirtualListCoreNative extends Component {
 		this.state = {firstIndex: 0, numOfItems: 0};
 		this.initContainerRef = this.initRef('containerRef');
 		this.initWrapperRef = this.initRef('wrapperRef');
-
-		this.wrapperStyle.willChange = 'transform';
 	}
 
 	componentWillMount () {
@@ -244,7 +242,7 @@ class VirtualListCoreNative extends Component {
 	cc = []
 	scrollPosition = 0
 
-	wrapperStyle = {}
+	wrapperClass = null
 	containerRef = null
 	wrapperRef = null
 
@@ -372,7 +370,6 @@ class VirtualListCoreNative extends Component {
 
 	calculateScrollBounds (props) {
 		const
-			{wrapperStyle} = this,
 			{clientSize} = props,
 			node = this.getContainerNode();
 
@@ -401,14 +398,7 @@ class VirtualListCoreNative extends Component {
 			this.props.cbScrollTo({position: (isPrimaryDirectionVertical) ? {y: maxPos} : {x: maxPos}});
 		}
 
-
-		if (isPrimaryDirectionVertical) {
-			wrapperStyle.overflowY = 'scroll';
-			wrapperStyle.overflowX = 'hidden';
-		} else {
-			wrapperStyle.overflowX = 'scroll';
-			wrapperStyle.overflowY = 'hidden';
-		}
+		this.wrapperClass = (isPrimaryDirectionVertical) ? css.vertical : css.horizontal;
 
 		this.containerRef.style.width = scrollBounds.scrollWidth + 'px';
 		this.containerRef.style.height = scrollBounds.scrollHeight + 'px';
@@ -698,12 +688,10 @@ class VirtualListCoreNative extends Component {
 
 		const
 			{className, style, ...rest} = props,
-			{wrapperStyle} = this,
-			mergedStyle = {...style, ...wrapperStyle},
-			mergedClasses = classNames(css.list, className);
+			mergedClasses = classNames(css.list, this.wrapperClass, className);
 
 		return (
-			<div ref={this.initWrapperRef} className={mergedClasses} style={mergedStyle}>
+			<div ref={this.initWrapperRef} className={mergedClasses} style={style}>
 				<div {...rest} ref={this.initContainerRef}>
 					{cc}
 				</div>

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.less
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.less
@@ -2,6 +2,14 @@
 	position: relative;
 	height: 100%;
 	width: 100%;
+	&.vertical {
+		overflow-x: hidden;
+		overflow-y: scroll;
+	}
+	&.horizontal {
+		overflow-x: scroll;
+		overflow-y: hidden;
+	}
 }
 
 .list::-webkit-scrollbar {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If we change items to be positioned by `transform` instead of `left` and `top`,
we can reduce composition layers in items (e.g. GridListImageItem) and get better performance.

### Links
[//]: # (Related issues, references)
PLAT-40178

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
