### PR TITLE
ENYO-4586: Changed VirtualGridList to scroll by item via 5way

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Added
+
+### Changed
+- `moonstone/VirtualGridList` to scroll by item via 5 way key
+
+### Fixed
+
 ## [1.6.0] - 2017-08-04
 
 ### Added

--- a/packages/moonstone/VirtualList/VirtualList.js
+++ b/packages/moonstone/VirtualList/VirtualList.js
@@ -388,7 +388,7 @@ const VirtualGridList = kind({
 		 */
 	},
 
-	render: (props) => <VirtualListBase {...props} pageScroll />
+	render: (props) => <VirtualListBase {...props} />
 });
 
 export default VirtualList;

--- a/packages/moonstone/VirtualList/VirtualListNative.js
+++ b/packages/moonstone/VirtualList/VirtualListNative.js
@@ -203,7 +203,7 @@ const VirtualGridListNative = kind({
 		 */
 	},
 
-	render: (props) => <VirtualListBase {...props} pageScroll />
+	render: (props) => <VirtualListBase {...props} />
 });
 
 export default VirtualListNative;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
By UX, VirtualGridList should scroll by item via 5 way key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `pageScroll` prop from VirtualGridList.

### Links
[//]: # (Related issues, references)
ENYO-4586

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)