### PR TITLE
ENYO-4248: Fixing rewindManually behavior for mini-feedback values

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1441,6 +1441,8 @@ const VideoPlayerBase = class extends React.Component {
 			adjustedDistance = (distance * pbRate) / 1000;
 
 		this.jump(adjustedDistance);
+		this.stopDelayedMiniFeedbackHide();
+		this.clearPulsedPlayback();
 		this.startRewindJob();	// Issue another rewind tick
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fixing an issue with `rewindManually` (on devices that don't support `rewind)`, where it calls `jump` - then incorrect values are used in the mini-feedback.

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>