### PR TITLE
ENYO-4039: Guard against trying to focus components outside of scroller

### DIFF
--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -183,7 +183,7 @@ class ScrollerBase extends Component {
 	}
 
 	calculatePositionOnFocus = (focusedItem, scrollInfo) => {
-		if (!this.isVertical() && !this.isHorizontal()) return;
+		if (!this.isVertical() && !this.isHorizontal() || !focusedItem || !this.containerRef.contains(focusedItem)) return;
 
 		const {
 			top: itemTop,


### PR DESCRIPTION
Scrollable tries to scroll the focused item into view on update. if the currently focused item is outside of the scroller and not within another spotlight container when that happens, it’ll walk up the tree from the focused item until it hits document, try to access .dataset.containerId and blow up because document doesn’t support dataset

This PR adds a guard within calculatePositionOnFocus to prevent trying
to focus either a falsey reference or a reference that is not within
the scroller.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)