### PR TITLE
ENYO-4314: Fix rendering views available on mount with children

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -28,6 +28,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 ## Removed
 
 - `ui/Holdable` and `ui/Pressable` which were replaced by `ui/Touchable`
+- `ui/Remeasurable` to update on every trigger change
+- `ui/ViewManager` to suppress `enteringProp` for views that are rendered at mount
 
 ## [1.12.1] - 2017-11-07
 

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -113,7 +113,7 @@ class View extends React.Component {
 		this.animation = null;
 		this._raf = null;
 		this.state = {
-			entering: true
+			entering: false
 		};
 	}
 
@@ -157,9 +157,9 @@ class View extends React.Component {
 		}
 	}
 
-	componentDidAppear () {
+	setEntering () {
 		this.setState({
-			entering: false
+			entering: true
 		});
 	}
 
@@ -168,6 +168,8 @@ class View extends React.Component {
 	// will not be called on the initial render of a TransitionGroup.
 	componentWillEnter (callback) {
 		const {arranger, reverseTransition} = this.props;
+		this.setEntering();
+
 		if (arranger) {
 			this.prepareTransition(reverseTransition ? arranger.leave : arranger.enter, callback);
 		} else {


### PR DESCRIPTION
The prior implementation assuming views would be entering at construction and cleared the state when appearing or entering completed. This caused appearing panels to have a two renders to show children. In some cases (e.g. on slow hardware), this could happen across frames causing the unexpected side-effects such as moonstone/Panels.Panel fading in when the visible class was added.

This change reverses the assumption and only sets the entering state when entering removing the extra render or appearing panels while still supporing the prior behavior of setting the enteringProp when entering completed.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)