### PR TITLE
Updated Checkbox to use Toggleable instead of its own approach

### DIFF
--- a/packages/moonstone/Checkbox/Checkbox.js
+++ b/packages/moonstone/Checkbox/Checkbox.js
@@ -5,10 +5,10 @@
  */
 
 import kind from '@enact/core/kind';
-import {handle, forward} from '@enact/core/handle';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Pure from '@enact/ui/internal/Pure';
+import Toggleable from '@enact/ui/Toggleable';
 
 import Icon from '../Icon';
 import Skinnable from '../Skinnable';
@@ -67,16 +67,6 @@ const CheckboxBase = kind({
 		className: 'checkbox'
 	},
 
-	handlers: {
-		onToggle: handle(
-			forward('onClick'),
-			(ev, {selected, onToggle}) => {
-				if (onToggle) {
-					onToggle({selected: !selected});
-				}
-			}
-		)
-	},
 
 	computed: {
 		className: ({selected, styler}) => styler.append({selected})
@@ -94,8 +84,11 @@ const CheckboxBase = kind({
 });
 
 const Checkbox = Pure(
-	Skinnable(
-		CheckboxBase
+	Toggleable(
+		{prop: 'selected'},
+		Skinnable(
+			CheckboxBase
+		)
 	)
 );
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
`Checkbox` is so old that it implements its own technique for Toggleable


### Resolution
Converts `Checkbox` to use the standard `Toggleable` HOC for its selected state.