### PR TITLE
ENYO-4685: Set lastContainer as current containerId

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -12,7 +12,6 @@ import intersection from 'ramda/src/intersection';
 import last from 'ramda/src/last';
 
 import {matchSelector} from './utils';
-import Spotlight from './spotlight';
 
 const containerAttribute = 'data-container-id';
 const containerConfigs   = new Map();


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight sets focus to target as container base. For example, When mode is changed from pointer to 5way, Spotlight finds a target in `getLastContainer` and then sets a focus to it. 
However, There is an issue in case like preserve item case after panel transition

panel 0 : item 100
panel 1 : none

When panel0 is changed to panel1 by clicking any item using pointer, panel1 is rendered without any spotted focus. 
In this case, If the keydown is pressed, Panel1 restores focused item with `getLastContainer` (= Panel0) because panel1 doesn't have any items to set focus.
However, panel1 also doesn't have item to restore with preserved key from panel0, so breadcrumb gets a focus.
Thus, panel0's preserve key is lost. If backkey is pressed, Panel0 sets focus 1st item as default.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When Spotlight restores target with containerId, We can set a `lastContainerId` as given containerId. 
Thus, If keydown is pressed in Panel1, lastContainer is 'Panel1', so we can preserve panel0's last focused key.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
ENYO-4685

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>