### PR TITLE
ENYO-4234: Spinner qa-sampler and minor css update

### DIFF
--- a/packages/sampler/stories/qa-stories/Spinner.js
+++ b/packages/sampler/stories/qa-stories/Spinner.js
@@ -14,8 +14,7 @@ const
 	style = {
 		spinnerDiv: {
 			height: ri.scale(420) + 'px',
-			border: '1px dotted red',
-			backgroundColor: '#222'
+			border: '3px dotted red'
 		}
 	};
 


### PR DESCRIPTION
Update qa-sampler.
For centered positioning, use `left: 0;` instead of `left-margin: 0;`

### Links
ENYO-4234


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com