### PR TITLE
ENYO-4516: Add Popup prop onActivatorFocusFail

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/styles/mixins.less` mixins: `.moon-spotlight-margin()` and `.moon-spotlight-padding()`
 - `moonstone/Button` property `noAnimation` to support non-animating pressed visual
+- `moonstone/Popup` property `onActivatorFocusFail` to support user-defined behavior when the popup closes and cannot set focus to its activating control
 
 ### Changed
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -36,6 +36,12 @@ const getContainerNode = (containerId) => {
 const forwardHide = forward('onHide');
 const forwardShow = forward('onShow');
 
+const shouldChangeFocus = (containerId) => {
+	let current = Spotlight.getCurrent();
+	const containerNode = getContainerNode(containerId);
+	return !current || (containerNode && containerNode.contains(current));
+};
+
 /**
  * {@link moonstone/Popup.PopupBase} is a modal component that appears at the bottom of
  * the screen and takes up the full screen width.
@@ -232,6 +238,15 @@ class Popup extends React.Component {
 		 * @public
 		 */
 		noAutoDismiss: PropTypes.bool,
+
+		/**
+		 * A function to be run after the popup closes and fails to set focus to the activating
+		 * control.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onActivatorFocusFail: PropTypes.func,
 
 		/**
 		 * A function to be run when a closing action is invoked by the user. These actions include
@@ -442,15 +457,24 @@ class Popup extends React.Component {
 	}
 
 	spotActivator = (activator) => {
-		const current = Spotlight.getCurrent();
-		const containerNode = getContainerNode(this.state.containerId);
+		const {containerId} = this.state;
 
 		// if there is no currently-spotted control or it is wrapped by the popup's container, we
 		// know it's safe to change focus
-		if (!current || (containerNode && containerNode.contains(current))) {
+		if (shouldChangeFocus(containerId)) {
 			// attempt to set focus to the activator, if available
 			if (!Spotlight.focus(activator)) {
-				Spotlight.focus();
+				const {onActivatorFocusFail} = this.props;
+
+				if (onActivatorFocusFail) {
+					onActivatorFocusFail();
+				}
+
+				// as a last resort, we check if it's safe to allow spotlight to set focus since
+				// `onActivatorFocusFail` may or may not have changed focus above
+				if (shouldChangeFocus(containerId)) {
+					Spotlight.focus();
+				}
 			}
 		}
 	}
@@ -472,6 +496,7 @@ class Popup extends React.Component {
 
 	render () {
 		const {noAutoDismiss, onClose, scrimType, ...rest} = this.props;
+		delete rest.onActivatorFocusFail;
 		delete rest.spotlightRestrict;
 
 		return (

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -37,7 +37,7 @@ const forwardHide = forward('onHide');
 const forwardShow = forward('onShow');
 
 const shouldChangeFocus = (containerId) => {
-	let current = Spotlight.getCurrent();
+	const current = Spotlight.getCurrent();
 	const containerNode = getContainerNode(containerId);
 	return !current || (containerNode && containerNode.contains(current));
 };


### PR DESCRIPTION
### Issue Resolved / Feature Added
Need a way to direct focus in the case where a `Popup` closes and the activating control doesn't exist anymore. Currently, we simply call `Spotlight.focus()` and allow spotlight to perform a default focus behavior. This sets focus back to the app, but sometimes the focus is somewhere unexpected or a developer wants to direct focus in a particular way.


### Resolution
I'm adding an `onActivatorFocusFail` prop to `Popup` that will execute when the popup's activating control cannot gain focus after the popup closes. This hook allows a developer to include a function that can include focus-change behavior when the popup cannot re-spot the activating control.

This option seems less intrusive and more flexible than other proposed solutions:
- add a `activator` prop to `Popup`, allowing a dev to provide a node to set focus to when the activator disappears
- query for all container id's of the activator during mount and attempt to set focus to them recursively when the activator no longer exists

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
