### PR TITLE
ENYO-4610: Update Scroll to Clicked FocusedItem

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -402,6 +402,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 		lastScrollPositionOnFocus = null
 		indexToFocus = null
 		nodeToFocus = null
+		nodeToScrollTo = null
 
 		// component info
 		childRef = null
@@ -1104,7 +1105,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 		updateScrollOnFocus () {
 			const
-				focusedItem = Spotlight.getCurrent(),
+				focusedItem = this.nodeToScrollTo ? this.nodeToScrollTo : Spotlight.getCurrent(),
 				{containerRef, calculatePositionOnFocus} = this.childRef;
 
 			if (focusedItem && containerRef && containerRef.contains(focusedItem)) {
@@ -1126,6 +1127,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 
 			// update `scrollHeight`
 			this.bounds.scrollHeight = this.getScrollBounds().scrollHeight;
+			this.nodeToScrollTo = null;
 		}
 
 		// forceUpdate is a bit jarring and may interrupt other actions like animation so we'll
@@ -1153,6 +1155,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				this.childRef.containerRef.scrollTop = this.scrollTop;
 				this.childRef.containerRef.scrollLeft = this.scrollLeft;
 			}
+		}
+
+		handleMouseDown = () => {
+			this.nodeToScrollTo = Spotlight.getCurrent();
 		}
 
 		render () {
@@ -1185,6 +1191,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 							{...props}
 							cbScrollTo={this.scrollTo}
 							className={css.content}
+							onMouseDown={this.handleMouseDown}
 							onScroll={this.handleScroll}
 							ref={this.initChildRef}
 						/>


### PR DESCRIPTION
### Issue Resolved / Feature Added
It doesn't scroll when bottom ExpandableList opens by clicking.


### Resolution
`UpdateScrollOnFocus` is called after `componentDidUpdate` to scroll to `Spotlight.getCurrent()`, but there is a case where the pointer could move to spot another element in the time between when an item is clicked and when `Scroller` finished updating. Here we have `Scrollable` cache the node that was spotted at the time of pointer click so that `UpdateScrollOnFocus` will scroll to that node instead regardless of where Spotlight is after component update.


### Links
ENYO-4610


Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
