### PR TITLE
ENYO-4246: Snapshot build failed in fontGenerator.js

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -9,8 +9,6 @@
 import ilib from '@enact/i18n';
 import Locale from '@enact/i18n/ilib/lib/Locale';
 
-// eslint-disable-next-line no-console
-const dev = console;
 const debugFonts = false;
 const pendingFontsLoadedCallbacks = [];
 
@@ -81,6 +79,9 @@ function fontGenerator (locale = ilib.getLocale()) {
 
 	// If the locale is the same as the last time this ran, bail out and don't bother to recompile this again.
 	if (locale === previousLocale) return;
+
+	// eslint-disable-next-line no-console
+	const dev = console;
 
 	previousLocale = locale;
 	const


### PR DESCRIPTION
### Issue Resolved / Feature Added
Unguarded console reference at a modular level was causing snapshot builds to fail.

### Resolution
Moved the reference declaration into the fontgenerator function, which is called during the render (and itself has a safeguard checking the existence of `document`)

### Additional Considerations

### Links

### Comments

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>