### PR TITLE
ENYO-4321: Corrected Picker's icon positions and sizing for large mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -38,6 +38,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to correctly change sources
 - `moonstone/VideoPlayer` to show or hide feedback tooltip properly
 - `moonstone/DateTimeDecorator` to work properly with `RadioControllerDecorator`
+- `moonstone/Picker` in joined, large text mode so the arrows are properly aligned and sized
+- `moonstone/Icon` to reflect the same proportion in relation to its size in large-text mode
 
 ### Removed
 

--- a/packages/moonstone/Icon/Icon.less
+++ b/packages/moonstone/Icon/Icon.less
@@ -23,6 +23,9 @@
 
 	.moon-custom-text({
 		font-size: @moon-icon-font-size-large;
+		width: @moon-icon-size-large;
+		height: @moon-icon-size-large;
+		line-height: @moon-icon-size-large;
 	});
 
 	.font-kerning(none);
@@ -38,6 +41,9 @@
 
 		.moon-custom-text({
 			font-size: @moon-icon-small-font-size-large;
+			width: @moon-icon-small-size-large;
+			height: @moon-icon-small-size-large;
+			line-height: @moon-icon-small-size-large;
 		});
 
 		// .moon-taparea(@moon-icon-small-size);

--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -6,15 +6,17 @@
 @import '../../styles/skin.less';
 
 .picker {
-	@button-width: (@moon-button-small-height - 12);
-
 	display: inline-block;
-	border-radius: @button-width;
+	border-radius: @moon-button-small-height;
 	vertical-align: bottom;
 	position: relative;
 	text-align: center;
 	margin-left: @moon-spotlight-outset;
 	margin-right: @moon-spotlight-outset;
+
+	.moon-custom-text({
+		border-radius: @moon-button-small-height-large;
+	});
 
 	.sizingPlaceholder,
 	.valueWrapper {
@@ -89,6 +91,10 @@
 
 		.icon {
 			vertical-align: top;
+			margin: 0;
+			width: @moon-button-small-height;
+			height: @moon-button-small-height;
+			line-height: @moon-button-small-height;
 		}
 
 		.incrementer,
@@ -126,16 +132,20 @@
 			}
 			.incrementer,
 			.decrementer {
-				width: @button-width;
+				margin: 0;
 				height: @moon-button-small-height;
 				line-height: @moon-button-small-height;
 			}
-			.incrementer .icon {
-				margin-left: 0;
-			}
-			.decrementer .icon {
-				margin-right: 0;
-			}
+			.moon-custom-text({
+				.incrementer,
+				.decrementer {
+					&,
+					.icon {
+						height: @moon-button-small-height-large;
+						line-height: @moon-button-small-height-large;
+					}
+				}
+			});
 		}
 
 		&.vertical {

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -22,6 +22,7 @@ const PickerButtonBase = kind({
 		]),
 		joined: PropTypes.bool,
 		onSpotlightDisappear: PropTypes.func,
+		skin: PropTypes.string,
 		spotlightDisabled: PropTypes.bool
 	},
 
@@ -39,6 +40,7 @@ const PickerButtonBase = kind({
 		if (joined) {
 			delete rest.hidden;
 			delete rest.onSpotlightDisappear;
+			delete rest.skin;
 			delete rest.spotlightDisabled;
 
 			return (

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -163,7 +163,9 @@
 // Icon Sizes
 // ---------------------------------------
 @moon-icon-size: 48px;
+@moon-icon-size-large: (@moon-icon-size * 1.2);
 @moon-icon-small-size: 36px;
+@moon-icon-small-size-large: (@moon-icon-small-size * 1.2);
 @moon-icon-font-size: (@moon-icon-size * 2);
 @moon-icon-font-size-large: (@moon-icon-font-size * 1.2);
 @moon-icon-small-font-size: (@moon-icon-small-size * 2);


### PR DESCRIPTION
Also updated sizing/layout of Icon in large mode.
Also also fixed skin prop bleed on PickerButton.

Picker Icons in Joined mode no longer rely on margin for spacing and instead rely on their own width and height to more reliably position them for LTR/RTL, scaling, and in large-text mode.