### PR TITLE
ENYO-4233: Fix Slider's selectors to work correctly with skinning system

### DIFF
--- a/packages/moonstone/Slider/Slider.less
+++ b/packages/moonstone/Slider/Slider.less
@@ -1,5 +1,6 @@
 // Slider.less
 //
+@import '../styles/mixins.less';
 @import '../styles/variables.less';
 @import '../styles/text.less';
 @import '../styles/skin.less';
@@ -89,6 +90,10 @@
 				width: @moon-slider-knob-width-large;
 				border-radius: @moon-slider-knob-width-large;
 			})
+		}
+
+		:global(.enact-locale-right-to-left)& {
+			direction: ltr;
 		}
 	}
 
@@ -207,18 +212,12 @@
 			}
 		}
 	}
-
-	:global(.enact-locale-right-to-left)& .input {
-		direction: ltr;
-	}
 }
 
-[data-container-muted='true'] {
-	.slider {
-		&:global(.spottable):focus {
-			.knob {
-				background-color: @moon-slider-knob-bg-color;
-			}
-		}
+.mutedFocus({
+	&.slider .knob::before {
+		background-color: @moon-slider-knob-bg-color;
 	}
-}});
+});
+
+});

--- a/packages/moonstone/Slider/SliderTooltip.less
+++ b/packages/moonstone/Slider/SliderTooltip.less
@@ -4,57 +4,56 @@
 @import '../styles/text.less';
 @import '../styles/skin.less';
 
-.applySkins({.tooltip {
+.applySkins({
 	@offset-large: 0px;
 
-	&.horizontal {
-		&.before {
-			bottom: @moon-slider-tooltip-offset;
+	.tooltip {
+		&.horizontal {
+			&.before {
+				bottom: @moon-slider-tooltip-offset;
 
-			.moon-custom-text({
-				bottom: (@moon-slider-tooltip-offset + @offset-large);
-			});
-		}
-		&.after {
-			top: @moon-slider-tooltip-offset;
+				.moon-custom-text({
+					bottom: (@moon-slider-tooltip-offset + @offset-large);
+				});
+			}
+			&.after {
+				top: @moon-slider-tooltip-offset;
 
-			.moon-custom-text({
-				top: (@moon-slider-tooltip-offset + @offset-large);
-			});
-		}
-	}
-
-	&.vertical {
-		// Left side
-		&.before,
-		:global(.enact-locale-right-to-left) &.before.ignoreLocale,
-		:global(.enact-locale-right-to-left) &.after {
-			right: 0;
-			transform: translate(-54px, -50%);
-
-			.moon-custom-text({
-				transform: translate((-54px - @offset-large), -50%);
-			});
-		}
-		// Right side
-		&.after,
-		:global(.enact-locale-right-to-left) &.after.ignoreLocale,
-		:global(.enact-locale-right-to-left) &.before {
-			right: auto;
-			transform: translate(54px, -50%);
-
-			.moon-custom-text({
-				transform: translate((54px + @offset-large), -50%);
-			});
+				.moon-custom-text({
+					top: (@moon-slider-tooltip-offset + @offset-large);
+				});
+			}
 		}
 	}
-}
 
-// In order to reference an ancestor selector ([data-climax="falling"]) that is also a descendant of
-// the skin (.moonstone), we have to extract it from the main ruleset to inject the ancestor
-// selector while still prefixing it with the skin selector.
-[data-climax="falling"] .tooltip.horizontal {
+	// Left side
+	.tooltip.vertical.before,
+	&:global(.enact-locale-right-to-left) .tooltip.vertical.before.ignoreLocale,
+	&:global(.enact-locale-right-to-left) .tooltip.vertical.after {
+		right: 0;
+		transform: translate(-54px, -50%);
+
+		.moon-custom-text({
+			transform: translate((-54px - @offset-large), -50%);
+		});
+	}
+
+	// Right side
+	.tooltip.vertical.after,
+	&:global(.enact-locale-right-to-left) .tooltip.vertical.after.ignoreLocale,
+	&:global(.enact-locale-right-to-left) .tooltip.vertical.before {
+		right: auto;
+		transform: translate(54px, -50%);
+
+		.moon-custom-text({
+			transform: translate((54px + @offset-large), -50%);
+		});
+	}
+
+	// In order to reference an ancestor selector ([data-climax="falling"]) that is also a descendant of
+	// the skin (.moonstone), we have to extract it from the main ruleset to inject the ancestor
+	// selector while still prefixing it with the skin selector.
+	[data-climax="falling"] .tooltip.horizontal {
 		transform: translateX(-100%);
-}
-
+	}
 });


### PR DESCRIPTION
The ordering of the RTL rules was incorrect for the skinning changes.
Reorganized the rules a bit to ensure they are applied correctly.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)