### PR TITLE
PLAT-48442: Change deep node comparisons to prop comparisons

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -30,7 +30,7 @@ import Spinner from '../Spinner';
 import Skinnable from '../Skinnable';
 import Touchable from '../internal/Touchable';
 
-import {calcNumberValueOfPlaybackRate, secondsToTime} from './util';
+import {calcNumberValueOfPlaybackRate, compareSources, secondsToTime} from './util';
 import Overlay from './Overlay';
 import MediaControls from './MediaControls';
 import MediaTitle from './MediaTitle';
@@ -782,7 +782,8 @@ const VideoPlayerBase = class extends React.Component {
 
 		const {source} = this.props;
 		const {source: nextSource} = nextProps;
-		if (nextSource.props.src !== source.props.src || nextSource.props.type !== source.props.type) {
+
+		if (!compareSources(source, nextSource)) {
 			this.setState({currentTime: 0, buffered: 0, proportionPlayed: 0, proportionLoaded: 0});
 			this.reloadVideo();
 		}
@@ -791,9 +792,11 @@ const VideoPlayerBase = class extends React.Component {
 	shouldComponentUpdate (nextProps, nextState) {
 		const {source} = this.props;
 		const {source: nextSource} = nextProps;
-		if (nextSource.props.src !== source.props.src || nextSource.props.type !== source.props.type) {
+
+		if (!compareSources(source, nextSource)) {
 			return true;
 		}
+
 		if (
 			!this.state.miniFeedbackVisible && this.state.miniFeedbackVisible === nextState.miniFeedbackVisible &&
 			!this.state.mediaSliderVisible && this.state.mediaSliderVisible === nextState.mediaSliderVisible &&
@@ -835,7 +838,7 @@ const VideoPlayerBase = class extends React.Component {
 		const {source: prevSource} = prevProps;
 
 		// Detect a change to the video source and reload if necessary.
-		if (prevSource.props.src !== source.props.src || prevSource.props.type !== source.props.type) {
+		if (!compareSources(source, prevSource)) {
 			this.reloadVideo();
 		}
 

--- a/packages/moonstone/VideoPlayer/util.js
+++ b/packages/moonstone/VideoPlayer/util.js
@@ -73,9 +73,31 @@ const calcNumberValueOfPlaybackRate = (rate) => {
 	return (pbArray.length > 1) ? parseInt(pbArray[0]) / parseInt(pbArray[1]) : parseInt(rate);
 };
 
+/**
+ * Compares two source(s) of a video, mainly `src` and `type`.
+ *
+ * @param {Object|Array} source Source node(s)
+ * @param {Object|Array} nextSource Source node(s)
+ * @return {Boolean} true if two sources are the same
+ * @private
+ */
+const compareSources = (source, nextSource) => {
+	if (Array.isArray(source) !== Array.isArray(nextSource)) {
+		return false;
+	} else if (Array.isArray(source) && Array.isArray(nextSource)) {
+		return source.every((src, i) => {
+			return src.props.src === nextSource[i].props.src && src.props.type === nextSource[i].props.type;
+		});
+	} else if (nextSource.props.src === source.props.src && nextSource.props.type === source.props.type) {
+		return true;
+	} else {
+		return false;
+	}
+};
 
 export {
 	calcNumberValueOfPlaybackRate,
+	compareSources,
 	parseTime,
 	secondsToPeriod,
 	secondsToTime


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In react 16, newly introduced FiberNodes contain extra information which prevents us from a deep comparison of two nodes to check equality. moonstone/VideoPlayer compares <source> slot and it will fail to check correctly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove deep comparison of nodes and change it to prop comparisons

### See also
https://github.com/enyojs/enact/pull/1364
https://github.com/enyojs/enact/pull/1366

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

  