### PR TITLE
ENYO-4378: Fix lack of padding in joined vertical Picker

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -187,6 +187,16 @@
 				.position(0);
 			}
 		}
+
+		&.vertical {
+			.valueWrapper {
+				.item {
+					.moon-custom-text({
+						margin: 0 @moon-spotlight-outset;
+					});
+				}
+			}
+		}
 	}
 
 	&.vertical .valueWrapper {
@@ -198,6 +208,10 @@
 
 		.item {
 			margin: 0 @moon-spotlight-outset;
+
+			.moon-custom-text({
+				margin: 0;
+			});
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix lack of padding in joined vertical Picker when large text is used.


### Resolution
Removed the style which sets the margin as 0 for large text.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4378

### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)