### PR TITLE
ENYO-4036: Fix Enact ExpandableInput-VKB Does Not Reappear issue

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableContainer.js
+++ b/packages/moonstone/ExpandableItem/ExpandableContainer.js
@@ -62,9 +62,11 @@ const ExpandableContainerBase = class extends React.Component {
 
 	highlightContents = () => {
 		const current = Spotlight.getCurrent();
-		const contents = this.containerNode.querySelector('[data-expandable-container]');
-		if (contents && !this.props.noAutoFocus && !contents.contains(current)) {
-			Spotlight.focus(contents.dataset.containerId);
+		if (this.containerNode.contains(current) || document.activeElement === document.body) {
+			const contents = this.containerNode.querySelector('[data-expandable-container]');
+			if (contents && !this.props.noAutoFocus && !contents.contains(current)) {
+				Spotlight.focus(contents.dataset.containerId);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix Enact ExpandableInput-VKB Does Not Reappear issue


### Resolution
`highlightContents` function checks for the current in the container node, which will be `undefined` if the mouse is moved down (as body is the activeElement).
Removed `this.containerNode.contains(current)` check as this is checks the if `LabeledItem` is current which will not be true if the mouse is moved down.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
https://jira2.lgsvl.com/browse/ENYO-4036


### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)