### PR TITLE
Added support for a defaultProp value on Toggleable

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Toggleable` to respect the `defaultProp` value of the 'prop' on the component
 - `ui/Pressable` to properly set pressed state to false on blur and release
 
 ## [1.10.0] - 2017-10-09

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -112,7 +112,7 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static defaultProps = {
-			[defaultPropKey]: false,
+			[defaultPropKey]: (Wrapped.defaultProps && Wrapped.defaultProps[prop]) || false,
 			disabled: false
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
`defaultProps` value for the `prop` used in `Toggleable` isn't respected by `Toggleable`, so it gives the impression that `Toggleable` doesn't work when it actually does. `Toggleable` currently only respects the incoming props from the instantiation of a component.

### Resolution
Added support for a `defaultProps` value on `Toggleable` so it's more intuitive to use. `Toggleable` now looks at the default props defined on the `Wrapped` component to determine an initial value to work from. All other existing behavior is unaffected.

The following case is now supported:
```
const MainPanel = kind({
...
	defaultProps: {
		myBoolean: true
	},
...
export default Toggleable({prop: 'myBoolean'}, MainPanel);
```
