### PR TITLE
PLAT-42041: Sync up VirtualListNative with VirtualList

### DIFF
--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -282,10 +282,12 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		componentWillUnmount () {
 			const
 				{containerRef} = this,
-				childContainerRef = this.childRef.getContainerNode();
+				childContainerRef = this.childRef.containerRef;
 
 			// Before call cancelAnimationFrame, you must send scrollStop Event.
-			this.doScrollStop();
+			if (this.scrolling) {
+				this.doScrollStop();
+			}
 			this.forceUpdateJob.stop();
 			this.scrollStopJob.stop();
 
@@ -353,15 +355,15 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		}
 
 		onMouseOver = () => {
-			this.resetPosition = this.childRef.getContainerNode().scrollTop;
+			this.resetPosition = this.childRef.containerRef.scrollTop;
 		}
 
 		onMouseMove = () => {
 			if (this.resetPosition !== null) {
-				const containerNode = this.childRef.getContainerNode();
-				containerNode.style.scrollBehavior = null;
-				containerNode.scrollTop = this.resetPosition;
-				containerNode.style.scrollBehavior = 'smooth';
+				const childContainerRef = this.childRef.containerRef;
+				childContainerRef.style.scrollBehavior = null;
+				childContainerRef.scrollTop = this.resetPosition;
+				childContainerRef.style.scrollBehavior = 'smooth';
 				this.resetPosition = null;
 			}
 		}
@@ -563,8 +565,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		}
 
 		scrollToAccumulatedTarget = (delta, vertical) => {
-			const bounds = this.getScrollBounds();
-
 			if (!this.isScrollAnimationTargetAccumulated) {
 				this.accumulatedTargetX = this.scrollLeft;
 				this.accumulatedTargetY = this.scrollTop;
@@ -572,9 +572,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 
 			if (vertical) {
-				this.accumulatedTargetY = clamp(0, bounds.maxTop, this.accumulatedTargetY + delta);
+				this.accumulatedTargetY += delta;
 			} else {
-				this.accumulatedTargetX = clamp(0, bounds.maxLeft, this.accumulatedTargetX + delta);
+				this.accumulatedTargetX += delta;
 			}
 
 			this.start(this.accumulatedTargetX, this.accumulatedTargetY);
@@ -641,7 +641,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		start (targetX, targetY, animate = true) {
 			const
 				bounds = this.getScrollBounds(),
-				containerNode = this.childRef.getContainerNode();
+				childContainerRef = this.childRef.containerRef;
 
 			targetX = clamp(0, bounds.maxLeft, targetX);
 			targetY = clamp(0, bounds.maxTop, targetY);
@@ -656,9 +656,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			if (animate) {
 				this.childRef.scrollToPosition(targetX, targetY);
 			} else {
-				containerNode.style.scrollBehavior = null;
+				childContainerRef.style.scrollBehavior = null;
 				this.childRef.scrollToPosition(targetX, targetY);
-				containerNode.style.scrollBehavior = 'smooth';
+				childContainerRef.style.scrollBehavior = 'smooth';
 				this.focusOnItem();
 			}
 		}
@@ -883,7 +883,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		updateEventListeners = () => {
 			const
 				{containerRef} = this,
-				childContainerRef = this.childRef.getContainerNode();
+				childContainerRef = this.childRef.containerRef;
 
 			if (containerRef && containerRef.addEventListener) {
 				// FIXME `onWheel` doesn't work on the v8 snapshot.
@@ -969,7 +969,13 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					style={style}
 				>
 					<div className={css.container}>
-						<Wrapped {...props} ref={this.initChildRef} cbScrollTo={this.scrollTo} className={css.content} onKeyUp={this.onKeyUp} />
+						<Wrapped
+							{...props}
+							cbScrollTo={this.scrollTo}
+							className={css.content}
+							onKeyUp={this.onKeyUp}
+							ref={this.initChildRef}
+						/>
 						{isVerticalScrollbarVisible ? <Scrollbar {...this.verticalScrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}
 					</div>
 					{isHorizontalScrollbarVisible ? <Scrollbar {...this.horizontalScrollbarProps} corner={isVerticalScrollbarVisible} disabled={!isHorizontalScrollbarVisible} /> : null}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -404,8 +404,6 @@ class ScrollerBase extends Component {
 		scrollBounds.maxTop = Math.max(0, scrollHeight - clientHeight);
 	}
 
-	getContainerNode = () => (this.containerRef)
-
 	onKeyDown = ({keyCode, target}) => {
 		const direction = getDirection(keyCode);
 

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -187,8 +187,8 @@ class VirtualListCoreNative extends Component {
 		super(props);
 
 		this.state = {firstIndex: 0, numOfItems: 0};
+		this.initContentRef = this.initRef('contentRef');
 		this.initContainerRef = this.initRef('containerRef');
-		this.initWrapperRef = this.initRef('wrapperRef');
 	}
 
 	componentWillMount () {
@@ -273,9 +273,9 @@ class VirtualListCoreNative extends Component {
 	scrollPosition = 0
 	isScrolledBy5way = false
 
-	wrapperClass = null
+	containerClass = null
+	contentRef = null
 	containerRef = null
-	wrapperRef = null
 
 	// spotlight
 	lastFocusedIndex = null
@@ -288,7 +288,7 @@ class VirtualListCoreNative extends Component {
 
 	isPlaceholderFocused () {
 		const current = Spotlight.getCurrent();
-		if (current && current.dataset.vlPlaceholder && this.containerRef.contains(current)) {
+		if (current && current.dataset.vlPlaceholder && this.contentRef.contains(current)) {
 			return true;
 		}
 
@@ -363,8 +363,6 @@ class VirtualListCoreNative extends Component {
 	gridPositionToItemPosition = ({primaryPosition, secondaryPosition}) =>
 		(this.isPrimaryDirectionVertical ? {left: secondaryPosition, top: primaryPosition} : {left: primaryPosition, top: secondaryPosition})
 
-	getContainerNode = () => (this.wrapperRef)
-
 	getClientSize = (node) => {
 		return {
 			clientWidth: node.clientWidth,
@@ -375,7 +373,7 @@ class VirtualListCoreNative extends Component {
 	calculateMetrics (props) {
 		const
 			{clientSize, direction, itemSize, spacing} = props,
-			node = this.getContainerNode();
+			node = this.containerRef;
 
 		if (!clientSize && !node) {
 			return;
@@ -473,7 +471,7 @@ class VirtualListCoreNative extends Component {
 	calculateScrollBounds (props) {
 		const
 			{clientSize} = props,
-			node = this.getContainerNode();
+			node = this.containerRef;
 
 		if (!clientSize && !node) {
 			return;
@@ -500,13 +498,13 @@ class VirtualListCoreNative extends Component {
 			this.props.cbScrollTo({position: (isPrimaryDirectionVertical) ? {y: maxPos} : {x: maxPos}});
 		}
 
-		this.wrapperClass = (isPrimaryDirectionVertical) ? css.vertical : css.horizontal;
+		this.containerClass = (isPrimaryDirectionVertical) ? css.vertical : css.horizontal;
 	}
 
 	setContainerSize = () => {
-		if (this.containerRef) {
-			this.containerRef.style.width = this.scrollBounds.scrollWidth + 'px';
-			this.containerRef.style.height = this.scrollBounds.scrollHeight + 'px';
+		if (this.contentRef) {
+			this.contentRef.style.width = this.scrollBounds.scrollWidth + 'px';
+			this.contentRef.style.height = this.scrollBounds.scrollHeight + 'px';
 		}
 	}
 
@@ -630,7 +628,7 @@ class VirtualListCoreNative extends Component {
 	}
 
 	scrollToPosition (x, y) {
-		const node = this.wrapperRef;
+		const node = this.containerRef;
 		node.scrollTo((this.context.rtl && !this.isPrimaryDirectionVertical) ? this.scrollBounds.maxLeft - x : x, y);
 	}
 
@@ -679,7 +677,7 @@ class VirtualListCoreNative extends Component {
 	focusByIndex = (index) => {
 		// We have to focus node async for now since list items are not yet ready when it reaches componentDid* lifecycle methods
 		setTimeout(() => {
-			const item = this.containerRef.querySelector(`[data-index='${index}'].spottable`);
+			const item = this.contentRef.querySelector(`[data-index='${index}'].spottable`);
 
 			if (Spotlight.isPaused()) {
 				Spotlight.resume();
@@ -879,7 +877,7 @@ class VirtualListCoreNative extends Component {
 	}
 
 	setContainerDisabled = (bool) => {
-		const containerNode = this.getContainerNode();
+		const containerNode = this.containerRef;
 
 		if (containerNode) {
 			containerNode.setAttribute(dataContainerMutedAttribute, bool);
@@ -889,7 +887,7 @@ class VirtualListCoreNative extends Component {
 	syncClientSize = () => {
 		const
 			{props} = this,
-			node = this.getContainerNode();
+			node = this.containerRef;
 
 		if (!props.clientSize && !node) {
 			return;
@@ -936,11 +934,11 @@ class VirtualListCoreNative extends Component {
 
 		const
 			{className, style, ...rest} = props,
-			mergedClasses = classNames(css.list, this.wrapperClass, className);
+			mergedClasses = classNames(css.list, this.containerClass, className);
 
 		return (
-			<div className={mergedClasses} ref={this.initWrapperRef} style={style}>
-				<div {...rest} onKeyDown={this.onKeyDown} ref={this.initContainerRef}>
+			<div className={mergedClasses} ref={this.initContainerRef} style={style}>
+				<div {...rest} onKeyDown={this.onKeyDown} ref={this.initContentRef}>
 					{cc.length ? cc : null}
 					{primary ? null : (
 						<SpotlightPlaceholder


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A few works for lists were only applied to VirtualList but not to VirtualListNative.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Applied missing changes from VIrtuaList, and refined some code to avoid confusion between both lists.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Some differences are quickly shared in the scrum to prevent the next release from bugs. So those differences are fixed and merged already by other related PR.

And some differences are unclear whether those should be fixed(changed) or not, and not changed in this PR for safety.

In this PR, names of `ref`s of VirtualListNative is changed; from `wrapperRef` to `containerRef`, from `containerRef` to `contentRef`. Since `containerRef` is used as the root node of lists or scrollers in a viewpoint of VirtualList, Scroller, and ScrollerNative, mismatched name `wrapperRef` could lead some human errors. So made it matched.

### Links
[//]: # (Related issues, references)
PLAT-42041

### Comments

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
