### PR TITLE
ENYO-4519: Fix ContextualPopup focus behavior when spotlightModal

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -10,6 +10,8 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Changed
 
+- `spotlight` containers using a `restrict` value of 'self-only' will ignore `leaveFor` directives when attempting to leave the container via 5-way
+
 ### Fixed
 
 - `spotlight` to not blur and re-focus an element that is already focused

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -363,7 +363,7 @@ function getTargetByDirectionFromPosition (direction, position, containerId) {
 function getLeaveForTarget (containerId, direction) {
 	const config = getContainerConfig(containerId);
 
-	const target = config.leaveFor && config.leaveFor[direction];
+	const target = config.restrict !== 'self-only' && config.leaveFor && config.leaveFor[direction];
 	if (typeof target === 'string') {
 		if (target === '') {
 			return false;


### PR DESCRIPTION
### Issue Resolved / Feature Added
When using a `ContextualPopup` configured with a `spotlightRestrict: 'self-only'`, the popup will close when attempting to 5-way at the edge of the popup (when there are no available spottable controls in x direction within the popup to navigate to). The popup should not close in this scenario, leaving focus on the current control.

### Resolution
This issue was caused when we added a `leaveFor` configuration for the `ContextualPopup`. That allows us to return focus to the activator when attempting to leave the popup. However, we weren't taking into account popups using `spotlightRestrict: 'self-only'` - where attempting to leave such a popup will still follow the rules set by `leaveFor`, even though 5-way navigation should not naturally leave that popup.

I believe there is an unclear spotlight behavior that we could address here. Using `leaveFor` to specify rules in a container using `spotlightRestrict='self-only'` will override the restrictions that `'self-only'` attempts to enforce. This will allow focus to leave a container that has configured rules against that very behavior. I don't see a benefit of providing an "out" to a container using `restrict: 'self-only'`. In cases like `ContextualPopup`, I'd suggest handling that desired behavior from within that component.

There are a couple possible solutions to this issue. We could handle this directly within `ContextualPopup`. or change the spotlight behavior where `getLeaveForTarget()` will ignore containers configured as `restrict: 'self-only'`. I'm proposing changing the spotlight behavior and think makes the most sense, but I'm open to thoughts/suggestions.

### Links
The commit that ultimately exposed this issue: https://github.com/enyojs/enact/commit/84a55c6fcdfcc56a2dd45c08f4c1cb93d99027a8

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>