### PR TITLE
Revert "ENYO-4314: Fix rendering views available on mount with children (#1293)"

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Remeasurable` to update on every trigger change
-- `ui/ViewManager` to suppress `enteringProp` for views that are rendered at mount
+
 
 ## [1.12.1] - 2017-11-07
 

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -113,7 +113,7 @@ class View extends React.Component {
 		this.animation = null;
 		this._raf = null;
 		this.state = {
-			entering: false
+			entering: true
 		};
 	}
 
@@ -157,9 +157,9 @@ class View extends React.Component {
 		}
 	}
 
-	setEntering () {
+	componentDidAppear () {
 		this.setState({
-			entering: true
+			entering: false
 		});
 	}
 
@@ -168,8 +168,6 @@ class View extends React.Component {
 	// will not be called on the initial render of a TransitionGroup.
 	componentWillEnter (callback) {
 		const {arranger, reverseTransition} = this.props;
-		this.setEntering();
-
 		if (arranger) {
 			this.prepareTransition(reverseTransition ? arranger.leave : arranger.enter, callback);
 		} else {


### PR DESCRIPTION
This reverts commit 283dc3cdc2c8409223cfb1c9b5f603a142ef15e9.