### PR TITLE
ENYO-4270: Add check for falsy button

### DIFF
--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -107,7 +107,7 @@ const NotificationBase = kind({
 			}
 		},
 		buttons: ({buttons}) => React.Children.map(buttons, (button) => {
-			if (!button.props.small) {
+			if (button && button.props && !button.props.small) {
 				return React.cloneElement(button, {small: true});
 			} else {
 				return button;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add check for a falsy button in Notification for the conditional cases where the button can be `null`. 

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
