### PR TITLE
ENYO-4200: Moonstone skin classes don't get app-root level rules

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -89,7 +89,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		static displayName = 'MoonstoneDecorator';
 
 		render () {
-			let className = 'enact-unselectable';
+			let className = css.root + ' enact-unselectable';
 			if (!float) {
 				className += ' ' + bgClassName;
 			}

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
@@ -5,5 +5,17 @@
 @import '~@enact/ui/styles/core.less';
 
 // Moonstone Rules
+@import '../styles/variables.less';
 @import '../styles/fonts.less';
 @import '../styles/rules.less';
+
+.root {
+	&.bg,
+	& > .bg {
+		padding: @moon-app-keepout;
+	}
+
+	&:global(.enact-locale-right-to-left) {
+		direction: rtl;
+	}
+}

--- a/packages/moonstone/styles/rules.less
+++ b/packages/moonstone/styles/rules.less
@@ -14,16 +14,11 @@
 	font-weight: normal;
 	font-style: normal;
 	letter-spacing: normal;
-	padding: @moon-app-keepout;
 	color: @moon-text-color;
 
 	::selection {
 		color: @moon-spotlight-text-color;
 		background-color: lighten(@moon-spotlight-bg-color, 18%);
-	}
-
-	&:global(.enact-locale-right-to-left) {
-		direction: rtl;
 	}
 
 	// For cases where we have a skin inside another skin, we actually do want to impose a BG color


### PR DESCRIPTION
The RTL rules were moved because they only need to be applied once at root, not replaced and overridden on every child.

CHANGELOG entry skipped because this fixes an issue introduced within this release.