### PR TITLE
PLAT-43488: Force to update when jumping to 0 index

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -699,6 +699,9 @@ class VirtualListCore extends Component {
 
 			this.focusOnNode(item);
 			this.nodeIndexToBeFocused = null;
+			if (index === 0) {
+				this.forceUpdate();
+			}
 		}, 0);
 	}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When jumping to the target item far from a current item, we added a placeholder in `VirtualList` to keep focus in it. Then we deleted it when the target item got to focus. But when jumping to 0 index, there was still a placeholder even though the 0 index item got to focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When getting to focus the 0 index item after jumping, this.nodeIndexToBeFocused became null. But render() in `VirtualListBase` was not called. On the other hand, when jumping to another index item, this.nodeIndexToBeFocused became null, the `firstIndex` of `VirtualList`'s state changed, then the render() was called 1 or 2 times more. Finally, the placeholder could be deleted correctly.

So I tried to force render() when this.nodeIndexToBeFocused became null.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-43488

### Comments
