### PR TITLE
ENYO-4913: Fix overlapping tall glyphs in Header for both latin and non-latin

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,7 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` to scroll correctly using page down key with disabled items
 - `moonstone/Scrollable` to not cause a script error when scrollbar is not rendered
 - `moonstone/Picker` incrementer and decrementer to not change size when focused
-- `moonstone/Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai
+- `moonstone/Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai, as well as latin locales
 - `moonstone/Scroller` and `moonstone/VirtualList` to keep spotlight when pressing a 5-way control while scrolling
 - `moonstone/Panels` to prevent user interaction with panel contents during transition
 - `moonstone/Slider` and related components to correctly position knob for `detachedKnob` on mouse down and fire value where mouse was positioned on mouse up

--- a/packages/moonstone/Panels/Header.less
+++ b/packages/moonstone/Panels/Header.less
@@ -60,12 +60,9 @@
 			.moon-locale-non-latin({line-height: @moon-non-latin-medium-header-line-height;});
 		}
 
-		.titleBelow {
-			line-height: 48px;
-		}
-
+		.titleBelow,
 		.subTitleBelow {
-			line-height: 45px;
+			line-height: 1.4em;
 		}
 	}
 


### PR DESCRIPTION
…which should work for both latin and non-latin

### Issue Resolved / Feature Added
`titleBelow` with tall glyphs in latin collide with the `title`. :bummer:

### Resolution
Update the `line-height` setting to be not only a relative unit, but one that more tightly fits the tallest (known) glyph ascenders and descenders in both latin and non-latin.