### PR TITLE
ENYO-4576: Handle left right key only when VideoPlayer gains focus

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1014,7 +1014,6 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	handleGlobalKeyDown = this.handle(
-		this.handleKeyDown,
 		forKey('down'),
 		() => (
 			!this.state.bottomControlsVisible &&
@@ -1724,6 +1723,7 @@ const VideoPlayerBase = class extends React.Component {
 					className={css.controlsHandleAbove}
 					onSpotlightDown={this.showControls}
 					onClick={this.showControls}
+					onKeyDown={this.handleKeyDown}
 				/>
 				<Announce ref={this.setAnnounceRef} />
 			</div>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Handle left right key only when VideoPlayer gains focus. If VideoPlayer is placed with other focusable components around, it prevents left/right navigation as it captures for jump.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>