### PR TITLE
ENYO-4554: Fix reading order is not working in VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -972,7 +972,7 @@ class VirtualListCore extends Component {
 						data-index={0}
 						data-vl-placeholder
 						onFocus={this.handlePlaceholderFocus}
-						role="alert"
+						role="region"
 					/>
 				)}
 				{needsScrollingPlaceholder ? (

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -940,7 +940,7 @@ class VirtualListCoreNative extends Component {
 							data-index={0}
 							data-vl-placeholder
 							onFocus={this.handlePlaceholderFocus}
-							role="alert"
+							role="region"
 						/>
 					)}
 				</div>


### PR DESCRIPTION
Fix reading order is not working in VirtualList

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In VirtualList, `spotlightPlaceholder` gets a focus before the child item is focused for preserving last-focus.
However, Reading order feature is only worked when the first child is focused, so the reading order is not worked.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If `spotlightPlaceholder` is set to `region` role, first focus item can be child item in VirtualList.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4554

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>