### PR TITLE
ENYO-4660: Fixed aria-valuetext to be applied to picker's buttons.

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -801,13 +801,8 @@ const PickerBase = class extends React.Component {
 					</PickerViewManager>
 				</div>
 				<PickerButton
-<<<<<<< HEAD
-					aria-controls={!joined ? id : null}
-					aria-label={this.calcDecrementLabel(ariaValueText != null ? ariaValueText : valueText)}
-=======
 					aria-controls={!joined ? decrementerAriaControls : null}
-					aria-label={this.calcDecrementLabel(valueText)}
->>>>>>> release/1.x
+					aria-label={this.calcDecrementLabel(ariaValueText != null ? ariaValueText : valueText)}
 					className={css.decrementer}
 					disabled={decrementerDisabled}
 					hidden={reachedStart}


### PR DESCRIPTION
### Issue Resolved / Feature Added
aria-valuetext does not apply to picker button.

### Resolution
Fixed picker button to apply aria-valuetext.

### Links
ENYO-4660

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)