### PR TITLE
ENYO-4980: fixed VirtualListNative to pause Spotlight when scrolled by page keys

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -938,6 +938,9 @@ class VirtualListCoreNative extends Component {
 				isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right');
 
 			// Scroll to the next spottable item without animation
+			if (!Spotlight.isPaused()) {
+				Spotlight.pause();
+			}
 			focusedItem.blur();
 			this.lastFocusedIndex = indexToScroll;
 			this.props.cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', focus: true, animate: false});


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When page up/down key pressed on a virtual native list which has disabled items in it, the expected behavior is to move a focus to the next enable item without animation. But, sometimes, a focus moves with an unwanted animation and moves back to the starting item without an animation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed a virtual native list to pause `Spotlight` to avoid unwanted recovery

### Links
[//]: # (Related issues, references)
ENYO-4980

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
