### PR TITLE
ENYO-4968: hide scroll thumb when it is scrolled on zero or max position

### DIFF
--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -407,7 +407,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				canScrollVertically = this.canScrollVertically(bounds),
 				eventDeltaMode = e.deltaMode,
 				eventDelta = (-e.wheelDeltaY || e.deltaY);
-			let delta = 0;
+			let
+				delta = 0,
+				needToHideThumb = false;
 
 			this.lastFocusedItem = null;
 			if (typeof window !== 'undefined') {
@@ -429,7 +431,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					if ((horizontalScrollbarRef && horizontalScrollbarRef.containerRef.contains(e.target)) ||
 						(verticalScrollbarRef && verticalScrollbarRef.containerRef.contains(e.target))) {
 						delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+						needToHideThumb = !delta;
 					}
+				} else {
+					needToHideThumb = true;
 				}
 			} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 				if (eventDelta < 0 && this.scrollLeft > 0 || eventDelta > 0 && this.scrollLeft < bounds.maxLeft) {
@@ -438,6 +443,9 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						this.isWheeling = true;
 					}
 					delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+					needToHideThumb = !delta;
+				} else {
+					needToHideThumb = true;
 				}
 			}
 
@@ -451,6 +459,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 					this.pageDirection = direction;
 				}
 				this.scrollToAccumulatedTarget(delta, canScrollVertically);
+			}
+
+			if (needToHideThumb) {
+				this.hideThumbJob.start();
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Native list hides scroll thumb after it gets a scroll event. However, If current scroll position is zero or max, scroll event handler is not called because it isn't scrolled.
The wheel handler shows scrollThumb, but it can't hide scrollThumb because scroll event handler is not called.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If Native list can't wheel scroll, it makes hide scrollThumb.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-4968

### Comments
Enact-DCO-1.0-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>