### PR TITLE
ENYO-4825: Add imperative API to unmount all floating layers

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -884,9 +884,15 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	setFloatingLayerShowing = (showing) => {
-		const layer = this.context.getFloatingLayer && this.context.getFloatingLayer();
-		if (layer) {
-			layer.style.display = showing ? 'block' : 'none';
+		if (this.context.getFloatingLayer) {
+			const layer = this.context.getFloatingLayer();
+			if (layer) {
+				layer.style.display = showing ? 'block' : 'none';
+			}
+		}
+
+		if (!showing && this.context.unmountFloatingLayers) {
+			this.context.unmountFloatingLayers();
 		}
 	}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -890,15 +890,8 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	setFloatingLayerShowing = (showing) => {
-		if (this.context.getFloatingLayer) {
-			const layer = this.context.getFloatingLayer();
-			if (layer) {
-				layer.style.display = showing ? 'block' : 'none';
-			}
-		}
-
-		if (!showing && this.context.unmountFloatingLayers) {
-			this.context.unmountFloatingLayers();
+		if (!showing && this.context.unmountAllFromFloatingLayer) {
+			this.context.unmountAllFromFloatingLayer();
 		}
 	}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -759,7 +759,13 @@ const VideoPlayerBase = class extends React.Component {
 			this.reloadVideo();
 		}
 
-		this.setFloatingLayerShowing(this.state.mediaControlsVisible || this.state.mediaSliderVisible);
+		if (
+			prevState.mediaControlsVisible !== this.state.mediaControlsVisible ||
+			prevState.mediaSliderVisible !== this.state.mediaSliderVisible
+		) {
+			const showing = this.state.mediaControlsVisible || this.state.mediaSliderVisible;
+			this.setFloatingLayerShowing(showing);
+		}
 
 		// Added to set default focus on the media control (play) when controls become visible.
 		if (

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
+- `ui/FloatingLayerDecorator` imperative API for hiding all floating layers it owns
+
 ### Changed
 
 ### Fixed

--- a/packages/ui/FloatingLayer/FloatingLayerDecorator.js
+++ b/packages/ui/FloatingLayer/FloatingLayerDecorator.js
@@ -5,10 +5,12 @@
 import hoc from '@enact/core/hoc';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 const contextTypes = {
 	getFloatingLayer: PropTypes.func,
-	getRootFloatingLayer: PropTypes.func
+	getRootFloatingLayer: PropTypes.func,
+	unmountFloatingLayers: PropTypes.func
 };
 
 /**
@@ -61,8 +63,20 @@ const FloatingLayerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		getChildContext () {
 			return {
 				getFloatingLayer: this.getFloatingLayer,
-				getRootFloatingLayer: this.getRootFloatingLayer
+				getRootFloatingLayer: this.getRootFloatingLayer,
+				unmountFloatingLayers: this.unmountFloatingLayers
 			};
+		}
+
+		unmountFloatingLayers = () => {
+			const layer = this.getFloatingLayer();
+
+			if (layer) {
+				for (let i = 0; i < layer.children.length; i++) {
+					const child = layer.children.item(i);
+					ReactDOM.unmountComponentAtNode(child);
+				}
+			}
 		}
 
 		getFloatingLayer = () => {


### PR DESCRIPTION
When FloatingLayerDecorator is used within a subtree of the app, the
app/component may want to unmount all floating layers it owns (e.g. if it
is hiding all layers as in moonstone/VideoPlayer).

This change adds a new imperative API available, unmountFloatingLayers, via
context to support this.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)