### PR TITLE
ENYO-4674: Accessibility-VideoPlayer: Fixed not to read unintended button's

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -736,10 +736,6 @@ const VideoPlayerBase = class extends React.Component {
 		) {
 			this.focusDefaultMediaControl();
 		}
-
-		if (this.state.more !== prevState.more) {
-			this.refocusMoreButton.start();
-		}
 	}
 
 	componentWillUnmount () {
@@ -754,7 +750,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopDelayedFeedbackHide();
 		this.announceJob.stop();
 		this.renderBottomControl.stop();
-		this.refocusMoreButton.stop();
 		this.stopListeningForPulses();
 		this.sliderTooltipTimeJob.stop();
 	}
@@ -907,12 +902,12 @@ const VideoPlayerBase = class extends React.Component {
 
 	autoCloseJob = new Job(this.hideControls)
 
-	refocusMoreButton = new Job(() => {
+	refocusMoreButton = () => {
 		// Readout 'more' or 'back' button explicitly.
 		let selectedButton = Spotlight.getCurrent();
 		selectedButton.blur();
 		selectedButton.focus();
-	}, 100)
+	}
 
 	startDelayedTitleHide = () => {
 		if (this.props.titleHideDelay) {
@@ -1554,6 +1549,8 @@ const VideoPlayerBase = class extends React.Component {
 			more: !this.state.more,
 			titleVisible: true,
 			announce: this.state.announce < AnnounceState.INFO ? AnnounceState.INFO : AnnounceState.DONE
+		}, () => {
+			this.refocusMoreButton();
 		});
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
In media controller of videoPlayer, If 'more' button is pressed, the controller is rendered, and then it has to read out 'back' button. This is enyo parity UX, and there is no problem. However, Photo&Video is using customized enact videoPlayer and this videoPlayer has issues like this:

1. If spot component does not exist by timing, the runtime error occurs because 'selectedButton' is undefined.
2. If the current spot component is not 'More' button by timing, spot component is blurred and focused. So the audio guidance works twice unexpectedly.

The above issues also can be a potential problem in enact VideoPlayer, so we need to improve enact VideoPlayer.

### Resolution
1. Fixed the timing of reading the button. (More/Back button)
: Removed timer function for reading out button because it reads out button label well without timer function. In Photo&Video videoPlayer, this timer function is cause of issue.

2. Fixed the 'refocusMoreButton' to only work when the More/Back button was pressed.
: 'this.state.more' can be changed by other actions as well as 'more / back button' behavior. So I modified it to work only when 'more / back button' is pressed. However, It is difficult to handle this changes in 'componentDidUpdate' step because 'componentDidUpdate' is frequently called during movie playback.
Thus, I added this code in 'More / Back button' handler.

### Links
ENYO-4674

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)