### PR TITLE
ENYO-4628: Handle page up and down keys properly with disabled items in VirtualList/VirtualListNative

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -894,7 +894,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.animator.stop();
 			this.isScrollAnimationTargetAccumulated = false;
 			this.childRef.setContainerDisabled(false);
-			this.focusOnItem();
+			if (!this.childRef.getNodeIndexToBeFocused || !this.childRef.getNodeIndexToBeFocused()) {
+				this.focusOnItem();
+			}
 			this.lastFocusedItem = null;
 			this.lastScrollPositionOnFocus = null;
 			this.hideThumb();

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -894,9 +894,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.animator.stop();
 			this.isScrollAnimationTargetAccumulated = false;
 			this.childRef.setContainerDisabled(false);
-			if (!this.childRef.getNodeIndexToBeFocused || !this.childRef.getNodeIndexToBeFocused()) {
-				this.focusOnItem();
-			}
+			this.focusOnItem();
 			this.lastFocusedItem = null;
 			this.lastScrollPositionOnFocus = null;
 			this.hideThumb();
@@ -962,11 +960,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				} else {
 					if (typeof opt.index === 'number' && typeof this.childRef.getItemPosition === 'function') {
 						itemPos = this.childRef.getItemPosition(opt.index, opt.stickTo);
-						// If the first or the last item to the sticked direction is disabled,
-						// focus another item which is enabled.
-						if (opt.nodeIndexToBeFocused) {
-							this.childRef.setNodeIndexToBeFocused(opt.nodeIndexToBeFocused);
-						}
 					} else if (opt.node instanceof Object) {
 						if (opt.node.nodeType === 1 && typeof this.childRef.getNodePosition === 'function') {
 							itemPos = this.childRef.getNodePosition(opt.node);

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -810,11 +810,6 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				} else {
 					if (typeof opt.index === 'number' && typeof this.childRef.getItemPosition === 'function') {
 						itemPos = this.childRef.getItemPosition(opt.index, opt.stickTo);
-						// If the first or the last item to the sticked direction is disabled,
-						// focus another item which is enabled.
-						if (opt.nodeIndexToBeFocused) {
-							this.childRef.setNodeIndexToBeFocused(opt.nodeIndexToBeFocused);
-						}
 					} else if (opt.node instanceof Object) {
 						if (opt.node.nodeType === 1 && typeof this.childRef.getNodePosition === 'function') {
 							itemPos = this.childRef.getNodePosition(opt.node);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -838,7 +838,7 @@ class VirtualListCore extends Component {
 			}
 
 			// If there is the enabled item with the shortest distance from a current focus item
-			if (!data[i].disabled && (Math.abs(column - i % dimensionToExtent) < nextDistance || nextDistance === -1)) {
+			if (!data[i] && !data[i].disabled && (Math.abs(column - i % dimensionToExtent) < nextDistance || nextDistance === -1)) {
 				nextIndex = i;
 				nextDistance = Math.abs(column - i % dimensionToExtent);
 			}
@@ -853,30 +853,41 @@ class VirtualListCore extends Component {
 		return nextIndex;
 	}
 
+	findLastIndex = (array, callback) => {
+		const reverseIndex = [...array].reverse().findIndex(callback);
+		if (reverseIndex < 0) {
+			return reverseIndex;
+		}
+		return array.length - reverseIndex - 1;
+	}
+
+	checkEnabledItem = (item) => !item.disabled
+
 	getIndexForPageScroll = (direction, currentIndex) => {
 		const
 			{context, dimensionToExtent, isPrimaryDirectionVertical, moreInfo, primary} = this,
-			{data, dataSize, spacing} = this.props;
+			{data, dataSize, spacing} = this.props,
+			firstItemIndexExceptFirstLine = moreInfo.firstVisibleIndex + dimensionToExtent,
+			lastItemIndexExceptLastLine = moreInfo.lastVisibleIndex - (moreInfo.lastVisibleIndex % dimensionToExtent || dimensionToExtent),
+			firstItemIndexToBeJumpedForward = currentIndex - (currentIndex % dimensionToExtent) + dimensionToExtent,
+			lastItemIndexToBeJumpedBackward = currentIndex - (currentIndex % dimensionToExtent) - 1,
+			numOfItemsInPage = (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent);
 		let
 			factor = 1,
 			indexToJump,
 			hasEnabledItemInVirtualGridList = false,
-			firstItemIndexExceptFirstLine = moreInfo.firstVisibleIndex + dimensionToExtent,
-			lastItemIndexExceptLastLine = moreInfo.lastVisibleIndex - (moreInfo.lastVisibleIndex % dimensionToExtent || dimensionToExtent),
-			firstItemIndexToBeJumpedForward = currentIndex - (currentIndex % dimensionToExtent) + dimensionToExtent,
-			lastItemIndexToBeJumpedBackward = currentIndex - (currentIndex % dimensionToExtent) - 1;
+			nodeIndexToBeFocused;
 
 		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
 		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
-		// Check if there is any enabled item between a current item and the last visible item in VirtualGridList
-		// to make a decision to jump or to scroll.
+		// 1. Check if there is any enabled item in a current page of VirtualGridList.
 		// We don't have to check it in VirtualList because spotlight already did.
 		if (this.isItemSized) {
 			if (factor === 1 && currentIndex <= lastItemIndexExceptLastLine && firstItemIndexToBeJumpedForward <= moreInfo.lastVisibleIndex) {
-				hasEnabledItemInVirtualGridList = data.slice(firstItemIndexToBeJumpedForward, moreInfo.lastVisibleIndex + 1).some((item) => !item.disabled);
+				hasEnabledItemInVirtualGridList = data.slice(firstItemIndexToBeJumpedForward, moreInfo.lastVisibleIndex + 1).some(this.checkEnabledItem);
 			} else if (factor === -1 && firstItemIndexExceptFirstLine <= currentIndex && moreInfo.firstVisibleIndex <= lastItemIndexToBeJumpedBackward) {
-				hasEnabledItemInVirtualGridList = data.slice(moreInfo.firstVisibleIndex, lastItemIndexToBeJumpedBackward + 1).some((item) => !item.disabled);
+				hasEnabledItemInVirtualGridList = data.slice(moreInfo.firstVisibleIndex, lastItemIndexToBeJumpedBackward + 1).some(this.checkEnabledItem);
 			}
 		}
 
@@ -887,11 +898,11 @@ class VirtualListCore extends Component {
 			} else {
 				indexToJump = moreInfo.firstVisibleIndex;
 			}
-		// If a current focused item is stick to the first visible line or the last visible line of VirtualList, scroll the VirtualList without animation.
+		// 2. Check if there is any enabled item in a next page.
 		} else if (factor === 1) {
-			indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
+			indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + numOfItemsInPage);
 		} else {
-			indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
+			indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - numOfItemsInPage);
 		}
 
 		if (
@@ -903,15 +914,34 @@ class VirtualListCore extends Component {
 			return {scroll: 'stop'};
 		}
 
-		// If a current index is different from a new index and the item with the new index is disabled,
-		// try to find a next item which is enabled.
-		let nodeIndexToBeFocused = this.findEnableItemForPageScroll(
-			indexToJump > currentIndex,
-			indexToJump, currentIndex, data
-		);
+		if (Array.isArray(data)) {
+			// If a current index is different from a new index and the item with the new index is disabled,
+			// try to find a next item which is enabled.
+			nodeIndexToBeFocused = this.findEnableItemForPageScroll(
+				indexToJump > currentIndex,
+				indexToJump, currentIndex, data
+			);
+		} else {
+			nodeIndexToBeFocused = indexToJump;
+		}
 
+		// 3. Check if there is any enabled item after the next page
 		if (nodeIndexToBeFocused === -1) {
-			return {scroll: 'one page with animation'};
+			if (factor === 1) {
+				indexToJump = indexToJump + 1 + data.slice(indexToJump + 1, dataSize).findIndex(this.checkEnabledItem);
+				if (indexToJump !== -1) {
+					return {scroll: 'scroll without animation', indexToJump, nodeIndexToBeFocused: indexToJump};
+				} else {
+					return {scroll: 'stop'};
+				}
+			} else {
+				indexToJump = this.findLastIndex(data.slice(0, indexToJump), this.checkEnabledItem);
+				if (indexToJump !== -1) {
+					return {scroll: 'scroll without animation', indexToJump, nodeIndexToBeFocused: indexToJump};
+				} else {
+					return {scroll: 'stop'};
+				}
+			}
 		} else {
 			return {scroll: 'scroll without animation', indexToJump, nodeIndexToBeFocused};
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -820,13 +820,26 @@ class VirtualListCore extends Component {
 	}
 
 	findEnableItemForPageScroll = (isForward, indexFrom, indexTo, data) => {
-		let nextIndex = -1;
+		let
+			{dimensionToExtent} = this,
+			nextIndex = -1,
+			nextDistance = 99,
+			row = parseInt(indexFrom / dimensionToExtent);
+		const column = indexTo % dimensionToExtent;
 
 		if (isForward) {
 			for (let i = indexFrom; i < indexTo; i++) {
-				if (!data[i].disabled) {
-					nextIndex = i;
+				if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {
+					// If there is enabled items in a row, stop finding enabled items
 					break;
+				} else {
+					row = parseInt(i / dimensionToExtent);
+				}
+
+				// If there is the enabled item with the shortest distance from a current focus item
+				if (!data[i].disabled && Math.abs(column - i % dimensionToExtent) < nextDistance) {
+					nextIndex = i;
+					nextDistance = Math.abs(column - i % dimensionToExtent);
 				}
 			}
 
@@ -837,9 +850,17 @@ class VirtualListCore extends Component {
 			}
 		} else if (!isForward) {
 			for (let i = indexFrom; i > indexTo; i--) {
-				if (!data[i].disabled) {
-					nextIndex = i;
+				if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {
+					// If there is enabled items in a row, stop finding enabled items
 					break;
+				} else {
+					row = parseInt(i / dimensionToExtent);
+				}
+
+				// If there is the enabled item with the shortest distance from a current focus item
+				if (!data[i].disabled && Math.abs(column - i % dimensionToExtent) < nextDistance) {
+					nextIndex = i;
+					nextDistance = Math.abs(column - i % dimensionToExtent);
 				}
 			}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -863,7 +863,7 @@ class VirtualListCore extends Component {
 
 	checkEnabledItem = (item) => !item.disabled
 
-	getIndexForPageScroll = (direction, currentIndex) => {
+	getPageScrollInfoWithDisabledItem = (direction, currentIndex) => {
 		const
 			{context, dimensionToExtent, isPrimaryDirectionVertical, moreInfo, primary} = this,
 			{data, dataSize, spacing} = this.props,
@@ -914,16 +914,12 @@ class VirtualListCore extends Component {
 			return {scroll: 'stop'};
 		}
 
-		if (Array.isArray(data)) {
-			// If a current index is different from a new index and the item with the new index is disabled,
-			// try to find a next item which is enabled.
-			nodeIndexToBeFocused = this.findEnableItemForPageScroll(
-				indexToJump > currentIndex,
-				indexToJump, currentIndex, data
-			);
-		} else {
-			nodeIndexToBeFocused = indexToJump;
-		}
+		// If a current index is different from a new index and the item with the new index is disabled,
+		// try to find a next item which is enabled.
+		nodeIndexToBeFocused = this.findEnableItemForPageScroll(
+			indexToJump > currentIndex,
+			indexToJump, currentIndex, data
+		);
 
 		// 3. Check if there is any enabled item after the next page
 		if (nodeIndexToBeFocused === -1) {
@@ -947,12 +943,38 @@ class VirtualListCore extends Component {
 		}
 	}
 
+	getPageScrollInfoWithoutDisabledItem = (direction, currentIndex) => {
+		const
+			{context, dimensionToExtent, isPrimaryDirectionVertical, primary} = this,
+			{dataSize, spacing} = this.props,
+			numOfItemsInPage = Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent;
+		let
+			factor = 1,
+			indexToJump;
+
+		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
+		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
+
+		indexToJump = clamp(0, dataSize - 1, currentIndex + factor * numOfItemsInPage);
+
+		return {scroll: 'scroll without animation', indexToJump, nodeIndexToBeFocused: indexToJump};
+	}
+
 	scrollToNextPage = ({direction, focusedItem}) => {
 		const
+			{data} = this.props,
 			isRtl = this.context.rtl,
 			isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right'),
-			focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute)),
-			{scroll, indexToJump, nodeIndexToBeFocused} = this.getIndexForPageScroll(direction, focusedIndex);
+			focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute));
+		let pageScrollInfo;
+
+		if (Array.isArray(data) && data.some((item) => item.disabled)) {
+			pageScrollInfo = this.getPageScrollInfoWithDisabledItem(direction, focusedIndex);
+		} else {
+			pageScrollInfo = this.getPageScrollInfoWithoutDisabledItem(direction, focusedIndex);
+		}
+
+		const {scroll, indexToJump, nodeIndexToBeFocused} = pageScrollInfo;
 
 		if (scroll === 'one page with animation') {
 			return false; // Scroll one page with animation
@@ -964,16 +986,15 @@ class VirtualListCore extends Component {
 			// If the index to jump is disabled
 			focusedIndex !== nodeIndexToBeFocused && indexToJump !== nodeIndexToBeFocused
 		) {
-			if (!Spotlight.isPaused()) {
-				Spotlight.pause();
-			}
-
-			focusedItem.blur();
 			// To prevent item positioning issue, make all items to be rendered.
 			this.updateFrom = null;
 			this.updateTo = null;
 			// Scroll to the next spottable item without animation
 			if (nodeIndexToBeFocused !== -1) {
+				if (!Spotlight.isPaused()) {
+					Spotlight.pause();
+				}
+				focusedItem.blur();
 				this.setNodeIndexToBeFocused(nodeIndexToBeFocused);
 				this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', animate: false});
 			} else {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -872,12 +872,10 @@ class VirtualListCore extends Component {
 				indexToJump = moreInfo.firstVisibleIndex;
 			}
 		// If a current focused item is stick to the first visible line or the last visible line of VirtualList, scroll the VirtualList without animation.
+		} else if (factor === 1) {
+			indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
 		} else {
-			if (factor === 1) {
-				indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
-			} else {
-				indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
-			}
+			indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
 		}
 
 		if (

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -831,7 +831,7 @@ class VirtualListCore extends Component {
 
 		for (let i = indexFrom; i !== indexTo; i += delta) {
 			if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {
-				// If there is enabled items in a row, stop finding enabled items
+				// If there are enabled items in a row, stop finding enabled items
 				break;
 			} else {
 				row = parseInt(i / dimensionToExtent);
@@ -942,9 +942,9 @@ class VirtualListCore extends Component {
 			// Scroll to the next spottable item without animation
 			if (nodeIndexToBeFocused !== -1) {
 				this.setNodeIndexToBeFocused(nodeIndexToBeFocused);
-				this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+				this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', animate: false});
 			} else {
-				this.props.cbScrollTo({index: indexToJump, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+				this.props.cbScrollTo({index: indexToJump, stickTo: isForward ? 'end' : 'start', focus: true, animate: false});
 			}
 
 			return true; // Do not scroll additionally
@@ -1046,8 +1046,6 @@ class VirtualListCore extends Component {
 	setNodeIndexToBeFocused = (nextIndex) => {
 		this.nodeIndexToBeFocused = this.lastFocusedIndex = nextIndex;
 	}
-
-	getNodeIndexToBeFocused = () => this.nodeIndexToBeFocused
 
 	onKeyDown = (e) => {
 		const {keyCode, target} = e;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -860,25 +860,28 @@ class VirtualListCore extends Component {
 		let
 			factor = 1,
 			indexToJump,
-			hasEnabledItem;
-
-		// Check if there is any enabled item to the direction in VirtualGridList
-		// to make a decision to jump or to scroll.
-		// We don't have to check it in VirtualList because spotlight already did.
-		if (direction === 'up') {
-			hasEnabledItem = data.slice(currentIndex + 1, moreInfo.lastVisibleIndex).some((item) => !item.disabled);
-		} else {
-			hasEnabledItem = data.slice(moreInfo.firstVisibleIndex, currentIndex - 1).some((item) => !item.disabled);
-		}
+			hasEnabledItemInVirtualGridList = false,
+			firstItemIndexExceptFirstLine = moreInfo.firstVisibleIndex + dimensionToExtent,
+			lastItemIndexExceptLastLine = moreInfo.lastVisibleIndex - (moreInfo.lastVisibleIndex % dimensionToExtent || dimensionToExtent),
+			firstItemIndexToBeJumpedForward = currentIndex - (currentIndex % dimensionToExtent) + dimensionToExtent,
+			lastItemIndexToBeJumpedBackward = currentIndex - (currentIndex % dimensionToExtent) - 1;
 
 		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
 		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
+		// Check if there is any enabled item between a current item and the last visible item in VirtualGridList
+		// to make a decision to jump or to scroll.
+		// We don't have to check it in VirtualList because spotlight already did.
+		if (this.isItemSized) {
+			if (factor === 1 && currentIndex <= lastItemIndexExceptLastLine && firstItemIndexToBeJumpedForward <= moreInfo.lastVisibleIndex) {
+				hasEnabledItemInVirtualGridList = data.slice(firstItemIndexToBeJumpedForward, moreInfo.lastVisibleIndex + 1).some((item) => !item.disabled);
+			} else if (factor === -1 && firstItemIndexExceptFirstLine <= currentIndex && moreInfo.firstVisibleIndex <= lastItemIndexToBeJumpedBackward) {
+				hasEnabledItemInVirtualGridList = data.slice(moreInfo.firstVisibleIndex, lastItemIndexToBeJumpedBackward + 1).some((item) => !item.disabled);
+			}
+		}
+
 		// If a current focused item is not stick to the first visible line or the last visible line of VirtualGridList, jump to the line.
-		if (this.isItemSized && hasEnabledItem && (
-			factor === 1 && currentIndex <= (moreInfo.lastVisibleIndex - (moreInfo.lastVisibleIndex % dimensionToExtent || dimensionToExtent)) ||
-			factor === -1 && (moreInfo.firstVisibleIndex + (moreInfo.firstVisibleIndex % dimensionToExtent || dimensionToExtent)) <= currentIndex
-		)) {
+		if (hasEnabledItemInVirtualGridList) {
 			if (factor === 1) {
 				indexToJump = moreInfo.lastVisibleIndex;
 			} else {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -820,14 +820,14 @@ class VirtualListCore extends Component {
 	}
 
 	findEnableItemForPageScroll = (isIncreasingIndex, indexFrom, indexTo, data) => {
-		let
+		const
 			{dimensionToExtent} = this,
+			column = indexTo % dimensionToExtent,
+			delta = isIncreasingIndex ? -1 : 1;
+		let
 			nextIndex = -1,
 			nextDistance = -1,
 			row = parseInt(indexFrom / dimensionToExtent);
-		const
-			column = indexTo % dimensionToExtent,
-			delta = isIncreasingIndex ? -1 : 1;
 
 		for (let i = indexFrom; i !== indexTo; i += delta) {
 			if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -864,7 +864,7 @@ class VirtualListCore extends Component {
 		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
 		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
-		// If a currnet focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
+		// If a current focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
 		if (factor === 1 && currentIndex <= moreInfo.lastVisibleIndex - dimensionToExtent || factor === -1 && moreInfo.firstVisibleIndex + dimensionToExtent <= currentIndex) {
 			if (factor === 1) {
 				indexToJump = moreInfo.lastVisibleIndex;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -859,13 +859,26 @@ class VirtualListCore extends Component {
 			{data, dataSize, spacing} = this.props;
 		let
 			factor = 1,
-			indexToJump;
+			indexToJump,
+			hasEnabledItem;
+
+		// Check if there is any enabled item to the direction in VirtualGridList
+		// to make a decision to jump or to scroll.
+		// We don't have to check it in VirtualList because spotlight already did.
+		if (direction === 'up') {
+			hasEnabledItem = data.slice(currentIndex + 1, moreInfo.lastVisibleIndex).some((item) => !item.disabled);
+		} else {
+			hasEnabledItem = data.slice(moreInfo.firstVisibleIndex, currentIndex - 1).some((item) => !item.disabled);
+		}
 
 		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
 		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
-		// If a current focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
-		if (factor === 1 && currentIndex <= moreInfo.lastVisibleIndex - dimensionToExtent || factor === -1 && moreInfo.firstVisibleIndex + dimensionToExtent <= currentIndex) {
+		// If a current focused item is not stick to the first visible line or the last visible line of VirtualGridList, jump to the line.
+		if (this.isItemSized && hasEnabledItem && (
+			factor === 1 && currentIndex <= (moreInfo.lastVisibleIndex - (moreInfo.lastVisibleIndex % dimensionToExtent || dimensionToExtent)) ||
+			factor === -1 && (moreInfo.firstVisibleIndex + (moreInfo.firstVisibleIndex % dimensionToExtent || dimensionToExtent)) <= currentIndex
+		)) {
 			if (factor === 1) {
 				indexToJump = moreInfo.lastVisibleIndex;
 			} else {
@@ -927,7 +940,12 @@ class VirtualListCore extends Component {
 			this.updateFrom = null;
 			this.updateTo = null;
 			// Scroll to the next spottable item without animation
-			this.props.cbScrollTo({index: indexToJump, nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', focus: true, animate: false});
+			if (nodeIndexToBeFocused !== -1) {
+				this.setNodeIndexToBeFocused(nodeIndexToBeFocused);
+				this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+			} else {
+				this.props.cbScrollTo({index: indexToJump, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+			}
 
 			return true; // Do not scroll additionally
 		} else {

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -805,14 +805,14 @@ class VirtualListCoreNative extends Component {
 	}
 
 	findEnableItemForPageScroll = (isIncreasingIndex, indexFrom, indexTo, data) => {
-		let
+		const
 			{dimensionToExtent} = this,
+			column = indexTo % dimensionToExtent,
+			delta = isIncreasingIndex ? -1 : 1;
+		let
 			nextIndex = -1,
 			nextDistance = -1,
 			row = parseInt(indexFrom / dimensionToExtent);
-		const
-			column = indexTo % dimensionToExtent,
-			delta = isIncreasingIndex ? -1 : 1;
 
 		for (let i = indexFrom; i !== indexTo; i += delta) {
 			if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -804,37 +804,35 @@ class VirtualListCoreNative extends Component {
 		this.setRestrict(isSelfOnly);
 	}
 
-	findEnableItemForPageScroll = (isForward, indexFrom, indexTo, data) => {
-		let nextIndex = -1;
+	findEnableItemForPageScroll = (isIncreasingIndex, indexFrom, indexTo, data) => {
+		let
+			{dimensionToExtent} = this,
+			nextIndex = -1,
+			nextDistance = -1,
+			row = parseInt(indexFrom / dimensionToExtent);
+		const
+			column = indexTo % dimensionToExtent,
+			delta = isIncreasingIndex ? -1 : 1;
 
-		if (isForward) {
-			for (let i = indexFrom; i < indexTo; i++) {
-				if (!data[i].disabled) {
-					nextIndex = i;
-					break;
-				}
-			}
-
-			// If there is no item which could get focus forward,
-			// we need to set restriction option to `self-first`.
-			if (nextIndex === -1) {
-				this.setRestrict(false);
-			}
-		} else if (!isForward) {
-			for (let i = indexFrom; i > indexTo; i--) {
-				if (!data[i].disabled) {
-					nextIndex = i;
-					break;
-				}
+		for (let i = indexFrom; i !== indexTo; i += delta) {
+			if (parseInt(i / dimensionToExtent) !== row && nextIndex !== -1) {
+				// If there is enabled items in a row, stop finding enabled items
+				break;
+			} else {
+				row = parseInt(i / dimensionToExtent);
 			}
 
-			// If there is no item which could get focus backward,
-			// we need to set restriction option to `self-first`.
-			if (indexTo === 0 && nextIndex === -1) {
-				this.setRestrict(false);
+			// If there is the enabled item with the shortest distance from a current focus item
+			if (!data[i].disabled && (Math.abs(column - i % dimensionToExtent) < nextDistance || nextDistance === -1)) {
+				nextIndex = i;
+				nextDistance = Math.abs(column - i % dimensionToExtent);
 			}
-		} else {
-			return -1;
+		}
+
+		// If there is no item which could get focus,
+		// we need to set restriction option to `self-first`.
+		if (nextIndex === -1) {
+			this.setRestrict(false);
 		}
 
 		return nextIndex;
@@ -842,14 +840,30 @@ class VirtualListCoreNative extends Component {
 
 	getIndexForPageScroll = (direction, currentIndex) => {
 		const
-			{context, dimensionToExtent, isPrimaryDirectionVertical, primary} = this,
+			{context, dimensionToExtent, isPrimaryDirectionVertical, moreInfo, primary} = this,
 			{data, dataSize, spacing} = this.props;
-		let offsetIndex = Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent;
+		let
+			factor = 1,
+			indexToJump;
 
-		offsetIndex *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
-		offsetIndex *= (direction === 'down' || direction === 'right') ? 1 : -1;
+		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
+		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
-		let indexToJump = clamp(0, dataSize - 1, currentIndex + offsetIndex);
+		// If a currnet focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
+		if (factor === 1 && currentIndex <= moreInfo.lastVisibleIndex - dimensionToExtent || factor === -1 && moreInfo.firstVisibleIndex + dimensionToExtent <= currentIndex) {
+			if (factor === 1) {
+				indexToJump = moreInfo.lastVisibleIndex;
+			} else {
+				indexToJump = moreInfo.firstVisibleIndex;
+			}
+		// If a current focused item is stick to the first visible line or the last visible line of VirtualList, scroll the VirtualList without animation.
+		} else {
+			if (factor === 1) {
+				indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
+			} else {
+				indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
+			}
+		}
 
 		if (
 			// If a currnet index is same as a new index.
@@ -863,7 +877,7 @@ class VirtualListCoreNative extends Component {
 		// If a current index is different from a new index and the item with the new index is disabled,
 		// try to find a next item which is enabled.
 		let nodeIndexToBeFocused = this.findEnableItemForPageScroll(
-			indexToJump < currentIndex,
+			indexToJump > currentIndex,
 			indexToJump, currentIndex, data
 		);
 
@@ -876,6 +890,7 @@ class VirtualListCoreNative extends Component {
 
 	scrollToNextPage = ({direction, focusedItem}) => {
 		const
+			{moreInfo} = this,
 			isRtl = this.context.rtl,
 			isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right'),
 			focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute)),
@@ -891,17 +906,22 @@ class VirtualListCoreNative extends Component {
 			// If the index to jump is disabled
 			focusedIndex !== nodeIndexToBeFocused && indexToJump !== nodeIndexToBeFocused
 		) {
-			if (!Spotlight.isPaused()) {
-				Spotlight.pause();
-			}
-
 			const nodeToBeFocused = this.contentRef.querySelector(`[data-index='${nodeIndexToBeFocused}'].spottable`);
 
 			if (nodeToBeFocused) {
 				nodeToBeFocused.focus();
 
-				this.props.cbScrollTo({index: indexToJump, focus: false, animate: false});
+				if (nodeIndexToBeFocused < moreInfo.firstVisibleIndex || nodeIndexToBeFocused > moreInfo.lastVisibleIndex) {
+					if (!Spotlight.isPaused()) {
+						Spotlight.pause();
+					}
+					this.props.cbScrollTo({index: indexToJump, focus: false, animate: false});
+				}
 			} else {
+				if (!Spotlight.isPaused()) {
+					Spotlight.pause();
+				}
+
 				// Scroll to the next spottable item without animation
 				focusedItem.blur();
 				// To prevent item positioning issue, make all items to be rendered.
@@ -1010,6 +1030,8 @@ class VirtualListCoreNative extends Component {
 	setNodeIndexToBeFocused = (nextIndex) => {
 		this.nodeIndexToBeFocused = this.lastFocusedIndex = nextIndex;
 	}
+
+	getNodeIndexToBeFocused = () => this.nodeIndexToBeFocused
 
 	onKeyDown = (e) => {
 		const {keyCode, target} = e;

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -857,12 +857,10 @@ class VirtualListCoreNative extends Component {
 				indexToJump = moreInfo.firstVisibleIndex;
 			}
 		// If a current focused item is stick to the first visible line or the last visible line of VirtualList, scroll the VirtualList without animation.
+		} else if (factor === 1) {
+			indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
 		} else {
-			if (factor === 1) {
-				indexToJump = clamp(0, dataSize - 1, moreInfo.lastVisibleIndex + (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
-			} else {
-				indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
-			}
+			indexToJump = clamp(0, dataSize - 1, moreInfo.firstVisibleIndex - (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent));
 		}
 
 		if (

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -849,7 +849,7 @@ class VirtualListCoreNative extends Component {
 		factor *= !isPrimaryDirectionVertical && context.rtl ? -1 : 1;
 		factor *= (direction === 'down' || direction === 'right') ? 1 : -1;
 
-		// If a currnet focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
+		// If a current focused item is not stick to the first visible line or the last visible line of VirtualList, jump to the line.
 		if (factor === 1 && currentIndex <= moreInfo.lastVisibleIndex - dimensionToExtent || factor === -1 && moreInfo.firstVisibleIndex + dimensionToExtent <= currentIndex) {
 			if (factor === 1) {
 				indexToJump = moreInfo.lastVisibleIndex;

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -822,7 +822,7 @@ class VirtualListCoreNative extends Component {
 				row = parseInt(i / dimensionToExtent);
 			}
 
-			// If there is the enabled item with the shortest distance from a current focus item
+			// If there are the enabled item with the shortest distance from a current focus item
 			if (!data[i].disabled && (Math.abs(column - i % dimensionToExtent) < nextDistance || nextDistance === -1)) {
 				nextIndex = i;
 				nextDistance = Math.abs(column - i % dimensionToExtent);
@@ -940,9 +940,9 @@ class VirtualListCoreNative extends Component {
 				// Scroll to the next spottable item without animation
 				if (nodeIndexToBeFocused !== -1) {
 					this.setNodeIndexToBeFocused(nodeIndexToBeFocused);
-					this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+					this.props.cbScrollTo({index: nodeIndexToBeFocused, stickTo: isForward ? 'end' : 'start', animate: false});
 				} else {
-					this.props.cbScrollTo({index: indexToJump, stickTo: isForward ? 'end' : 'start', focus: false, animate: false});
+					this.props.cbScrollTo({index: indexToJump, stickTo: isForward ? 'end' : 'start', focus: true, animate: false});
 				}
 			}
 
@@ -1045,8 +1045,6 @@ class VirtualListCoreNative extends Component {
 	setNodeIndexToBeFocused = (nextIndex) => {
 		this.nodeIndexToBeFocused = this.lastFocusedIndex = nextIndex;
 	}
-
-	getNodeIndexToBeFocused = () => this.nodeIndexToBeFocused
 
 	onKeyDown = (e) => {
 		const {keyCode, target} = e;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is a VirtualList/VirtualListNative with disabled items.

Case 1) If a current focused item was not stick to the first visible line or the last visible line of VirtualList, the VirtualList did not jump to the first or last visible line and did scroll without animation.

Case 2) A VirtualList focused the wrong item when starting scrolling without animation.

Case 3) A VirtualList did not focus an item properly via page up and down keys.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Case 1) Try to stick to the first or last line first, then try to scroll

Case 2) When starting scrolling, the VirtualList tried to focus the item with index. If not needed, skip focusing an item.

Case 3) Instead of finding an enabled item linearly, try to find an enabled item which is close to a current item

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-4628

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)