### PR TITLE
Use stable NPM release (master branch) of enact-dev for tests on rele…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "node"
 sudo: false
 install:
-    - npm install -g enyojs/enact-dev#develop
+    - npm install -g enact-dev
     - npm install
     - npm run bootstrap
 script:


### PR DESCRIPTION
…ase/1.x and master to isolate from any 2.x changes on enact-dev#develop

### Issue Resolved / Feature Added
* Travis using tests against `enact-dev#develop` but should be using stable release for `release/1.x` and `master` to avoid experimental changes in 2.x.

### Resolution
* Use Stable NPM release (master)

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>