### PR TITLE
ENYO-4733: Fix Skinnable cascading

### DIFF
--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -105,7 +105,7 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 		getChildContext () {
 			return {
-				skin: this.getSkin(this.props.skin, this.state.skin),
+				skin: this.determineSkin(this.props.skin, this.state.skin),
 				Subscriber: this.publisher.getSubscriber()
 			};
 		}
@@ -113,7 +113,7 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 		componentWillMount () {
 			this.publisher = Publisher.create('skin', this.context.Subscriber);
 			this.publisher.publish({
-				skin: this.getSkin(this.props.skin, this.state.skin)
+				skin: this.determineSkin(this.props.skin, this.state.skin)
 			});
 
 			if (this.context.Subscriber) {
@@ -123,7 +123,7 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 		componentWillReceiveProps (nextProps) {
 			if (this.props.skin !== nextProps.skin) {
-				const skin = this.getSkin(nextProps.skin, this.state.skin);
+				const skin = this.determineSkin(nextProps.skin, this.state.skin);
 				this.updateSkin(skin);
 			}
 		}
@@ -135,7 +135,7 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleSubscription = ({message}) => {
-			const skin = this.getSkin(this.props.skin, message.skin);
+			const skin = this.determineSkin(this.props.skin, message.skin);
 			this.updateSkin(skin);
 		}
 
@@ -148,12 +148,12 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		getSkin (authorSkin, parentSkin) {
+		determineSkin (authorSkin, parentSkin) {
 			return authorSkin || defaultSkin || parentSkin;
 		}
 
 		getClassName () {
-			const skin = skins[this.getSkin(this.props.skin, this.state.skin)];
+			const skin = skins[this.determineSkin(this.props.skin, this.state.skin)];
 			let {className} = this.props;
 
 			// only apply the skin class if it's set and different from the "current" skin as


### PR DESCRIPTION
Skinnable was not correctly cascading the current skin to child
components causing "dark" components to be rendered in "light"
containers.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)