### PR TITLE
ENYO-4888: Update Lerna to current release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "6"
+    - "node"
 sudo: false
 install:
     - npm install -g enyojs/enact-cli#develop

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "lerna": "2.0.0-beta.30",
+  "lerna": "2.8.0",
   "version": "2.0.0-alpha.3"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "lerna": "2.0.0-beta.30"
+    "lerna": "2.8.0"
   }
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Some combination of shrinkwrap/dependency/lerna/npm factors have brought to the attention that Sampler is failing to build under the current environment with NPM 5.x with `package-lock` functionality enabled.  Upgrading Lerna to a version compatible with the latest NPM standards/features appears to resolve the issue and is something we've been meaning to do for a while anyway.

### Resolution
* Upgrades to Lerna 2.8.0 release.
* Restores latest Node/NPM usage on Travis

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
