### PR TITLE
ENYO-4232: added deprecation to input

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Deprecated
 
 - `moonstone/Scroller.Scrollable` option `indexToFocus` in `scrollTo` method to be removed in 2.0.0
+- `moonstone/Input` prop `noDecorator` is being replaced by `focusInput` in 2.0.0.
+
 
 ### Added
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -1,3 +1,4 @@
+import deprecate from '@enact/core/internal/deprecate';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
@@ -77,6 +78,7 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			 *
 			 * @type {Boolean}
 			 * @default false
+			 * @deprecated will be replaced by `focusInput` in 2.0.0
 			 * @public
 			 */
 			noDecorator: PropTypes.bool,
@@ -107,6 +109,12 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 				focused: null,
 				node: null
 			};
+		}
+
+		componentWillMount () {
+			if (this.props.noDecorator) {
+				deprecate({name: 'noDecorator', since: '1.3.0', replacedBy: 'focusInput'});
+			}
 		}
 
 		componentDidUpdate (_, prevState) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Since we're not using noDecorator in `ExpandableInput` it's not being used anywhere. We should deprecate it.

### Resolution
Added deprecation warnings

### Links
ENYO-4232

Enact-DCO-1.0-Signed-off-by: Derek Tor derek.tor@lge.com