### PR TITLE
PLAT-52178: Rename `component` in `VirtualList as `itemRenderer` (develop)

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,7 +15,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
-- `moonstone/VirtualList` and `moonstone/VirtualGridList` prop `component` to be replaced by `itemRenderer`
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `component` to be replaced by `itemRenderer`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` exports `SliderFactory` and `SliderBaseFactory`
 - `moonstone/IncrementSlider` exports `IncrementSliderFactory` and `IncrementSliderBaseFactory`
 
+### Changed
+
+- `moonstone/VirtualList` and `moonstone/VirtualGridList` prop `component` to be replaced by `itemRenderer`
+
 ### Fixed
 
 - `moonstone/ExpandableItem` to be more performant when animating

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -92,7 +92,7 @@ const VirtualListBaseFactory = (type) => {
 			 * @type {Function}
 			 * @public
 			 */
-			component: PropTypes.func.isRequired,
+			itemRenderer: PropTypes.func.isRequired,
 
 			/**
 			 * The render function for the items.
@@ -692,7 +692,7 @@ const VirtualListBaseFactory = (type) => {
 
 		render () {
 			const
-				{component, itemsRenderer, ...rest} = this.props,
+				{itemRenderer, itemsRenderer, ...rest} = this.props,
 				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
 
 			delete rest.initUiChildRef;
@@ -700,14 +700,14 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<UiBase
 					{...rest}
-					component={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
-						component({
+					getComponentProps={this.getComponentProps}
+					itemRenderer={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
+						itemRenderer({
 							... itemRest,
 							[dataIndexAttribute]: index,
 							index
 						})
 					)}
-					getComponentProps={this.getComponentProps}
 					ref={this.initUiRef}
 					updateStatesAndBounds={this.updateStatesAndBounds}
 					itemsRenderer={(props) => { // eslint-disable-line react/jsx-no-bind

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -64,11 +64,11 @@ const VirtualListBaseFactory = (type) => {
 		static propTypes = /** @lends moonstone/VirtualList.VirtualList.prototype */ {
 			/**
 			 * The `render` function for an item of the list receives the following parameters:
-			 * - `data` is for accessing the supplied `data` property of the list.
 			 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 			 * is parameters due to performance optimizations.
 			 *
 			 * @param {Object} event
+			 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 			 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 			 * @param {Number} event.index The index number of the componet to render
 			 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -64,11 +64,11 @@ const VirtualListBaseFactory = (type) => {
 		static propTypes = /** @lends moonstone/VirtualList.VirtualList.prototype */ {
 			/**
 			 * The `render` function for an item of the list receives the following parameters:
+			 * - `data` is for accessing the supplied `data` property of the list.
 			 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 			 * is parameters due to performance optimizations.
 			 *
 			 * @param {Object} event
-			 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 			 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 			 * @param {Number} event.index The index number of the componet to render
 			 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -79,9 +79,9 @@ describe('VirtualList', () => {
 		const subject = mount(
 			<VirtualList
 				clientSize={clientSize}
-				component={renderItem}
 				data={items}
 				dataSize={dataSize}
+				itemRenderer={renderItem}
 				itemSize={30}
 			/>
 		);
@@ -96,9 +96,9 @@ describe('VirtualList', () => {
 		const subject = mount(
 			<VirtualList
 				clientSize={clientSize}
-				component={renderItem}
 				data={items}
 				dataSize={dataSize}
+				itemRenderer={renderItem}
 				itemSize={30}
 			/>
 		);
@@ -113,10 +113,10 @@ describe('VirtualList', () => {
 		const subject = mount(
 			<VirtualList
 				clientSize={clientSize}
-				component={renderItem}
 				data={items}
 				dataSize={dataSize}
 				direction="horizontal"
+				itemRenderer={renderItem}
 				itemSize={30}
 			/>
 		);
@@ -133,9 +133,9 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -154,10 +154,10 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
 					direction="horizontal"
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -176,9 +176,9 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -198,9 +198,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScrollStart={handlerOnScrollStart}
 					/>
@@ -219,9 +219,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScroll={handlerOnScroll}
 					/>
@@ -240,9 +240,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScrollStop={handlerOnScrollStop}
 					/>
@@ -265,9 +265,9 @@ describe('VirtualList', () => {
 			const subject = mount(
 				<VirtualList
 					clientSize={clientSize}
-					component={renderItem}
 					data={itemArray}
 					dataSize={itemArray.length}
+					itemRenderer={renderItem}
 					itemSize={30}
 				/>
 			);

--- a/packages/moonstone/docs/virtual-list-scroller.md
+++ b/packages/moonstone/docs/virtual-list-scroller.md
@@ -21,15 +21,15 @@ This document describes VirtualList, VirtualGridList, and Scroller.
         <VirtualList
             data={data}
             dataSize={data.length}
-        	itemRenderer={this.renderItem}
-        	itemSize={ri.scale(72)}
+            itemRenderer={this.renderItem}
+            itemSize={ri.scale(72)}
         />
 
         <VirtualGridList
             data={data}
             dataSize={data.length}
-        	itemRenderer={this.renderItem}
-        	itemSize={{minWidth: ri.scale(90), minHeight: ri.scale(135)}}
+            itemRenderer={this.renderItem}
+            itemSize={{minWidth: ri.scale(90), minHeight: ri.scale(135)}}
         />
         ```
 
@@ -39,9 +39,9 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     <VirtualList
         data={data}
         dataSize={data.length} //<-- numeric property
-    	itemRenderer={this.renderItem}
-    	itemSize={ri.scale(72)} //<-- numeric property
-    	spacing={ri.scale(10)} //<-- numeric property
+        itemRenderer={this.renderItem}
+        itemSize={ri.scale(72)} //<-- numeric property
+        spacing={ri.scale(10)} //<-- numeric property
     />
     ```
 
@@ -59,22 +59,22 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     ```
     //.js
     renderItem = ({data, index, ...rest}) => {
-    	return (
-    		<div {...rest}>
-    			{data[index].name}
-    		</div>
-    	);
+        return (
+            <div {...rest}>
+                {data[index].name}
+            </div>
+        );
     }
     ...
     render = () => {
-    	return (
-    		<VirtualList
+        return (
+            <VirtualList
                 data={data}
                 dataSize={data.length}
-    			itemRenderer={this.renderItem}
-    			itemSize={this.itemSize}
-    		/>
-    	);
+                itemRenderer={this.renderItem}
+                itemSize={this.itemSize}
+            />
+        );
     }
     ```
 
@@ -83,27 +83,27 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     ```
     //MyListItem.js
     const MyListItem = kind({
-    	.....
-    	render = (props) => { //<-- should pass props
-    		return (
-    			<div {...props}>
-    				...
-    			</div>
-    		);
-    	}
+        .....
+        render = (props) => { //<-- should pass props
+            return (
+                <div {...props}>
+                    ...
+                </div>
+            );
+        }
     });
 
     //app.js
     renderItem = ({data, index, ...rest}) => {
-    	return (
-    		<MyListItem index={index} {...rest} />
-    	);
+        return (
+            <MyListItem index={index} {...rest} />
+        );
     }
     ```
 
 ### Items for VirtualGridList
 
-*   `GridListImageItem` itemRenderers can be used as items of `VirtualGridList`. They have Moonstone styling applied and have a placeholder image as a background.
+*   `GridListImageItem` components can be used as items of `VirtualGridList`. They have Moonstone styling applied and have a placeholder image as a background.
 
 *   `caption` and `subCaption` are supported.
 
@@ -116,16 +116,16 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
     ```
     renderItem = ({data, index, ...rest}) => {
-    	const {text, subText, source} = data[index];
-    	return (
-    		<GridListImageItem
-    			{...rest}
-    			caption={text}
-    			className={css.item}
-    			source={source}
-    			subCaption={subText}
-    		/>
-    	);
+        const {text, subText, source} = data[index];
+        return (
+            <GridListImageItem
+                {...rest}
+                caption={text}
+                className={css.item}
+                source={source}
+                subCaption={subText}
+            />
+        );
     };
     ```
 
@@ -140,18 +140,18 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     ```
     //.less
     .scroller {
-    	height: 550px;
-    	width: 480px;
+        height: 550px;
+        width: 480px;
     }
 
     //.js
     <Scroller
-    	className={css.scroller}
-    	direction="both"
+        className={css.scroller}
+        direction="both"
     >
-    	<div className={css.content}>
-    		Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
-    	</div>
+        <div className={css.content}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
+        </div>
     </Scroller>
     ```
 
@@ -162,40 +162,40 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     *   The callback function is called just once when a list or a scroller is created to prevent repeated calls when a list or a scroller is updated.
     *   Do not change `cbScrollTo` prop after a list or a scroller is mounted. It does not have any effect.
 *   The binding of a callback function
-    *   Please make sure the context of a callback function is properly bound. In general, your app itemRenderer instance would be the right one.
+    *   Please make sure the context of a callback function is properly bound. In general, your app component instance would be the right one.
     *   We recommend to use ECMAScript 2015 (a.k.a ECMAScript 6 or ES6) arrow functions to handle binding.
         *   [https://googlechrome.github.io/samples/arrows-es6/](https://googlechrome.github.io/samples/arrows-es6/)
         *   [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 *   Example:
 
     ```
-    class SampleApp extends React.itemRenderer {
-    	constructor (props) {
-    		super(props);
+    class SampleApp extends React.Component {
+        constructor (props) {
+            super(props);
 
-    		this.y = 0;
-    	}
-    	...
-    	getScrollTo = (scrollTo) => { // callback function to get scrollTo method; arrow function (ES6) is recommended to make sure `this` binding.
-    		this.scrollTo = scrollTo;
-    	}
-    	...
-    	doSomething = () => {
-    		...
-    		this.scrollTo({position: {y: this.y + offset}, animate: true}); // call the function of SampleApp, not a list.
-    	}
-    	...
-    	render = () => {
-    		return (
-    			<VirtualList
-    				cbScrollTo={this.getScrollTo} // pass callback function
+            this.y = 0;
+        }
+        ...
+        getScrollTo = (scrollTo) => { // callback function to get scrollTo method; arrow function (ES6) is recommended to make sure `this` binding.
+            this.scrollTo = scrollTo;
+        }
+        ...
+        doSomething = () => {
+            ...
+            this.scrollTo({position: {y: this.y + offset}, animate: true}); // call the function of SampleApp, not a list.
+        }
+        ...
+        render = () => {
+            return (
+                <VirtualList
+                    cbScrollTo={this.getScrollTo} // pass callback function
                     data={data}
                     dataSize={data.length}
-    				itemRenderer={this.renderItem}
-    				itemSize={this.itemSize}
-    			/>
-    		);
-    	}
+                    itemRenderer={this.renderItem}
+                    itemSize={this.itemSize}
+                />
+            );
+        }
     }
     ```
 
@@ -225,24 +225,24 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     //app.js
     ...
     handlerOnScrollStart = () => {
-    	this.setState({message: 'startScroll'});
+        this.setState({message: 'startScroll'});
     }
     handlerOnScroll = ({scrollTop}) => {
-    	this.y = scrollTop;
+        this.y = scrollTop;
     }
     handlerOnScrollStop = ({scrollTop}) => {
-    	this.y = scrollTop;
-    	this.setState({message: 'scrollStopped'});
+        this.y = scrollTop;
+        this.setState({message: 'scrollStopped'});
     }
     ...
     render = () => {
-    	return (
-    		<VirtualList
-    			...
-    			onScrollStart={this.handlerOnScrollStart}
-    			onScroll={this.handlerOnScroll}
-    			onScrollStop={this.handlerOnScrollStop}
-    		/>
-    	);
+        return (
+            <VirtualList
+                ...
+                onScrollStart={this.handlerOnScrollStart}
+                onScroll={this.handlerOnScroll}
+                onScrollStop={this.handlerOnScrollStop}
+            />
+        );
     }
     ```

--- a/packages/moonstone/docs/virtual-list-scroller.md
+++ b/packages/moonstone/docs/virtual-list-scroller.md
@@ -14,21 +14,21 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
     *   `dataSize`: Size of the data. A list does not check the size of `data` prop. dataSize prop is the only value to count items in a list.
     *   `itemSize`: Size of an item for the list. This is a required prop, and you will get an error when you build an app in dev mode without it.
-    *   `component`: The render function for an item of the list.
+    *   `itemRenderer`: The render function for an item of the list.
     *   Example
 
         ```
         <VirtualList
-        	component={this.renderItem}
-        	data={data}
-        	dataSize={data.length}
+            data={data}
+            dataSize={data.length}
+        	itemRenderer={this.renderItem}
         	itemSize={ri.scale(72)}
         />
 
         <VirtualGridList
-        	component={this.renderItem}
-        	data={data}
-        	dataSize={data.length}
+            data={data}
+            dataSize={data.length}
+        	itemRenderer={this.renderItem}
         	itemSize={{minWidth: ri.scale(90), minHeight: ri.scale(135)}}
         />
         ```
@@ -37,9 +37,9 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
     ```
     <VirtualList
-    	component={this.renderItem}
-    	data={data}
-    	dataSize={data.length} //<-- numeric property
+        data={data}
+        dataSize={data.length} //<-- numeric property
+    	itemRenderer={this.renderItem}
     	itemSize={ri.scale(72)} //<-- numeric property
     	spacing={ri.scale(10)} //<-- numeric property
     />
@@ -47,13 +47,13 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
 ### Common rules of Items for VirtualList/VirtualGridList
 
-*   A renderer for an item should be specified in `component` prop in VirtualList.
-*   VirtualList passes `data`, `index`, `data-index`, and `key` to the `component` function.
-*   Be sure you are passing `{...rest}` to the item component for reusing DOM.
+*   A renderer for an item should be specified in `itemRenderer` prop in VirtualList.
+*   VirtualList passes `data`, `index`, `data-index`, and `key` to the `itemRenderer` function.
+*   Be sure you are passing `{...rest}` to the item itemRenderer for reusing DOM.
 *   VirtualList will automatically give proper className for items.
-*   Be sure to compose `className` prop when you make customized item component.
-*   Make sure you are not using an inline function for `component`.
-*   If you want to scroll the list via 5-way navigation on the certain component in an item, you should pass `data-index` prop.
+*   Be sure to compose `className` prop when you make customized item itemRenderer.
+*   Make sure you are not using an inline function for `itemRenderer`.
+*   If you want to scroll the list via 5-way navigation on the certain itemRenderer in an item, you should pass `data-index` prop.
 *   Example:
 
     ```
@@ -69,9 +69,9 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     render = () => {
     	return (
     		<VirtualList
-    			component={this.renderItem}
-    			data={data}
-    			dataSize={data.length}
+                data={data}
+                dataSize={data.length}
+    			itemRenderer={this.renderItem}
     			itemSize={this.itemSize}
     		/>
     	);
@@ -103,7 +103,7 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
 ### Items for VirtualGridList
 
-*   `GridListImageItem` components can be used as items of `VirtualGridList`. They have Moonstone styling applied and have a placeholder image as a background.
+*   `GridListImageItem` itemRenderers can be used as items of `VirtualGridList`. They have Moonstone styling applied and have a placeholder image as a background.
 
 *   `caption` and `subCaption` are supported.
 
@@ -162,14 +162,14 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     *   The callback function is called just once when a list or a scroller is created to prevent repeated calls when a list or a scroller is updated.
     *   Do not change `cbScrollTo` prop after a list or a scroller is mounted. It does not have any effect.
 *   The binding of a callback function
-    *   Please make sure the context of a callback function is properly bound. In general, your app component instance would be the right one.
+    *   Please make sure the context of a callback function is properly bound. In general, your app itemRenderer instance would be the right one.
     *   We recommend to use ECMAScript 2015 (a.k.a ECMAScript 6 or ES6) arrow functions to handle binding.
         *   [https://googlechrome.github.io/samples/arrows-es6/](https://googlechrome.github.io/samples/arrows-es6/)
         *   [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 *   Example:
 
     ```
-    class SampleApp extends React.Component {
+    class SampleApp extends React.itemRenderer {
     	constructor (props) {
     		super(props);
 
@@ -189,9 +189,9 @@ This document describes VirtualList, VirtualGridList, and Scroller.
     		return (
     			<VirtualList
     				cbScrollTo={this.getScrollTo} // pass callback function
-    				component={this.renderItem}
-    				data={data}
-    				dataSize={data.length}
+                    data={data}
+                    dataSize={data.length}
+    				itemRenderer={this.renderItem}
     				itemSize={this.itemSize}
     			/>
     		);

--- a/packages/moonstone/docs/virtual-list-scroller.md
+++ b/packages/moonstone/docs/virtual-list-scroller.md
@@ -49,11 +49,11 @@ This document describes VirtualList, VirtualGridList, and Scroller.
 
 *   A renderer for an item should be specified in `itemRenderer` prop in VirtualList.
 *   VirtualList passes `data`, `index`, `data-index`, and `key` to the `itemRenderer` function.
-*   Be sure you are passing `{...rest}` to the item itemRenderer for reusing DOM.
+*   Be sure you are passing `{...rest}` to the item component for reusing DOM.
 *   VirtualList will automatically give proper className for items.
-*   Be sure to compose `className` prop when you make customized item itemRenderer.
+*   Be sure to compose `className` prop when you make customized item component.
 *   Make sure you are not using an inline function for `itemRenderer`.
-*   If you want to scroll the list via 5-way navigation on the certain itemRenderer in an item, you should pass `data-index` prop.
+*   If you want to scroll the list via 5-way navigation on the certain component in an item, you should pass `data-index` prop.
 *   Example:
 
     ```

--- a/packages/sampler/stories/moonstone-stories/VirtualGridList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualGridList.js
@@ -65,10 +65,10 @@ storiesOf('UI', module)
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<UiVirtualGridList
-				component={uiRenderItem}
 				data={items}
 				dataSize={number('dataSize', items.length)}
 				direction={select('direction', prop.direction, 'vertical')}
+				itemRenderer={uiRenderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', 180)),
 					minHeight: ri.scale(number('minHeight', 270))
@@ -91,11 +91,11 @@ storiesOf('Moonstone', module)
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<VirtualGridList
-				component={renderItem}
 				data={items}
 				dataSize={number('dataSize', items.length)}
 				direction={select('direction', prop.direction, 'vertical')}
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', 180)),
 					minHeight: ri.scale(number('minHeight', 270))

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -44,9 +44,9 @@ storiesOf('UI', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<UiVirtualList
-					component={renderItem(itemSize)}
 					data={items}
 					dataSize={number('dataSize', items.length)}
+					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
@@ -69,10 +69,10 @@ storiesOf('Moonstone', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<VirtualList
-					component={renderItem(itemSize)}
 					data={items}
 					dataSize={number('dataSize', items.length)}
 					focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}

--- a/packages/sampler/stories/qa-stories/VirtualGridList.js
+++ b/packages/sampler/stories/qa-stories/VirtualGridList.js
@@ -44,11 +44,11 @@ storiesOf('VirtualList.VirtualGridList', module)
 		'Horizontal VirtualGridList',
 		() => (
 			<VirtualGridList
-				component={renderItem}
 				data={items}
 				dataSize={number('dataSize', items.length)}
 				direction="horizontal"
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', 180)),
 					minHeight: ri.scale(number('minHeight', 270))

--- a/packages/sampler/stories/qa-stories/VirtualList.js
+++ b/packages/sampler/stories/qa-stories/VirtualList.js
@@ -80,10 +80,10 @@ storiesOf('VirtualList', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<VirtualList
-					component={renderItem(itemSize)}
 					data={items}
 					dataSize={number('dataSize', items.length)}
 					focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/VirtualList` and `ui/VirtualGridList` prop `component` to be replaced by `itemRenderer`
+- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` prop `component` to be replaced by `itemRenderer`
 
 ### Fixed
 
@@ -25,7 +25,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/GridListImageItem` component
 
 ### Changed
-- `ui/VirtualList.VirtualList`, `ui/VirtualList.VirtualGridList`, and `ui/Scroller` components as unstyled base components to support UI libraries
+- `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` components as unstyled base components to support UI libraries
 
 ## [2.0.0-alpha.4] - 2018-02-13
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -25,7 +25,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/GridListImageItem` component
 
 ### Changed
-- `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` components as unstyled base components to support UI libraries
+- `ui/VirtualList.VirtualList`, `ui/VirtualList.VirtualGridList`, and `ui/Scroller` components as unstyled base components to support UI libraries
 
 ## [2.0.0-alpha.4] - 2018-02-13
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Transition` property `clipHeight`
 
+### Changed
+
+- `ui/VirtualList` and `ui/VirtualGridList` prop `component` to be replaced by `itemRenderer`
+
 ### Fixed
 
 - `ui/Transition` animation for `clip` for "up", "left", and "right" directions. This includes a DOM addition to the Transition markup.

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -38,11 +38,11 @@ class VirtualListBase extends Component {
 	static propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
 		/**
 		 * The `render` function for an item of the list receives the following parameters:
+		 * - `data` is for accessing the supplied `data` property of the list.
 		 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 		 * is parameters due to performance optimizations.
 		 *
 		 * @param {Object} event
-		 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 		 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 		 * @param {Number} event.index The index number of the componet to render
 		 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -38,11 +38,11 @@ class VirtualListBase extends Component {
 	static propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
 		/**
 		 * The `render` function for an item of the list receives the following parameters:
-		 * - `data` is for accessing the supplied `data` property of the list.
 		 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 		 * is parameters due to performance optimizations.
 		 *
 		 * @param {Object} event
+		 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 		 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 		 * @param {Number} event.index The index number of the componet to render
 		 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -66,7 +66,7 @@ class VirtualListBase extends Component {
 		 * @type {Function}
 		 * @public
 		 */
-		component: PropTypes.func.isRequired,
+		itemRenderer: PropTypes.func.isRequired,
 
 		/**
 		 * Size of an item for the list; valid values are either a number for `VirtualList`
@@ -111,7 +111,7 @@ class VirtualListBase extends Component {
 		}),
 
 		/**
-		 * Data for passing it through `component` prop.
+		 * Data for passing it through `itemRenderer` prop.
 		 * NOTICE: For performance reason, changing this prop does NOT always cause the list to
 		 * redraw its items.
 		 *
@@ -578,10 +578,10 @@ class VirtualListBase extends Component {
 
 	applyStyleToNewNode = (index, ...rest) => {
 		const
-			{component, getComponentProps, data} = this.props,
+			{itemRenderer, getComponentProps, data} = this.props,
 			{numOfItems} = this.state,
 			key = index % numOfItems,
-			itemElement = component({
+			itemElement = itemRenderer({
 				data,
 				index,
 				key
@@ -716,11 +716,11 @@ class VirtualListBase extends Component {
 
 		delete rest.cbScrollTo;
 		delete rest.clientSize;
-		delete rest.component;
 		delete rest.data;
 		delete rest.dataSize;
 		delete rest.direction;
 		delete rest.getComponentProps;
+		delete rest.itemRenderer;
 		delete rest.itemSize;
 		delete rest.overhang;
 		delete rest.pageScroll;

--- a/packages/ui/VirtualList/VirtualListBaseNative.js
+++ b/packages/ui/VirtualList/VirtualListBaseNative.js
@@ -53,7 +53,7 @@ class VirtualListBaseNative extends Component {
 		 * @type {Function}
 		 * @public
 		 */
-		component: PropTypes.func.isRequired,
+		itemRenderer: PropTypes.func.isRequired,
 
 		/**
 		 * Size of an item for the list; valid values are either a number for `VirtualList`
@@ -98,7 +98,7 @@ class VirtualListBaseNative extends Component {
 		}),
 
 		/**
-		 * Data for passing it through `component` prop.
+		 * Data for passing it through `itemRenderer` prop.
 		 * NOTICE: For performance reason, changing this prop does NOT always cause the list to
 		 * redraw its items.
 		 *
@@ -555,10 +555,10 @@ class VirtualListBaseNative extends Component {
 
 	applyStyleToNewNode = (index, ...rest) => {
 		const
-			{component, getComponentProps, data} = this.props,
+			{itemRenderer, getComponentProps, data} = this.props,
 			{numOfItems} = this.state,
 			key = index % numOfItems,
-			itemElement = component({
+			itemElement = itemRenderer({
 				data,
 				index,
 				key
@@ -718,11 +718,11 @@ class VirtualListBaseNative extends Component {
 
 		delete rest.cbScrollTo;
 		delete rest.clientSize;
-		delete rest.component;
 		delete rest.data;
 		delete rest.dataSize;
 		delete rest.direction;
 		delete rest.getComponentProps;
+		delete rest.itemRenderer;
 		delete rest.itemSize;
 		delete rest.overhang;
 		delete rest.pageScroll;

--- a/packages/ui/VirtualList/VirtualListBaseNative.js
+++ b/packages/ui/VirtualList/VirtualListBaseNative.js
@@ -25,11 +25,11 @@ class VirtualListBaseNative extends Component {
 	static propTypes = /** @lends ui/VirtualList.VirtualListNative.prototype */ {
 		/**
 		 * The `render` function for an item of the list receives the following parameters:
+		 * - `data` is for accessing the supplied `data` property of the list.
 		 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 		 * is parameters due to performance optimizations.
 		 *
 		 * @param {Object} event
-		 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 		 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 		 * @param {Number} event.index The index number of the componet to render
 		 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/ui/VirtualList/VirtualListBaseNative.js
+++ b/packages/ui/VirtualList/VirtualListBaseNative.js
@@ -25,11 +25,11 @@ class VirtualListBaseNative extends Component {
 	static propTypes = /** @lends ui/VirtualList.VirtualListNative.prototype */ {
 		/**
 		 * The `render` function for an item of the list receives the following parameters:
-		 * - `data` is for accessing the supplied `data` property of the list.
 		 * > NOTE: In most cases, it is recommended to use data from redux store instead of using
 		 * is parameters due to performance optimizations.
 		 *
 		 * @param {Object} event
+		 * @param {*} event.data It is for accessing the supplied `data` property of the list.
 		 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
 		 * @param {Number} event.index The index number of the componet to render
 		 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -78,9 +78,9 @@ describe('VirtualList', () => {
 		const subject = mount(
 			<VirtualList
 				clientSize={clientSize}
-				component={renderItem}
 				data={items}
 				dataSize={dataSize}
+				itemRenderer={renderItem}
 				itemSize={30}
 			/>
 		);
@@ -95,9 +95,9 @@ describe('VirtualList', () => {
 		const subject = mount(
 			<VirtualList
 				clientSize={clientSize}
-				component={renderItem}
 				data={items}
 				dataSize={dataSize}
+				itemRenderer={renderItem}
 				itemSize={30}
 			/>
 		);
@@ -114,9 +114,9 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -135,10 +135,10 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
 					direction="horizontal"
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -157,9 +157,9 @@ describe('VirtualList', () => {
 				<VirtualList
 					cbScrollTo={getScrollTo}
 					clientSize={clientSize}
-					component={renderItem}
 					data={items}
 					dataSize={dataSize}
+					itemRenderer={renderItem}
 					itemSize={30}
 					onScrollStop={handlerOnScrollStop}
 				/>
@@ -179,9 +179,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScrollStart={handlerOnScrollStart}
 					/>
@@ -200,9 +200,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScroll={handlerOnScroll}
 					/>
@@ -221,9 +221,9 @@ describe('VirtualList', () => {
 					<VirtualList
 						cbScrollTo={getScrollTo}
 						clientSize={clientSize}
-						component={renderItem}
 						data={items}
 						dataSize={dataSize}
+						itemRenderer={renderItem}
 						itemSize={30}
 						onScrollStop={handlerOnScrollStop}
 					/>
@@ -246,9 +246,9 @@ describe('VirtualList', () => {
 			const subject = mount(
 				<VirtualList
 					clientSize={clientSize}
-					component={renderItem}
 					data={itemArray}
 					dataSize={itemArray.length}
+					itemRenderer={renderItem}
 					itemSize={30}
 				/>
 			);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Rename the `component` prop as `itemRenderer` because
- the name of the `component` could cause misunderstanding
- only a function could be defined as the `component` prop

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Rename `component` as `itemRenderer`
- Update samplers
- Update VirtualList, Scroller developer guide

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-52178

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)