### PR TITLE
ENYO-4312: Search containers from the innermost container

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -522,7 +522,7 @@ const isNavigable = (node, containerId, verify) => {
 };
 
 /**
- * Returns the IDs of all containers
+ * Returns the IDs of all containers in the order of innermost container to the outermost container
  *
  * @return {String[]}  Array of container IDs
  * @memberof spotlight/container
@@ -535,7 +535,7 @@ const getAllContainerIds = () => {
 	// PhantomJS-friendly iterator->array conversion
 	let id;
 	while ((id = keys.next()) && !id.done) {
-		ids.push(id.value);
+		ids.unshift(id.value);
 	}
 
 	return ids;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Default target for containers is searched in the order of outermost container to the innermost container. This will cause `spotlightRootDecorator` container to be spotted first when containerIds not provided to `getTargetByContainer()`. In this proposed solution, `container` will provide in the order of innermost container to the outermost container.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>