### PR TITLE
Fix eslint no-module-exports-import error on Sampler

### DIFF
--- a/packages/sampler/src/configure.js
+++ b/packages/sampler/src/configure.js
@@ -1,3 +1,5 @@
+/* eslint enact/no-module-exports-import: off */
+
 import {configure, setAddon, addDecorator} from '@kadira/storybook';
 import infoAddon from '@kadira/react-storybook-addon-info';
 import {withKnobs} from '@kadira/storybook-addon-knobs';


### PR DESCRIPTION
### Issue Resolved / Feature Added
The Sampler is a hybrid Enact-Storybook combo app, so it needs raw module.exports on ./src/configure.js (rather than used named or default ES6 export). This triggers our `enact/no-module-exports-import` eslint rule.

### Resolution
* Inline disable `enact/no-module-exports-import` rule for Storybook's ./src/configure.js file.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>