### PR TITLE
PLAT-50337: Set default value of 0 for proportionPlayed to avoid warning in react 16

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1278,7 +1278,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			// Non-standard state computed from properties
 			proportionLoaded: el.buffered.length && el.buffered.end(el.buffered.length - 1) / el.duration,
-			proportionPlayed: el.currentTime / el.duration,
+			proportionPlayed: el.currentTime / el.duration || 0,
 			error: el.networkState === el.NETWORK_NO_SOURCE,
 			loading: el.readyState < el.HAVE_ENOUGH_DATA,
 			sliderTooltipTime: this.sliderScrubbing ? (this.sliderKnobProportion * el.duration) : el.currentTime


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Turns out react 16 warns on "NaN" value input (e.g. `<input value={NaN} />`), where it didn't in react 15. When video player reloads a source, `duration` value is `NaN` and therefore the `proportionPlayed`, an internal value used for <input>'s value which is driven by the current time divided by duration, calculates to `NaN`.

We can avoid this warning by setting the default `proportionPlayed` value to 0.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
