### PR TITLE
ENYO-5025: Fixes ToggleItems to be toggleable in 5-way mode

### DIFF
--- a/packages/moonstone/Item/Item.js
+++ b/packages/moonstone/Item/Item.js
@@ -11,7 +11,7 @@
  */
 import kind from '@enact/core/kind';
 import Spottable from '@enact/spotlight/Spottable';
-import UiItem from '@enact/ui/Item';
+import {ItemBase as UiItemBase, ItemDecorator as UiItemDecorator} from '@enact/ui/Item';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -56,7 +56,7 @@ const ItemBase = kind({
 
 	render: ({css, ...rest}) => {
 		return (
-			<UiItem
+			<UiItemBase
 				{...rest}
 				css={css}
 			/>
@@ -77,6 +77,7 @@ const ItemBase = kind({
  */
 const ItemDecorator = compose(
 	Pure,
+	UiItemDecorator,
 	Spottable,
 	MarqueeDecorator({invalidateProps: ['inline', 'autoHide']}),
 	Skinnable

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -15,6 +15,7 @@ import Spottable from '@enact/spotlight/Spottable';
 import Pure from '@enact/ui/internal/Pure';
 import {RemeasurableDecorator} from '@enact/ui/Remeasurable';
 import {SlotItemBase as UiSlotItemBase, SlotItemDecorator as UiSlotItemDecorator} from '@enact/ui/SlotItem';
+import {ItemDecorator as UiItemDecorator} from '@enact/ui/Item';
 import Toggleable from '@enact/ui/Toggleable';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -95,6 +96,7 @@ const SlotItemDecorator = compose(
 	Toggleable(
 		{prop: 'remeasure', activate: 'onFocus', deactivate: 'onBlur', toggle: null}
 	),
+	UiItemDecorator, // (Touchable)
 	Spottable,
 	RemeasurableDecorator({trigger: 'remeasure'}),
 	MarqueeDecorator({className: componentCss.content, invalidateProps: ['inline', 'autoHide', 'remeasure']}),


### PR DESCRIPTION
…pottable, instead of under it in the rendered component.


### Issue Resolved / Feature Added
Key events are not being fired when pressing [Enter]


### Resolution
Rearranged the HOC stack so the Touchable HOC lands on the component after Spottable so spottable can respond to the actions coming from Touchable.
