### PR TITLE
PLAT-43852: Restored Vietnamese to the non-latin overrides list

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -10,6 +10,8 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 
 ### Changed
 
+- Vietnamese to be classified as a non-latin language
+
 ### Fixed
 
 ## [1.8.0] - 2017-09-07

--- a/packages/i18n/locale/locale.js
+++ b/packages/i18n/locale/locale.js
@@ -29,7 +29,7 @@ function isNonLatinLocale (spec) {
 
 	// We use the non-latin fonts for these languages (even though their scripts are technically
 	// considered latin)
-	const nonLatinLanguageOverrides = ['en-JP'];
+	const nonLatinLanguageOverrides =  ['vi', 'en-JP'];
 	// We use the latin fonts (with non-Latin fallback) for these languages (even though their
 	// scripts are non-latin)
 	const latinLanguageOverrides = ['ko', 'ha'];

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -8,6 +8,8 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 ### Added
 
+- Vietnamese to the locale list knob
+
 ### Changed
 
 ### Fixed

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -58,6 +58,7 @@ const locales = {
 	'ar-SA': 'ar-SA - Arabic, RTL and standard font',
 	'ur-PK': 'ur-PK - Urdu, RTL and custom Urdu font',
 	'zh-Hant-HK': 'zh-Hant-HK - Traditional Chinese, custom Hant font',
+	'vi-VN': 'vi-VN - Vietnamese, Special non-latin font handling',
 	'ja-JP': 'ja-JP - Japanese, custom Japanese font',
 	'en-JP': 'en-JP - English, custom Japanese font'
 };


### PR DESCRIPTION
### Resolution
* Restored Vietnamese to the non-latin overrides list.
* Also added Vietnamese to the Sampler Locales for easier testing/observing.
