### PR TITLE
ENYO-4750:  VideoPlayer load video faster

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,8 +7,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 ### Changed
-- `moonstone/VideoPlayer` to initially renderBottomControls when `onPlay` instead of `componentDidMount`, 
-- `moonstone/VideoPlayer` to run `DurationFmt` asynchronously
 
 ### Fixed
 
@@ -24,6 +22,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to correctly position knob when interacting with media slider
 - `moonstone/VideoPlayer` to not read out the focused button when the media controls hide
 - `moonstone/MarqueeDecorator` to stop when unhovering a disabled component using `marqueeOn` `'focus'`
+- `moonstone/VideoPlayer` loading speed by deferring several blocking tasks
 
 ## [1.12.2] - 2017-11-15
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -786,7 +786,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopListeningForPulses();
 		this.sliderTooltipTimeJob.stop();
 		this.slider5WayPressJob.stop();
-		this.setDurFmt.stop();
+		this.setDurationFormat.stop();
 	}
 
 	//
@@ -828,11 +828,11 @@ const VideoPlayerBase = class extends React.Component {
 		if (this.locale !== locale && typeof window === 'object') {
 			this.locale = locale;
 
-			this.setDurFmt.idle();
+			this.setDurationFormat.idle();
 		}
 	}
 
-	setDurFmt = new Job(() => {
+	setDurationFormat = new Job(() => {
 		this.durfmt = new DurationFmt({length: 'medium', style: 'clock', useNative: false});
 	})
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Video player was taking a while to load and play the video


### Resolution
Moved all things that blocked `loadstart` and `play` to load afterward to prevent load blocking. Seems to have a big improvement on TV.


### Links
ENYO-4750

