### PR TITLE
ENYO-4347: Allow pointer to spot Scroller paging controls

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -54,7 +54,7 @@ const dataIndexAttribute = 'data-index';
 const ScrollableSpotlightContainer = SpotlightContainerDecorator(
 	{
 		navigableFilter: (elem, {focusableScrollbar}) => {
-			if (!focusableScrollbar && elem.classList.contains(scrollbarCss.scrollButton)) {
+			if (!focusableScrollbar && elem.classList.contains(scrollbarCss.scrollButton) && !Spotlight.getPointerMode()) {
 				return false;
 			}
 		},


### PR DESCRIPTION
### Issue Resolved / Feature Added
The paging controls in `Scroller` do not gain focus when hovering with the pointer. We are unable to spot paging controls when `focusableScrollbar` is `false`.


### Resolution
Some recent changes to spotlight logic changed the value that can be returned in the `isNavigable()` method. Since `Scrollable` uses its own `navigableFilter`, for the time-being we can add a `!Spotlight.getPointerMode()` check to allow focus to the paging controls when in pointer-mode only.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>