### PR TITLE
PLAT-40828: Add withSkinnableProps HOC to forward context to props

### DIFF
--- a/packages/moonstone/Scroller/ScrollButton.js
+++ b/packages/moonstone/Scroller/ScrollButton.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import $L from '../internal/$L';
 import IconButton from '../IconButton';
+import {withSkinnableProps} from '../Skinnable';
 
 import css from './Scrollbar.less';
 
@@ -93,8 +94,10 @@ const ScrollButtonBase = kind({
  * @ui
  * @private
  */
-const ScrollButton = onlyUpdateForKeys(['children', 'disabled'])(
-	ScrollButtonBase
+const ScrollButton = withSkinnableProps(
+	onlyUpdateForKeys(['children', 'disabled', 'skin'])(
+		ScrollButtonBase
+	)
 );
 
 export default ScrollButton;

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -17,9 +17,10 @@ import ri from '@enact/ui/resolution';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
-import css from './Scrollable.less';
 import ScrollAnimator from './ScrollAnimator';
 import Scrollbar from './Scrollbar';
+
+import css from './Scrollable.less';
 import scrollbarCss from './Scrollbar.less';
 
 const

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -8,8 +8,9 @@ import ri from '@enact/ui/resolution';
 import Spotlight from '@enact/spotlight';
 
 import $L from '../internal/$L';
-import css from './Scrollbar.less';
 import ScrollButton from './ScrollButton';
+
+import css from './Scrollbar.less';
 
 const
 	verticalProperties = {

--- a/packages/moonstone/Skinnable/Skinnable.js
+++ b/packages/moonstone/Skinnable/Skinnable.js
@@ -6,7 +6,7 @@
  */
 
 import hoc from '@enact/core/hoc';
-import SkinnableBase from '@enact/ui/Skinnable';
+import SkinnableBase, {withSkinnableProps} from '@enact/ui/Skinnable';
 
 const defaultConfig = {
 	skins: {
@@ -49,5 +49,6 @@ const Skinnable = hoc(defaultConfig, SkinnableBase);
 
 export default Skinnable;
 export {
-	Skinnable
+	Skinnable,
+	withSkinnableProps
 };

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -59,11 +59,6 @@ const forwardBlur = forward('onBlur'),
 const Picker = class extends React.Component {
 	static displayName = 'Picker'
 
-	static contextTypes = {
-		// import Skinnable's context to force skin changes to picker buttons
-		skin: PropTypes.string
-	}
-
 	static propTypes = /** @lends moonstone/internal/Picker.Picker.prototype */ {
 		/**
 		 * Index for internal ViewManager
@@ -614,7 +609,6 @@ const Picker = class extends React.Component {
 					onMouseDown={this.handleIncDown}
 					onMouseUp={this.handleUp}
 					onSpotlightDisappear={onSpotlightDisappear}
-					skin={this.context.skin}
 					spotlightDisabled={spotlightDisabled}
 				/>
 				<div
@@ -648,7 +642,6 @@ const Picker = class extends React.Component {
 					onMouseDown={this.handleDecDown}
 					onMouseUp={this.handleUp}
 					onSpotlightDisappear={onSpotlightDisappear}
-					skin={this.context.skin}
 					spotlightDisabled={spotlightDisabled}
 				/>
 			</div>

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -6,6 +6,7 @@ import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 import Icon from '../../Icon';
 import IconButton from '../../IconButton';
+import {withSkinnableProps} from '../../Skinnable';
 
 import css from './Picker.less';
 
@@ -21,7 +22,6 @@ const PickerButtonBase = kind({
 		]),
 		joined: PropTypes.bool,
 		onSpotlightDisappear: PropTypes.func,
-		skin: PropTypes.string,
 		spotlightDisabled: PropTypes.bool
 	},
 
@@ -39,7 +39,6 @@ const PickerButtonBase = kind({
 		if (joined) {
 			delete rest.hidden;
 			delete rest.onSpotlightDisappear;
-			delete rest.skin;
 			delete rest.spotlightDisabled;
 
 			return (
@@ -59,8 +58,10 @@ const PickerButtonBase = kind({
 
 const PickerButton = Holdable(
 	{resume: true, endHold: 'onLeave'},
-	onlyUpdateForKeys(['aria-label', 'disabled', 'icon', 'joined', 'onMouseUp', 'skin', 'spotlightDisabled'])(
-		PickerButtonBase
+	withSkinnableProps(
+		onlyUpdateForKeys(['aria-label', 'disabled', 'icon', 'joined', 'onMouseUp', 'skin', 'spotlightDisabled'])(
+			PickerButtonBase
+		)
 	)
 );
 

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -11,6 +11,7 @@
  */
 
 import hoc from '@enact/core/hoc';
+import getContext from 'recompose/getContext';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -131,5 +132,28 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 	};
 });
 
+const getSkin = getContext(/** @lends ui/Skinnable.withSkinnableProps.prototype */{
+	/**
+	 * Derived from the context from the parent, included as a prop.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	skin: PropTypes.string
+});
+
+/**
+ * Occasionally, there's a case where context isn't available or your component only updates on
+ * specific props changes. This HOC supplies the relevant context state values as props. In this
+ * case, `skin` is avaliable as a prop to the wrapped component.
+ *
+ * @class withSkinnableProps
+ * @memberof ui/Skinnable
+ * @hoc
+ * @public
+ */
+const withSkinnableProps = hoc((config, Wrapped) => getSkin(Wrapped));
+
+
 export default Skinnable;
-export {Skinnable};
+export {Skinnable, withSkinnableProps};


### PR DESCRIPTION
Updated ScrollButton to use a context->props hoc so it picks up skin changes

### Issue Resolved / Feature Added
Arrow buttons don't change skin when everything else changes. They don't need to be skinnable, they just need to be aware of skin changes.

### Resolution
Updated ScrollButton to use a context->props hoc so it picks up skin changes
Updated PickerButton to use the same Skinnable hoc
Also, minor cleanup on import order of Scrollable and Scrollbar.