### PR TITLE
ENYO-4300: Change to functional setState

### DIFF
--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -158,23 +158,26 @@ class ScrollbarBase extends Component {
 	updateButtons = (bounds) => {
 		const
 			{prevButtonNodeRef, nextButtonNodeRef} = this,
-			{prevButtonDisabled, nextButtonDisabled} = this.state,
 			{vertical} = this.props,
 			currentPos = vertical ? bounds.scrollTop : bounds.scrollLeft,
 			maxPos = vertical ? bounds.maxTop : bounds.maxLeft,
 			shouldDisablePrevButton = currentPos <= 0,
 			shouldDisableNextButton = currentPos >= maxPos,
-			updatePrevButton = prevButtonDisabled !== shouldDisablePrevButton,
-			updateNextButton = nextButtonDisabled !== shouldDisableNextButton,
 			spotItem = window.document.activeElement;
 
-		if (updatePrevButton && updateNextButton) {
-			this.setState({prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton});
-		} else if (updatePrevButton) {
-			this.setState({prevButtonDisabled: shouldDisablePrevButton});
-		} else if (updateNextButton) {
-			this.setState({nextButtonDisabled: shouldDisableNextButton});
-		}
+		this.setState((prevState) => {
+			const
+				updatePrevButton = (prevState.prevButtonDisabled !== shouldDisablePrevButton),
+				updateNextButton = (prevState.nextButtonDisabled !== shouldDisableNextButton);
+
+			if (updatePrevButton && updateNextButton) {
+				return {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};
+			} else if (updatePrevButton) {
+				return {prevButtonDisabled: shouldDisablePrevButton};
+			} else if (updateNextButton) {
+				return {nextButtonDisabled: shouldDisableNextButton};
+			}
+		});
 
 		if (shouldDisablePrevButton && spotItem === prevButtonNodeRef) {
 			Spotlight.focus(nextButtonNodeRef);


### PR DESCRIPTION
By setState internal logic, the previous state just is not updated, so initial scrollTo can't update disable state of scrollbar button.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Change setState with object parameter to setState with function parameter

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4300

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>