### PR TITLE
ENYO-4231: Adjust QA stories to test muted spotlight containers/controls

### DIFF
--- a/packages/sampler/stories/qa-stories/Spotlight.js
+++ b/packages/sampler/stories/qa-stories/Spotlight.js
@@ -7,6 +7,7 @@ import ExpandableInput from '@enact/moonstone/ExpandableInput';
 import ExpandableItem from '@enact/moonstone/ExpandableItem';
 import ExpandableList from '@enact/moonstone/ExpandableList';
 import ExpandablePicker from '@enact/moonstone/ExpandablePicker';
+import FormCheckboxItem from '@enact/moonstone/FormCheckboxItem';
 import IconButton from '@enact/moonstone/IconButton';
 import IncrementSlider from '@enact/moonstone/IncrementSlider';
 import Input from '@enact/moonstone/Input';
@@ -229,34 +230,6 @@ storiesOf('Spotlight')
 		)
 	)
 	.addWithInfo(
-		'Muted Containers',
-		() => (
-			<div>
-				<p>
-					The container below will be muted. The items within the container can gain
-					focus, but they should not have a typical spotlight highlight. Instead, they
-					should appear as though they do not have focus and they should not generate
-					onFocus or onBlur events in the action logger.
-				</p>
-				<div style={style.flexBox}>
-					<Container style={style.container} spotlightMuted>
-						<Item onFocus={action('onFocus')} onBlur={action('onBlur')}>1</Item>
-						<ExpandableList
-							noLockBottom
-							title="ExpandableList"
-						>
-							{Items}
-						</ExpandableList>
-						<CheckboxItem>
-							Hello
-						</CheckboxItem>
-						<Item onFocus={action('onFocus')} onBlur={action('onBlur')}>3</Item>
-					</Container>
-				</div>
-			</div>
-		)
-	)
-	.addWithInfo(
 		'Nested Containers',
 		() => (
 			<div>
@@ -324,7 +297,7 @@ storiesOf('Spotlight')
 					Use the knobs to test the available behaviors for the spottable components
 					below.
 				</p>
-				<div style={style.flexBox}>
+				<Container style={style.flexBox} spotlightMuted={boolean('spotlightMuted', false)}>
 					<div style={style.flexItem}>
 						<Divider>
 							Misc Components
@@ -335,18 +308,32 @@ storiesOf('Spotlight')
 							>
 								Button
 							</Button>
+							<Button
+								backgroundOpacity="translucent"
+								spotlightDisabled={boolean('spotlightDisabled', false)}
+							>
+								Translucent
+							</Button>
+						</div>
+						<div style={style.flexBox}>
+							<Button
+								backgroundOpacity="transparent"
+								spotlightDisabled={boolean('spotlightDisabled', false)}
+							>
+								Transparent
+							</Button>
 							<ToggleButton
 								spotlightDisabled={boolean('spotlightDisabled', false)}
 							>
 								ToggleButton
 							</ToggleButton>
+						</div>
+						<div style={style.flexBox}>
 							<IconButton
 								spotlightDisabled={boolean('spotlightDisabled', false)}
 							>
 								plus
 							</IconButton>
-						</div>
-						<div style={style.flexBox}>
 							<Input
 								spotlightDisabled={boolean('spotlightDisabled', false)}
 							/>
@@ -396,6 +383,11 @@ storiesOf('Spotlight')
 								>
 									CheckboxItem
 								</CheckboxItem>
+								<FormCheckboxItem
+									spotlightDisabled={boolean('spotlightDisabled', false)}
+								>
+									FormCheckboxItem
+								</FormCheckboxItem>
 								<RadioItem
 									spotlightDisabled={boolean('spotlightDisabled', false)}
 								>
@@ -449,7 +441,7 @@ storiesOf('Spotlight')
 							/>
 						</Scroller>
 					</div>
-				</div>
+				</Container>
 			</div>
 		)
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
The initial work for this ticket involved verifying all `Spottable` components included muted styles (when used within muted spotlight containers). The legwork of this fix coincides with and has been incorporated into a related [pull request](https://github.com/enyojs/enact/pull/807), which modifies component CSS to support `Skinnable` components.

In order to fully test muted styles for `Spottable` components, I'm proposing removing the "Spotlight > Muted Container" QA-story in favor of using the "Spotlight > Kitchen Sink" QA-story (which includes all `Spottable` components) with an added `spotlightMuted` knob that can be used to test the focus styles when the components/container has been muted.


### Resolution
- Removed QA-story "Spotlight > Muted Containers"
- Added Spotlight Container with `spotlightMuted` knob to QA-story "Spotlight > Kitchen Sink"
- Added missing `Spottable` components to QA-story "Spotlight > Kitchen Sink"


### Links
Related PR: https://github.com/enyojs/enact/pull/807

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>