### PR TITLE
ENYO-4540: Ignore empty sub-containers when finding container target

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -667,13 +667,20 @@ function getContainerFocusTarget (containerId) {
 	// deferring restoration until it's requested to allow containers to prepare first
 	restoreLastFocusedElement(containerId);
 
-	const next = getContainerNavigableElements(containerId)[0] || null;
-	if (isContainer(next)) {
-		const nextId = isContainerNode(next) ? getContainerId(next) : next;
-		return getContainerFocusTarget(nextId);
-	}
+	let next = getContainerNavigableElements(containerId);
 
-	return next;
+	// If multiple candidates returned, we need to find the first viable target since some may
+	// be empty containers which should be skipped.
+	return next.reduce((result, element) => {
+		if (result) {
+			return result;
+		} else if (isContainer(element)) {
+			const nextId = isContainerNode(element) ? getContainerId(element) : element;
+			return getContainerFocusTarget(nextId);
+		}
+
+		return element;
+	}, null) || null;
 }
 
 function getContainerPreviousTarget (containerId, direction, destination) {

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -117,6 +117,15 @@ const scenarios = {
 			}),
 			spottable({id: 'lastFocused'})
 		)
+	}),
+	emptySubcontainer: container({
+		[containerAttribute]: 'container',
+		children: join(
+			container({
+				[containerAttribute]: 'subcontainer'
+			}),
+			spottable({id: 'afterSubcontainer'}),
+		)
 	})
 };
 
@@ -590,6 +599,19 @@ describe('container', () => {
 				setContainerLastFocusedElement(root.querySelector('#lastChildFocused'), [rootContainerId, 'container', 'child']);
 
 				const expected = 'lastChildFocused';
+				const actual = getContainerFocusTarget('container').id;
+
+				expect(actual).to.equal(expected);
+			}
+		));
+
+		it('should skip empty subcontainers', testScenario(
+			scenarios.emptySubcontainer,
+			() => {
+				configureContainer('container');
+				configureContainer('subcontainer');
+
+				const expected = 'afterSubcontainer';
 				const actual = getContainerFocusTarget('container').id;
 
 				expect(actual).to.equal(expected);


### PR DESCRIPTION
Follows logic in `target` which "retries" when finding an empty container. Should consider moving `getContainerFocusTarget` into `target` in a future ticket.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)