### PR TITLE
ENYO-4957: revert PR #1247 to show scroll thumbs properly when scroll position reaches the top or the bottom

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scrollbar` to show its thumb properly when scroll position reaches the top or the bottom by paging controls
+
+### Changed
+
+- `moonstone/Scrollbar` not to hide scroll thumb immediately after scroll position reaches the top or the bottom
+
 ## [1.13.1] - 2017-12-06
 
 ### Fixed

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -216,10 +216,6 @@ class ScrollbarBase extends PureComponent {
 			shouldDisableNextButton = maxPos - currentPos <= 1,
 			spotItem = Spotlight.getCurrent();
 
-		if (currentPos <= 0 || currentPos >= maxPos) {
-			this.startHidingThumb();
-		}
-
 		this.setState((prevState) => {
 			const
 				updatePrevButton = (prevState.prevButtonDisabled !== shouldDisablePrevButton),


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In ENYO-4790, We hide scroll thumb immediately when scrollbar button is disabled. 
However, this code prevents thumbs to be displayed when a user presses paging controls repeatedly regardless of automatic focus moving.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reverted ENYO-4790 changes. We discussed ENYO-4790 issue again. And we concluded ENYO-4957 is a bug but ENYO-4790 maybe not.

### Links
[//]: # (Related issues, references)
ENYO-4957

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim (bongsub.kim@lgepartner.com)