### PR TITLE
ENYO-4134: Added scrollToBoundaries to Scroller

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -14,7 +14,7 @@ import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ri from '@enact/ui/resolution';
-import Spotlight, {getDirection} from '@enact/spotlight';
+import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import ScrollAnimator from './ScrollAnimator';
@@ -73,7 +73,7 @@ const ScrollableSpotlightContainer = SpotlightContainerDecorator(
  * {@link moonstone/Scroller.Scrollable} is a Higher-order Component
  * that applies a Scrollable behavior to its wrapped component.
  *
- * Scrollable catches `onFocus` and `onKeyDown` events from its wrapped component for spotlight features,
+ * Scrollable catches `onFocus` event from its wrapped component for spotlight features,
  * and also catches `onMouseDown`, `onMouseLeave`, `onMouseMove`, `onMouseUp`, and `onWheel` events
  * from its wrapped component for scrolling behaviors.
  *
@@ -198,13 +198,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.initChildRef = this.initRef('childRef');
 			this.initContainerRef = this.initRef('containerRef');
 
-			const {onKeyDown} = this;
-			// We have removed all mouse event handlers for now.
-			// Revisit later for touch usage.
-			this.eventHandlers = {
-				onKeyDown
-			};
-
 			this.verticalScrollbarProps = {
 				ref: this.initRef('scrollbarVerticalRef'),
 				vertical: true,
@@ -236,9 +229,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		isDragging = false
 		isKeyDown = false
 		isInitializing = true
-
-		// event handlers
-		eventHandlers = {}
 
 		// drag info
 		dragInfo = {
@@ -439,24 +429,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 				if (item && item !== this.lastFocusedItem && item === spotItem && positionFn) {
 					const pos = positionFn(item);
-					if (pos) {
-						this.startScrollOnFocus(pos, item);
-					}
-				}
-			}
-		}
-
-		onKeyDown = ({keyCode, target}) => {
-			const direction = getDirection(keyCode);
-
-			if (direction) {
-				if (this.childRef.setSpotlightContainerRestrict) {
-					const index = Number.parseInt(target.getAttribute(dataIndexAttribute));
-					this.childRef.setSpotlightContainerRestrict(keyCode, index);
-				}
-
-				if (this.childRef.scrollToBoundaries) {
-					this.childRef.scrollToBoundaries(direction, target);
+					this.startScrollOnFocus(pos, item);
 				}
 			}
 		}
@@ -979,7 +952,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				>
 					<Wrapped
 						{...props}
-						{...this.eventHandlers}
 						cbScrollTo={this.scrollTo}
 						className={css.container}
 						onScroll={this.handleScroll}

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -10,12 +10,12 @@ import {contextTypes as contextTypesResize} from '@enact/ui/Resizable';
 import {contextTypes as contextTypesRtl} from '@enact/i18n/I18nDecorator';
 import deprecate from '@enact/core/internal/deprecate';
 import {forward} from '@enact/core/handle';
-import {getDirection} from '@enact/spotlight';
 import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ri from '@enact/ui/resolution';
+import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import css from './Scrollable.less';
@@ -69,7 +69,7 @@ const ScrollableSpotlightContainer = SpotlightContainerDecorator(
  * {@link moonstone/Scroller.ScrollableNative} is a Higher-order Component
  * that applies a Scrollable behavior to its wrapped component.
  *
- * Scrollable catches `onFocus`, `onKeyUp`, and `onKeyDown` events from its wrapped component for spotlight features,
+ * Scrollable catches `onFocus` event from its wrapped component for spotlight features,
  * and also catches `onWheel` and `onScroll` events from its wrapped component for scrolling behaviors.
  *
  * Scrollable calls `onScrollStart`, `onScroll`, and `onScrollStop` callback functions during scroll.
@@ -194,12 +194,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.initChildRef = this.initRef('childRef');
 			this.initContainerRef = this.initRef('containerRef');
 
-			// wheel, scroll, and focus event handlers will be added after mounting
-			this.eventHandlers = {
-				onKeyDown: this.onKeyDown,
-				onKeyUp: this.onKeyUp
-			};
-
 			this.verticalScrollbarProps = {
 				ref: this.initRef('scrollbarVerticalRef'),
 				vertical: true,
@@ -227,7 +221,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		horizontalScrollability = false
 		verticalScrollability = false
 		isScrollAnimationTargetAccumulated = false
-		isKeyDown = false
 		isInitializing = true
 
 		// event handlers
@@ -335,45 +328,26 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 		// event handlers for Spotlight support
 
+		startScrollOnFocus = (pos, item) => {
+			if (pos) {
+				if (pos.left !== this.scrollLeft || pos.top !== this.scrollTop) {
+					this.start(pos.left, pos.top);
+				}
+				this.lastFocusedItem = item;
+			}
+		}
+
 		onFocus = (e) => {
-			if (this.isKeyDown) {
+			if (!(Spotlight.getPointerMode() || this.isDragging)) {
 				const
 					item = e.target,
 					positionFn = this.childRef.calculatePositionOnFocus,
-					spotItem = (typeof window === 'object') ? window.document.activeElement : null;
+					spotItem = Spotlight.getCurrent();
 
 				if (item && item !== this.lastFocusedItem && item === spotItem && positionFn) {
 					const pos = positionFn(item);
-					if (pos) {
-						if (pos.left !== this.scrollLeft || pos.top !== this.scrollTop) {
-							this.start(pos.left, pos.top);
-						}
-						this.lastFocusedItem = item;
-					}
+					this.startScrollOnFocus(pos, item);
 				}
-			}
-		}
-
-		onKeyDown = ({keyCode, target}) => {
-			const direction = getDirection(keyCode);
-
-			if (direction) {
-				if (this.childRef.setSpotlightContainerRestrict) {
-					const index = Number.parseInt(target.getAttribute(dataIndexAttribute));
-					this.childRef.setSpotlightContainerRestrict(keyCode, index);
-				}
-
-				if (this.childRef.scrollToBoundaries) {
-					this.childRef.scrollToBoundaries(direction, target);
-				}
-
-				this.isKeyDown = true;
-			}
-		}
-
-		onKeyUp = ({keyCode}) => {
-			if (getDirection(keyCode)) {
-				this.isKeyDown = false;
 			}
 		}
 
@@ -844,7 +818,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					focusableScrollbar={focusableScrollbar}
 					style={style}
 				>
-					<Wrapped {...props} {...this.eventHandlers} ref={this.initChildRef} cbScrollTo={this.scrollTo} className={css.container} />
+					<Wrapped {...props} ref={this.initChildRef} cbScrollTo={this.scrollTo} className={css.container} />
 					{vscrollbar}
 					{hscrollbar}
 				</ScrollableSpotlightContainer>

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,7 +7,6 @@
 
 import classNames from 'classnames';
 import {contextTypes} from '@enact/i18n/I18nDecorator';
-import {is} from '@enact/core/keymap';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Spotlight from '@enact/spotlight';
@@ -19,11 +18,6 @@ import css from './ListItem.less';
 
 const
 	dataContainerMutedAttribute = 'data-container-muted',
-	dataContainerIdAttribute = 'data-container-id',
-	isDown = is('down'),
-	isLeft = is('left'),
-	isRight = is('right'),
-	isUp = is('up'),
 	nop = () => {};
 
 /**
@@ -629,29 +623,6 @@ class VirtualListCore extends Component {
 			gridPosition.secondaryPosition = 0;
 			return this.gridPositionToItemPosition(gridPosition);
 		}
-	}
-
-	setRestrict = (bool) => {
-		Spotlight.set(this.props[dataContainerIdAttribute], {restrict: (bool) ? 'self-only' : 'self-first'});
-	}
-
-	setSpotlightContainerRestrict = (keyCode, index) => {
-		const
-			{dataSize} = this.props,
-			{isPrimaryDirectionVertical, dimensionToExtent} = this,
-			canMoveBackward = index >= dimensionToExtent,
-			canMoveForward = index < (dataSize - (((dataSize - 1) % dimensionToExtent) + 1));
-		let isSelfOnly = false;
-
-		if (isPrimaryDirectionVertical) {
-			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
-				isSelfOnly = true;
-			}
-		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
-			isSelfOnly = true;
-		}
-
-		this.setRestrict(isSelfOnly);
 	}
 
 	setContainerDisabled = (bool) => {

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -7,7 +7,6 @@
 
 import classNames from 'classnames';
 import {contextTypes} from '@enact/i18n/I18nDecorator';
-import {is} from '@enact/core/keymap';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Spotlight from '@enact/spotlight';
@@ -20,11 +19,6 @@ import cssItem from './ListItem.less';
 
 const
 	dataContainerMutedAttribute = 'data-container-muted',
-	dataContainerIdAttribute = 'data-container-id',
-	isDown = is('down'),
-	isLeft = is('left'),
-	isRight = is('right'),
-	isUp = is('up'),
 	nop = () => {};
 
 /**
@@ -605,29 +599,6 @@ class VirtualListCoreNative extends Component {
 			gridPosition.secondaryPosition = 0;
 			return this.gridPositionToItemPosition(gridPosition);
 		}
-	}
-
-	setRestrict = (bool) => {
-		Spotlight.set(this.props[dataContainerIdAttribute], {restrict: (bool) ? 'self-only' : 'self-first'});
-	}
-
-	setSpotlightContainerRestrict = (keyCode, index) => {
-		const
-			{dataSize} = this.props,
-			{isPrimaryDirectionVertical, dimensionToExtent} = this,
-			canMoveBackward = index >= dimensionToExtent,
-			canMoveForward = index < (dataSize - (((dataSize - 1) % dimensionToExtent) + 1));
-		let isSelfOnly = false;
-
-		if (isPrimaryDirectionVertical) {
-			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
-				isSelfOnly = true;
-			}
-		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
-			isSelfOnly = true;
-		}
-
-		this.setRestrict(isSelfOnly);
 	}
 
 	setContainerDisabled = (bool) => {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When there is non-spottable content at the bottom of the scroller, there was no way to reveal it so the code was added to scroll to boundaries when leaving with 5-way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The approach that I took here is that if the user presses 5 way from elements on the boundaries, Scroller will scroll to specified align.
The condition when the scrolling to boundaries happens are that if `getTargetByDirectionFromElement` is null or if there is a next spottable but that is not contained in the current container.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We changed approach from having developers specify the `data-spottable-boundaries` to the elements. See details in the ticket.

### Links
[//]: # (Related issues, references)
ENYO-4123

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
