### PR TITLE
ENYO-4627: VideoPlayer Disable Video Seeking Prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Popup` callback property `onShow` which fires after popup appears for both animating and non-animating popups
+- `moonstone/VideoPlayer` prop `seekDisabled` to disable seek functionality
 
 ### Changed
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Need to block "Seek" function in specific case.


### Resolution
Add `seekDisabled` prop to prevent video seeking when scrubbing through slider and scrubbing with left/right keys on video (when `mediaControls` are hidden).



### Links
ENYO-4627


Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
