### PR TITLE
PLAT-43873: Fix the JSDoc of VirtualFlexList for next versions of `eslint-config-enact`

### DIFF
--- a/packages/moonstone/VirtualFlexList/Positionable.js
+++ b/packages/moonstone/VirtualFlexList/Positionable.js
@@ -69,9 +69,7 @@ const Positionable = hoc((config, Wrapped) => {
 
 		static defaultProps = {
 			handlesNavigation: false,
-			onPositionChange: nop,
-			x: 0,
-			y: 0
+			onPositionChange: nop
 		}
 
 		/*

--- a/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
+++ b/packages/moonstone/VirtualFlexList/VirtualFlexListBase.js
@@ -122,12 +122,8 @@ class VirtualFlexListCore extends Component {
 	}
 
 	static defaultProps = {
-		component: null,
-		data: [],
-		dataSize: 0,
 		flexAxis: 'row',
-		overhang: 3,
-		style: {}
+		overhang: 3
 	}
 
 	/*


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When applying next versions of `eslint-config-enact`, there were several JS Doc warnings related with VirtualFlexList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Fixed the JSDoc warnings.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-43873

### Comments

Travis CI reported there was a lint error. But I could not find it with `npm run lint`.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)