### PR TITLE
ENYO-4764: Fix event payload sent to sampler action logger

### DIFF
--- a/packages/sampler/stories/qa-stories/Holdable.js
+++ b/packages/sampler/stories/qa-stories/Holdable.js
@@ -1,5 +1,6 @@
 import Button from '@enact/moonstone/Button';
 import Holdable from '@enact/ui/Holdable';
+import pick from 'ramda/src/pick';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {boolean, select, text} from '@kadira/storybook-addon-knobs';
@@ -14,6 +15,14 @@ const LongPressButton = Holdable({
 }, Button);
 const ResumeHoldButton = Holdable({resume: true, endHold: 'onLeave'}, Button);
 
+const safeAction = (actionName) => {
+	const actionHandler = action(actionName);
+
+	return (ev) => {
+		actionHandler(pick(['type', 'holdTime'], ev));
+	};
+};
+
 // Set up some defaults for info and knobs
 const prop = {
 	backgroundOpacity: {'opaque': 'opaque', 'translucent': 'translucent', 'transparent': 'transparent'}
@@ -24,8 +33,8 @@ storiesOf('Holdable')
 		'with default hold events',
 		() => (
 			<HoldableButton
-				onHold={action('onHold')}
-				onHoldPulse={action('onHoldPulse')}
+				onHold={safeAction('onHold')}
+				onHoldPulse={safeAction('onHoldPulse')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
 			>
@@ -37,8 +46,8 @@ storiesOf('Holdable')
 		'with a custom longpress event and 1 second frequency',
 		() => (
 			<LongPressButton
-				onHold={action('onHold')}
-				onHoldPulse={action('onHoldPulse')}
+				onHold={safeAction('onHold')}
+				onHoldPulse={safeAction('onHoldPulse')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
 			>
@@ -50,8 +59,8 @@ storiesOf('Holdable')
 		'that can resume a hold on re-entry',
 		() => (
 			<ResumeHoldButton
-				onHold={action('onHold')}
-				onHoldPulse={action('onHoldPulse')}
+				onHold={safeAction('onHold')}
+				onHoldPulse={safeAction('onHoldPulse')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
 			>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Holdable QA sampler would lock up as it tried to log circular references in the event object

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Only display type and relevant field for pulse action.  As this is a QA sample, this is probably OK.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The bug exists inside Storybook but there's not a great solution to it yet.
Our event handling in `Holdable` probably needs more work.  We `pick()` a number of fields
out into a new object then we clone it with the spread operator each time we pass to an
event.  I'm not certain if using React's in-build ability to keep a safe copy of the `SyntheticEvent`
object would be better or worse.  We'd still have to either clone or mutate it and Storybook would
not display it anyhow, I think.

### Links
[//]: # (Related issues, references)
ENYO-4764

### Comments
