### PR TITLE
ENYO-4989: Fix Scroller to update scrollbar state when contents change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 - `core/kind` and `core/hoc` public documentation to be visible
 - `moonstone/TimePicker` to not read out meridiem label when meridiem picker gets a focus
+- `moonstone/Scroller` to correctly update scrollbars when the scroller's contents change
 - Several samples that would not rescale correctly when the viewport was resized
 
 ## [1.13.2] - 2017-12-14

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/TimePicker` to not read out meridiem label when meridiem picker gets a focus
+- `moonstone/Scroller` to correctly update scrollbars when the scroller's contents change
 
 ## [1.13.2] - 2017-12-14
 

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -299,6 +299,8 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				this.childRef.syncClientSize();
 			}
 
+			this.clampScrollPosition();
+
 			this.direction = this.childRef.props.direction;
 			this.updateEventListeners();
 			this.updateScrollbars();
@@ -466,6 +468,18 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				return false;
 			} else {
 				return true;
+			}
+		}
+
+		clampScrollPosition () {
+			const bounds = this.getScrollBounds();
+
+			if (this.scrollTop > bounds.maxTop) {
+				this.scrollTop = bounds.maxTop;
+			}
+
+			if (this.scrollLeft > bounds.maxLeft) {
+				this.scrollLeft = bounds.maxLeft;
 			}
 		}
 


### PR DESCRIPTION
### Issue

After scrolling to the bottom of a scroller and shrinking and then growing the size of the contents, the scrollbars will not correctly re-enable the "next" button.

### Resolution

If the scroller's scroll position exceeds the max position due to the contents shrinking, clamp the position to the max position. Then, when the contents grow again, the scroll position will correctly reflect the truncated state and enable the "next" button.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)