### PR TITLE
ENYO-4670: Fix not focused item issue in virtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -25,7 +25,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList` to show scroll thumb when preserve item is focused
+- `moonstone/VirtualList` to show scroll thumb when a preserved item is focused in a Panel
 - `moonstone/Scroller` to navigate properly with 5-way when expandable child is opened
 - `moonstone/VirtualList` to stop scrolling when a focus is moved on an item from paging controls or outside
 - `moonstone/VirtualList` to move out with 5-way navigation when the 1st or the last item is disabled

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -935,7 +935,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 		canScrollVertically = (bounds) => {
 			const {direction} = this;
-
 			return (direction === 'vertical' || direction === 'both') && (bounds.scrollHeight > bounds.clientHeight) && !isNaN(bounds.scrollHeight);
 		}
 
@@ -1003,11 +1002,13 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
 					// no visibility change but need to notify whichever scrollbars are visible of the
 					// updated bounds and scroll position
-					const updatedBounds = {
-						...bounds,
-						scrollLeft: this.scrollLeft,
-						scrollTop: this.scrollTop
-					};
+					const
+						updatedBounds = {
+							...bounds,
+							scrollLeft: this.scrollLeft,
+							scrollTop: this.scrollTop
+						},
+						spotItem = Spotlight.getCurrent();
 
 					if (curHorizontalScrollbarVisible) {
 						this.horizontalScrollbarRef.update(updatedBounds);
@@ -1016,7 +1017,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						this.verticalScrollbarRef.update(updatedBounds);
 					}
 
-					if (!Spotlight.getPointerMode()) {
+					if (!Spotlight.getPointerMode() && spotItem && this.childRef.containerRef.contains(spotItem)) {
 						this.alertThumb();
 					}
 				}

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -904,11 +904,13 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
 					// no visibility change but need to notify whichever scrollbars are visible of the
 					// updated bounds and scroll position
-					const updatedBounds = {
-						...bounds,
-						scrollLeft: this.scrollLeft,
-						scrollTop: this.scrollTop
-					};
+					const
+						updatedBounds = {
+							...bounds,
+							scrollLeft: this.scrollLeft,
+							scrollTop: this.scrollTop
+						},
+						spotItem = Spotlight.getCurrent();
 
 					if (curHorizontalScrollbarVisible) {
 						this.horizontalScrollbarRef.update(updatedBounds);
@@ -917,7 +919,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						this.verticalScrollbarRef.update(updatedBounds);
 					}
 
-					if (!Spotlight.getPointerMode()) {
+					if (!Spotlight.getPointerMode() && spotItem && this.childRef.containerRef.contains(spotItem)) {
 						this.alertThumb();
 					}
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Each Panel has a VirtualList. When panel is changed, showing thumb behavior doesn't work well.
VirtualList restore focus in componentDidUpdate(), and then scrollbar is rendered, so scrollable can not refer scrollbar ref, is using showThumb().

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add alertThumb() to updateScrollbars(), is called in componentDidUpdate of scrollable.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4670

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>