### PR TITLE
ENYO-4883: Hide an opposite scrollbar's thumb if the thumb of a current scrollbar is located at the first or at the end

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -239,6 +239,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.verticalScrollbarProps = {
 				ref: this.initRef('verticalScrollbarRef'),
 				vertical: true,
+				hideOppositeThumb: this.startHidingThumb,
 				cbAlertThumb: this.alertThumbAfterRendered,
 				onPrevScroll: this.onScrollbarButtonClick,
 				onNextScroll: this.onScrollbarButtonClick
@@ -247,6 +248,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.horizontalScrollbarProps = {
 				ref: this.initRef('horizontalScrollbarRef'),
 				vertical: false,
+				hideOppositeThumb: this.startHidingThumb,
 				cbAlertThumb: this.alertThumbAfterRendered,
 				onPrevScroll: this.onScrollbarButtonClick,
 				onNextScroll: this.onScrollbarButtonClick

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -229,6 +229,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.verticalScrollbarProps = {
 				ref: this.initRef('verticalScrollbarRef'),
 				vertical: true,
+				hideOppositeThumb: this.startHidingThumb,
 				cbAlertThumb: this.alertThumbAfterRendered,
 				onPrevScroll: this.onScrollbarButtonClick,
 				onNextScroll: this.onScrollbarButtonClick
@@ -237,6 +238,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.horizontalScrollbarProps = {
 				ref: this.initRef('horizontalScrollbarRef'),
 				vertical: false,
+				hideOppositeThumb: this.startHidingThumb,
 				cbAlertThumb: this.alertThumbAfterRendered,
 				onPrevScroll: this.onScrollbarButtonClick,
 				onNextScroll: this.onScrollbarButtonClick

--- a/packages/moonstone/Scroller/Scrollbar.js
+++ b/packages/moonstone/Scroller/Scrollbar.js
@@ -96,6 +96,14 @@ class ScrollbarBase extends PureComponent {
 		disabled: PropTypes.bool,
 
 		/**
+		 * Called when the scroll thumb is hidden immediately when scroll button is disabled.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		hideOppositeThumb: PropTypes.func,
+
+		/**
 		 * Called when the scrollbar's down/right button is pressed.
 		 *
 		 * @type {Function}
@@ -147,6 +155,7 @@ class ScrollbarBase extends PureComponent {
 
 	static defaultProps = {
 		corner: false,
+		hideOppositeThumb: nop,
 		onNextScroll: nop,
 		onPrevScroll: nop,
 		vertical: true
@@ -217,7 +226,7 @@ class ScrollbarBase extends PureComponent {
 	updateButtons = (bounds) => {
 		const
 			{prevButtonNodeRef, nextButtonNodeRef} = this,
-			{vertical} = this.props,
+			{hideOppositeThumb, vertical} = this.props,
 			currentPos = vertical ? bounds.scrollTop : bounds.scrollLeft,
 			maxPos = vertical ? bounds.maxTop : bounds.maxLeft,
 			shouldDisablePrevButton = currentPos <= 0,
@@ -225,6 +234,11 @@ class ScrollbarBase extends PureComponent {
 			   browsers's max scroll position could be smaller than maxPos by 1 pixel.*/
 			shouldDisableNextButton = maxPos - currentPos <= 1,
 			spotItem = Spotlight.getCurrent();
+
+		if (currentPos <= 0 || currentPos >= maxPos) {
+			// If there is an opposite scrollbar with different direction, the scroll thumb in it should be also hidden
+			hideOppositeThumb();
+		}
 
 		this.setState((prevState) => {
 			const


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though the thumb of a scroll bar is located at the end or at the first, the thumb is not hidden.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Hide an opposite scrollbar's thumb if the thumb of a current scrollbar is located at the first or at the end

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)