### PR TITLE
ENYO-4201: Fixed not working focusing via scrollTo when the list is not scrollable

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -701,15 +701,13 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					deprecate({name: 'indexToFocus', since: '1.2.0', message: 'Use `focus` instead', until: '2.0.0'});
 				}
 
-				if (left !== null || top !== null) {
-					this.start({
-						targetX: (left !== null) ? left : this.scrollLeft,
-						targetY: (top !== null) ? top : this.scrollTop,
-						animate: opt.animate,
-						indexToFocus: (opt.focus && typeof opt.index === 'number') ? opt.index : indexToFocus,
-						nodeToFocus:  (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null
-					});
-				}
+				this.start({
+					targetX: (left !== null) ? left : this.scrollLeft,
+					targetY: (top !== null) ? top : this.scrollTop,
+					animate: opt.animate,
+					indexToFocus: (opt.focus && typeof opt.index === 'number') ? opt.index : indexToFocus,
+					nodeToFocus:  (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null
+				});
 			} else {
 				this.scrollToInfo = opt;
 			}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed the issue of not working focusing via scrollTo when the list is short so that it's not scrollable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed the guard for checking null values for target positions.
I think we are okay to remove the guard because it's supposed not to be called frequently and we scroll to the same position if the target values are null.

### Links
[//]: # (Related issues, references)
ENYO-4201

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)