### PR TITLE
ENYO-4978: Deprecate sliderTooltip in 1.x

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Marquee.Marquee`, to be moved to `moonstone/Marquee.MarqueeBase` in 2.0.0
 - `moonstone/Marquee.MarqueeText`, to be moved to `moonstone/Marquee.Marquee` in 2.0.0
+- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Deprecated
+- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
+
 ## [1.15.0] - 2018-02-28
 
 ### Deprecated
 
 - `moonstone/Marquee.Marquee`, to be moved to `moonstone/Marquee.MarqueeBase` in 2.0.0
 - `moonstone/Marquee.MarqueeText`, to be moved to `moonstone/Marquee.Marquee` in 2.0.0
-- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `component`, to be replaced by `itemRenderer` in 2.0.0
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,6 +5,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [unreleased]
 
 ### Deprecated
+
 - `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
 
 ## [1.15.0] - 2018-02-28

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -19,7 +19,7 @@ import {computeProportionProgress} from '../internal/SliderDecorator/util';
 import Skinnable from '../Skinnable';
 
 import SliderBarFactory from './SliderBar';
-import SliderTooltip from './SliderTooltip';
+import {privateSliderTooltip as SliderTooltip} from './SliderTooltip';
 import componentCss from './Slider.less';
 
 const isActive = (ev, props) => props.active || props.activateOnFocus || props.detachedKnob;

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -1,3 +1,4 @@
+import deprecate from '@enact/core/internal/deprecate';
 import kind from '@enact/core/kind';
 
 import {contextTypes} from '@enact/i18n/I18nDecorator';
@@ -15,6 +16,7 @@ import css from './SliderTooltip.less';
  * @memberof moonstone/Slider
  * @ui
  * @public
+ * @deprecated
  */
 const SliderTooltipBase = kind({
 	name: 'SliderTooltip',
@@ -130,5 +132,11 @@ const SliderTooltipBase = kind({
 	}
 });
 
-export default SliderTooltipBase;
-export {SliderTooltipBase, SliderTooltipBase as SliderTooltip};
+const deprecatedSliderTooltipBase = deprecate(SliderTooltipBase, {name: 'moonstone/Slider.SliderTooltip', since: '1.15.0', until: '2.0.0', message: 'Use `moonstone/Tooltip.ProgressBarTooltip` instead when using 2.0.0'});
+
+export default deprecatedSliderTooltipBase;
+export {
+	deprecatedSliderTooltipBase as SliderTooltipBase,
+	SliderTooltipBase as privateSliderTooltip,
+	SliderTooltipBase as privateSliderTooltipBase
+};


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Because `Slider.sliderTooltip` is moving to `Tooltip.ProgressBarTooltip` in 2.0.0 in #1467 , `sliderTooltip` needs to be deprecated for in 1.x



### Links
[//]: # (Related issues, references)
ENYO-4978

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com