### PR TITLE
ENYO-5072: ComponentOverride should support strings as HTML tag names

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -28,6 +28,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` components to use their base UI components
 - `moonstone/Slider` to highlight knob when selected
 - `moonstone/Slider` to handle updates to its `value` prop correctly
+- `moonstone/ToggleItem` to accept HTML DOM node tag names as strings for its `component` property
 
 ## [2.0.0-alpha.5] - 2018-03-07
 

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -50,7 +50,7 @@ const ToggleItemBase = kind({
 		 * @required
 		 * @public
 		 */
-		iconComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+		iconComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]).isRequired,
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Transition` animation for `clip` for "up", "left", and "right" directions. This includes a DOM addition to the Transition markup.
+- `ui/ComponentOverride` and `ui/ToggleItem` to accept HTML DOM node tag names as strings for its `component` property
 
 ## [2.0.0-alpha.5] - 2018-03-07
 

--- a/packages/ui/ComponentOverride/ComponentOverride.js
+++ b/packages/ui/ComponentOverride/ComponentOverride.js
@@ -52,7 +52,7 @@ import React from 'react';
  * @public
  */
 const ComponentOverride = ({component, ...props}) => component ? (
-	typeof component === 'function' && React.createElement(component, props) ||
+	(typeof component === 'function' || typeof component === 'string') && React.createElement(component, props) ||
 	React.isValidElement(component) && React.cloneElement(component, props)
 ) : null;
 

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -77,7 +77,7 @@ const ToggleItemBase = kind({
 		 * @required
 		 * @public
 		 */
-		iconComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+		iconComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]).isRequired,
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the


### PR DESCRIPTION
### Issue Resolved / Feature Added
ComponentOverride doesn't accept strings.

### Resolution
Now it does, and ToggleItem also accepts strings like "div" for its `iconComponent`