### PR TITLE
ENYO-4229: Add wheel support on scrollbars for native lists

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -414,22 +414,12 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 		}
 
-		wheel (e, canScrollHorizontally, canScrollVertically) {
+		calculateDistanceByWheel (e, maxPixel) {
 			const
-				bounds = this.getScrollBounds(),
 				deltaMode = e.deltaMode,
 				wheelDeltaY = -e.wheelDeltaY;
 			let
-				delta = (wheelDeltaY || e.deltaY),
-				maxPixel;
-
-			if (canScrollVertically) {
-				maxPixel = bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel;
-			} else if (canScrollHorizontally) {
-				maxPixel = bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel;
-			} else {
-				return 0;
-			}
+				delta = (wheelDeltaY || e.deltaY);
 
 			if (deltaMode === 0) {
 				delta = clamp(-maxPixel, maxPixel, ri.scale(delta * scrollWheelMultiplierForDeltaPixel));
@@ -500,6 +490,42 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		onMouseLeave = (e) => {
 			this.onMouseMove(e);
 			this.onMouseUp();
+		}
+
+		onWheel = (e) => {
+			e.preventDefault();
+			if (!this.isDragging) {
+				const
+					bounds = this.getScrollBounds(),
+					canScrollHorizontally = this.canScrollHorizontally(bounds),
+					canScrollVertically = this.canScrollVertically(bounds),
+					focusedItem = Spotlight.getCurrent();
+				let
+					delta = 0, direction;
+
+				if (canScrollVertically) {
+					delta = this.calculateDistanceByWheel(e, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+				} else if (canScrollHorizontally) {
+					delta = this.calculateDistanceByWheel(e, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+				}
+				direction = Math.sign(delta);
+
+				Spotlight.setPointerMode(false);
+				if (focusedItem) {
+					focusedItem.blur();
+				}
+
+				this.childRef.setContainerDisabled(true);
+
+				if (direction !== this.wheelDirection) {
+					this.isScrollAnimationTargetAccumulated = false;
+					this.wheelDirection = direction;
+				}
+
+				if (delta !== 0) {
+					this.scrollToAccumulatedTarget(delta, canScrollVertically);
+				}
+			}
 		}
 
 		startScrollOnFocus = (pos, item) => {
@@ -634,32 +660,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.animateOnFocus = true;
 			if ((isPageUp(e.keyCode) || isPageDown(e.keyCode)) && this.hasFocus()) {
 				this.scrollByPage(e.keyCode);
-			}
-		}
-
-		onWheel = (e) => {
-			e.preventDefault();
-			if (!this.isDragging) {
-				const
-					bounds = this.getScrollBounds(),
-					canScrollHorizontally = this.canScrollHorizontally(bounds),
-					canScrollVertically = this.canScrollVertically(bounds),
-					delta = this.wheel(e, canScrollHorizontally, canScrollVertically),
-					direction = Math.sign(delta),
-					focusedItem = Spotlight.getCurrent();
-
-				Spotlight.setPointerMode(false);
-				if (focusedItem) {
-					focusedItem.blur();
-				}
-
-				this.childRef.setContainerDisabled(true);
-
-				if (direction !== this.wheelDirection) {
-					this.isScrollAnimationTargetAccumulated = false;
-					this.wheelDirection = direction;
-				}
-				this.scrollToAccumulatedTarget(delta, canScrollVertically);
 			}
 		}
 

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -390,7 +390,7 @@ class ScrollbarBase extends PureComponent {
 }
 
 const Scrollbar = ApiDecorator(
-	{api: ['hideThumb', 'showThumb', 'startHidingThumb', 'update']},
+	{api: ['containerRef', 'hideThumb', 'showThumb', 'startHidingThumb', 'update']},
 	DisappearSpotlightDecorator(
 		{events: {
 			onNextSpotlightDisappear: '[data-scroll-button="previous"]',


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Native scroll by the wheel is possible when a pointer is over a scrollable area which has an overflow CSS attribute. Scrollbars are located out of a scrollable area, we could not scroll by the wheel over them.

In this PR, Added JavaScript routine to catch and handle wheel events on scrollbars.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Our native lists already have a `wheel` event handler for horizontal scrolling. So the solution is to add check condition for wheeling on scrollbars. The `wheel` event handler uses DOM element's `scrollTo` API, so actual scroll action is performed by web engine.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
To sync up JS versions and native versions, some methods are renamed and refined.

To use a scrollbar's internal node ref from `ScrollableNative`, `containerRef` is added as an API in a config for ApiDecorator.


### Links
[//]: # (Related issues, references)
ENYO-4229

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
