### PR TITLE
ENYO-4590: Panel Breadcrumb Aria-label Correction

### DIFF
--- a/packages/moonstone/Panels/Breadcrumb.js
+++ b/packages/moonstone/Panels/Breadcrumb.js
@@ -73,7 +73,7 @@ const BreadcrumbBase = kind({
 	render: ({children, index, onSelect, ...rest}) => (
 		<SpottableDiv
 			{...rest}
-			aria-label={$L('go to previous')}
+			aria-label={$L('GO TO PREVIOUS')}
 			data-index={index}
 			onClick={onSelect}
 		>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Breadcrumb aria label is not translated

### Resolution
Replace aria-label string with the correct string for translation


### Links
ENYO-4590


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com