### PR TITLE
PLAT-39743: changed scroll distance by wheel with maximum limits

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -349,9 +349,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 
 			if (deltaMode === 0) {
-				delta = Math.min(maxPixel, ri.scale(delta) * scrollWheelMultiplierForDeltaPixel);
+				delta = clamp(-maxPixel, maxPixel, ri.scale(delta * scrollWheelMultiplierForDeltaPixel));
 			} else if (deltaMode === 1) { // line; firefox
-				delta = Math.min(maxPixel, ri.scale(delta * pixelPerLine) * scrollWheelMultiplierForDeltaPixel);
+				delta = clamp(-maxPixel, maxPixel, ri.scale(delta * pixelPerLine * scrollWheelMultiplierForDeltaPixel));
 			} else if (deltaMode === 2) { // page
 				delta = delta < 0 ? -maxPixel : maxPixel;
 			}

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -311,9 +311,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				}
 
 				if (deltaMode === 0) {
-					delta = Math.min(maxPixel, ri.scale(delta) * scrollWheelMultiplierForDeltaPixel);
+					delta = clamp(-maxPixel, maxPixel, ri.scale(delta * scrollWheelMultiplierForDeltaPixel));
 				} else if (deltaMode === 1) { // line; firefox
-					delta = Math.min(maxPixel, ri.scale(delta * pixelPerLine) * scrollWheelMultiplierForDeltaPixel);
+					delta = clamp(-maxPixel, maxPixel, ri.scale(delta * pixelPerLine * scrollWheelMultiplierForDeltaPixel));
 				} else if (deltaMode === 2) { // page
 					delta = delta < 0 ? -maxPixel : maxPixel;
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Lists or scrollers are scrolled twice than expected.
- We decided to make lists scrolled as much as 75% of Enyo/Moonstone lists.
- We missed a limitation of the maximum scroll distance. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Changed a scroll distance by wheel: 180 px / wheel tick (240px in Enyo/Moonstone)
- Added a maximum distance limit: 20% of scrollable view area


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This PR does not contain any changes for native scrolling. Changes in ScrollableNative are related with horizontal wheel support which is handled by script.

### Links
[//]: # (Related issues, references)
PLAT-39743

### Comments

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)