### PR TITLE
PLAT-52439: Enact docs: fix too many doclets error

### DIFF
--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -28,11 +28,10 @@ const unorderedKeys = compose(sort((a, b) => a - b), orderedKeys);
 const unorderedEquals = useWith(equals, [unorderedKeys, unorderedKeys]);
 const orderedEquals = useWith(equals, [orderedKeys, orderedKeys]);
 
-/**
+/*
  * Compares the keys of two sets of children and returns `true` if they are equal.
  *
  * @method
- * @memberof core/util
  * @param  {Node[]}		prev		Array of children
  * @param  {Node[]}		next		Array of children
  * @param  {Boolean}	[ordered]	`true` to require the same order


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This patch fixes the `Too many doclets` error when parsing `ui/ViewManager` when using https://github.com/enactjs/docs.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed the jsdoc comment for `childrenEquals` in `ui/ViewManager/TransitionGroup` since it is not exported anyway.


### Links
[//]: # (Related issues, references)
PLAT-52439

Enact-DCO-1.0-Signed-off-by: Dave Freeman <dave.freeman@lge.com>