### PR TITLE
ENYO-4203: Add popupProps for ContextualPopupDecorator

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Deprecated
 
 ### Added
+
 - `moonstone/ContextualPopupDecorator` property `popupProps` to attach props to popup component
 
 ### Changed

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -48,22 +48,32 @@ const ContextualPopupContainer = SpotlightContainerDecorator({enterTo: 'last-foc
  *
  * Example:
  * ```
- * const PopupComponent = ({props}) => (
- * 	<Component {...props} />
- * )
+ * import PopupComponent from './PopupComponent';
  *
- * const popupProps = {
- * 	functionProp: () => {},
- * 	stringProp: '',
- * 	booleanProp: false
- * };
+ * const ContextualPopupComponent = ContextualPopupDecorator(Button);
  *
- * const ContextualPopupComponent = ContextualPopupDecorator(Component);
+ * const MyComponent = kind({
+ * 	name: 'MyComponent',
  *
- * <ContextualPopupComponent
- * 	popupComponent={PopupComponent}
- * 	popupProps={popupProps}
- * />
+ * 	render: (props) => {
+ * 		const popupProps = {
+ * 			functionProp: () => {},
+ * 			stringProp: '',
+ * 			booleanProp: false
+ * 		};
+ *
+ * 		return (
+ * 			<div {...props}>
+ * 				<ContextualPopupComponent
+ * 					popupComponent={PopupComponent}
+ * 					popupProps={popupProps}
+ * 				>
+ * 					Open Popup
+ * 				</ContextualPopupComponent>
+ * 			</div>
+ * 		);
+ * 	}
+ * });
  * ```
  *
  * @class ContextualPopupDecorator


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a `popupComponent` in `ContextualPopupDecorator` is defined as a stateless functional component and needs props, there's no good way. This sometimes causes a problem if it were defined as `computed` props. In this case, react reconciler determines to tear down and re-render it. This problem can be noticed, for example, when a component inside the popupComponent is spotted and gets to be re-rendered.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>