### PR TITLE
ENYO-4577: Prevents reading a tooltip label

### DIFF
--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -238,6 +238,7 @@ const MediaControls = kind({
 							className={css.moreButton}
 							disabled={moreButtonDisabled}
 							onClick={onToggleMore}
+							tooltipProps={{role: 'dialog'}}
 							tooltipText={moreIconLabel}
 						>
 							{moreIcon}


### PR DESCRIPTION
Prevent reading a tooltip label from VideoPlayer's IconButton.

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The tooltipText is added to More/Back IconButton, so it reads tooltipText more because tooltip has alert role. These IconButtons are already set to "More" as aria-label, so it is not necessary to read a tooltipText same with aria-label. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add dialog role as tooltipPros

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4577

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>