### PR TITLE
ENYO-4779: Positionable imports proptypes from React

### DIFF
--- a/packages/moonstone/VirtualFlexList/Positionable.js
+++ b/packages/moonstone/VirtualFlexList/Positionable.js
@@ -5,7 +5,8 @@
 import clamp from 'ramda/src/clamp';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
 
 const forwardPositionChange = forward('onPositionChange');
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Positionable was importing PropTypes from `react`. As of React 16, direct usage like this will throw an error (currently emits a warning).

### Resolution
* Switch to importing PropTypes from `prop-types` package.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>