### PR TITLE
PLAT-47659: Handle global iLib data objects in Enact loading

### DIFF
--- a/packages/i18n/locale/locale.js
+++ b/packages/i18n/locale/locale.js
@@ -8,7 +8,6 @@
 
 import ilib from '../ilib/lib/ilib';
 import LocaleInfo from '../ilib/lib/LocaleInfo';
-import ResBundle from '../ilib/lib/ResBundle';
 import ScriptInfo from '../ilib/lib/ScriptInfo';
 
 import {initCaseMappers} from '../src/case';
@@ -83,8 +82,6 @@ const updateLocale = function (locale) {
 	delete ilib._platform;
 	// load any external ilib data
 	ilib.data = global.ilibData || ilib.data;
-	ResBundle.strings = ResBundle.strings || {};
-	ResBundle.strings.cache = global.resBundleData || ResBundle.strings.cache;
 	// ilib handles falsy values and automatically uses local locale when encountered which
 	// is expected and desired
 	ilib.setLocale(locale);

--- a/packages/i18n/src/resBundle.js
+++ b/packages/i18n/src/resBundle.js
@@ -39,6 +39,10 @@ function createResBundle (locale) {
  * @returns {undefined}
  */
 function setResBundleLocale (spec) {
+	// Load any ResBundle external data into cache.
+	ResBundle.strings = ResBundle.strings || {};
+	ResBundle.strings.cache = global.resBundleData || ResBundle.strings.cache;
+	// Get active bundle and if needed, (re)initialize.
 	const locale = new Locale(spec);
 	const rb = getResBundle();
 	if (!rb || spec !== rb.getLocale().getSpec()) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Need to support external iLib data bundles


### Resolution
* Loads core iLib data bundle from `global.ilibData` and ResBundle string data from `global.resBundleData` within our `@enact/i18n` before any iLib APIs are invoked.
* The result is that no XHR is needed if the correct iLib core data and restbundle data is present in memory (otherwise normal XHR procedure follows).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>