### PR TITLE
ENYO-4248: P&V: VideoPlayer mini feedback

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ExpandableItem`, `moonstone/ExpandableList`, `moonstone/ExpandablePicker`, `moonstone/DatePicker`, and `moonstone/TimePicker` to pause spotlight when animating in 5-way mode
 - `moonstone/Spinner` to position the text content under the spinner, rather than to the right side
 - `moonstone/VideoPlayer` to include hour when announcing the time while scrubbing
+- `moonstone/VideoPlayer` to display 'mini' feedback when controlling playback from the remote control
 
 ### Fixed
 

--- a/packages/moonstone/VideoPlayer/Feedback.less
+++ b/packages/moonstone/VideoPlayer/Feedback.less
@@ -26,6 +26,7 @@
 		font-size: @moon-video-feedback-icon-font-size;
 		line-height: @moon-video-feedback-icon-line-height; /* use line-height to middle align the icon, the defaut 32px from moon-icon will make it too low */
 		height: @moon-video-feedback-icon-line-height;
+		vertical-align: bottom;
 
 		&.shrink {
 			font-size: @moon-video-feedback-icon-shrunken-size;

--- a/packages/moonstone/VideoPlayer/FeedbackIcons.js
+++ b/packages/moonstone/VideoPlayer/FeedbackIcons.js
@@ -8,8 +8,8 @@ export default {
 	slowRewind    : {icon: 'pausebackward',  position: 'before',  allowHide: false,  message: 'x'},
 	fastForward   : {icon: 'forward',        position: 'after',   allowHide: false,  message: 'x'},
 	slowForward   : {icon: 'pauseforward',   position: 'after',   allowHide: false,  message: 'x'},
-	jumpBackward  : {icon: 'skipbackward',   position: 'before',  allowHide: false,  message: 'sec'},
-	jumpForward   : {icon: 'skipforward',    position: 'after',   allowHide: false,  message: 'sec'},
+	jumpBackward  : {icon: 'skipbackward',   position: 'before',  allowHide: false,  message: ' SEC'},
+	jumpForward   : {icon: 'skipforward',    position: 'after',   allowHide: false,  message: ' SEC'},
 	jumpToStart   : {icon: 'skipbackward',   position: 'before',  allowHide: true,   message: null},
 	jumpToEnd     : {icon: 'skipforward',    position: 'after',   allowHide: true,   message: null},
 	stop          : {icon: null,             position: null,      allowHide: true,   message: null}

--- a/packages/moonstone/VideoPlayer/FeedbackIcons.js
+++ b/packages/moonstone/VideoPlayer/FeedbackIcons.js
@@ -8,8 +8,8 @@ export default {
 	slowRewind    : {icon: 'pausebackward',  position: 'before',  allowHide: false,  message: 'x'},
 	fastForward   : {icon: 'forward',        position: 'after',   allowHide: false,  message: 'x'},
 	slowForward   : {icon: 'pauseforward',   position: 'after',   allowHide: false,  message: 'x'},
-	jumpBackward  : {icon: 'skipbackward',   position: 'before',  allowHide: true,   message: null},
-	jumpForward   : {icon: 'skipforward',    position: 'after',   allowHide: true,   message: null},
+	jumpBackward  : {icon: 'skipbackward',   position: 'before',  allowHide: false,  message: 'sec'},
+	jumpForward   : {icon: 'skipforward',    position: 'after',   allowHide: false,  message: 'sec'},
 	jumpToStart   : {icon: 'skipbackward',   position: 'before',  allowHide: true,   message: null},
 	jumpToEnd     : {icon: 'skipforward',    position: 'after',   allowHide: true,   message: null},
 	stop          : {icon: null,             position: null,      allowHide: true,   message: null}

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.js
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.js
@@ -90,9 +90,9 @@ const FeedbackTooltipBase = kind({
 	},
 
 	computed: {
-		className: ({playbackState: s, styler, visible}) => styler.append({
+		className: ({playbackState: s, standalone, styler, visible}) => styler.append({
 			hidden: !visible && states[s] && states[s].allowHide
-		})
+		}, standalone ? css.standalone : '')
 	},
 
 	render: ({children, noFeedback, playbackState, playbackRate, thumbnailSrc, ...rest}) => {

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.less
@@ -37,6 +37,23 @@
 		bottom: @moon-spotlight-outset;
 	}
 
+
+	&.miniFeedback {
+		position: absolute;
+		top: 87px;
+		left: 12px;
+
+		.content {
+			background-color: rgba(0, 0, 0, 0.5);
+			border-radius: 24px;
+			padding: 3px 12px 0 3px;
+
+			& > div:first-child > div {
+				padding-bottom: 6px;
+			}
+		}
+	}
+
 	// .knob[data-climax="rising"] {
 	// 	.thumbnail,
 	// 	.content {

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.less
@@ -38,7 +38,7 @@
 		bottom: @moon-spotlight-outset;
 	}
 
-	&.miniFeedback {
+	&.standalone {
 		position: absolute;
 		top: @moon-video-mini-feedback-position-top;
 		left: @moon-video-mini-feedback-position-left;
@@ -79,7 +79,7 @@
 			text-shadow: @moon-video-player-title-text-shadow;
 		}
 
-		&.miniFeedback {
+		&.standalone {
 			.content {
 				background-color: @moon-video-mini-feedback-bg-color;
 				text-shadow: none;

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.less
@@ -41,16 +41,17 @@
 	&.miniFeedback {
 		position: absolute;
 		top: @moon-video-mini-feedback-position-top;
-		left: @moon-video-mini-feedback-padding;
+		left: @moon-video-mini-feedback-position-left;
 
 		.content {
-			background-color: @moon-video-mini-feedback-bg-color;
-			border-radius: @moon-video-mini-feedback-padding*2;
-			padding: @moon-video-mini-feedback-padding/4 @moon-video-mini-feedback-padding 0 @moon-video-mini-feedback-padding/4;
-
-			& > div:first-child > div {
-				padding-bottom: @moon-video-mini-feedback-padding/2;
-			}
+			font-family: @moon-video-mini-feedback-font-family;
+			font-weight: @moon-video-mini-feedback-font-weight;
+			font-style: @moon-video-mini-feedback-font-style;
+			font-size: @moon-video-mini-feedback-font-size;
+			border-radius: 999px;
+			padding: 0 @moon-video-mini-feedback-padding-side;
+			bottom: auto;
+			transform: none;
 		}
 	}
 
@@ -76,6 +77,13 @@
 		.content {
 			color: @moon-white;
 			text-shadow: @moon-video-player-title-text-shadow;
+		}
+
+		&.miniFeedback {
+			.content {
+				background-color: @moon-video-mini-feedback-bg-color;
+				text-shadow: none;
+			}
 		}
 	});
 }

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.less
@@ -1,8 +1,9 @@
 // FeedbackTooltip.less
 //
 @import "../styles/text.less";
-@import "../styles/variables.less";
+@import "../styles/colors.less";
 @import "../styles/skin.less";
+@import "../styles/variables.less";
 
 .feedbackTooltip {
 	&.hidden {
@@ -37,19 +38,18 @@
 		bottom: @moon-spotlight-outset;
 	}
 
-
 	&.miniFeedback {
 		position: absolute;
-		top: 87px;
-		left: 12px;
+		top: @moon-video-mini-feedback-position-top;
+		left: @moon-video-mini-feedback-padding;
 
 		.content {
-			background-color: rgba(0, 0, 0, 0.5);
-			border-radius: 24px;
-			padding: 3px 12px 0 3px;
+			background-color: @moon-video-mini-feedback-bg-color;
+			border-radius: @moon-video-mini-feedback-padding*2;
+			padding: @moon-video-mini-feedback-padding/4 @moon-video-mini-feedback-padding 0 @moon-video-mini-feedback-padding/4;
 
 			& > div:first-child > div {
-				padding-bottom: 6px;
+				padding-bottom: @moon-video-mini-feedback-padding/2;
 			}
 		}
 	}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -15,7 +15,7 @@ import {forKey, forward, forwardWithPrevent, handle, stopImmediate} from '@enact
 import ilib from '@enact/i18n';
 import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';
-import {add,is} from '@enact/core/keymap';
+import {add, is} from '@enact/core/keymap';
 import {platform} from '@enact/core/platform';
 import Slottable from '@enact/ui/Slottable';
 import {getDirection, Spotlight} from '@enact/spotlight';
@@ -1427,13 +1427,13 @@ const VideoPlayerBase = class extends React.Component {
 				{this.state.bottomControlsRendered ?
 					<div className={css.fullscreen + ' enyo-fit scrim'} style={{display: this.state.bottomControlsVisible ? 'block' : 'none'}}>
 						{this.state.playbackControlsVisible ? null :
-							<FeedbackTooltip
-								className={feedbackCss.miniFeedback}
-								playbackState={this.prevCommand}
-								playbackRate={this.selectPlaybackRate(this.speedIndex)}
-							>
-								{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
-							</FeedbackTooltip>
+						<FeedbackTooltip
+							className={feedbackCss.miniFeedback}
+							playbackState={this.prevCommand}
+							playbackRate={this.selectPlaybackRate(this.speedIndex)}
+						>
+							{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
+						</FeedbackTooltip>
 						}
 						<Container className={css.bottom} data-container-disabled={!this.state.bottomControlsVisible}>
 							{/* Info Section: Title, Description, Times */}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -34,7 +34,6 @@ import MediaSlider from './MediaSlider';
 import Times from './Times';
 
 import css from './VideoPlayer.less';
-import feedbackCss from './FeedbackTooltip.less';
 
 const SpottableDiv = Spottable('div');
 const Container = SpotlightContainerDecorator({enterTo: ''}, 'div');
@@ -402,8 +401,6 @@ const VideoPlayerBase = class extends React.Component {
 		 * @type {moonstone/VideoPlayer.playbackRateHash}
 		 * @default {
 		 *	fastForward: ['2', '4', '8', '16'],
-		 *	jumpBackward: ['15'],
-		 *	jumpForward: ['15'],
 		 *	rewind: ['-2', '-4', '-8', '-16'],
 		 *	slowForward: ['1/4', '1/2'],
 		 *	slowRewind: ['-1/2', '-1']
@@ -412,8 +409,6 @@ const VideoPlayerBase = class extends React.Component {
 		 */
 		playbackRateHash: PropTypes.shape({
 			fastForward: PropTypes.arrayOf(PropTypes.string),
-			jumpBackward: PropTypes.arrayOf(PropTypes.string),
-			jumpForward: PropTypes.arrayOf(PropTypes.string),
 			rewind: PropTypes.arrayOf(PropTypes.string),
 			slowForward: PropTypes.arrayOf(PropTypes.string),
 			slowRewind: PropTypes.arrayOf(PropTypes.string)
@@ -520,8 +515,6 @@ const VideoPlayerBase = class extends React.Component {
 		pauseIcon: 'pause',
 		playbackRateHash: {
 			fastForward: ['2', '4', '8', '16'],
-			jumpBackward: ['15'],
-			jumpForward: ['15'],
 			rewind: ['-2', '-4', '-8', '-16'],
 			slowForward: ['1/4', '1/2'],
 			slowRewind: ['-1/2', '-1']
@@ -992,21 +985,18 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	jump = (distance) => {
-		if (distance < 0) {
-			// jumpBackward
-			this.selectPlaybackRates('jumpBackward');
-			this.prevCommand = 'jumpBackward';
-		} else {
-			// jumpForward
-			this.selectPlaybackRates('jumpForward');
-			this.prevCommand = 'jumpForward';
-		}
+		const commandBeforeJump = this.prevCommand;
+		this.prevCommand = distance < 0 ? 'jumpBackward' : 'jumpForward';
 		this.speedIndex = 0;
-		this.setPlaybackRate(this.selectPlaybackRate(this.speedIndex));
 
 		this.showFeedback();
 		this.startDelayedFeedbackHide();
 		this.seek(this.state.currentTime + distance);
+		// after jumping, reset playback rate and prevCommand
+		this.setPlaybackRate(1);
+		if (commandBeforeJump === 'play' || commandBeforeJump === 'pause') {
+			this.prevCommand = commandBeforeJump;
+		}
 	}
 
 	/**
@@ -1430,13 +1420,13 @@ const VideoPlayerBase = class extends React.Component {
 				{this.state.bottomControlsRendered ?
 					<div className={css.fullscreen + ' enyo-fit scrim'} style={{display: this.state.bottomControlsVisible ? 'block' : 'none'}}>
 						{this.state.playbackControlsVisible ? null :
-						<FeedbackTooltip
-							className={feedbackCss.miniFeedback}
-							playbackState={this.prevCommand}
-							playbackRate={this.selectPlaybackRate(this.speedIndex)}
-						>
-							{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
-						</FeedbackTooltip>
+							<FeedbackTooltip
+								playbackState={this.prevCommand}
+								playbackRate={this.props.jumpBy}
+								standalone
+							>
+								{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
+							</FeedbackTooltip>
 						}
 						<Container className={css.bottom} data-container-disabled={!this.state.bottomControlsVisible}>
 							{/* Info Section: Title, Description, Times */}

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -194,6 +194,7 @@
 
 // VideoPlayer
 // ---------------------------------------
+@moon-video-mini-feedback-bg-color: rgba(0, 0, 0, 0.5);
 @moon-video-slider-tooltip-thumbnail-border-color: @moon-contextual-popup-border-color;
 @moon-video-player-indicator-text-color: @moon-white;
 @moon-video-player-bottom-bg-color: transparent;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -122,6 +122,10 @@
 @moon-button-font-style: normal;
 @moon-button-letter-spacing: normal;
 
+@moon-video-mini-feedback-font-family: @moon-alt-font-family;
+@moon-video-mini-feedback-font-weight: normal;
+@moon-video-mini-feedback-font-style: normal;
+
 @moon-icon-font-family: "Moonstone Icons";
 
 // Spotlight
@@ -316,15 +320,17 @@
 // ---------------------------------------
 @moon-video-slider-tooltip-font-size:              24px;
 @moon-video-slider-tooltip-line-height:            36px;
-@moon-video-slider-tooltip-gutter-width:           12px;
+@moon-video-slider-tooltip-gutter-width:           (@moon-spotlight-outset / 2);
 @moon-video-slider-tooltip-thumbnail-border-width: @moon-contextual-popup-border-width;
 @moon-video-slider-tooltip-thumbnail-border-radius: @moon-contextual-popup-border-radius;
 @moon-video-feedback-icon-width:                   36px;
 @moon-video-feedback-icon-font-size:               72px;	// For most icons
 @moon-video-feedback-icon-shrunken-size:           48px;	// For play and pause icons, since they're larger scale than the others
-@moon-video-feedback-icon-line-height:             30px;
-@moon-video-mini-feedback-padding:                 12px;
-@moon-video-mini-feedback-position-top:            90px;
+@moon-video-feedback-icon-line-height:             (@moon-video-feedback-icon-font-size / 2);
+@moon-video-mini-feedback-position-top:            24px;
+@moon-video-mini-feedback-position-left:           24px;
+@moon-video-mini-feedback-padding-side:            18px;
+@moon-video-mini-feedback-font-size:               27px;
 // @moon-video-feedback-icon-pausejumpbackward-width: 36px;	// May need this later
 // @moon-video-feedback-icon-pausejumpforward-width:  36px;	// May need this later
 @moon-video-player-badge-text-size:                24px;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -323,6 +323,8 @@
 @moon-video-feedback-icon-font-size:               72px;	// For most icons
 @moon-video-feedback-icon-shrunken-size:           48px;	// For play and pause icons, since they're larger scale than the others
 @moon-video-feedback-icon-line-height:             30px;
+@moon-video-mini-feedback-padding:                 12px;
+@moon-video-mini-feedback-position-top:            90px;
 // @moon-video-feedback-icon-pausejumpbackward-width: 36px;	// May need this later
 // @moon-video-feedback-icon-pausejumpforward-width:  36px;	// May need this later
 @moon-video-player-badge-text-size:                24px;


### PR DESCRIPTION
### Issue Resolved / Feature Added
"Mini" feedback should be displayed when controlling the video playback via remote control and only when the playback controls are not visible.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I can't get left/right (skip back/forward) to function while the feedback/slider are displayed, so I can't verify the changes I made to the feedback icons are correct.


### Links
[//]: # (Related issues, references)
ENYO-4248

### Comments
I'm anticipating comments about the styles :D