### PR TITLE
Remeasure ContextualPopupDecorator when props change

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` and `moonstone/VirtualGridList` to scroll by 5-way keys right after wheeling
 - `moonstone/VirtualList` not to move focus when a current item and the last item are located at the same line and pressing a page down key
 - `moonstone/Header` to layout header row correctly in `standard` type
+- `moonstone/ContextualPopupDecorator` to remeasure the popup when the popup component or props change
 
 ## [1.10.0] - 2017-10-09
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -286,8 +286,10 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// we can't remeasure yet, as the component will not be refreshed in the DOM. This will
 			// cause a double (or triple??) update.
 			if (
-				!equals(this.props.popupProps, prevProps.popupProps) ||
-				this.props.popupComponent !== prevProps.popupComponent
+				this.props.open && (
+					!equals(this.props.popupProps, prevProps.popupProps) ||
+					this.props.popupComponent !== prevProps.popupComponent
+				)
 			) {
 				this.setState({containerPosition: null});	// eslint-disable-line react/no-did-update-set-state
 			}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -6,6 +6,7 @@
  * @module moonstone/ContextualPopupDecorator
  */
 
+import equals from 'ramda/src/equals';
 import {extractAriaProps} from '@enact/core/util';
 import FloatingLayer from '@enact/ui/FloatingLayer';
 import hoc from '@enact/core/hoc';
@@ -280,6 +281,20 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				off('keydown', this.handleKeyDown);
 				off('keyup', this.handleKeyUp);
 				this.spotActivator(prevState.activator);
+			}
+			// If the Popup component or props have changed, we probably need to re-layout. However,
+			// we can't remeasure yet, as the component will not be refreshed in the DOM. This will
+			// cause a double (or triple??) update.
+			if (
+				!equals(this.props.popupProps, prevProps.popupProps) ||
+				this.props.popupComponent !== prevProps.popupComponent
+			) {
+				this.setState({containerPosition: null});	// eslint-disable-line react/no-did-update-set-state
+			}
+			// Now, if our state change has come in and we had a position before but not now, we can
+			// remeasure and all should be good.
+			if (prevState.containerPosition && !this.state.containerPosition) {
+				this.setContainerPosition();
 			}
 		}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If the `popupComponent` or `popupProps` changes while a contextual
popup is open, it will not be laid out correct as it is never remeasured.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Detect props changes and trigger a remeasure afterwards

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This will causes three updates to the popup in this case.  It should be rare, though.
One of the updates is calling `setState` in `componentDidUpdate`, which will
also trigger another `setState` in `componentDidUpdate`.  :feelsbadman:

### Links
[//]: # (Related issues, references)
ENYO-4808

### Comments
