### PR TITLE
PLAT-51917: TooltipDecorator: Want to investigate if there are ways we can reduce how much work is done per instance

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## Unreleased 
+
+### Changed
+
+- `moonstone/TooltipDecorator` to not use `forward` and `handle` for performance reasons.
+
 ## [2.0.0-alpha.4] - 2018-02-13
 
 ### Removed


### PR DESCRIPTION
### Issue Resolved / Feature Added
`TooltipDecorator` is spending too much time mounting. When we don't have a tooltip.

### Resolution
Removed forward and handle from TooltopDecorator. Those functions slowing down the mounting time because they use ramda's `curry`.

### Additional Consideration
I did not remove `forProp`. It seems like it wouldn't run unless we actually had a `tooltipText` so I figured it would skip in the case we want to speed up.

### Links
PLAT-51917
