### PR TITLE
ENYO-4364: Fix spotlight error when hovering native scroller

### DIFF
--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -323,6 +323,8 @@ function getLeaveForTarget (containerId, direction) {
 }
 
 function getNavigableTarget (target) {
+	if (target === document) return null;
+
 	let parent;
 	while (target && (isContainer(target) || !isFocusable(target))) {
 		parent = target.parentNode;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Using chrome on a mac, if a native scrollbar is hovered, spotlight will throw errors.

### Resolution
Chrome scrollbars on a mac will overlap/obscure the document body, so `mouseover` and `mousemove` events will occur when hovering the scrollbar. This results in spotlight attempting to perform actions on the `target` (the `document`) during these events. The spotlight error is due to calling `getNavigableTarget(target)` when `target === document`.

We could prevent the call to `getNavigableTarget` in the mouse event handlers, but since `getNavigableTarget` a) makes an unprotected call to `isFocusable(target)` (the source of the error) and b) attempts to traverse the parentNode of `target`, I think it may make more sense to validate `target` within the `getNavigableTarget` method.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>