### PR TITLE
ENYO-5016: Fix applying the same classes multiple times

### DIFF
--- a/packages/core/kind/styles.js
+++ b/packages/core/kind/styles.js
@@ -42,16 +42,18 @@ import {addInternalProp} from './util';
  * @private
  */
 const styles = (cfg, optProps) => {
-	const {className, prop = 'className', style} = cfg;
-	let {publicClassNames: allowedClassNames, css} = cfg;
+	const {className, css: configCss, prop = 'className', style} = cfg;
+	let {publicClassNames: allowedClassNames} = cfg;
 
-	if (css && allowedClassNames === true) {
-		allowedClassNames = Object.keys(css);
+	if (configCss && allowedClassNames === true) {
+		allowedClassNames = Object.keys(configCss);
 	} else if (typeof allowedClassNames === 'string') {
 		allowedClassNames = allowedClassNames.split(/\s+/);
 	}
 
 	const renderStyles = (props) => {
+		let css = configCss;
+
 		if (style) {
 			props.style = Object.assign({}, style, props.style);
 		}


### PR DESCRIPTION
## Issue

I was mistakenly reusing a component creation-scoped variable (`css`) in `core/kind/styles` causing the CSS map to be merged with the same classes every render. Then, when the map was referenced during render, the value would contain multiple entries of the same obfuscated class name.

## Resolution

Use a render-scoped variable for CSS map merges.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)