### PR TITLE
PLAT-42841: Normalized the input heights across all locales

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -22,7 +22,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Picker` to show numbers when changing values rapidly
 - `moonstone/Popup` layout in large text mode to show close button correctly
 - `moonstone/Picker` from moving scroller when pressing 5-way keys in `joined` Picker
-- `moonstone/Input` styling for some non-latin locales
+- `moonstone/Input` so it displays all locales the same way, without cutting off the edges of characters
 - `moonstone/TooltipDecorator` to hide tooltip when 5-way keys are pressed for disabled components
 - `moonstone/Picker` to not tremble in width when changing values while using a numeric width prop value
 

--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -53,7 +53,7 @@
 .decorator {
 	display: inline-flex;
 	position: relative;
-	padding: 12px 30px;
+	padding: 3px 30px;
 	border-radius: 1008px;
 	margin: 6px;
 	border: @moon-input-border-width solid transparent;
@@ -62,8 +62,8 @@
 	.input,
 	.iconBefore,
 	.iconAfter {
-		line-height: 39px;
-		height: 39px;
+		line-height: 57px;
+		height: 57px;
 	}
 
 	.iconBefore,
@@ -174,40 +174,3 @@
 		});
 	}
 });
-
-:global(.enact-locale-non-latin) {
-	.decorator {
-		padding: 6px 30px 12px;
-	}
-
-	// Languages with combining accent characters
-	&:global(.enact-locale-th), // Thai - Test Chars: ฟิ้ไััุุ
-	&:global(.enact-locale-ar), // Arabic
-	&:global(.enact-locale-fa), // Farsi
-	&:global(.enact-locale-ur), // Urdu
-	&:global(.enact-locale-ku), // Kurdish
-	&:global(.enact-locale-he), // Hebrew
-	&:global(.enact-locale-hi), // Hindi
-	&:global(.enact-locale-ta), // Tamil
-	&:global(.enact-locale-te), // Telugu
-	&:global(.enact-locale-kn), // Kannada
-	&:global(.enact-locale-ml), // Malayalam
-	&:global(.enact-locale-mr), // Marathi
-	&:global(.enact-locale-bn), // Bengali
-	&:global(.enact-locale-pa) {// Panjabi
-		.input,
-		.iconBefore,
-		.iconAfter {
-			line-height: 48px;
-			height: 48px;
-		}
-
-		.input {
-			font-size: 24px;
-		}
-
-		.decorator {
-			padding: 1px 30px;
-		}
-	}
-}


### PR DESCRIPTION
… and made the internal input taller

### Issue Resolved / Feature Added
Some glyphs in some locales are just too dang tall! Oh, what ever shall we do; mercy.

### Resolution
We'll remove some of the decorator's padding and replace it with the input's line-height, so there's a net-zero change in external height, but there's an 18 pixel gain in input's available height. This more than compensates for the height of any locales, bumping the height up to a whopping 57px for a 33px latin font (previous height of 39px) and a 27px non-latin font (previous height of 48px).


### Additional Considerations
This eliminates the changes done during ENYO-4684 (#1116 and #1119) as they are no longer needed, since the new taller universal line-height covers the affected locales.