### PR TITLE
ENYO-4353: Adds an inheritable set of spotlight rules for unskinned components

### DIFF
--- a/packages/moonstone/styles/rules.less
+++ b/packages/moonstone/styles/rules.less
@@ -22,8 +22,8 @@
 	// This rule-set applies a generic spottable set of colors to anything with the spottable class
 	// that is a child of a skin. It's a blanket rule for components that don't technically need to
 	// be skinnable themselves, but still need to be focusable and inherit rules from their parent.
-	// The rule below this, should look identical, with the exception of the absense of the `parent`
-	// argument to the focus mixin. This allows that set of rules to prevale over this generic set.
+	// The rule below this, should look identical, with the exception of the absence of the `parent`
+	// argument to the focus mixin. This allows that set of rules to prevail over this generic set.
 	//// Inherited Spottable rules (for components that aren't directly skinned)
 	.focus({
 		background-color: @moon-spotlight-bg-color;


### PR DESCRIPTION
Unskinned components like the following should also be qualified to at least get a generic set of focus rules:
```
const SpottableDiv = Spottable('div');

const MainPanel = kind({
	name: 'MainPanel',
	render: () => <SpottableDiv>Hello</SpottableDiv>
});
```