### PR TITLE
PLAT-51329: Add badges to enact-cli and enact readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Enact
+# Enact [![Travis](https://img.shields.io/travis/enactjs/enact.svg?style=flat-square)](https://travis-ci.org/enactjs/enact) [![license](https://img.shields.io/github/license/enactjs/enact.svg?style=flat-square)](http://www.apache.org/licenses/LICENSE-2.0) [![Gitter](https://img.shields.io/gitter/room/EnactJS/Lobby.svg?style=flat-square)](https://gitter.im/EnactJS/Lobby)
 
 > A mono-repo containing Enact framework modules
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @enact/core
+# @enact/core [![npm (scoped)](https://img.shields.io/npm/v/@enact/core.svg?style=flat-square)](https://www.npmjs.com/package/@enact/core)
 
 > `@enact/core` contains the set of basic building blocks for an Enact-based application.
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,4 +1,4 @@
-# @enact/i18n
+# @enact/i18n [![npm (scoped)](https://img.shields.io/npm/v/@enact/i18n.svg?style=flat-square)](https://www.npmjs.com/package/@enact/i18n)
 
 > Enact library for internationalization
 

--- a/packages/moonstone/README.md
+++ b/packages/moonstone/README.md
@@ -1,4 +1,4 @@
-# @enact/moonstone
+# @enact/moonstone [![npm (scoped)](https://img.shields.io/npm/v/@enact/moonstone.svg?style=flat-square)](https://www.npmjs.com/package/@enact/moonstone)
 
 > `@enact/moonstone` contains the set of reusable components for an Enact-based application
 targeting smart TVs.

--- a/packages/spotlight/README.md
+++ b/packages/spotlight/README.md
@@ -1,4 +1,4 @@
-# Spotlight
+# @enact/spotlight [![npm (scoped)](https://img.shields.io/npm/v/@enact/spotlight.svg?style=flat-square)](https://www.npmjs.com/package/@enact/spotlight)
 
 > An extensible library for 5-way navigation and focus control
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,4 +1,4 @@
-# @enact/ui
+# @enact/ui [![npm (scoped)](https://img.shields.io/npm/v/@enact/ui.svg?style=flat-square)](https://www.npmjs.com/package/@enact/ui)
 
 > `@enact/ui` contains the set of unstyled, reusabled components for an Enact-based application.
 

--- a/packages/webos/README.md
+++ b/packages/webos/README.md
@@ -1,4 +1,4 @@
-# @enact/webos
+# @enact/webos [![npm (scoped)](https://img.shields.io/npm/v/@enact/webos.svg?style=flat-square)](https://www.npmjs.com/package/@enact/webos)
 
 > `@enact/webos` contains utility functions for working with webOS devices
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Added NPM release badges to the individual package READMEs.
* Added Travis status, license, and gitter badges to top-level monorepo README.

### Resolution
* Similar to how the docs are currently setup under the `enactjs` github org URI assumption, so too do these badges assume `enactjs/enact` URI for travis status and license detection. They will both function correctly post-transfer.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>