### PR TITLE
ENYO-4126: Selected Height Differs from Unselected Height in Horizontal Orientation

### DIFF
--- a/packages/moonstone/Item/Item.less
+++ b/packages/moonstone/Item/Item.less
@@ -14,6 +14,7 @@
 
 	&.inline {
 		display: inline-flex;
+		vertical-align: top;
 		max-width: 240px;
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Enact QA SelectableItem: Selected Height Differs from Unselected Height in Horizontal Orientation  

### Resolution
Height mixmatch - vertical-align -top is added to fix the issues

### Additional Considerations

### Links
ENYO-4126

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)