### PR TITLE
ENYO-4772: TooltipDecorator add tooltipHidden prop

### DIFF
--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -92,6 +92,16 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			tooltipDelay: PropTypes.number,
 
 			/**
+			 * When `true`, tooltip does not show, overiding normal tooltip behavior. When `false`,
+			 * tooltip behaves as normal.
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @public
+			 */
+			tooltipHidden: PropTypes.bool,
+
+			/**
 			 * Position of the tooltip with respect to the activating control. Valid values are
 			 * `'above'`, `'above center'`, `'above left'`, `'above right'`, `'below'`, `'below center'`,
 			 * `'below left'`, `'below right'`, `'left bottom'`, `'left middle'`, `'left top'`,
@@ -154,6 +164,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			disabled: false,
 			tooltipCasing: 'upper',
 			tooltipDelay: 500,
+			tooltipHidden: false,
 			tooltipPosition: 'above',
 			tooltipPreserveCase: false
 		}
@@ -389,10 +400,11 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 */
 		renderTooltip () {
 			const {children, tooltipCasing, tooltipPreserveCase, tooltipProps, tooltipText, tooltipWidth} = this.props;
+			const showing = this.props.tooltipHidden ? false : this.state.showing;
 
 			if (tooltipText) {
 				const renderedTooltip = (
-					<FloatingLayer open={this.state.showing} scrimType="none" key="tooltipFloatingLayer">
+					<FloatingLayer open={showing} scrimType="none" key="tooltipFloatingLayer">
 						<Tooltip
 							aria-live="off"
 							role="alert"
@@ -439,6 +451,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				}
 			);
 
+			delete props.tooltipHidden;
 			delete props.tooltipDelay;
 			delete props.tooltipPosition;
 			delete props.tooltipCasing;

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -14,7 +14,8 @@ const MediaButton = onlyUpdateForKeys([
 	'children',
 	'disabled',
 	'onClick',
-	'spotlightDisabled'
+	'spotlightDisabled',
+	'tooltipHidden'
 ])(IconButton);
 
 /**
@@ -352,6 +353,7 @@ const MediaControls = kind({
 			rateButtonsDisabled,
 			rightComponents,
 			spotlightDisabled,
+			visible,
 			...rest
 		} = props;
 
@@ -363,7 +365,6 @@ const MediaControls = kind({
 		delete rest.playIcon;
 		delete rest.playLabel;
 		delete rest.showMoreComponents;
-		delete rest.visible;
 
 		return (
 			<div {...rest}>
@@ -391,6 +392,7 @@ const MediaControls = kind({
 							className={css.moreButton}
 							disabled={moreButtonDisabled}
 							onClick={onToggleMore}
+							tooltipHidden={!visible}
 							tooltipProps={{role: 'dialog'}}
 							tooltipText={moreIconLabel}
 							spotlightDisabled={spotlightDisabled}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Tooltip is not removed when VideoPlayer control panel is hidden


### Resolution
Tooltip visibility is based on its wrapped component DOM events. In the case that wrapped component is both disabled, un-focusable, _and_ hidden by its parent, there is no way `TooltipDecorator` knows when to hide tooltip... because there is no DOM event that `TooltipDecorator` can receive. Adding the prop `tooltipHidden` allows for control over hiding tooltip. When `tooltipHidden = false`, tooltip will show and hide as normal.

### Additional Considerations
We could also guard DOM eventlisteners with `tooltipHidden`


### Links
ENYO-4772

Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
