### PR TITLE
ENYO-4603: Fix not updating issue when scrollbar is visible

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -281,6 +281,7 @@ class VirtualListCore extends Component {
 	shouldComponentUpdate (nextProps, nextState) {
 		if (!this.restoreLastFocused &&
 			(this.props.dataSize > 0 && this.props.dataSize !== nextProps.dataSize) &&
+			(this.state.numOfItems === nextState.numOfItems) &&
 			(nextState.firstIndex + nextState.numOfItems) < nextProps.dataSize) {
 			return false;
 		}

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -276,6 +276,7 @@ class VirtualListCoreNative extends Component {
 	shouldComponentUpdate (nextProps, nextState) {
 		if (!this.restoreLastFocused &&
 			(this.props.dataSize > 0 && this.props.dataSize !== nextProps.dataSize) &&
+			(this.state.numOfItems === nextState.numOfItems) &&
 			(nextState.firstIndex + nextState.numOfItems) < nextProps.dataSize) {
 			return false;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When verticalScrollbar or horizontalScrollbar isn't 'auto' and dataSize is increased, VirtualListBase skips update by shouldComponentUpdate.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We added the skipped condition for not updating the current view in shouldComponentUpdate when dataSize is appended more and more. However, If verticalScrollbar is not 'auto', always VirtualListBase satisfies skipped condtion, so list dosen't update.

If current numOfItems is not different nextState's numOfItems, we fixed to update list.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4603

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>