### PR TITLE
ENYO-4346: Update disabled container fix to be explicit

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -509,7 +509,7 @@ const isNavigable = (node, containerId, verify) => {
 	}
 
 	const containerNode = getContainerNode(containerId);
-	if (containerNode !== document && containerNode.dataset.containerDisabled) {
+	if (containerNode !== document && containerNode.dataset.containerDisabled === 'true') {
 		return false;
 	}
 


### PR DESCRIPTION
Checking only for a truthy value of the dataset property allowed the
value `"false"` to be treated at `true`. Now explicitly checks for
strictly equal to `"true"`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)