### PR TITLE
ENYO-4673: Fix to enable focus when wheel scroll is stopped

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -25,6 +25,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scrollable` to enable focus when wheel scroll is stopped
 - `moonstone/VirtualList` to show scroll thumb when a preserved item is focused in a Panel
 - `moonstone/Scroller` to navigate properly with 5-way when expandable child is opened
 - `moonstone/VirtualList` to stop scrolling when a focus is moved on an item from paging controls or outside

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -515,6 +515,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				} else if (canScrollHorizontally) {
 					delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				}
+
 				direction = Math.sign(delta);
 
 				Spotlight.setPointerMode(false);
@@ -522,14 +523,13 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					focusedItem.blur();
 				}
 
-				this.childRef.setContainerDisabled(true);
-
 				if (direction !== this.wheelDirection) {
 					this.isScrollAnimationTargetAccumulated = false;
 					this.wheelDirection = direction;
 				}
 
 				if (delta !== 0) {
+					this.childRef.setContainerDisabled(true);
 					this.scrollToAccumulatedTarget(delta, canScrollVertically);
 				}
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When wheel scroll is stopped, stop event is not triggered so that VirtualList can not get a spotlight focus.
If the number of items is not enough to scroll, stop event is not called, so this issue is reproduced. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set spotlight disabled option to true when only scroll is possible. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4673

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>