### PR TITLE
ENYO-4102: Support 'aria-owns' for preventing reading a breadcrumb

### DIFF
--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -43,6 +43,7 @@ const ApplicationCloseButton = kind({
 				small
 				backgroundOpacity="transparent"
 				onClick={onApplicationClose}
+				id="app_close_button"
 			>
 				closex
 			</IconButton>

--- a/packages/moonstone/Panels/Breadcrumb.js
+++ b/packages/moonstone/Panels/Breadcrumb.js
@@ -74,6 +74,7 @@ const BreadcrumbBase = kind({
 			aria-label={$L('go to previous')}
 			data-index={index}
 			onClick={onSelect}
+			id="breadcrumb"
 		>
 			<div className={css.breadcrumbHeader}>
 				{children}

--- a/packages/moonstone/Panels/Panel.js
+++ b/packages/moonstone/Panels/Panel.js
@@ -53,6 +53,17 @@ const PanelBase = kind({
 		'aria-label': PropTypes.string,
 
 		/**
+		 * Identifies an element (or elements) in order to define contextual parent/child relationship
+		 * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+		 * When `aria-owns` is set, it will be considered as children.
+		 *
+		 * @memberof moonstone/Panels.Panel.prototype
+		 * @type {String}
+		 * @public
+		 */
+		'aria-owns': PropTypes.string,
+
+		/**
 		 * Header for the panel. This is usually passed by the {@link ui/Slottable.Slottable} API by
 		 * using a [Header]{@link moonstone/Panels.Header} component as a child of the Panel.
 		 *
@@ -120,15 +131,16 @@ const PanelBase = kind({
 		// nulling headerId prevents the aria-labelledby relationship which is necessary to allow
 		// aria-label to take precedence
 		// (see https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby)
-		headerId: ({'aria-label': label}) => label ? null : `panel_${++panelId}_header`
+		headerId: ({'aria-label': label}) => label ? null : `panel_${++panelId}_header`,
+		'aria-owns': ({'aria-owns': owns}) => owns ? `breadcrumb app_close_button ${owns}` : 'breadcrumb app_close_button'
 	},
 
-	render: ({bodyClassName, children, header, headerId, spotOnRender, ...rest}) => {
+	render: ({'aria-owns': ariaOwns, bodyClassName, children, header, headerId, spotOnRender, ...rest}) => {
 		delete rest.hideChildren;
 		delete rest.noAutoFocus;
 
 		return (
-			<article role="region" {...rest} aria-labelledby={headerId} ref={spotOnRender}>
+			<article role="region" {...rest} aria-labelledby={headerId} aria-owns={ariaOwns} ref={spotOnRender}>
 				<div className={css.header} id={headerId}>{header}</div>
 				<section className={bodyClassName}>{children}</section>
 			</article>


### PR DESCRIPTION
Support 'aria-owns' for the panel.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the focus is back from breadcrumb or exit app button, it shouldn't read out panel title again. However, this is readorder spec ( parent/child relationship ), so panel title is read out again.
The breadcrumb and exit app button are positioned on outside of panel, so it reads it again. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We added 'aria-owns' to the panel for creating contextual parent/child relationships.
Also, By supporting 'aria-owns' props, App can prevent reading a panel title. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The section tag element is using in Panel.js. However, If section element is used in Panel, it reads out panel title again when the focus is back to breadcrumb or exit button. This issue is handling in PLAT-41009.

### Links
[//]: # (Related issues, references)
ENYO-4102

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>