### PR TITLE
ENYO-4844: Enact QA sampler failing to build due to usage of Ramda

### DIFF
--- a/packages/sampler/stories/qa-stories/Holdable.js
+++ b/packages/sampler/stories/qa-stories/Holdable.js
@@ -1,6 +1,5 @@
 import Button from '@enact/moonstone/Button';
 import Holdable from '@enact/ui/Holdable';
-import pick from 'ramda/src/pick';
 import React from 'react';
 import {storiesOf, action} from '@kadira/storybook';
 import {boolean, select, text} from '@kadira/storybook-addon-knobs';
@@ -19,7 +18,7 @@ const safeAction = (actionName) => {
 	const actionHandler = action(actionName);
 
 	return (ev) => {
-		actionHandler(pick(['type', 'holdTime'], ev));
+		actionHandler({type: ev.type, holdTime: ev.holdTime});
 	};
 };
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
* QA sampler story for Holdable is using `ramda/src/pick`, but Ramda is not a dependency of Sampler.

### Resolution
* Remove Ramda import and use a simple alternative to the `pick()` usage to avoid an additional unneeded import.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>