### PR TITLE
ENYO-4624 - Converted Changeable and Holdable to PureComponents

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Added
 
 ### Changed
+- `ui/Holdable` and `ui/Changeable` to be PureComponents to reduce the amount of updates
 
 ### Fixed
 

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -56,7 +56,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 	const {prop, change} = config;
 	const defaultPropKey = 'default' + cap(prop);
 
-	return class extends React.Component {
+	return class extends React.PureComponent {
 		static displayName = 'Changeable'
 
 		static propTypes = /** @lends ui/Changeable.Changeable.prototype */ {

--- a/packages/ui/Holdable/Holdable.js
+++ b/packages/ui/Holdable/Holdable.js
@@ -137,7 +137,7 @@ const HoldableHOC = hoc(defaultConfig, (config, Wrapped) => {
 	const forwardPointerDepress = forward(pointerDepress);
 	const forwardPointerEnter = forward(pointerEnter);
 
-	return class Holdable extends React.Component {
+	return class Holdable extends React.PureComponent {
 		static propTypes = /** @lends ui/Holdable.Holdable.prototype */ {
 			/**
 			 * Whether or not the component is in a disabled state.


### PR DESCRIPTION
### Issue Resolved / Feature Added
TimePicker Animation performance is slow. Looks like Holdable and Changeable have quite a few wasted paints, that cause some frames to drop.


### Resolution
Converted Changeable and Holdable to be PureComponents to reduce the number of updates.


### Links
ENYO-4624

Enact-DCO-1.0-Signed-off-by: Derek Tor derek.tor@lge.com