### PR TITLE
ENYO-4806: Focus a list item when creaing it

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -618,26 +618,13 @@ class VirtualListCoreNative extends Component {
 		this.composeStyle(style, ...rest);
 
 		this.cc[key] = React.cloneElement(itemElement, {
-			ref: (index === this.nodeIndexToBeFocused) ? (ref) => this.focusOnNode(ref, index) : null,
 			className: classNames(cssItem.listItem, itemElement.props.className),
 			['data-preventscrollonfocus']: true, // Added this attribute to prevent scroll on focus by browser
 			style: {...itemElement.props.style, ...style}
 		});
-	}
 
-	focusOnNode = (ref, index) => {
-		if (ref) {
-			const node = this.containerRef.querySelector(`[data-index='${index}'].spottable`);
-
-			if (Spotlight.isPaused()) {
-				Spotlight.resume();
-				this.forceUpdate();
-			}
-
-			if (node) {
-				Spotlight.focus(node);
-			}
-			this.nodeIndexToBeFocused = null;
+		if (index === this.nodeIndexToBeFocused) {
+			this.focusByIndex(index);
 		}
 	}
 
@@ -744,6 +731,25 @@ class VirtualListCoreNative extends Component {
 		return (Math.ceil(curDataSize / dimensionToExtent) * primary.gridSize) - spacing;
 	}
 
+	focusByIndex = (index) => {
+		// We have to focus node async for now since list items are not yet ready when it reaches componentDid* lifecycle methods
+		setTimeout(() => {
+			const item = this.contentRef.querySelector(`[data-index='${index}'].spottable`);
+
+			if (Spotlight.isPaused()) {
+				Spotlight.resume();
+			}
+			this.focusOnNode(item);
+			this.nodeIndexToBeFocused = null;
+		}, 0);
+	}
+
+	focusOnNode = (node) => {
+		if (node) {
+			Spotlight.focus(node);
+		}
+	}
+
 	setLastFocusedIndex = (item) => {
 		this.lastFocusedIndex = Number.parseInt(item.getAttribute(dataIndexAttribute));
 	}
@@ -814,10 +820,6 @@ class VirtualListCoreNative extends Component {
 			safeIndexFrom = clamp(0, dataSize - 1, indexFrom),
 			safeIndexTo = clamp(-1, dataSize, indexTo),
 			delta = (indexFrom < indexTo) ? 1 : -1;
-
-		if (indexFrom < 0 && indexTo < 0 || indexFrom >= dataSize && indexTo >= dataSize) {
-			return -1;
-		}
 
 		if (safeIndexFrom !== safeIndexTo) {
 			for (let i = safeIndexFrom; i !== safeIndexTo; i += delta) {
@@ -921,8 +923,7 @@ class VirtualListCoreNative extends Component {
 	scrollToNextItem = ({direction, focusedItem}) => {
 		const
 			{data} = this.props,
-			focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute)),
-			{firstVisibleIndex, lastVisibleIndex} = this.moreInfo;
+			focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute));
 		let indexToScroll = -1;
 
 		if (Array.isArray(data) && data.some((item) => item.disabled)) {
@@ -936,17 +937,9 @@ class VirtualListCoreNative extends Component {
 				isRtl = this.context.rtl,
 				isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right');
 
-			if (firstVisibleIndex <= indexToScroll && indexToScroll <= lastVisibleIndex) {
-				const node = this.containerRef.querySelector(`[data-index='${indexToScroll}'].spottable`);
-
-				if (node) {
-					Spotlight.focus(node);
-				}
-			} else {
-				// Scroll to the next spottable item without animation
-				focusedItem.blur();
-			}
-			this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
+			// Scroll to the next spottable item without animation
+			focusedItem.blur();
+			this.lastFocusedIndex = indexToScroll;
 			this.props.cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', focus: true, animate: false});
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing a page up or down key in VirtualList or VirtualGridList, it took for a while to focus an item because the item was rendered and then the item got focused.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We did not know when the item in VirtualList is rendered before. But we could know it using `ref`. After rendering the item, `React` calls the `ref` callback function of the item after being rendered.
When rendering the item in VirtualList, force to focus the item if needed using `ref` without using `setTimeout`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I found there were some edge cases to navigate a VirtualList with disabled items. I tried to fix it.

### Links
[//]: # (Related issues, references)

ENYO-4806

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)