### PR TITLE
PLAT-50258: Update scroll button disable/enable status and scroll thumb size when the data size of VirtualList is changed

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -1104,7 +1104,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 		}
 
-		updateScrollThumbSize = (forceUpdate = false) => {
+		updateScrollThumbSize = (force = false) => {
 			const
 				{horizontalScrollbar, verticalScrollbar} = this.props,
 				bounds = this.getScrollBounds(),
@@ -1113,7 +1113,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? canScrollHorizontally : horizontalScrollbar === 'visible',
 				curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? canScrollVertically : verticalScrollbar === 'visible';
 
-			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible || forceUpdate) {
+			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible || force) {
 				// no visibility change but need to notify whichever scrollbars are visible of the
 				// updated bounds and scroll position
 				const
@@ -1123,10 +1123,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						scrollTop: this.scrollTop
 					};
 
-				if ((curHorizontalScrollbarVisible || forceUpdate) && this.horizontalScrollbarRef) {
+				if ((curHorizontalScrollbarVisible || force) && this.horizontalScrollbarRef) {
 					this.horizontalScrollbarRef.update(updatedBounds);
 				}
-				if ((curVerticalScrollbarVisible || forceUpdate) && this.verticalScrollbarRef) {
+				if ((curVerticalScrollbarVisible || force) && this.verticalScrollbarRef) {
 					this.verticalScrollbarRef.update(updatedBounds);
 				}
 				return true;

--- a/packages/moonstone/Scroller/Scrollable.js
+++ b/packages/moonstone/Scroller/Scrollable.js
@@ -310,7 +310,12 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.direction = this.childRef.props.direction;
 			this.updateEventListeners();
 			if (!this.isFitClientSize) {
+				// Update scrollbar visibility, scroll button disable/enable status and scroll thumb size
 				this.updateScrollbars();
+			} else {
+				// Update only scroll button disable/enable status and scroll thumb size
+				// If updating scrollbar visibility with setState, it is possible to generate infinite loop call
+				this.updateScrollThumbSize(true);
 			}
 
 			if (this.scrollToInfo !== null) {
@@ -1099,7 +1104,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 		}
 
-		updateScrollThumbSize = () => {
+		updateScrollThumbSize = (forceUpdate = false) => {
 			const
 				{horizontalScrollbar, verticalScrollbar} = this.props,
 				bounds = this.getScrollBounds(),
@@ -1108,7 +1113,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? canScrollHorizontally : horizontalScrollbar === 'visible',
 				curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? canScrollVertically : verticalScrollbar === 'visible';
 
-			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
+			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible || forceUpdate) {
 				// no visibility change but need to notify whichever scrollbars are visible of the
 				// updated bounds and scroll position
 				const
@@ -1118,10 +1123,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						scrollTop: this.scrollTop
 					};
 
-				if (curHorizontalScrollbarVisible && this.horizontalScrollbarRef) {
+				if ((curHorizontalScrollbarVisible || forceUpdate) && this.horizontalScrollbarRef) {
 					this.horizontalScrollbarRef.update(updatedBounds);
 				}
-				if (curVerticalScrollbarVisible && this.verticalScrollbarRef) {
+				if ((curVerticalScrollbarVisible || forceUpdate) && this.verticalScrollbarRef) {
 					this.verticalScrollbarRef.update(updatedBounds);
 				}
 				return true;

--- a/packages/moonstone/Scroller/ScrollableNative.js
+++ b/packages/moonstone/Scroller/ScrollableNative.js
@@ -285,7 +285,12 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			this.direction = this.childRef.props.direction;
 			this.updateEventListeners();
 			if (!this.isFitClientSize) {
+				// Update scrollbar visibility, scroll button disable/enable status and scroll thumb size
 				this.updateScrollbars();
+			} else {
+				// Update only scroll button disable/enable status and scroll thumb size
+				// If updating scrollbar visibility with setState, it is possible to generate infinite loop call
+				this.updateScrollThumbSize(true);
 			}
 
 			if (this.scrollToInfo !== null) {
@@ -964,7 +969,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 			}
 		}
 
-		updateScrollThumbSize = () => {
+		updateScrollThumbSize = (force = false) => {
 			const
 				{horizontalScrollbar, verticalScrollbar} = this.props,
 				bounds = this.getScrollBounds(),
@@ -973,7 +978,7 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 				curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? canScrollHorizontally : horizontalScrollbar === 'visible',
 				curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? canScrollVertically : verticalScrollbar === 'visible';
 
-			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
+			if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible || force) {
 				// no visibility change but need to notify whichever scrollbars are visible of the
 				// updated bounds and scroll position
 				const
@@ -983,10 +988,10 @@ const ScrollableHoC = hoc((config, Wrapped) => {
 						scrollTop: this.scrollTop
 					};
 
-				if (curHorizontalScrollbarVisible) {
+				if (curHorizontalScrollbarVisible || force && this.horizontalScrollbarRef && this.horizontalScrollbarRef.update) {
 					this.horizontalScrollbarRef.update(updatedBounds);
 				}
-				if (curVerticalScrollbarVisible) {
+				if (curVerticalScrollbarVisible || force && this.verticalScrollbarRef && this.verticalScrollbarRef.update) {
 					this.verticalScrollbarRef.update(updatedBounds);
 				}
 				return true;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Due to the edge case in ENYO-4603 and ENYO-4620, we prevented updating scrollbar visibility, scroll button disable/enable status, and scroll thumb size when the data size of `VirtualList` is changed. So even though its data size is very small, the `ScrollButton` in it is enabled.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When changing the data size of `VirtualList`, I updated not scrollbar visibility but scrollbar visibility, scroll button disable/enable status.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-50258

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)