### PR TITLE
Fix a bug that returning wrong time when starting DST

### DIFF
--- a/packages/i18n/ilib/lib/GregorianDate.js
+++ b/packages/i18n/ilib/lib/GregorianDate.js
@@ -161,7 +161,11 @@ var GregorianDate = function(params) {
 				// in the overlap time at the end of DST. Do you mean the daylight 1:30am or the standard 1:30am? In this
 				// case, use the ilib calculations below, which can distinguish between the two properly
 				var d = new Date(this.year, this.month-1, this.day, this.hour, this.minute, this.second, this.millisecond);
+				var hBefore = new Date(this.year, this.month-1, this.day, this.hour - 1, this.minute, this.second, this.millisecond);
 				this.offset = -d.getTimezoneOffset() / 1440;
+				if (d.getTimezoneOffset() < hBefore.getTimezoneOffset()) {
+					var startOffset = -hBefore.getTimezoneOffset() / 1440;
+				}
 			} else {
 				if (!this.tz) {
 					this.tz = new TimeZone({id: this.timezone});
@@ -171,7 +175,11 @@ var GregorianDate = function(params) {
 				// what the offset is at that point in the year
 				this.offset = this.tz._getOffsetMillisWallTime(this) / 86400000;
 			}
-			if (this.offset !== 0) {
+			if (typeof(startOffset) !== 'undefined') {
+				this.rd = this.newRd({
+					rd: this.rd.getRataDie() - startOffset
+				});
+			} else if (this.offset !== 0) {
 				this.rd = this.newRd({
 					rd: this.rd.getRataDie() - this.offset
 				});

--- a/packages/i18n/ilib/lib/GregorianDate.js
+++ b/packages/i18n/ilib/lib/GregorianDate.js
@@ -156,6 +156,7 @@ var GregorianDate = function(params) {
 			
 			// add the time zone offset to the rd to convert to UTC
 			this.offset = 0;
+			this.startOffset = 0;
 			if (this.timezone === "local" && typeof(params.dst) === 'undefined') {
 				// if dst is defined, the intrinsic Date object has no way of specifying which version of a time you mean
 				// in the overlap time at the end of DST. Do you mean the daylight 1:30am or the standard 1:30am? In this
@@ -164,7 +165,7 @@ var GregorianDate = function(params) {
 				var hBefore = new Date(this.year, this.month-1, this.day, this.hour - 1, this.minute, this.second, this.millisecond);
 				this.offset = -d.getTimezoneOffset() / 1440;
 				if (d.getTimezoneOffset() < hBefore.getTimezoneOffset()) {
-					var startOffset = -hBefore.getTimezoneOffset() / 1440;
+					this.startOffset = -hBefore.getTimezoneOffset() / 1440;
 				}
 			} else {
 				if (!this.tz) {
@@ -175,9 +176,9 @@ var GregorianDate = function(params) {
 				// what the offset is at that point in the year
 				this.offset = this.tz._getOffsetMillisWallTime(this) / 86400000;
 			}
-			if (typeof(startOffset) !== 'undefined') {
+			if (this.startOffset !== 0) {
 				this.rd = this.newRd({
-					rd: this.rd.getRataDie() - startOffset
+					rd: this.rd.getRataDie() - this.startOffset
 				});
 			} else if (this.offset !== 0) {
 				this.rd = this.newRd({


### PR DESCRIPTION
### Issue Resolved
 When the Timer picker is in the DST adjustment range, the date picker can't be changed to the next day from the DST date.


### Resolution
iLib RataDie was based on old javascript engine, So I fixed a bug that returning wrong time when starting DST.
- Align with the way to applying DST in javascript native engine when it is started on starting boundary time.

