### PR TITLE
PLAT-43386: Added `data-preventscrollonfocus` attribute

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -572,6 +572,7 @@ class VirtualListCoreNative extends Component {
 
 		this.cc[key] = React.cloneElement(itemElement, {
 			className: classNames(cssItem.listItem, itemElement.props.className),
+			['data-preventscrollonfocus']: true, // Added this attribute to prevent scroll on focus by browser
 			style: {...itemElement.props.style, ...style}
 		});
 	}


### PR DESCRIPTION
to items in VirtualListNative

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`element.scrollTo` aborts its animation when an element got focused. It leads showing partial items during navigation with 5way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To prevent scroll on focus in `VirtualListNative` , we added `data-preventscrollonfocus` attribute.
We need web engine's modification to make this fully work.

### Links
[//]: # (Related issues, references)
PLAT-43386

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)