### PR TITLE
Use develop branch of enact-dev on 2.x develop branch of enact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "node"
 sudo: false
 install:
-    - npm install -g enact-dev
+    - npm install -g enyojs/enact-dev#develop
     - npm install
     - npm run bootstrap
 script:


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Need to update 2.x `develop` stream to use enact-dev `develop` in tests/linting


### Resolution
* Restores `enact-dev#develop` in travis.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
