### PR TITLE
ENYO-4582 Allow browser to determine text directionality

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -22,6 +22,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to align tooltip with detached knob
 - `moonstone/FormCheckbox` to display correct colors in light skin
 - `moonstone/SelectableItem` to display correct icon width and alignment
+- `moonstone/LabeledItem` to align correctly with RTL texts
 
 ## [1.6.1] - 2017-08-07
 

--- a/packages/moonstone/LabeledItem/LabeledItem.js
+++ b/packages/moonstone/LabeledItem/LabeledItem.js
@@ -7,13 +7,14 @@
 import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
+import Spottable from '@enact/spotlight/Spottable';
 
 import Icon from '../Icon';
-import Item from '../Item';
+import {ItemBase} from '../Item';
 import Skinnable from '../Skinnable';
 import {MarqueeController, MarqueeText} from '../Marquee';
 
-const Controller = MarqueeController(Item);
+const Controller = MarqueeController({marqueeOnFocus: true}, Spottable(ItemBase));
 
 import css from './LabeledItem.less';
 

--- a/packages/moonstone/LabeledItem/LabeledItem.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.less
@@ -15,6 +15,7 @@
 	// Header
 	.text {
 		display: flex;
+		width: 100%;
 
 		.title {
 			overflow: hidden;

--- a/packages/moonstone/Marquee/Marquee.js
+++ b/packages/moonstone/Marquee/Marquee.js
@@ -132,9 +132,8 @@ const MarqueeBase = kind({
 
 	computed: {
 		clientClassName: ({animating}) => animating ? animated : css.text,
-		clientStyle: ({animating, centered, distance, forceDirection, overflow, rtl, speed}, {rtl: contextRtl}) => {
-			const isTextRtl = forceDirection ? forceDirection === 'rtl' : rtl;
-			const overrideRtl = forceDirection ? true : contextRtl !== isTextRtl;
+		clientStyle: ({animating, centered, distance, forceDirection, overflow, rtl, speed}) => {
+			const isTextRtl = forceDirection ? forceDirection === 'rtl' : !!rtl;
 
 			// We only attempt to set the textAlign of this control if the locale's directionality
 			// differs from the directionality of our current marqueeable control (as determined by
@@ -142,7 +141,7 @@ const MarqueeBase = kind({
 			let textAlign = null;
 			if (centered) {
 				textAlign = 'center';
-			} else if (overrideRtl && distance > 0) {
+			} else if (forceDirection && distance > 0) {
 				if (isTextRtl) {
 					textAlign = 'right';
 				} else {
@@ -152,8 +151,8 @@ const MarqueeBase = kind({
 
 			// If the components content directionality doesn't match the context, we need to set it
 			// inline
-			let direction = 'inherit';
-			if (overrideRtl) {
+			let direction = null;
+			if (forceDirection) {
 				direction = isTextRtl ? 'rtl' : 'ltr';
 			}
 
@@ -181,6 +180,7 @@ const MarqueeBase = kind({
 		return (
 			<div className={className}>
 				<div
+					dir="auto"
 					className={clientClassName}
 					ref={clientRef}
 					style={clientStyle}

--- a/packages/moonstone/Marquee/Marquee.less
+++ b/packages/moonstone/Marquee/Marquee.less
@@ -10,10 +10,11 @@
 	// -webkit-box-orient: block-axis;
 	// -webkit-line-clamp: 1;
 
-    width: auto;
-    text-overflow: ellipsis;
-    white-space: pre !important;
-    overflow: hidden;
+	width: auto;
+	text-overflow: ellipsis;
+	white-space: pre !important;
+	overflow: hidden;
+	text-align: left;
 
 	.text {
 		pointer-events: none;

--- a/packages/moonstone/Marquee/Marquee.less
+++ b/packages/moonstone/Marquee/Marquee.less
@@ -14,7 +14,7 @@
 	text-overflow: ellipsis;
 	white-space: pre !important;
 	overflow: hidden;
-	text-align: left;
+	text-align: start;
 
 	.text {
 		pointer-events: none;
@@ -29,9 +29,5 @@
 			text-overflow: clip;
 			overflow: visible;
 		}
-	}
-
-	:global(.enact-locale-right-to-left) & {
-		text-align: right;
 	}
 }

--- a/packages/moonstone/Marquee/Marquee.less
+++ b/packages/moonstone/Marquee/Marquee.less
@@ -14,7 +14,7 @@
 	text-overflow: ellipsis;
 	white-space: pre !important;
 	overflow: hidden;
-	text-align: start;
+	text-align: left;
 
 	.text {
 		pointer-events: none;
@@ -29,5 +29,9 @@
 			text-overflow: clip;
 			overflow: visible;
 		}
+	}
+
+	:global(.enact-locale-right-to-left) & {
+		text-align: right;
 	}
 }

--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -1,7 +1,6 @@
 import hoc from '@enact/core/hoc';
 import {forward} from '@enact/core/handle';
 import {childrenEquals} from '@enact/core/util';
-import {isRtlText} from '@enact/i18n/util';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -130,7 +129,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Forces the `direction` of the marquee. Valid values are `'rtl'` and `'ltr'`. This
 			 * includes non-text elements as well. The default behavior, if this prop is unset, is
-			 * to evaluate the text content for directionality using {@link i18n/util.isRtlText}.
+			 * to evaluate the text content for directionality using the browser engine.
 			 *
 			 * @type {String}
 			 * @public
@@ -513,9 +512,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		checkRtl = () => {
 			const {forceDirection} = this.props;
-			const textContent = this.node && this.node.textContent;
+			const textContentDirection = this.node && window.getComputedStyle(this.node).direction;
 			// If forceDirection is set, check if it is RTL; otherwise, determine the directionality
-			return (forceDirection ? (forceDirection === 'rtl') : isRtlText(textContent));
+			return (forceDirection ? (forceDirection === 'rtl') : textContentDirection === 'rtl');
 		}
 
 		renderMarquee () {

--- a/packages/moonstone/Marquee/tests/Marquee-specs.js
+++ b/packages/moonstone/Marquee/tests/Marquee-specs.js
@@ -46,28 +46,6 @@ describe('Marquee', () => {
 		expect(actual).to.have.property('transition');
 	});
 
-	it('should set RTL direction in LTR context when the text directionality is RTL', function () {
-		const subject = shallow(
-			<Marquee rtl />,
-			{context: {rtl: false}}
-		);
-
-		const expected = 'rtl';
-		const actual = subject.childAt(0).prop('style').direction;
-		expect(actual).to.equal(expected);
-	});
-
-	it('should set LTR direction in RTL when the text directionality is LTR', function () {
-		const subject = shallow(
-			<Marquee />,
-			{context: {rtl: true}}
-		);
-
-		const expected = 'ltr';
-		const actual = subject.childAt(0).prop('style').direction;
-		expect(actual).to.equal(expected);
-	});
-
 	it('should have negative translate for LTR text', function () {
 		const subject = shallow(
 			<Marquee animating distance={100} />
@@ -137,25 +115,25 @@ describe('Marquee', () => {
 		expect(actual).to.have.property('direction').to.equal(expected);
 	});
 
-	it('should have direction of inherit when forceDirection is null, and content and context are LTR', function () {
+	it('should have direction of null when forceDirection is null, and content and context are LTR', function () {
 		const subject = shallow(
 			<Marquee />,
 			{context: {rtl: false}}
 		);
 
-		const expected = 'inherit';
+		const expected = null;
 		const actual = subject.find(`.${css.text}`).prop('style');
 
 		expect(actual).to.have.property('direction').to.equal(expected);
 	});
 
-	it('should have direction of inherit when forceDirection is null, and content and context are RTL', function () {
+	it('should have direction of null when forceDirection is null, and content and context are RTL', function () {
 		const subject = shallow(
 			<Marquee rtl />,
 			{context: {rtl: true}}
 		);
 
-		const expected = 'inherit';
+		const expected = null;
 		const actual = subject.find(`.${css.text}`).prop('style');
 
 		expect(actual).to.have.property('direction').to.equal(expected);

--- a/packages/moonstone/Marquee/tests/MarqueeText-specs.js
+++ b/packages/moonstone/Marquee/tests/MarqueeText-specs.js
@@ -9,23 +9,23 @@ const
 	rtlText = 'العربية - العراق';
 
 describe('MarqueeText', () => {
-	it('should determine the correct directionality of latin text on initial render', function () {
+	it('should not set directionality of latin text on initial render without forceDirection', function () {
 		const subject = mount(
 			<MarqueeText>{ltrText}</MarqueeText>
 		);
 
-		const expected = 'ltr';
+		const expected = null;
 		const actual = subject.find(`.${css.text}`).prop('style');
 
 		expect(actual).to.have.property('direction').to.equal(expected);
 	});
 
-	it('should determine the correct directionality of non-latin text on initial render', function () {
+	it('should note set correct directionality of rtl text on initial render without forceDirection', function () {
 		const subject = mount(
 			<MarqueeText>{rtlText}</MarqueeText>
 		);
 
-		const expected = 'rtl';
+		const expected = null;
 		const actual = subject.find(`.${css.text}`).prop('style');
 
 		expect(actual).to.have.property('direction').to.equal(expected);
@@ -37,19 +37,6 @@ describe('MarqueeText', () => {
 		);
 
 		const expected = 'ltr';
-		const actual = subject.find(`.${css.text}`).prop('style');
-
-		expect(actual).to.have.property('direction').to.equal(expected);
-	});
-
-	it('should switch directionality when the text content changes after initial render', function () {
-		const subject = mount(
-			<MarqueeText>{ltrText}</MarqueeText>
-		);
-
-		subject.setProps({children: rtlText});
-
-		const expected = 'rtl';
 		const actual = subject.find(`.${css.text}`).prop('style');
 
 		expect(actual).to.have.property('direction').to.equal(expected);

--- a/packages/sampler/stories/moonstone-stories/LabeledItem.js
+++ b/packages/sampler/stories/moonstone-stories/LabeledItem.js
@@ -14,7 +14,7 @@ storiesOf('LabeledItem')
 		'Basic usage of LabeledItem',
 		() => (
 			<LabeledItem
-				label="Label"
+				label={text('label', 'Label')}
 				disabled={boolean('disabled', false)}
 			>
 				{text('children', 'Hello LabeledItem')}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Corrects text direction detection by not using `isTextRtl()` and instead relying on browser to
detect direction.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Using `window.getComputedStyle` and `dir="auto"`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Sample text: "English,한국어,العربية"

### Links
[//]: # (Related issues, references)
ENYO-4582

### Comments
