### PR TITLE
ENYO-4328: Enact QA ProgressBar (sampler issue): TypeError 'backgroundProgress' of undefined Displays

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -10,8 +10,6 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 ### Changed
 
-- `moonstone/ProgressBar` sample to use `ProgressBarBase.defaultProps`
-
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
### Issue Resolved / Feature Added
The `<ProgressBar>` sample used `ProgressBar.defaultProps` for some defaults and it was causing the `TypeError`.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This changes the sample to use `ProgressBarBase.defaultProps` instead.


### Links
[//]: # (Related issues, references)
ENYO-4328

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)
