### PR TITLE
ENYO-4689: Fix RangePicker to display fixed width while changing values

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/RangePicker` to display fixed width while changing values
+
 ## [1.8.0] - 2017-09-07
 
 ### Deprecated

--- a/packages/moonstone/RangePicker/RangePicker.js
+++ b/packages/moonstone/RangePicker/RangePicker.js
@@ -215,6 +215,12 @@ const RangePickerBase = kind({
 
 			return value;
 		},
+		width: ({max, min, width}) => {
+			if (width) {
+				return width;
+			}
+			return Math.max(max.toString().length, min.toString().length);
+		},
 		value: ({min, max, value}) => {
 			if (__DEV__) {
 				validateRange(value, min, max, 'RangePicker');

--- a/packages/moonstone/internal/Picker/Picker.less
+++ b/packages/moonstone/internal/Picker/Picker.less
@@ -207,12 +207,17 @@
 		});
 
 		.item {
-			margin: 0 @moon-spotlight-outset;
+			min-width: @moon-picker-vertical-item-width;
+			padding: 0 @moon-spotlight-outset/2;
 
 			.moon-custom-text({
 				margin: 0;
 			});
 		}
+	}
+
+	&.vertical .sizingPlaceholder {
+		padding: 0 @moon-spotlight-outset/2;
 	}
 
 	// Skin colors

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -265,6 +265,11 @@
 @moon-slider-knob-height-large: @moon-button-small-height-large;
 @moon-slider-tooltip-offset: 54px;
 
+
+// Picker
+// ---------------------------------------
+@moon-picker-vertical-item-width: 48px;
+
 // IntegerPicker
 // ---------------------------------------
 @moon-integer-picker-shadow-width: 6px;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
While changing values, the width of the text could change and the width of the picker gets affected. (e.g. 11 -> 12) This becomes a problem in `vertical joined` Range picker.

`min-width` is set for the one digit numbers, and we can set a fixed width for two or more digit max/min picker with the `width` property.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
