### PR TITLE
Removed unused `onScrollbarVisibility` prop from Scrollable

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -156,14 +156,6 @@ class ScrollableBase extends Component {
 		onScroll: PropTypes.func,
 
 		/**
-		 * Called when scrollbar visibility changes.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onScrollbarVisibilityChange: PropTypes.func,
-
-		/**
 		 * Called when scroll starts.
 		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
 		 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
@@ -950,10 +942,6 @@ class ScrollableBase extends Component {
 			);
 
 		if (isVisibilityChanged) {
-			if (this.props.onScrollbarVisibilityChange) {
-				this.props.onScrollbarVisibilityChange();
-			}
-
 			// one or both scrollbars have changed visibility
 			this.setState({
 				isHorizontalScrollbarVisible: curHorizontalScrollbarVisible,
@@ -1079,7 +1067,6 @@ class ScrollableBase extends Component {
 		delete rest.onKeyDown;
 		delete rest.onMouseUp;
 		delete rest.onScroll;
-		delete rest.onScrollbarVisibilityChange;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
 		delete rest.onWheel;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -141,14 +141,6 @@ class ScrollableBaseNative extends Component {
 		onScroll: PropTypes.func,
 
 		/**
-		 * Called when scrollbar visibility changes.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onScrollbarVisibilityChange: PropTypes.func,
-
-		/**
 		 * Called when scroll starts.
 		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
 		 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
@@ -834,9 +826,6 @@ class ScrollableBaseNative extends Component {
 			);
 
 		if (isVisibilityChanged) {
-			if (this.props.onScrollbarVisibilityChange) {
-				this.props.onScrollbarVisibilityChange();
-			}
 			// one or both scrollbars have changed visibility
 			this.setState({
 				isHorizontalScrollbarVisible: curHorizontalScrollbarVisible,
@@ -970,7 +959,6 @@ class ScrollableBaseNative extends Component {
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;
 		delete rest.onScroll;
-		delete rest.onScrollbarVisibilityChange;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
 		delete rest.onWheel;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We’ve found that “onScrollbarVisibility” prop added on 6th Sep 2017 from this PR: https://github.com/enyojs/enact/pull/1096
It seems to be used for RemeasurableDecorator in Scroller which is removed from this PR on 19th Sep 2017: https://github.com/enyojs/enact/pull/1131
Even though RemeasurableDecorator has been removed from Scroller, “onScrollbarVisibility” prop still lives in Scrollable.
So we're going to remove this prop.

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)