### PR TITLE
ENYO-4688: Apply Skinnable to Components

### DIFF
--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -16,6 +16,7 @@ import pure from 'recompose/pure';
 import {Expandable, ExpandableItemBase} from '../ExpandableItem';
 import IconButton from '../IconButton';
 import Picker from '../Picker';
+import {withSkinnableProps} from '../Skinnable';
 
 import ExpandablePickerDecorator from './ExpandablePickerDecorator';
 
@@ -172,6 +173,14 @@ const ExpandablePickerBase = kind({
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
 		/**
+		 * Skin prop from `Skinnable`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		skin: PropTypes.string,
+
+		/**
 		 * When `true`, the component cannot be navigated using spotlight.
 		 *
 		 * @type {Boolean}
@@ -253,6 +262,7 @@ const ExpandablePickerBase = kind({
 			onSpotlightRight,
 			open,
 			orientation,
+			skin,
 			spotlightDisabled,
 			value,
 			width,
@@ -285,6 +295,7 @@ const ExpandablePickerBase = kind({
 					onSpotlightLeft={!rtl ? onSpotlightLeft : null}
 					onSpotlightRight={rtl ? onSpotlightRight : null}
 					orientation={orientation}
+					skin={skin}
 					spotlightDisabled={spotlightDisabled}
 					width={width}
 					wrap={wrap}
@@ -329,10 +340,12 @@ const ExpandablePickerBase = kind({
  * @public
  */
 const ExpandablePicker = pure(
-	Expandable(
-		Changeable(
-			ExpandablePickerDecorator(
-				ExpandablePickerBase
+	withSkinnableProps(
+		Expandable(
+			Changeable(
+				ExpandablePickerDecorator(
+					ExpandablePickerBase
+				)
 			)
 		)
 	)

--- a/packages/moonstone/IncrementSlider/IncrementSliderButton.js
+++ b/packages/moonstone/IncrementSlider/IncrementSliderButton.js
@@ -4,6 +4,7 @@ import IconButton from '../IconButton';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {withSkinnableProps} from '../Skinnable';
 
 const HoldableIconButton = Holdable(IconButton);
 
@@ -40,8 +41,8 @@ const IncrementSliderButtonBase = kind({
 	}
 });
 
-const OnlyUpdate = onlyUpdateForKeys(['children', 'disabled', 'spotlightDisabled', 'aria-label']);
-const IncrementSliderButton = OnlyUpdate(IncrementSliderButtonBase);
+const OnlyUpdate = onlyUpdateForKeys(['children', 'disabled', 'skin', 'spotlightDisabled', 'aria-label']);
+const IncrementSliderButton = withSkinnableProps(OnlyUpdate(IncrementSliderButtonBase));
 
 export default IncrementSliderButton;
 export {

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -11,6 +11,7 @@ import ri from '@enact/ui/resolution';
 
 import $L from '../internal/$L';
 import DisappearSpotlightDecorator from '../internal/DisappearSpotlightDecorator';
+import {Skinnable} from '../Skinnable';
 
 import ScrollButton from './ScrollButton';
 import ScrollThumb from './ScrollThumb';
@@ -395,12 +396,15 @@ class ScrollbarBase extends PureComponent {
 
 const Scrollbar = ApiDecorator(
 	{api: ['containerRef', 'hideThumb', 'showThumb', 'startHidingThumb', 'update']},
-	DisappearSpotlightDecorator(
-		{events: {
-			onNextSpotlightDisappear: '[data-scroll-button="previous"]',
-			onPrevSpotlightDisappear: '[data-scroll-button="next"]'
-		}},
-		ScrollbarBase
+	Skinnable(
+		DisappearSpotlightDecorator(
+			{events: {
+				onNextSpotlightDisappear: '[data-scroll-button="previous"]',
+				onPrevSpotlightDisappear: '[data-scroll-button="next"]'
+			}},
+
+			ScrollbarBase
+		)
 	)
 );
 

--- a/packages/moonstone/internal/DateComponentPicker/DateComponentPicker.js
+++ b/packages/moonstone/internal/DateComponentPicker/DateComponentPicker.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import Spottable from '@enact/spotlight/Spottable';
 
 import PickerCore, {PickerItem} from '../Picker';
+import {withSkinnableProps} from '../../Skinnable';
 
 import DateComponentPickerChrome from './DateComponentPickerChrome';
 
@@ -116,8 +117,10 @@ const DateComponentPickerBase = kind({
  * @ui
  * @private
  */
-const DateComponentPicker = Changeable(
-	DateComponentPickerBase
+const DateComponentPicker = withSkinnableProps(
+	Changeable(
+		DateComponentPickerBase
+	)
 );
 
 export default DateComponentPicker;

--- a/packages/moonstone/internal/DateComponentPicker/DateComponentRangePicker.js
+++ b/packages/moonstone/internal/DateComponentPicker/DateComponentRangePicker.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import RangePicker from '../../RangePicker';
+import {withSkinnableProps} from '../../Skinnable';
 
 import DateComponentPickerChrome from './DateComponentPickerChrome';
 
@@ -99,8 +100,10 @@ const DateComponentRangePickerBase = kind({
  * @ui
  * @private
  */
-const DateComponentRangePicker = Changeable(
-	DateComponentRangePickerBase
+const DateComponentRangePicker = withSkinnableProps(
+	Changeable(
+		DateComponentRangePickerBase
+	)
 );
 
 export default DateComponentRangePicker;

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -58,9 +58,9 @@ const PickerButtonBase = kind({
 	}
 });
 
-const PickerButton = Holdable(
-	{resume: true, endHold: 'onLeave'},
-	withSkinnableProps(
+const PickerButton = withSkinnableProps(
+	Holdable(
+		{resume: true, endHold: 'onLeave'},
 		onlyUpdateForKeys(['aria-label', 'disabled', 'icon', 'joined', 'onMouseUp', 'skin', 'spotlightDisabled'])(
 			PickerButtonBase
 		)


### PR DESCRIPTION
### Issue Resolved / Feature Added
Certain components don't update visually when changing skins.


### Resolution
With the implementation of `PureComponents` in ENYO-4624 (#1073), certain components won't update or re-render with shallow comparison. Using `Skinnable` hoc's will trigger update on the wrapped components when changing skin. 
Apply `Skinnable` to the following components that needed visual updates when skins change.
`DatePicker`, `ExpandablePicker`, `IncrementSlider`, `Picker`, `RangePicker`, `Scroller`, `TimePicker`

### Additional Consideration
Using `Broadcast` on `Moonstone/Skinnable` and `Subscriber` on the aforementioned components is also another solution. Decided to go with `Skinnable` hoc's because `Broadcast` is most likely undergoing more changes.


### Links
ENYO-4688


Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
