### PR TITLE
ENYO-4440: Reset the scrollTop of VirtualListNative with 0

### DIFF
--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -266,7 +266,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		}
 
 		onMouseMove = () => {
-			if (this.resetPosition) {
+			if (this.resetPosition !== null) {
 				const containerNode = this.childRef.getContainerNode();
 				containerNode.style.scrollBehavior = null;
 				containerNode.scrollTop = this.resetPosition;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If hovering an item on an edge, `ScrollableNative` try to reset the `scrollTop` of VirtualListNative to the previous position. But if the previous position is 0, `ScrollableNative` did not do it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Instead of checking `this.resetPosition`, I checked whether this.resetPosition equals `null` or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-4440

### Comments
