### PR TITLE
ENYO-4221: Restore platform detection to VideoPlayer

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -28,7 +28,6 @@ No significant changes.
 ### Added
 
 - `core/handle.oneOf` to support branching event handlers
-- `core/platform` to support platform detection across multiple browsers
 
 ## [1.1.0] - 2017-04-21
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -66,7 +66,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to not disable media button (play/pause)
 - `moonstone/Scroller.Scrollable` so that paging controls are not spottable by default with 5-way
 - `moonstone/VideoPlayer`'s more/less button to use updated arrow icon
-- `moonstone/VideoPlayer` to simulate rewind functionality on non-webOS platforms only
 
 ### Fixed
 

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -866,8 +866,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			} else {
 				this.updateScrollOnFocus();
 			}
-
-			this.updateScrollOnFocus();
 		}
 
 		componentWillUnmount () {

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -7,9 +7,6 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 ### Deprecated
 
 ### Added
-- `Platform` sample
-
-- `Platform` sample
 
 - `Platform` sample
 
@@ -20,6 +17,7 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 - `moonstone/VideoPlayer` sample to update poster images
 
 ### Removed
+
 ## [1.2.2] - 2017-05-31
 
 No significant changes.

--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact webos module, newest cha
 ### Fixed
 
 ### Removed
+
 ## [1.2.2] - 2017-05-31
 
 No significant changes.


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Platform detection added to `@enact/moonstone/VideoPlayer` so that simulated rewind only runs in non-webOS environments.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`@enact/core/platform` is added in this PR and it is a very lightly modified version of Enyo's user agent detection.  `@enact/webos/platform` now requires `@enact/core/platform` and just adds its additional properties as written.

`platform.unknown` is moved to `@enact/core/platform` and this PR will probably result in fewer unknowns.

### Links
[//]: # (Related issues, references)
ENYO-4221

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)