### PR TITLE
ENYO-4601:  Fix using locale-specific fonts during prerendering

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -207,7 +207,7 @@ function fontGenerator (locale = ilib.getLocale()) {
 		styleElem.innerHTML = fontDefinitionCss;
 	} else if (global && global.enactHooks && global.enactHooks.prerender) {
 		// We're rendering without the DOM
-		global.enactHooks.prerender({appendToHead: `<style type="text/css" id="${styleId}>${fontDefinitionCss}</style>`});
+		global.enactHooks.prerender({appendToHead: `<style type="text/css" id="${styleId}">${fontDefinitionCss}</style>`});
 	}
 }
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fonts being loaded via js API prevents prerendering from using those fonts. (ex./ japanese prerender would not have japanese font loaded)

### Resolution
* Reverts back to injection font generator which injects `<style>` tag with font css
* enact-dev https://github.com/enyojs/enact-dev/pull/90 adds an optional global hook to inject content into the prerendered HTML head which this PR uses to inject correct fonts for each locale.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
