### PR TITLE
ENYO-4523: VideoPlayer Prevent Focus When SpotlightDisabled

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -704,7 +704,6 @@ const VideoPlayerBase = class extends React.Component {
 			this.state.bottomControlsVisible &&
 			!nextState.bottomControlsVisible &&
 			(!Spotlight.getCurrent() || this.player.contains(Spotlight.getCurrent())) &&
-			!this.props.spotlightDisabled &&
 			!nextProps.spotlightDisabled
 		) {
 			// set focus to the hidden spottable control - maintaining focus on available spottable


### PR DESCRIPTION
### Issue Resolved / Feature Added
VideoPlayer focuses on the hidden spottable control during component update and when hiding controls.


### Resolution
Prevent focus from happening when `spotlightDisabled` is true.


### Links
ENYO-4523


Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com