### PR TITLE
Corrected input's color rules by relocating them into the decorator's…

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -22,7 +22,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Dialog` to properly focus via pointer on child components
 - `moonstone` component hold delay time
-- `moonstone/Input` placeholder-text color
+- `moonstone/Input` text colors
 
 ### Removed
 

--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -118,10 +118,10 @@
 				color: @moon-input-text-color;
 				background-color: inherit;
 			});
+		}
 
-			.invalid & {
-				color: @moon-red;
-			}
+		&.invalid input {
+			color: @moon-red;
 		}
 
 		&:global(.spottable):focus {


### PR DESCRIPTION
… skin colors section

### Issue Resolved / Feature Added
`.input` didn't have a skin class, so it wasn't using any skin colors.

### Resolution
Relocated the input's color rules into the decorator's skin colors section so the colors can be applied.