### PR TITLE
ENYO-4972: Scroller/IconButton spacing fix

### DIFF
--- a/packages/moonstone/Scroller/Scrollable.less
+++ b/packages/moonstone/Scroller/Scrollable.less
@@ -32,5 +32,9 @@
 		position: relative;
 		overflow: hidden;
 		flex: 1 1 100%;
+
+		> :last-child {
+			overflow: hidden;
+		}
 	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller doesn't scroll all the way down when `IconButton` is at the bottom.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`IconButton` uses pseudo element to increase the tap area of the button. `Scrollable` doesn't include the dimensions of the pseudo element when calculating scroll on focus and there is no performant way to have `Scrollable` include the calculations of children of focused items that are bigger than their parent. Easy fix here is to aim for the last-child of `Scrollable` and make sure they have `overflow: hidden`.
Suppressing the invisible tap area for `IconButton` and hiding children that are bigger than the focused item will be the side-effects of this fix.


### Links
[//]: # (Related issues, references)
ENYO-4972

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com