### PR TITLE
ENYO-4394-Implemented hover support when MarqueeOn is Render and has …

### DIFF
--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -525,9 +525,13 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			// TODO: cancel others on hover
-			if (marqueeOnHover || marqueeOnRender || (disabled && marqueeOnFocus)) {
+			if (marqueeOnHover || (disabled && marqueeOnFocus)) {
 				rest[enter] = this.handleEnter;
 				rest[leave] = this.handleLeave;
+			}
+
+			if (marqueeOnRender) {
+				rest[enter] = this.handleEnter;
 			}
 
 			delete rest.marqueeDelay;


### PR DESCRIPTION
Implemented hover support in Marquee when the  marqueeOn="render" and it has delay

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Marquee will start instantaneously once hovered in cases like - the marquee is having marqueeOn="Render" and it also has  "marqueeOnRenderDelay". The user need not to wait till the delay is finished. He/She can start the marquee by just focusing or hovering on it.

### Comments
Enact-DCO-1.0-Signed-off-by:Madala Satyanarayana <madala.satyanarayana@lge.com>