### PR TITLE
ENYO-4060 : Fix Popup Overlaps Button in ContextualPopup

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -144,6 +144,7 @@ class FloatingLayerBase extends React.Component {
 
 	closeFloatingLayer () {
 		if (this.node) {
+			off('scroll', this.handleScroll, this.node);
 			ReactDOM.unmountComponentAtNode(this.node);
 			document.getElementById(this.props.floatLayerId).removeChild(this.node);
 
@@ -151,7 +152,6 @@ class FloatingLayerBase extends React.Component {
 				this.props.onClose();
 			}
 		}
-		off('scroll', this.handleScroll, this.node);
 		this.floatLayer = null;
 		this.node = null;
 
@@ -164,11 +164,11 @@ class FloatingLayerBase extends React.Component {
 		if (!this.node) {
 			this.node = document.createElement('div');
 			document.getElementById(floatLayerId).appendChild(this.node);
+			on('scroll', this.handleScroll, this.node);
 		}
 
 		this.node.className = floatLayerClassName;
 		this.node.style.zIndex = 100;
-		on('scroll', this.handleScroll, this.node);
 
 		return this.node;
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix Popup Overlaps Button in ContextualPopup


### Resolution
This was due to the scroll of the layer on focussing close button which was outside the viewport.
Add the scroll prevention code in the Floating Layer.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
ENYO-4060


### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)