### PR TITLE
ENYO-4879: Skip to focus when container is muted

### DIFF
--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -13,7 +13,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import {getContainersForNode} from '../src/container';
+import {getContainersForNode, getContainerNode} from '../src/container';
 import Spotlight from '../src/spotlight';
 
 /**
@@ -214,9 +214,13 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 						Spotlight.setPointerMode(true);
 					}
 				} else if (!Spotlight.getCurrent() && !Spotlight.isPaused()) {
-					const containers = getContainersForNode(this.node);
-					const containerId = Spotlight.getActiveContainer();
-					if (containers.indexOf(containerId) >= 0) {
+					const
+						containers = getContainersForNode(this.node),
+						containerId = Spotlight.getActiveContainer(),
+						containerNode = getContainerNode(containerId),
+						isContainerMuted = containerNode && (containerNode.nodeType === 1) && containerNode.dataset.containerMuted;
+
+					if (!isContainerMuted && containers.indexOf(containerId) >= 0) {
 						Spotlight.focus(containerId);
 					}
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For resolving `ENYO-4858` issue ( focus is positioned out of viewport when the 5way key is triggered during wheel action), We stop wheel scroll animation.

During wheel action, if spottable Item is from the disabled state to enabled, spotlight restores focus.
Since the item is focused during wheel action, the scroll is stopped, so this issue is reproduced.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If the current container has muted as `true`, prevent to focus to the container. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4879

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>