### PR TITLE
ENYO-4343: Prevent checkbox from deselecting in ExpandableList

### DIFF
--- a/packages/moonstone/ExpandableList/ExpandableList.js
+++ b/packages/moonstone/ExpandableList/ExpandableList.js
@@ -193,15 +193,16 @@ const ExpandableListBase = kind({
 
 	handlers: {
 		onSelect: (ev, {closeOnSelect, onClose, onSelect, select}) => {
-			const deselect = ev.selected !== null;
-			const allowDeselect = select === 'multiple' ? true : deselect;
+			// The same value is being deselected when `ev.selected === null`
+			const selected = ev.selected !== null;
+			const allowSelect = select === 'multiple' ? true : selected;
 
 			// Call onClose if closeOnSelect is enabled and not selecting multiple
-			if (closeOnSelect && onClose && select !== 'multiple' && deselect) {
+			if (closeOnSelect && onClose && select !== 'multiple' && selected) {
 				onClose();
 			}
 
-			if (onSelect && allowDeselect) {
+			if (onSelect && allowSelect) {
 				onSelect(ev);
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
`ExpandableList` checkboxes should not be able to be deselected in `single` selection mode.

### Resolution
Make sure `ev.selected` is not `null` when `ExpandableList` is in `single` selection mode.
Also prevents closing when `closeOnSelect` and trying to deselect the same value in `single` selection mode.


### Links
ENYO-4343


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com