### PR TITLE
ENYO-4375: Snapshot: platform.tv doesn't updated when launching app

### DIFF
--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -91,45 +91,49 @@ let _platform;
  */
 
 const detect = () => {
-	if (typeof window === 'undefined') {
+	if (_platform) {
+		// if we've already determined the platform, we'll use that determination
+		return _platform;
+	} else if (typeof window === 'undefined') {
 		return {
 			gesture: false,
 			node: true,
 			touch: false,
 			unknown: true
 		};
-	} else if (!_platform) {
-		const userAgent = ua();
+	}
 
-		_platform = {
-			gesture: hasGesture(),
-			node: false,
-			touch: hasTouch(),
-			unknown: true
-		};
+	const userAgent = ua();
 
-		for (let i = 0, p, m, v; (p = platforms[i]); i++) {
-			m = p.regex.exec(userAgent);
-			if (m) {
-				_platform.unknown = false;
+	_platform = {
+		gesture: hasGesture(),
+		node: false,
+		touch: hasTouch(),
+		unknown: true
+	};
 
-				if (p.forceVersion) {
-					v = p.forceVersion;
-				} else {
-					v = Number(m[1]);
-				}
-				_platform[p.platform] = v;
-				if (p.extra) {
-					_platform = {
-						..._platform,
-						...p.extra
-					};
-				}
-				_platform.platformName = p.platform;
-				break;
+	for (let i = 0, p, m, v; (p = platforms[i]); i++) {
+		m = p.regex.exec(userAgent);
+		if (m) {
+			_platform.unknown = false;
+
+			if (p.forceVersion) {
+				v = p.forceVersion;
+			} else {
+				v = Number(m[1]);
 			}
+			_platform[p.platform] = v;
+			if (p.extra) {
+				_platform = {
+					..._platform,
+					...p.extra
+				};
+			}
+			_platform.platformName = p.platform;
+			break;
 		}
 	}
+
 	return _platform;
 };
 

--- a/packages/webos/platform/platform.js
+++ b/packages/webos/platform/platform.js
@@ -6,6 +6,68 @@
  * @module webos/platform
  */
 
+function is (type) {
+	return window.navigator.userAgent.indexOf(type) > -1;
+}
+
+let _platform;
+
+/**
+ * {@link webos/platform.detect} returns the {@link webos/platform.platform} object.
+ *
+ * @type {Function}
+ * @returns {Object} the {@link webos/platform.platform} object
+ *
+ * @method detect
+ * @memberof webos/platform
+ * @public
+ */
+
+function detect () {
+	if (_platform) {
+		// if we've already determined the platform, we'll use that determination
+		return _platform;
+	} else if (typeof window === 'undefined' || !window.PalmSystem) {
+		// if window isn't available (in prerendering or snapshot runs), bail out early
+		return {
+			unknown: true
+		};
+	}
+
+	// build out our cached platform determination for future usage
+	_platform = {};
+
+	if (is('SmartWatch')) {
+		_platform.watch = true;
+	} else if (is('SmartTV') || is('Large Screen')) {
+		_platform.tv = true;
+	} else {
+		try {
+			let legacyInfo = JSON.parse(window.PalmSystem.deviceInfo || '{}');
+			if (legacyInfo.platformVersionMajor && legacyInfo.platformVersionMinor) {
+				let major = parseInt(legacyInfo.platformVersionMajor);
+				let minor = parseInt(legacyInfo.platformVersionMinor);
+				if (major < 3 || (major === 3 && minor <= 0)) {
+					_platform.legacy = true;
+				} else {
+					_platform.open = true;
+				}
+			} else {
+				_platform.unknown = true;
+			}
+		} catch (e) {
+			_platform.open = true;
+		}
+
+		// TODO: clean these up. They shouldn't be here
+		window.Mojo = window.Mojo || {relaunch: function () {}};
+		if (window.PalmSystem.stageReady) window.PalmSystem.stageReady();
+	}
+
+	return _platform;
+}
+
+
 /**
  * {@link webos/platform.platform} provides identification of webOS variants.
  *
@@ -20,47 +82,8 @@
  * @memberof webos/platform
  * @public
  */
+
 const platform = {};
-let cache;
-
-function detect () {
-	if (typeof window !== 'undefined' && cache) {
-		return cache;
-	} else {
-		let device = {};
-		if (typeof window !== 'undefined' && window.PalmSystem) {
-			if (window.navigator.userAgent.indexOf('SmartWatch') > -1) {
-				device.watch = true;
-			} else if ((window.navigator.userAgent.indexOf('SmartTV') > -1) || (window.navigator.userAgent.indexOf('Large Screen') > -1)) {
-				device.tv = true;
-			} else {
-				try {
-					let legacyInfo = JSON.parse(window.PalmSystem.deviceInfo || '{}');
-					if (legacyInfo.platformVersionMajor && legacyInfo.platformVersionMinor) {
-						let major = parseInt(legacyInfo.platformVersionMajor);
-						let minor = parseInt(legacyInfo.platformVersionMinor);
-						if (major < 3 || (major === 3 && minor <= 0)) {
-							device.legacy = true;
-						} else {
-							device.open = true;
-						}
-					} else {
-						device.unknown = true;
-					}
-				} catch (e) {
-					device.open = true;
-				}
-				window.Mojo = window.Mojo || {relaunch: function () {}};
-				if (window.PalmSystem.stageReady) window.PalmSystem.stageReady();
-			}
-		} else {
-			device.unknown = true;
-		}
-		if (typeof window !== 'undefined') cache = device;
-		return device;
-	}
-}
-
 [
 	'tv',
 	'watch',


### PR DESCRIPTION
### Issue Resolved / Feature Added
webOS platform formfactor detection was happening at a modular level and not getting updated between snapshot and in-window runtime.


### Resolution
* Uses dynamic object properties that update as used (with caching once `window` object is loaded)
* Similar to how we handle `@enact/core/platform` (which ideally in the future this code will migrate into anyway).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>