### PR TITLE
ENYO-4147: Fix not working scrollTo

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -778,17 +778,20 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					isHorizontalScrollbarVisible: curHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible: curVerticalScrollbarVisible
 				});
-			} else if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
-				// no visibility change but need to notify whichever scrollbars are visible of the
-				// updated bounds and scroll position
-				const updatedBounds = {
-					...bounds,
-					scrollLeft: this.scrollLeft,
-					scrollTop: this.scrollTop
-				};
+			} else {
+				this.isInitializing = false;
+				if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
+					// no visibility change but need to notify whichever scrollbars are visible of the
+					// updated bounds and scroll position
+					const updatedBounds = {
+						...bounds,
+						scrollLeft: this.scrollLeft,
+						scrollTop: this.scrollTop
+					};
 
-				if (canScrollHorizontally && curHorizontalScrollbarVisible) this.scrollbarHorizontalRef.update(updatedBounds);
-				if (canScrollVertically && curVerticalScrollbarVisible) this.scrollbarVerticalRef.update(updatedBounds);
+					if (canScrollHorizontally && curHorizontalScrollbarVisible) this.scrollbarHorizontalRef.update(updatedBounds);
+					if (canScrollVertically && curVerticalScrollbarVisible) this.scrollbarVerticalRef.update(updatedBounds);
+				}
 			}
 		}
 
@@ -843,11 +846,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		// component life cycle
 
 		componentDidMount () {
-			const {horizontalScrollbar, verticalScrollbar} = this.props;
 			this.updateScrollabilityAndEventListeners();
-			if ((this.horizontalScrollability && horizontalScrollbar !== 'auto') || (this.verticalScrollability && verticalScrollbar !== 'auto')) {
-				this.isInitializing = false;
-			}
 		}
 
 		componentDidUpdate () {
@@ -862,9 +861,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 			if (this.scrollToInfo !== null) {
 				this.scrollTo(this.scrollToInfo);
+			} else {
+				this.updateScrollOnFocus();
 			}
-
-			this.updateScrollOnFocus();
 		}
 
 		componentWillUnmount () {

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -656,17 +656,20 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					isHorizontalScrollbarVisible: curHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible: curVerticalScrollbarVisible
 				});
-			} else if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
-				// no visibility change but need to notify whichever scrollbars are visible of the
-				// updated bounds and scroll position
-				const updatedBounds = {
-					...bounds,
-					scrollLeft: this.scrollLeft,
-					scrollTop: this.scrollTop
-				};
+			} else {
+				this.isInitializing = false;
+				if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
+					// no visibility change but need to notify whichever scrollbars are visible of the
+					// updated bounds and scroll position
+					const updatedBounds = {
+						...bounds,
+						scrollLeft: this.scrollLeft,
+						scrollTop: this.scrollTop
+					};
 
-				if (canScrollHorizontally && curHorizontalScrollbarVisible) this.scrollbarHorizontalRef.update(updatedBounds);
-				if (canScrollVertically && curVerticalScrollbarVisible) this.scrollbarVerticalRef.update(updatedBounds);
+					if (canScrollHorizontally && curHorizontalScrollbarVisible) this.scrollbarHorizontalRef.update(updatedBounds);
+					if (canScrollVertically && curVerticalScrollbarVisible) this.scrollbarVerticalRef.update(updatedBounds);
+				}
 			}
 		}
 
@@ -713,11 +716,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		// component life cycle
 
 		componentDidMount () {
-			const {horizontalScrollbar, verticalScrollbar} = this.props;
 			this.updateScrollabilityAndEventListeners();
-			if ((this.horizontalScrollability && horizontalScrollbar !== 'auto') || (this.verticalScrollability && verticalScrollbar !== 'auto')) {
-				this.isInitializing = false;
-			}
 		}
 
 		componentDidUpdate () {


### PR DESCRIPTION
Fix scrollTo is not working in componentDidMount when verticalScrollbar or horizontalScrollbar is not 'auto'.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
scrollTo is called in componentDidUpdate(). However, If developer specifies verticalScrollbar value as 'visible', componentDidUpdate is not called. Thus, isInitializing property is not changed to false. Then, scrollTo function is not skipped.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4147

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>