### PR TITLE
Fixes background color of input inside decorator

### DIFF
--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -120,6 +120,10 @@
 	.applySkins({
 		background-color: @moon-input-decorator-bg-color;
 
+		.input {
+			background: transparent;
+		}
+
 		// For ExpandableInput, the decorator will not receive focus but it can be activated by clicking
 		// which should highlight the border
 		&.noDecorator:active,


### PR DESCRIPTION
Issue: ENYO-4322
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The background color of the `input` element inside the decorator was not being set properly and could use a value set by the system.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The background color is now being set to transparent so that the background comes from the decorator. No change log required as this was a regression.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
