### PR TITLE
ENYO-4966: Fix Panels losing focus when cancelling mid-transition

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scrollable` to not show scroll thumb when only child item is updated
 - `moonstone/Scrollbar` to show its thumb properly when scroll position reaches the top or the bottom by paging controls
 - `moonstone/Slider` to handle updates to its `value` prop correctly
+- `moonstone/Panels` to not accept back key presses during transition
 
 ### Changed
 

--- a/packages/moonstone/Panels/CancelDecorator.js
+++ b/packages/moonstone/Panels/CancelDecorator.js
@@ -2,6 +2,8 @@ import hoc from '@enact/core/hoc';
 import Cancelable from '@enact/ui/Cancelable';
 import Spotlight from '@enact/spotlight';
 
+import css from './Panels.less';
+
 const defaultConfig = {
 	cancel: null
 };
@@ -11,7 +13,8 @@ const CancelDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 	function handleCancel (props) {
 		const {index, [cancel]: handler} = props;
-		if (index > 0 && handler) {
+
+		if (index > 0 && handler && !document.querySelector(`.${css.transitioning}`)) {
 			// clear Spotlight focus
 			const current = Spotlight.getCurrent();
 			if (current) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Panels loses spotlight when going back immediately after starting transition.


### Resolution
We looked at Enyo, and Enyo doesn't allow key presses on transitions. So we've taken out the ability to cancel or go back during a transition.

### Additional Considerations
In the future, we will address something more permanent to resolve the async nature of `ViewManager`.

### Links
ENYO-4966

Enact-DCO-1.0-Signed-off-by: Derek Tor (derek.tor@lge.com)
