### PR TITLE
PLAT-40963: Ignore enterTo config when current focused visually overlaps container

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -22,6 +22,8 @@ import concat from 'ramda/src/concat';
 import difference from 'ramda/src/difference';
 import last from 'ramda/src/last';
 
+import {contains} from './utils';
+
 import Accelerator from '../Accelerator';
 import {spottableClass} from '../Spottable';
 
@@ -737,6 +739,24 @@ const Spotlight = (function () {
 				candidates.all,
 				getContainerConfig(candidates.allContainerId)
 			);
+		}
+
+		// if the next element is a container AND the current element is *visually* contained within
+		// the next element, we need to ignore container `enterTo` preferences and retreive its
+		// spottable descendants and try to navigate to them.
+		if (next && isContainer(next)) {
+			const containerRect = getRect(next);
+			const elementRect = getRect(currentFocusedElement);
+
+			if (contains(containerRect, elementRect)) {
+				const nextContainerId = next.dataset.containerId;
+				next = navigate(
+					currentFocusedElement,
+					direction,
+					getSpottableDescendants(nextContainerId),
+					getContainerConfig(nextContainerId)
+				);
+			}
 		}
 
 		if (next) {

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -39,7 +39,46 @@ function parseSelector (selector) {
 	return result;
 }
 
+const testIntersection = (type, containerRect, elementRect) => {
+	const {
+		left: L,
+		right: R,
+		top: T,
+		bottom: B
+	} = containerRect;
+
+	const {
+		left: l,
+		right: r,
+		top: t,
+		bottom: b
+	} = elementRect;
+
+	const right = r > L && r <= R;
+	const left = l >= L && l < R;
+	const top = t >= T && t < B;
+	const bottom = b > T && b <= B;
+
+	if (type === 'intersects') {
+		return (top || bottom) && (left || right);
+	} else if (type === 'contains') {
+		return top && bottom && left && right;
+	}
+
+	return true;
+};
+
+const intersects = curry((containerRect, elementRect) => {
+	return testIntersection('intersects', containerRect, elementRect);
+});
+
+const contains = curry((containerRect, elementRect) => {
+	return testIntersection('contains', containerRect, elementRect);
+});
+
 export {
+	contains,
+	intersects,
 	matchSelector,
 	parseSelector
 };


### PR DESCRIPTION
Supports navigating from "floating" elements (like the close button on
a Panel) to the visually closest element when that element is within a
container that would otherwise control spotlight entry to "last
focused" or "default element."

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)