### PR TITLE
ENYO-4810: Update to 15.6.x prop-types release to avoid multiple vers…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "classnames": "~2.2.5",
     "invariant": "~2.2.2",
-    "prop-types": "~15.5.10",
+    "prop-types": "~15.6.0",
     "ramda": "~0.24.1",
     "react": "~15.6.1",
     "react-dom": "~15.6.1"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@enact/core": "^1.10.0",
-    "prop-types": "~15.5.10",
+    "prop-types": "~15.6.0",
     "ramda": "~0.24.1",
     "react": "~15.6.1",
     "react-dom": "~15.6.1",

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -35,7 +35,7 @@
     "classnames": "~2.2.5",
     "eases": "~1.0.8",
     "invariant": "~2.2.2",
-    "prop-types": "~15.5.10",
+    "prop-types": "~15.6.0",
     "ramda": "~0.24.1",
     "react": "~15.6.1",
     "recompose": "~0.23.5",

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -50,7 +50,7 @@
     "@kadira/storybook": "~2.34.0",
     "@kadira/storybook-addon-knobs": "~1.7.1",
     "@kadira/storybook-addon-options": "^1.0.1",
-    "prop-types": "~15.5.0",
+    "prop-types": "~15.6.0",
     "react": "~15.6.1",
     "react-addons-perf": "~15.4.0",
     "react-dom": "~15.6.1",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@enact/core": "^1.10.0",
-    "prop-types": "~15.5.10",
+    "prop-types": "~15.6.0",
     "ramda": "~0.24.1",
     "react": "~15.6.1"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@enact/core": "^1.10.0",
     "invariant": "~2.2.2",
-    "prop-types": "~15.5.10",
+    "prop-types": "~15.6.0",
     "ramda": "~0.24.1",
     "react": "~15.6.1",
     "react-dom": "~15.6.1",


### PR DESCRIPTION
…ions of prop-types (as we use react 15.6.x).

### Issue Resolved / Feature Added
* We were using `react` and `react-dom` 15.6.x but using `prop-types` 15.5.x. As a result we were having multiple versions of `prop-types` in our dependency tree.


### Resolution
* Use `prop-types`15.6.x within enact.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
