### PR TITLE
PLAT-47085: Incorporated a mini-scrim into Input

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -235,29 +235,31 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, type, value, ...rest}) => {
+	render: ({dir, disabled, focused, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, type, value, ...rest}) => {
 		delete rest.dismissOnEnter;
-		delete rest.focused;
 		delete rest.invalid;
 		delete rest.invalidMessage;
 		delete rest.rtl;
 
 		return (
-			<div {...rest} disabled={disabled}>
-				<InputDecoratorIcon position="before">{iconBefore}</InputDecoratorIcon>
-				<input
-					aria-disabled={disabled}
-					className={css.input}
-					dir={dir}
-					disabled={disabled}
-					onChange={onChange}
-					placeholder={placeholder}
-					type={type}
-					value={value}
-				/>
-				<InputDecoratorIcon position="after">{iconAfter}</InputDecoratorIcon>
-				{invalidTooltip}
-			</div>
+			<React.Fragment>
+				<div className={css.isolatingScrim} style={{display: (focused ? 'block' : 'none')}} />
+				<div {...rest} disabled={disabled}>
+					<InputDecoratorIcon position="before">{iconBefore}</InputDecoratorIcon>
+					<input
+						aria-disabled={disabled}
+						className={css.input}
+						dir={dir}
+						disabled={disabled}
+						onChange={onChange}
+						placeholder={placeholder}
+						type={type}
+						value={value}
+					/>
+					<InputDecoratorIcon position="after">{iconAfter}</InputDecoratorIcon>
+					{invalidTooltip}
+				</div>
+			</React.Fragment>
 		);
 	}
 });

--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -58,7 +58,7 @@
 	margin: 6px;
 	border: @moon-input-border-width solid transparent;
 	box-sizing: border-box;
-	z-index: 2;
+	z-index: 20;
 
 	.input,
 	.iconBefore,
@@ -161,7 +161,7 @@
 	position: fixed;
 	.position(0);
 	background-color: fade(black, 30%);
-	z-index: 1;
+	z-index: 10;
 }
 
 .muted({

--- a/packages/moonstone/Input/Input.less
+++ b/packages/moonstone/Input/Input.less
@@ -58,6 +58,7 @@
 	margin: 6px;
 	border: @moon-input-border-width solid transparent;
 	box-sizing: border-box;
+	z-index: 2;
 
 	.input,
 	.iconBefore,
@@ -154,6 +155,13 @@
 		right: auto;
 		transform: translate(-100%, -100%) translateX(-@moon-input-tooltip-offset);
 	}
+}
+
+.isolatingScrim {
+	position: fixed;
+	.position(0);
+	background-color: fade(black, 30%);
+	z-index: 1;
 }
 
 .muted({


### PR DESCRIPTION
### Issue Resolved / Feature Added
`Input` fields need to be the only thing clickable when one of them is focused.


### Resolution
Add a scrim, local to `Input`, which when present, appears above all other elements but behind input fields.

Due to a browser implementation detail of GPU accelerated layers, it was not possible to use our existing `FloatingLayer` component. GPU rendered floating layers cannot be drawn between standard composited layers. Inputs being inside of a GPU accelerated Panel could not be pulled apart from that rendering stack to be interleaved with the FloatingLayer's `z-index`.