### PR TITLE
VideoPlayer: Remove unnecessary prop

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -2103,7 +2103,6 @@ const VideoPlayerBase = class extends React.Component {
 								noJumpButtons={noJumpButtons}
 								noRateButtons={noRateButtons}
 								onBackwardButtonClick={this.onBackward}
-								onClick={this.resetAutoTimeout}
 								onForwardButtonClick={this.onForward}
 								onJumpBackwardButtonClick={this.onJumpBackward}
 								onJumpForwardButtonClick={this.onJumpForward}


### PR DESCRIPTION
### Issue Resolved / Feature Added
`VideoPlayer` passes `this.resetAutoTimeout` value to `MediaControls` prop `onClick`.


### Resolution
As `this.resetAutoTimeout` doesn't exist (and doesn't appear to have ever existed), I've removed this line. The purpose of it was likely to prevent the media controls from hiding, but that happens via `this.activityDetected`, which is called on the out-most dom (`RootContainer`) `onClick` event.

Looking at the file history, it looks like `onClick={this.resetAutoTimeout}` was added back in 2.0.0-alpha.3, apparently by accident.

### Links
https://github.com/enyojs/enact/commit/64e16996956380351074b757449848a7b4347bf0#diff-598514a33c478cdac5391092c58009fe

Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
