### PR TITLE
ENYO-4506: Fix refocusing ContextualPopup activator on close

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -458,6 +458,9 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		spotActivator = (activator) => {
+			if (activator && activator === Spotlight.getCurrent()) {
+				activator.blur();
+			}
 			if (!Spotlight.focus(activator)) {
 				Spotlight.focus();
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
ContextualPopup: Parent Button Does Not Read Out after Popup Hides


### Resolution
Remove the check for the currently spotted activator in `spotActivator`. Now closing contextual popup will focus the activator button even if it is already focused.


### Links
ENYO-4506


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com