### PR TITLE
ENYO-4960: Prevent unnecessary renders due to focus changes

### DIFF
--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -182,7 +182,9 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 				} else if (!ev.currentTarget.contains(ev.relatedTarget)) {
 					// Blurring decorator but not focusing input
 					forwardBlur(ev, this.props);
-					this.blur();
+					if (this.state.focused !== null && this.state.node !== null) {
+						this.blur();
+					}
 				}
 			} else if (isBubbling(ev)) {
 				if (this.state.focused === 'input' && this.state.node === ev.target && ev.currentTarget !== ev.relatedTarget) {

--- a/packages/moonstone/Marquee/MarqueeDecorator.js
+++ b/packages/moonstone/Marquee/MarqueeDecorator.js
@@ -6,6 +6,7 @@ import {isRtlText} from '@enact/i18n/util';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {contextTypes as stateContextTypes} from '@enact/core/internal/PubSub';
+import equals from 'ramda/src/equals';
 
 import Marquee from './Marquee';
 import {contextTypes} from './MarqueeController';
@@ -302,6 +303,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (next.disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
 			}
+		}
+
+		shouldComponentUpdate (nextProps, nextState) {
+			return (
+				!childrenEquals(this.props.children, nextProps.children) ||
+				(invalidateProps && didPropChange(invalidateProps, this.props, nextProps)) ||
+				!equals(this.state, nextState)
+			);
 		}
 
 		componentDidUpdate () {

--- a/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
+++ b/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
@@ -6,6 +6,7 @@
  */
 
 import {contextTypes} from '@enact/core/internal/PubSub';
+import equals from 'ramda/src/equals';
 import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
@@ -282,6 +283,15 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				validateRange(backgroundProgress, 0, 1, SliderDecoratorClass.displayName,
 					'backgroundProgress', 'min', 'max');
 			}
+		}
+
+		shouldComponentUpdate (nextProps, nextState) {
+			const {focused, ...rest} = this.state;
+			const {focused: nextFocused, ...nextRest} = nextState;
+			return !(focused !== nextFocused &&
+				!this.props.tooltip &&
+				equals(this.props, nextProps) &&
+				equals(rest, nextRest));
 		}
 
 		componentDidUpdate () {

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
+- `spotlight/Spottable` to prevent unnecessary renders due to focus changes
+
 ## [2.0.0-alpha.2] - 2017-08-29
 
 No significant changes.

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -166,10 +166,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		constructor (props) {
 			super(props);
+			this.isFocused = false;
 			this.isHovered = false;
-			this.state = {
-				spotted: false
-			};
 		}
 
 		componentDidMount () {
@@ -178,8 +176,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			// if the component is spotted and became disabled,
-			if (this.state.spotted && (
+			// if the component is focused and became disabled,
+			if (this.isFocused && (
 				(!prevProps.disabled && this.props.disabled) ||
 				(!prevProps.spotlightDisabled && this.props.spotlightDisabled)
 			)) {
@@ -224,7 +222,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			if (this.state.spotted) {
+			if (this.isFocused) {
 				forward('onSpotlightDisappear', null, this.props);
 			}
 			if (lastSelectTarget === this) {
@@ -299,7 +297,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleBlur = (ev) => {
 			if (ev.currentTarget === ev.target) {
-				this.setState({spotted: false});
+				this.isFocused = false;
 			}
 
 			if (Spotlight.isMuted(ev.target)) {
@@ -311,7 +309,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleFocus = (ev) => {
 			if (ev.currentTarget === ev.target) {
-				this.setState({spotted: true});
+				this.isFocused = true;
 			}
 
 			if (Spotlight.isMuted(ev.target)) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Spottable components re-render each time focus is changed. This unnecessary re-rendering should be prevented. Additionally, certain other moonstone components needlessly re-render themselves based on focus changes.


### Resolution
Spottables contain an internal state to determine their focused status. This state is never used to determine any specific rendered output, and could easily be replaced with another state-less internal method to designate focused state (as we do with hovered state in Spottable).

Other components that ultimately re-render themselves due to focus changes will do so based on state changes. Sometimes the focus state value is passed along as a prop (e.g. when used in hocs). In these cases, I've implemented `shouldComponentUpdate` rules that will prevent an update when only focus is changed (where applicable). Otherwise, I would opt to use internal state `this.myState` rather than `this.state.myState`.


### Additional Considerations
Certain components require updating/re-rendering upon focus changes, such as `Item` and its relatives (`CheckboxItem`, `ToggleItem`, etc). The implementation in these components require remeasurement when focus changes, to allow a proper marquee function.
`Picker` components require changing an aria value due to focus changes, so I've left those component variants alone so they can properly re-render.


Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>