### PR TITLE
Set the value of marqueeOn for all types of headers

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/ContextualPopupDecorator` close button to account for large text size
 - `moonstone/ContextualPopupDecorator` to not spot controls other than its activator when navigating out via 5-way
+- `moonstone/Header` to set the value of `marqueeOn` for all types of headers
 
 ### Removed
 

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -175,7 +175,7 @@ const HeaderBase = kind({
 			// );
 			case 'standard': return (
 				<header aria-label={title} {...rest}>
-					<HeaderH1 casing={casing} className={css.title} preserveCase={preserveCase} marqueeOn="hover">
+					<HeaderH1 casing={casing} className={css.title} preserveCase={preserveCase} marqueeOn={marqueeOn}>
 						{title}
 					</HeaderH1>
 					<div className={css.headerRow}>


### PR DESCRIPTION
Issue: ENYO-4250
Enact-DCO-1.0-Signed-off-by Aaron Tam <aaron.tam@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Missed updating the `standard` header type to have its `marqueeOn` value be settable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated the `standard` header to use the incoming prop for `marqueeOn`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://github.com/enyojs/enact/pull/834

### Comments
