### PR TITLE
PLAT-45602: Button noAnimation Deprecation Fix

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -192,10 +192,12 @@ const ButtonBaseFactory = factory({css: componentCss}, ({css}) =>
 
 		computed: {
 			className: ({backgroundOpacity, className, color, minWidth, noAnimation, pressed, selected, small, styler}) => {
-				const isIconButton = className ? (className.indexOf('IconButton') !== -1) : false;
-				// Deprecate `noAnimation` except for `IconButton`, because it is used as a defaultProp.
-				if (noAnimation && !isIconButton) {
-					deprecate({name: 'noAnimation', since: '1.14.0', until: '2.0.0'});
+				if (__DEV__) {
+					const isIconButton = className ? (className.indexOf('IconButton') !== -1) : false;
+					// Deprecate `noAnimation` except for `IconButton`, because it is used as a defaultProp.
+					if (noAnimation && !isIconButton) {
+						deprecate({name: 'noAnimation', since: '1.14.0', until: '2.0.0'});
+					}
 				}
 
 				return styler.append(


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Use `indexOf` to check for substring in `className`, because `includes` breaks the tests.


### Links
PLAT-45602


### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com