### PR TITLE
ENYO-4295: Enact Panels does not pass onTransition prop to its Viewport

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -54,6 +54,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Notification` to align texts left in LTR locale and right in RTL locale
 - `moonstone/VideoPlayer` to simulate rewind functionality on non-webOS platforms only
 - `moonstone/Panels` to pass the `onTransition` prop to its underlying `<Viewport>`
+- `moonstone/Panels` to pass the `onTransition` and `onWillTransition` props to its underlying `<Viewport>`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -53,6 +53,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Notification` to break line in characters in ja and zh locale
 - `moonstone/Notification` to align texts left in LTR locale and right in RTL locale
 - `moonstone/VideoPlayer` to simulate rewind functionality on non-webOS platforms only
+- `moonstone/Panels` to pass the `onTransition` prop to its underlying `<Viewport>`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,9 +8,12 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
+- `moonstone/Panels/Viewport` properties `onTransition` and `onWillTransition`
+
 ### Changed
 
 - `moonstone/VideoPlayer` properties `autoCloseTimeout` and `titleHideDelay` default value to `5000`
+- `moonstone/Panels` to pass the `onTransition` and `onWillTransition` props to its underlying `<Viewport>`
 
 ### Fixed
 
@@ -53,8 +56,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Notification` to break line in characters in ja and zh locale
 - `moonstone/Notification` to align texts left in LTR locale and right in RTL locale
 - `moonstone/VideoPlayer` to simulate rewind functionality on non-webOS platforms only
-- `moonstone/Panels` to pass the `onTransition` prop to its underlying `<Viewport>`
-- `moonstone/Panels` to pass the `onTransition` and `onWillTransition` props to its underlying `<Viewport>`
 
 ### Fixed
 

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -160,8 +160,7 @@ const PanelsBase = kind({
 			return updatedChildProps;
 		}
 	},
-
-	render: ({applicationCloseButton, arranger, children, childProps, generateId, index, noAnimation, onTransition, ...rest}) => {
+	render: ({applicationCloseButton, arranger, children, childProps, generateId, index, noAnimation, onTransition, onWillTransition, ...rest}) => {
 		delete rest.noCloseButton;
 		delete rest.onApplicationClose;
 		delete rest.onBack;
@@ -176,6 +175,7 @@ const PanelsBase = kind({
 					index={index}
 					noAnimation={noAnimation}
 					onTransition={onTransition}
+					onWillTransition={onWillTransition}
 				>
 					{children}
 				</Viewport>

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -115,7 +115,14 @@ const PanelsBase = kind({
 		 *
 		 * @type {Function}
 		 */
-		onTransition: PropTypes.func
+		onTransition: PropTypes.func,
+
+		/**
+		 * A function that runs when view transition is beginning.
+		 *
+		 * @type {Function}
+		 */
+		onWillTransition: PropTypes.func
 	},
 
 	defaultProps: {

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -108,7 +108,14 @@ const PanelsBase = kind({
 		 * @type {Function}
 		 * @public
 		 */
-		onBack: PropTypes.func
+		onBack: PropTypes.func,
+
+		/**
+		 * A function that runs when view transition is completed.
+		 *
+		 * @type {Function}
+		 */
+		onTransition: PropTypes.func
 	},
 
 	defaultProps: {
@@ -154,7 +161,7 @@ const PanelsBase = kind({
 		}
 	},
 
-	render: ({noAnimation, arranger, childProps, children, generateId, index, applicationCloseButton, ...rest}) => {
+	render: ({applicationCloseButton, arranger, children, childProps, generateId, index, noAnimation, onTransition, ...rest}) => {
 		delete rest.noCloseButton;
 		delete rest.onApplicationClose;
 		delete rest.onBack;
@@ -168,6 +175,7 @@ const PanelsBase = kind({
 					generateId={generateId}
 					index={index}
 					noAnimation={noAnimation}
+					onTransition={onTransition}
 				>
 					{children}
 				</Viewport>

--- a/packages/moonstone/Panels/Viewport.js
+++ b/packages/moonstone/Panels/Viewport.js
@@ -56,7 +56,21 @@ const ViewportBase = kind({
 		 * @type {Boolean}
 		 * @default false
 		 */
-		noAnimation: PropTypes.bool
+		noAnimation: PropTypes.bool,
+
+		/**
+		 * A function that runs when view transition is completed.
+		 *
+		 * @type {Function}
+		 */
+		onTransition: PropTypes.func,
+
+		/**
+		 * A function that runs when view transition is beginning.
+		 *
+		 * @type {Function}
+		 */
+		onWillTransition: PropTypes.func
 	},
 
 	defaultProps: {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This lets a developer use `onTransition` and `onWillTransition` handlers for `<Panels>`.

### Links
[//]: # (Related issues, references)
ENYO-4295

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)