### PR TITLE
ENYO-4524 : Fix spotlight up hold not moving to to close button in Panel

### DIFF
--- a/packages/moonstone/Panels/Panel.js
+++ b/packages/moonstone/Panels/Panel.js
@@ -180,6 +180,7 @@ const PanelBase = kind({
 const Panel = SpotlightContainerDecorator(
 	{
 		// prefer any spottable within the panel body for first render
+		continue5WayHold: true,
 		defaultElement: [`.${spotlightDefaultClass}`, `.${css.body} *`],
 		enterTo: 'last-focused',
 		preserveId: true


### PR DESCRIPTION
### Issue Resolved / Feature Added
Holding "up" key in Panel will stop key navigation to application close button


### Resolution
add `continue5WayHold: true` to Panel's SpotlightContainerDecorator. 


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4524

### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)