### PR TITLE
ENYO-4595: Fix passing node to isNavigable rather than container ID

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -600,7 +600,12 @@ function getContainerDefaultElement (containerId) {
  * @public
  */
 function getContainerLastFocusedElement (containerId) {
-	const {lastFocusedElement} = getContainerConfig(containerId);
+	let {lastFocusedElement} = getContainerConfig(containerId);
+
+	// lastFocusedElement may be a container ID so try to convert it to a node
+	if (typeof lastFocusedElement === 'string') {
+		lastFocusedElement = getContainerNode(lastFocusedElement);
+	}
 
 	return isNavigable(lastFocusedElement, containerId, true) ? lastFocusedElement : null;
 }


### PR DESCRIPTION
`isNavigable` only accepts a node reference but _usually_ works with a
container id. If the container doesn't exist any more, `isContainer()`
will fail to catch that and will result in an `Illegal Invocation` when
`Element.prototype.matchesSelector` is called with a string instead of
a node.

Since the signature for `isNavigable` already specifies that it expects
a node, the proposed solution updates `getContainerLastFocusedElement`
to pass a node (or null) rather than the container id.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)