### PR TITLE
Travis fix for selectively disabling newly-enabled ESLint react/jsx-n…

### DIFF
--- a/packages/i18n/I18nDecorator/tests/I18nDecorator-specs.js
+++ b/packages/i18n/I18nDecorator/tests/I18nDecorator-specs.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-bind */
+
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 

--- a/packages/moonstone/Panels/tests/BreadcrumbDecorator-specs.js
+++ b/packages/moonstone/Panels/tests/BreadcrumbDecorator-specs.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-bind */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import kind from '@enact/core/kind';

--- a/packages/moonstone/Panels/tests/Router-specs.js
+++ b/packages/moonstone/Panels/tests/Router-specs.js
@@ -1,5 +1,6 @@
 /* globals console */
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
+/* eslint-disable react/jsx-no-bind */
 
 import React from 'react';
 import {shallow, mount} from 'enzyme';

--- a/packages/ui/Repeater/tests/Repeater-specs.js
+++ b/packages/ui/Repeater/tests/Repeater-specs.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-bind */
+
 import React from 'react';
 import {shallow} from 'enzyme';
 import Repeater from '../Repeater';

--- a/packages/ui/Touchable/tests/Touchable-specs.js
+++ b/packages/ui/Touchable/tests/Touchable-specs.js
@@ -1,4 +1,6 @@
 /* eslint-disable enact/prop-types */
+/* eslint-disable react/jsx-no-bind */
+
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';


### PR DESCRIPTION
…o-bind rule in test files.

### Issue Resolved / Feature Added
* Recent updates to react eslint configuration defaults have enabled the `jsx-no-bind` [rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md). This was causing a few of our test spec files to fail strict linting.

### Resolution
* Selectively disable the lint rule in the affect spec files (based on recommendation from Roy), as it's only test spec files, not the framework itself.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>