### PR TITLE
PLAT-39729: Enact Music crashes when V8 snapshot is enabled with V8 v5.8

### DIFF
--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -1,3 +1,4 @@
+/* global global */
 /*
  * glue.js - glue code to fit ilib into enyo
  *
@@ -34,7 +35,7 @@ if (typeof window === 'object' && typeof window.UILocale !== 'undefined') {
 // Temporary. In snapshot generation, do not run the locale initialization as it currently
 // causes V8 issues for some apps. for now, will execute only in browser or node environment.
 if (typeof window !== 'undefined' ||
-		(typeof process !== 'undefined' && process.versions && process.versions.node)) {
+		(global.process && global.process.versions && global.process.versions.node)) {
 	// we go ahead and run this once during loading of iLib settings are valid
 	// during the loads of later libraries.
 	updateLocale(null, true);


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Exception in mksnapshot was causing Music app to fail. Unknown cause at this point, though removing iLib locale initialization in the snapshot seems to get around the issue. I will reload when loading the window anyway.

### Resolution
* Check to existence of `window` or `process.versions.node` to only skip locale initialization in snapshot environment.

### Additional Considerations
* This is only a temporary fix. A proper fix within mkshapshot is planned.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>