### PR TITLE
ENYO-4655: Fixed showing invisible items in VirtualGridList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -445,11 +445,8 @@ class VirtualListCore extends Component {
 			{firstIndex} = this.state,
 			{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 			numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
-			wasFirstIndexMax = (
-				(this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) &&
-				(firstIndex === this.maxFirstIndex) &&
-				dataSize - this.curDataSize < dimensionToExtent
-			);
+			wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
+			dataSizeDiff = dataSize - this.curDataSize;
 		let newFirstIndex = firstIndex;
 
 		this.maxFirstIndex = dataSize - numOfItems;
@@ -468,7 +465,11 @@ class VirtualListCore extends Component {
 			// we call `scrollTo` to create DOM for it.
 			this.props.cbScrollTo({index: this.preservedIndex, animate: false});
 		} else if (wasFirstIndexMax) {
-			newFirstIndex = (dimensionToExtent > 1) ? this.maxFirstIndex : Math.min(this.maxFirstIndex, firstIndex + (overhang - 1));
+			if (dimensionToExtent > 1 && dataSizeDiff > 0 && dataSizeDiff < dimensionToExtent) {
+				newFirstIndex = this.maxFirstIndex;
+			} else {
+				newFirstIndex = Math.min(this.maxFirstIndex, firstIndex + (overhang - 1) * dimensionToExtent);
+			}
 		} else {
 			newFirstIndex = Math.min(firstIndex, this.maxFirstIndex);
 		}

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -431,11 +431,8 @@ class VirtualListCoreNative extends Component {
 			{firstIndex} = this.state,
 			{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 			numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
-			wasFirstIndexMax = (
-				(this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) &&
-				(firstIndex === this.maxFirstIndex) &&
-				dataSize - this.curDataSize < dimensionToExtent
-			);
+			wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
+			dataSizeDiff = dataSize - this.curDataSize;
 		let newFirstIndex = firstIndex;
 
 		this.maxFirstIndex = dataSize - numOfItems;
@@ -452,7 +449,11 @@ class VirtualListCoreNative extends Component {
 			// we call `scrollTo` to create DOM for it.
 			this.props.cbScrollTo({index: this.preservedIndex, animate: false});
 		} else if (wasFirstIndexMax) {
-			newFirstIndex = (dimensionToExtent > 1) ? this.maxFirstIndex : Math.min(this.maxFirstIndex, firstIndex + (overhang - 1));
+			if (dimensionToExtent > 1 && dataSizeDiff > 0 && dataSizeDiff < dimensionToExtent) {
+				newFirstIndex = this.maxFirstIndex;
+			} else {
+				newFirstIndex = Math.min(this.maxFirstIndex, firstIndex + (overhang - 1) * dimensionToExtent);
+			}
 		} else {
 			newFirstIndex = Math.min(firstIndex, this.maxFirstIndex);
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If dataSize prop grew dramatically from the bottom in VirtualGridList, firstIndex gets the wrong value in current logic.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Enhanded condition for `wasFirstIndexMax`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4655

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)