### PR TITLE
ENYO-4916: Fix MarqueeDecorator internal focus state

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -21,7 +21,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` by removing unnecessary repaints to the screen
 - `moonstone/VideoPlayer` to correctly position knob when interacting with media slider
 - `moonstone/VideoPlayer` to not read out the focused button when the media controls hide
-- `moonstone/MarqueeDecorator` to stop when unhovering a disabled component using `marqueeOn` `'focus'`
+- `moonstone/MarqueeDecorator` to correctly stop or continue when a focused `marqueeOn` `'focus'` component becomes disabled
 
 ## [1.12.2] - 2017-11-15
 

--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -303,7 +303,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.context.enter(this);
 			} else if (!this.props.disabled && next.disabled && this.isFocused) {
 				this.isFocused = false;
-				if (!this.sync && !this.isHovered) {
+				if (!this.isHovered) {
 					this.cancelAnimation();
 				}
 			}

--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -301,6 +301,11 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.cancelAnimation();
 			} else if (next.disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
+			} else if (!this.props.disabled && next.disabled && this.isFocused) {
+				this.isFocused = false;
+				if (!this.sync && !this.isHovered) {
+					this.cancelAnimation();
+				}
 			}
 		}
 
@@ -374,7 +379,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			return (
 				this.forceRestartMarquee ||
 				!this.sync && (
-					(this.isFocused && marqueeOn === 'focus' && !disabled) ||
+					(this.isFocused && marqueeOn === 'focus') ||
 					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus' && disabled))
 				)
 			);


### PR DESCRIPTION
### Issue Resolved / Feature Added
The internal state of `MarqueeDecorator` can be wrong within a focused control that becomes disabled, resulting in the marquee starting or continuing when it should be stopped.


### Resolution
Update the internal state of the component when it receives props to be disabled. This seems to be the most straight-forward and least intrusive solution for this issue.


### Additional Considerations
There is an alternative fix that involves updating the state when an `onSpotlightDisappear` event is emitted. I've opted against this for the time being due to various factors.

There is a [related bug](https://github.com/facebook/react/issues/9142) where a disabled component will not emit a `blur` event. While we cannot use blur to update internal state in `MarqueeDecorator`, we could use `onSpotlightDisappear`. However, updating the internal state based on that event could be problematic as `Spottable` does not update its own internal state in this case - meaning the internal "spotted" state would be out-of-sync between `MarqueeDecorator` and `Spottable`. Focused `Spottable` controls that become disabled still retain an internal spotted state in `Spottable`, which ultimately affect when `onSpotlightDisappear` events are emitted. I could update this `Spottable` behavior as well, but it's a) much more intrusive and impacts many more components and b) could cause issues if/when the blur issue is resolved.

I'm open to input/discussion.


Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
