### PR TITLE
ENYO-4804: Fix Header to layout header row without padding in standard type

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList` not to move focus when a current item and the last item are located at the same line and pressing a page down key
+- `moonstone/Header` to layout header row correctly in `standard` type
 
 ## [1.10.0] - 2017-10-09
 

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -194,7 +194,7 @@ const HeaderBase = kind({
 					<Cell component={HeaderH1} casing={casing} className={css.title} preserveCase={preserveCase} marqueeOn={marqueeOn}>
 						{title}
 					</Cell>
-					<Cell shrink size={63}>
+					<Cell className={css.headerRow} shrink size={63}>
 						<Layout align="end">
 							<Cell>
 								{titleBelowComponent}

--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -62,6 +62,12 @@
 		.subTitleBelow {
 			line-height: 39px;
 		}
+
+		.headerRow {
+			position: absolute;
+			width: 100%;
+			bottom: 12px;
+		}
 	}
 
 	// Compact Header


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`<Header type="standard" />` with header components seem shifted towards left. This is due to the padding added to header affects the header row.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set header row width to 100%, absolute position and bottom position with some margin.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
