### PR TITLE
ENYO-4229: Support scroll by wheel on scrollbar of vertical native lists

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller` not scrolled via 5 way when `moonstone/ExpandableList` is opened.
+- `moonstone/VirtualList` not to let the focus move outside of container even if there are children left when navigating with 5way
 - `moonstone/Scrollable` to update disability of paging controls when the scrollbar is set to `visible` and the content becomes shorter.
 
 ## [1.5.0] - 2017-07-19

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -269,8 +269,12 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.updateEventListeners();
 			this.updateScrollbars();
 
-			if (this.scrollToInfo !== null && !this.deferScrollTo) {
-				this.scrollTo(this.scrollToInfo);
+			if (this.scrollToInfo !== null) {
+				if (!this.deferScrollTo) {
+					this.scrollTo(this.scrollToInfo);
+				}
+			} else {
+				this.updateScrollOnFocus();
 			}
 		}
 
@@ -456,9 +460,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					// If scroll animation is ongoing, we need to pass last target position to
 					// determine correct scroll position.
 					if (this.scrolling && lastPos) {
-						pos = positionFn(item, (this.direction !== 'horizontal') ? lastPos.top : lastPos.left);
+						pos = positionFn({item, scrollPosition: (this.direction !== 'horizontal') ? lastPos.top : lastPos.left});
 					} else {
-						pos = positionFn(item);
+						pos = positionFn({item});
 					}
 					this.startScrollOnFocus(pos, item);
 				}
@@ -895,6 +899,32 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 
 			childContainerRef.style.scrollBehavior = 'smooth';
+		}
+
+		updateScrollOnFocus () {
+			const
+				focusedItem = Spotlight.getCurrent(),
+				{containerRef, calculatePositionOnFocus} = this.childRef;
+
+			if (focusedItem && containerRef && containerRef.contains(focusedItem)) {
+				const
+					scrollInfo = {
+						previousScrollHeight: this.bounds.scrollHeight,
+						scrollTop: this.scrollTop
+					},
+					pos = calculatePositionOnFocus({item: focusedItem, scrollInfo});
+
+				if (pos && (pos.left !== this.scrollLeft || pos.top !== this.scrollTop)) {
+					this.start({
+						targetX: pos.left,
+						targetY: pos.top,
+						animate: false
+					});
+				}
+			}
+
+			// update `scrollHeight`
+			this.bounds.scrollHeight = this.getScrollBounds().scrollHeight;
 		}
 
 		// forceUpdate is a bit jarring and may interrupt other actions like animation so we'll

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -709,7 +709,7 @@ class VirtualListCore extends Component {
 		this.lastFocusedIndex = Number.parseInt(item.getAttribute(dataIndexAttribute));
 	}
 
-	calculatePositionOnFocus = (item, scrollPosition = this.scrollPosition) => {
+	calculatePositionOnFocus = ({item, scrollPosition = this.scrollPosition}) => {
 		const
 			{pageScroll} = this.props,
 			{primary, numOfItems} = this,
@@ -738,6 +738,29 @@ class VirtualListCore extends Component {
 			gridPosition.secondaryPosition = 0;
 			return this.gridPositionToItemPosition(gridPosition);
 		}
+	}
+
+	setRestrict = (bool) => {
+		Spotlight.set(this.props['data-container-id'], {restrict: (bool) ? 'self-only' : 'self-first'});
+	}
+
+	setSpotlightContainerRestrict = (keyCode, index) => {
+		const
+			{dataSize} = this.props,
+			{isPrimaryDirectionVertical, dimensionToExtent} = this,
+			canMoveBackward = index >= dimensionToExtent,
+			canMoveForward = index < (dataSize - (((dataSize - 1) % dimensionToExtent) + 1));
+		let isSelfOnly = false;
+
+		if (isPrimaryDirectionVertical) {
+			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
+				isSelfOnly = true;
+			}
+		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
+			isSelfOnly = true;
+		}
+
+		this.setRestrict(isSelfOnly);
 	}
 
 	getIndicesForPageScroll = (direction, currentIndex) => {
@@ -857,7 +880,7 @@ class VirtualListCore extends Component {
 		this.isScrolledBy5way = false;
 		if (getDirection(keyCode)) {
 			const index = Number.parseInt(target.getAttribute(dataIndexAttribute));
-
+			this.setSpotlightContainerRestrict(keyCode, index);
 			this.isScrolledBy5way = this.jumpToSpottableItem(keyCode, index);
 		}
 		forwardKeyDown(e, this.props);

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -684,7 +684,7 @@ class VirtualListCoreNative extends Component {
 		this.lastFocusedIndex = Number.parseInt(item.getAttribute(dataIndexAttribute));
 	}
 
-	calculatePositionOnFocus = (item, scrollPosition = this.scrollPosition) => {
+	calculatePositionOnFocus = ({item, scrollPosition = this.scrollPosition}) => {
 		const
 			{pageScroll} = this.props,
 			{primary} = this,
@@ -711,6 +711,30 @@ class VirtualListCoreNative extends Component {
 			gridPosition.secondaryPosition = 0;
 			return this.gridPositionToItemPosition(gridPosition);
 		}
+	}
+
+	setRestrict = (bool) => {
+		Spotlight.set(this.props['data-container-id'], {restrict: (bool) ? 'self-only' : 'self-first'});
+	}
+
+	setSpotlightContainerRestrict = (keyCode, target) => {
+		const
+			{dataSize} = this.props,
+			{isPrimaryDirectionVertical, dimensionToExtent} = this,
+			index = Number.parseInt(target.getAttribute(dataIndexAttribute)),
+			canMoveBackward = index >= dimensionToExtent,
+			canMoveForward = index < (dataSize - (((dataSize - 1) % dimensionToExtent) + 1));
+		let isSelfOnly = false;
+
+		if (isPrimaryDirectionVertical) {
+			if (isUp(keyCode) && canMoveBackward || isDown(keyCode) && canMoveForward) {
+				isSelfOnly = true;
+			}
+		} else if (isLeft(keyCode) && canMoveBackward || isRight(keyCode) && canMoveForward) {
+			isSelfOnly = true;
+		}
+
+		this.setRestrict(isSelfOnly);
 	}
 
 	getIndicesForPageScroll = (direction, currentIndex) => {
@@ -832,6 +856,7 @@ class VirtualListCoreNative extends Component {
 		this.isScrolledBy5way = false;
 		if (getDirection(keyCode)) {
 			e.preventDefault();
+			this.setSpotlightContainerRestrict(keyCode, target);
 			this.isScrolledBy5way = this.jumpToSpottableItem(keyCode, target);
 		}
 		forwardKeyDown(e, this.props);

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -1,7 +1,9 @@
 import Button from '@enact/moonstone/Button';
 import ExpandableList from '@enact/moonstone/ExpandableList';
 import Scroller from '@enact/moonstone/Scroller';
+import Item from '@enact/moonstone/Item';
 import ri from '@enact/ui/resolution';
+import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {boolean, select} from '@kadira/storybook-addon-knobs';
@@ -29,6 +31,19 @@ const
 	};
 
 storiesOf('Scroller')
+	.addWithInfo(
+		'List of things',
+		() => (
+			<Scroller
+				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				style={{height: '600px'}}
+			>
+				<Group childComponent={Item}>
+					{itemData}
+				</Group>
+			</Scroller>
+		)
+	)
 	.addWithInfo(
 		'With ExpandableList',
 		() => (


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Native scroll by the wheel is possible when a pointer is over a scrollable area which has an `overflow` CSS attribute. Scrollbars are located out of a scrollable area, we could not scroll by the wheel over them. 

In this PR, the scrollable area is extended to include the scrollbar.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The basic strategy is to extend scrollable area including an area of the vertical scrollbar and make the vertical scrollbar `fixed`. To extend scrollable area, paddings should be added to `VirtualListBaseNative` node which has `overflow: scroll` CSS attribute not `ScrollableNative` node.
- Padding added to `VirtualListBaseNative`'s container node.
- `pointer-events: none` is added to `Scrolbar` and `pointer-events: auto` is added to paging control buttons.
- In `VirtualListBaseNative`, client size is derived from both the container and the content wrapper. For example, in a case of a vertical list, a client width is from the content wrapper and a client height is from the container.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

If both scrollbars are visible (e.g a scroller for zoomed image), scrollbars are overlapped on items. It may be not a problem on a scroller, but it looks weird for a list. For example, a horizontal scrollbar is overlapped on items for vertical lists. But, in my opinion, it's not a real requirement to show a scrollbar for a unscrollable direction in a list. Overlapping is removable by adding a new wrapping node, but it's worthless, I think.

Note that if a user tries to wheel on the _horizontal_ scrollbar in a _vertical_ list, a list will not be scrolled. Again, for a list, it is not natural to display the horizontal scrollbar for a vertical list, so it is not a deal. For a scroller, it would be better to support wheeling on the horizontal scrollbar. The problem is that there is no way to extend scrollable area to the horizontal scrollbar without breaking flexbox layout. For now, it is very rare to show up both scrollbars on our target apps.

Two ref nodes' names are changed for better understanding between scrollables and lists. ScrollableNative uses `getContainerNode` API of native lists, and `wrapperRef` is actually returned in `VirtualListBaseNative`. Also, this name is very confused when a framework developer works on both the JS version and the native version. So I renamed `containerRef` as `contentRef` and `wrapperRef` as `containerRef`.

### Links
[//]: # (Related issues, references)
ENYO-4229

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
