### PR TITLE
ENYO-4804: Adjusted header to properly account for the closeButton's presence.

### DIFF
--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -194,7 +194,7 @@ const HeaderBase = kind({
 					<Cell component={HeaderH1} casing={casing} className={css.title} preserveCase={preserveCase} marqueeOn={marqueeOn}>
 						{title}
 					</Cell>
-					<Cell className={css.headerRow} shrink size={63}>
+					<Cell shrink size={63}>
 						<Layout align="end">
 							<Cell>
 								{titleBelowComponent}

--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -60,12 +60,6 @@
 		.subTitleBelow {
 			line-height: 39px;
 		}
-
-		.headerRow {
-			position: absolute;
-			width: 100%;
-			bottom: 12px;
-		}
 	}
 
 	// Compact Header
@@ -110,6 +104,7 @@
 	});
 }
 
-:global(.hasCloseButton) .header {
+:global(.hasCloseButton) .header.compact,
+:global(.hasCloseButton) .header.standard .title {
 	.padding-start-end(0, @moon-spotlight-outset + @moon-icon-button-small-size + @moon-spotlight-outset);
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
Header was using absolute positioning and width 100% inside a flex layout which shouldn't have those properties.

### Resolution
Padding was moved to the header title in a standard layout to move it instead of the entire layout.