### PR TITLE
ENYO-4700: not to read out button label after media controller is hidden

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VideoPlayer` to not read out button label when media control is hidden after timeout
 - `moonstone/Expandable` and derivatives to use the new `ease-out-quart` animation timing function to better match the aesthetic of Enyo's Expandables
 
 ## [1.12.2] - 2017-11-15

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1853,6 +1853,7 @@ const VideoPlayerBase = class extends React.Component {
 							{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
 						</FeedbackContent>
 						<Container
+							aria-hidden={!this.state.mediaControlsVisible}
 							className={css.bottom + (this.state.mediaControlsVisible ? '' : ' ' + css.hidden)}
 							spotlightDisabled={!this.state.mediaControlsVisible || spotlightDisabled}
 						>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The last focused label is read out when media controller is hidden after timeout (5000ms).
When media controller is hidden, the focus is moved to spottableDiv in `componentWillUpdate`.
However, in `componentDidUpdate`, the current spotted element is last focused button before setting focus to spottableDiv. I tried to find any logic, sets focus to last focused button again, but I couldn't find it. It maybe is not applied setting code of `componentWillUpdate`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set {{aria-hidden}} as true when the controller is hidden.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We need to know why last focused button has a focus in `componentDidUpdate()`. 
In `componentWillUpdate()`, spottableDiv has a focus. Also, in `render()`, spottableDiv has a focus.

### Links
[//]: # (Related issues, references)
ENYO-4700

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>