### PR TITLE
ENYO-4859: Removed kerning from all marquee text

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
+- `moonstone/Marquee` to remove kerning from its text
+
 ### Fixed
 
 - `moonstone/RangePicker` to display negative values correctly in RTL

--- a/packages/moonstone/Marquee/Marquee.less
+++ b/packages/moonstone/Marquee/Marquee.less
@@ -1,5 +1,6 @@
 // Marquee.less
 //
+@import "../styles/mixins.less";
 
 .marquee {
 	// NOTE: Keeping this around for now to validate if we want to use box layout instead of white-space
@@ -17,6 +18,8 @@
 	text-align: left;
 
 	.text {
+		.font-kerning(none);
+
 		pointer-events: none;
 		text-overflow: ellipsis;
 		overflow: hidden;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Kerning seems to cause difficulty when applied to special characters in the web browser and measuring DOM elements; measurements don't correctly reflect the width of the string.

### Resolution
Just remove kerning.

### Additional Considerations
What could go wrong?
