### PR TITLE
ENYO-4223: Removed Skinnable from Scroller

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.less
+++ b/packages/moonstone/Scroller/Scrollable.less
@@ -1,8 +1,7 @@
 @import '../styles/mixins.less';
 @import '../styles/variables.less';
-@import '../styles/skin.less';
 
-.applySkins({.scrollableFill {
+.scrollableFill {
 	position: relative;
 	width: 100%;
 	height: 100%;
@@ -52,4 +51,4 @@
 	overflow: hidden;
 	.padding-start-end(0, 0);
 	padding-bottom: 0;
-}});
+}


### PR DESCRIPTION
The way scroller is built and is expected to work seems at odds with a modular construction, which causes precedence collisions. This will need to refactored more completely later to address these issues more completely.