### PR TITLE
ENYO-4169: Prevent pointer from changing active container when leavin…

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Changed
 
-- `spotlight/SpotlightContainerDecorator` config property, `enterTo`, default value to be null rather than `'last-focused'`.
+- `spotlight/SpotlightContainerDecorator` config property, `enterTo`, default value to be `null` rather than `'last-focused'`.
 
 ## [1.1.0] - 2017-04-21
 

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -42,10 +42,13 @@ const defaultConfig = {
 	defaultElement: `.${spotlightDefaultClass}`,
 
 	/**
-	 * Directs which component receives focus when gaining focus from another container.
+	 * Directs which element receives focus when gaining focus from another container. If
+	 * `'default-element'`, the default focused item will be selected. If `'last-focused'`, the
+	 * container will focus the last focused item; if the container has never had focus, the default
+	 * element will receive focus. If `null`, the default 5-way behavior will be applied.
 	 *
 	 * @type {String}
-	 * @default 'last-focused'
+	 * @default null
 	 * @memberof spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator.defaultConfig
 	 * @public
 	 */


### PR DESCRIPTION
…g self-only container

### Issue Resolved / Feature Added
We need to prevent the pointer from changing the active container when the pointer leaves a container using a `restrict: 'self-only'` config.


### Resolution
The fix is rather simple, however the behavior of `restrict: 'self-only'` containers may also depend on (and be related to a similar behavior/issue) using a scrim to block::
- other outside/underlying spottable controls from gaining focus
- other outside/underlying containers from emitting a `onMouseEnter` event when the pointer enters them
Both of these actions will ultimately change the active container id, which you'd expect to prevent when using a `restrict: 'self-only'` container. See https://jira2.lgsvl.com/browse/PLAT-40272 for a related use-case.

In these cases, maybe we should instruct or add docs specifying concerns and how `'self-only'` is expected to be used with a scrim, blocking pointer events from outside controls/containers. Also in these cases when `restrict: 'containers'` exist, we generally need to guarantee that the container id changes (generally to the last spotted container) when the container locking spotlight has been removed from the DOM. We do this in the case of `Popup` already, but it may be a good idea to note for potential dev use-cases.


### Links
Could relate to: https://jira2.lgsvl.com/browse/PLAT-40272

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>