### PR TITLE
ENYO-4345: Move height-related rules out of picker placeholder selector

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -22,14 +22,10 @@
 	.valueWrapper {
 		.moon-text-base();
 		.moon-locale-non-latin({line-height: @moon-button-small-height;});
-		height: @moon-button-small-height;
-		line-height: @moon-button-small-height;
 		max-width: 300px;
 
 		.moon-custom-text({
 			font-size: @moon-item-font-size-large;
-			line-height: @moon-button-small-height-large;
-			height: @moon-button-small-height-large;
 		});
 	}
 
@@ -43,6 +39,14 @@
 		margin-left: auto;
 		margin-right: auto;
 		vertical-align: bottom;
+
+		line-height: @moon-button-small-height;
+		height: @moon-button-small-height;
+
+		.moon-custom-text({
+			line-height: @moon-button-small-height-large;
+			height: @moon-button-small-height-large;
+		});
 	}
 
 	.incrementer,


### PR DESCRIPTION
* Moves `line-height` and `height` rules into existing `.valueWrapper` selector rather than the shared selector for both the value and the placeholder

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)