### PR TITLE
PLAT-48638: Normalize taparea for Button

### DIFF
--- a/packages/moonstone/styles/mixins.less
+++ b/packages/moonstone/styles/mixins.less
@@ -9,7 +9,7 @@
 
 .moon-taparea(@element-size) when (@moon-button-small-tap-area-height > @element-size) {
 	// Take the size of the minimum tappable area, and subtract the element's current size.
-	@_tap-offset: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @element-size) / 2);
+	@_tap-offset: -((@moon-button-small-tap-area-height - @element-size) / 2);
 
 	&::before {
 		content: "";

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -148,7 +148,7 @@
 @moon-button-small-height-large: 72px;
 @moon-button-border-width: 6px;
 @moon-button-border-radius: 9999px;
-@moon-button-small-tap-area-height: 78px;
+@moon-button-small-tap-area-height: (@moon-spotlight-outset + @moon-button-small-height + @moon-spotlight-outset);
 @moon-button-large-text-size: 30px;
 @moon-button-small-text-size: 24px;
 @moon-button-large-min-width: 180px;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Tap area for Button uses the deprecated styles to calculate the size of the tap area. This results in a tap area that is a different size than expected or desired.

### Resolution
Refactor the `.taparea` mixin to use the current Button sizing metrics, as well as change the tap-area variable to match the spotlight-outset variable, so there's never any overlap between horizontally arranged components.