### PR TITLE
ENYO-4728: Changed to render items from the first column in grid lists

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -654,7 +654,7 @@ class VirtualListCore extends Component {
 			style = {display: 'none', width, height},
 			attributes = {[dataIndexAttribute]: index, key, style};
 		this.composeTransform(style, primaryPosition, secondaryPosition);
-		this.cc[key] = <div {...attributes} />
+		this.cc[key] = (<div {...attributes} />);
 	}
 
 	positionItems ({updateFrom, updateTo}) {
@@ -695,7 +695,7 @@ class VirtualListCore extends Component {
 		}
 
 		for (let i = updateTo; i < hideTo; i++) {
-			this.applyStyleToHideNode(i);
+			this.applyStyleToHideNode(i, width, height, primaryPosition, secondaryPosition);
 		}
 
 		this.updateFrom = updateFrom;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If the last row of a grid list is not full by items, some space for items should be empty. Until now, lists handled this case by selecting the first rendered item which is not the first column so the last rendered item is the last item.

If the focus is moving step by step, this approach works well. But If the focus is moving fast by 5-way key holding down, the focus can move to the first rendered row before virtual items are swapped. In this case, if the focus is moving up from the left-side column of the first rendered item, the focus moves to the first rendered item by Spotlight.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In a viewpoint of Spotlight, moving focus to the first rendered item is a flawless behavior. So we can consider two approaches; one is to swap earlier before the focus reaches, and the other one is to make the first rendered item always to be the first column.

For the first approach, we need to change some threshold for swapping. Since the current threshold logic is quite stable and well-considered state, changing threshold looks not such a good idea. So the other one is our approach.

Since the first rendered item to be always the first column, we should handle empty items for empty spaces directly. Empty items are non-spottable <div> nodes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Since the first rendered index is one of the key variables in lists, at least combinations of below should be tested.
- grid lists vs. lists
- grid lists which have empty spaces at the last line vs. which have no empty spaces
- lists which items are fit to the all four edges (top/right/bottom/left) vs. not fit

### Links
ENYO-4728

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)