### PR TITLE
PLAT-42802 : Fix Spotlight is lost when disabling the activator of a popup

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Changed
 
 ### Fixed
-
+- `spotlight` to not to focus when a node is disabled and move the focus to a not disabled element.
 - `spotlight` to not try to focus something when the window is activated unless the window has been previously blurred
 
 ## [1.8.0] - 2017-09-07

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -589,6 +589,8 @@ const Spotlight = (function () {
 				} else {
 					target = getTargetBySelector(elem);
 				}
+			} else if (typeof elem === 'object' && elem.getAttribute('disabled') !== null) {
+				target = getTargetByContainer();
 			}
 
 			const nextContainerIds = getContainersForNode(target);


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix Spotlight is lost when disabling the activator of a popup


### Resolution
Added check for the `elem` of the type Object and  disabled state in the spotlight.focus function. If the condition is satisfied, find the new `target` by calling the 'getTargetByContainer()'


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-42802

### Comments
Enact-DCO-1.1-Signed-off-by: Srirama Singeri(srirama.singeri@lge.com)