### PR TITLE
ENYO-4293: Fix default fast forward to play when video is paused

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -788,7 +788,6 @@ const VideoPlayerBase = class extends React.Component {
 					this.selectPlaybackRates('fastForward');
 					this.speedIndex = 0;
 					this.prevCommand = 'fastForward';
-					return;
 				} else {
 					this.speedIndex = this.clampPlaybackRate(this.speedIndex + 1);
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix default fast forward to play when video is paused

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- `beginRewind()` pauses the video. Instead of handling `rewind` and `slowRewind` separately, we can easily check the `paused` state instead.

- NOTE: `slowRewind` with play rate in between 0 and -1 (i.e. -0.5x) does not pause the video. Not sure how this happens.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
