### PR TITLE
ENYO-4501: Fix to set the proper node as a spotlight container for native lists

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -896,7 +896,7 @@ class VirtualListCoreNative extends Component {
 			mergedClasses = classNames(css.list, this.wrapperClass, className);
 
 		return (
-			<div ref={this.initWrapperRef} className={mergedClasses} data-container-id={dataContainerId} style={style}>
+			<div className={mergedClasses} data-container-id={dataContainerId} ref={this.initWrapperRef} style={style}>
 				<div {...rest} onKeyDown={this.onKeyDown} ref={this.initContainerRef}>
 					{cc.length ? cc : null}
 					{primary ? null : (


### PR DESCRIPTION

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight moved back into a list by 5-way key in case of outbound moving since the spotlight container of a list is actually a contents container which can be very long.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of the current contents node, a container node (works as a view window) is now a spotlight container.




### Links
[//]: # (Related issues, references)
ENYO-4501

### Comments

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)