### PR TITLE
ENYO-4780: Feedback's playbackState throws an error when undefined.

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button` property value to `backgroundOpacity` called "lightTranslucent" to better serve colorful image backgrounds behind Buttons. This also affects `moonstone/IconButton` and `moonstone/Panels/ApplicationCloseButton`.
 - `moonstone/Panels` property `closeButtonBackgroundOpacity` to support `moonstone/Panels/ApplicationCloseButton`'s `backgroundOpacity` prop
-- `moonstone/VideoPlayer/Feedback` property `playbackState` now has a default value of `'play'`
 
 ### Changed
 

--- a/packages/moonstone/VideoPlayer/Feedback.js
+++ b/packages/moonstone/VideoPlayer/Feedback.js
@@ -52,7 +52,6 @@ const FeedbackBase = kind({
 	},
 
 	defaultProps: {
-		playbackState: 'play',
 		visible: true
 	},
 
@@ -80,9 +79,9 @@ const FeedbackBase = kind({
 		delete rest.visible;
 		return (
 			<div {...rest}>
-				{states[playbackState].position === 'before' ? <FeedbackIcon>{playbackState}</FeedbackIcon> : null}
+				{states[playbackState] && states[playbackState].position === 'before' ? <FeedbackIcon>{playbackState}</FeedbackIcon> : null}
 				{children ? <div className={css.message}>{children}</div> : null}
-				{states[playbackState].position === 'after' ? <FeedbackIcon>{playbackState}</FeedbackIcon> : null}
+				{states[playbackState] && states[playbackState].position === 'after' ? <FeedbackIcon>{playbackState}</FeedbackIcon> : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Property `playbackState` is assumed to exist however there is no default nor is marked required. This results in an error when generated externally with no property specified.

### Resolution
* Adds a `playbackState` default value of `'play'`

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>