### PR TITLE
ENYO-4240: Adjust spotNextFromPoint logic

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -742,6 +742,7 @@ export {
 	getContainerDefaultElement,
 	getContainerLastFocusedElement,
 	getContainerNavigableElements,
+	getContainerNode,
 	setContainerLastFocusedElement,
 
 	// Keep


### PR DESCRIPTION
### Issue Resolved / Feature Added
The spotlight `spotNextFromPoint` logic doesn't take into account restricted containers. We need to navigate the navigable elements based on the active container id to determine what can be navigated to.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
