### PR TITLE
ENYO-4855: Fix to call scrollToBoundary when focus is moved using hold

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller` to called scrollToBoundary once when focus is moved using holding child item
 - `moonstone/VideoPlayer` to apply skin correctly
 - `moonstone/Popup` from `last-focused` to `default-element` in `SpotlightContainerDecorator` config
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -123,6 +123,8 @@ class ScrollerBase extends Component {
 		left: 0
 	}
 
+	isScrolledToBoundary = false
+
 	getScrollBounds = () => this.scrollBounds
 
 	getRtlPositionX = (x) => (this.context.rtl ? this.scrollBounds.maxLeft - x : x)
@@ -425,9 +427,13 @@ class ScrollerBase extends Component {
 
 		const {keyCode, target} = ev;
 		const direction = getDirection(keyCode);
+		if (!ev.repeat) {
+			this.isScrolledToBoundary = false;
+		}
 
-		if (direction && !this.findInternalTarget(direction, target)) {
+		if (direction && !this.findInternalTarget(direction, target) && !this.isScrolledToBoundary) {
 			this.scrollToBoundary(direction);
+			this.isScrolledToBoundary = true;
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The onKeyDown handler calls `scrollToBoundary` function for moving to scroller bottom or top when next spottable item is outside of scroller. However, When hold event is triggered, this scrollToBoundary is called more times because scroll position is not the bottom or top position by animating. 

If accessibility option is enabled, engine performance is some lower compared to disabled because accessibility engine is enabled. In here, the repeated function call can affect performance.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix to call scrollToBoundary once by checking flag.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
If accessibility engine is enabled, performance degradation happens. According to engine team, this performance degradation can't avoid, so we should remove another performance degradation factor of enact-side as far as possible. 

### Links
[//]: # (Related issues, references)
ENYO-4855

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>