### PR TITLE
ENYO-4470: Add missing invariant dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "classnames": "~2.2.5",
+    "invariant": "~2.2.1",
     "prop-types": "~15.5.0",
     "ramda": "~0.23.0",
     "react": "~15.5.0",


### PR DESCRIPTION
### Issue Resolved / Feature Added
The ApiDecorator hoc was introduced in https://github.com/enyojs/enact/pull/841
and makes use of the invariant module, but that module has not been listed in the core package's package.json file and does not exist. When attempting to create a standalone application that makes use of this hoc, you cannot successfully compile/serve.

### Resolution
Add missing invariant dependency

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>