### PR TITLE
ENYO-5074: Replace `vertical` with `orientation`

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,11 +8,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Slider` exports `SliderFactory` and `SliderBaseFactory`
 - `moonstone/IncrementSlider` exports `IncrementSliderFactory` and `IncrementSliderBaseFactory`
+- `moonstone/ProgressBar`, `moonstone/Slider`, `moonstone/Slider.SliderTooltip`, `moonstone/IncrementSlider` components' `vertical` property and replaced it with `orientation`
 
 ### Added
 
 - `moonstone/IncrementSlider` properties `incrementAriaLabel` and `decrementAriaLabel` to configure the label set on each button
 - `moonstone/Input` support for `small` prop
+- `moonstone/ProgressBar`, `moonstone/Slider`, `moonstone/Slider.SliderTooltip`, `moonstone/IncrementSlider` property `orientation` to accept orientation strings like "vertical" and "horizontal" (replaced old `vertical` prop)
 
 ### Changed
 

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -324,6 +324,7 @@ const IncrementSliderBase = kind({
 		 * down. Must be either `'horizontal'` or `'vertical'`.
 		 *
 		 * @type {String}
+		 * @default 'horizontal'
 		 * @public
 		 */
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -320,6 +320,15 @@ const IncrementSliderBase = kind({
 		onSpotlightUp: PropTypes.func,
 
 		/**
+		 * Sets the orientation of the slider, whether the slider moves left and right or up and
+		 * down. Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * `scrubbing` only has an effect with a detachedKnob, and is a performance optimization
 		 * to not allow re-assignment of the knob's value (and therefore position) during direct
 		 * user interaction.
@@ -414,15 +423,7 @@ const IncrementSliderBase = kind({
 		* @default 0
 		* @public
 		*/
-		value: PropTypes.number,
-
-		/**
-		* If `true` the increment slider will be oriented vertically.
-		*
-		* @type {Boolean}
-		* @public
-		*/
-		vertical: PropTypes.bool
+		value: PropTypes.number
 	},
 
 	defaultProps: {
@@ -431,49 +432,49 @@ const IncrementSliderBase = kind({
 		max: 100,
 		min: 0,
 		noFill: false,
+		orientation: 'horizontal',
 		spotlightDisabled: false,
 		step: 1,
 		tooltip: false,
 		tooltipAsPercent: false,
 		tooltipForceSide: false,
 		tooltipSide: 'before',
-		value: 0,
-		vertical: false
+		value: 0
 	},
 
 	handlers: {
-		handleDecrementKeyDown: (ev, {onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, vertical}) => {
+		handleDecrementKeyDown: (ev, {onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, orientation}) => {
 			const {keyCode} = ev;
 
 			if (isLeft(keyCode) && onSpotlightLeft) {
 				onSpotlightLeft(ev);
 			} else if (isDown(keyCode) && onSpotlightDown) {
 				onSpotlightDown(ev);
-			} else if (isRight(keyCode) && onSpotlightRight && vertical) {
+			} else if (isRight(keyCode) && onSpotlightRight && orientation === 'vertical') {
 				onSpotlightRight(ev);
-			} else if (isUp(keyCode) && onSpotlightUp && !vertical) {
+			} else if (isUp(keyCode) && onSpotlightUp && orientation !== 'vertical') {
 				onSpotlightUp(ev);
 			}
 		},
-		handleIncrementKeyDown: (ev, {onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, vertical}) => {
+		handleIncrementKeyDown: (ev, {onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, orientation}) => {
 			const {keyCode} = ev;
 
 			if (isRight(keyCode) && onSpotlightRight) {
 				onSpotlightRight(ev);
 			} else if (isUp(keyCode) && onSpotlightUp) {
 				onSpotlightUp(ev);
-			} else if (isLeft(keyCode) && onSpotlightLeft && vertical) {
+			} else if (isLeft(keyCode) && onSpotlightLeft && orientation === 'vertical') {
 				onSpotlightLeft(ev);
-			} else if (isDown(keyCode) && onSpotlightDown && !vertical) {
+			} else if (isDown(keyCode) && onSpotlightDown && orientation !== 'vertical') {
 				onSpotlightDown(ev);
 			}
 		},
-		handleSliderKeyDown: (ev, {min, max, value, onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, vertical}) => {
+		handleSliderKeyDown: (ev, {min, max, value, onSpotlightDown, onSpotlightLeft, onSpotlightRight, onSpotlightUp, orientation}) => {
 			const {keyCode} = ev;
 			const isMin = value <= min;
 			const isMax = value >= max;
 
-			if (vertical) {
+			if (orientation === 'vertical') {
 				if (isLeft(keyCode) && onSpotlightLeft) {
 					onSpotlightLeft(ev);
 				} else if (isRight(keyCode) && onSpotlightRight) {
@@ -504,9 +505,9 @@ const IncrementSliderBase = kind({
 	computed: {
 		decrementDisabled: ({disabled, min, value}) => disabled || value <= min,
 		incrementDisabled: ({disabled, max, value}) => disabled || value >= max,
-		incrementSliderClasses: ({vertical, styler}) => styler.append({vertical, horizontal: !vertical}),
-		decrementIcon: ({decrementIcon, vertical}) => (decrementIcon || (vertical ? 'arrowlargedown' : 'arrowlargeleft')),
-		incrementIcon: ({incrementIcon, vertical}) => (incrementIcon || (vertical ? 'arrowlargeup' : 'arrowlargeright')),
+		incrementSliderClasses: ({orientation, styler}) => styler.append(orientation),
+		decrementIcon: ({decrementIcon, orientation}) => (decrementIcon || ((orientation === 'vertical') ? 'arrowlargedown' : 'arrowlargeleft')),
+		incrementIcon: ({incrementIcon, orientation}) => (incrementIcon || ((orientation === 'vertical') ? 'arrowlargeup' : 'arrowlargeright')),
 		decrementAriaLabel: ({'aria-valuetext': valueText, decrementAriaLabel, disabled, min, value}) => {
 			if (decrementAriaLabel == null) {
 				decrementAriaLabel = $L('press ok button to decrease the value');
@@ -558,6 +559,7 @@ const IncrementSliderBase = kind({
 		onIncrement,
 		onIncrementSpotlightDisappear,
 		onSpotlightDisappear,
+		orientation,
 		scrubbing,
 		sliderBarRef,
 		sliderRef,
@@ -568,7 +570,6 @@ const IncrementSliderBase = kind({
 		tooltipForceSide,
 		tooltipSide,
 		value,
-		vertical,
 		...rest
 	}) => {
 		const ariaProps = extractAriaProps(rest);
@@ -613,6 +614,7 @@ const IncrementSliderBase = kind({
 					onIncrement={onIncrement}
 					onKeyDown={handleSliderKeyDown}
 					onSpotlightDisappear={onSpotlightDisappear}
+					orientation={orientation}
 					scrubbing={scrubbing}
 					sliderBarRef={sliderBarRef}
 					sliderRef={sliderRef}
@@ -623,7 +625,6 @@ const IncrementSliderBase = kind({
 					tooltipForceSide={tooltipForceSide}
 					tooltipSide={tooltipSide}
 					value={value}
-					vertical={vertical}
 				>
 					{children}
 				</Slider>

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -234,6 +234,7 @@ const SliderBase = kind({
 		 * down. Must be either `'horizontal'` or `'vertical'`.
 		 *
 		 * @type {String}
+		 * @default 'horizontal'
 		 * @public
 		 */
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -26,8 +26,8 @@ import SliderTooltip from './SliderTooltip';
 import componentCss from './Slider.less';
 
 const isActive = (ev, props) => props.active || props.activateOnFocus || props.detachedKnob;
-const isIncrement = (ev, props) => forKey(props.vertical ? 'up' : 'right', ev);
-const isDecrement = (ev, props) => forKey(props.vertical ? 'down' : 'left', ev);
+const isIncrement = (ev, props) => forKey((props.orientation === 'vertical') ? 'up' : 'right', ev);
+const isDecrement = (ev, props) => forKey((props.orientation === 'vertical') ? 'down' : 'left', ev);
 
 // memoize percent formatter for each locale so that we only instantiate NumFmt when locale changes
 const memoizedPercentFormatter = memoize((/* locale */) => new NumFmt({type: 'percentage', useNative: false}));
@@ -230,6 +230,15 @@ const SliderBase = kind({
 		onMouseMove: PropTypes.func,
 
 		/**
+		 * Sets the orientation of the slider, whether the slider moves left and right or up and
+		 * down. Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * When `true`, a pressed visual effect is applied
 		 *
 		 * @type {Boolean}
@@ -321,15 +330,7 @@ const SliderBase = kind({
 		 * @default 0
 		 * @public
 		 */
-		value: PropTypes.number,
-
-		/**
-		 * If `true` the slider will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		vertical: PropTypes.bool
+		value: PropTypes.number
 	},
 
 	defaultProps: {
@@ -343,14 +344,14 @@ const SliderBase = kind({
 		min: 0,
 		noFill: false,
 		onChange: () => {}, // needed to ensure the base input element is mutable if no change handler is provided
+		orientation: 'horizontal',
 		pressed: false,
 		step: 1,
 		tooltip: false,
 		tooltipAsPercent: false,
 		tooltipForceSide: false,
 		tooltipSide: 'before',
-		value: 0,
-		vertical: false
+		value: 0
 	},
 
 	styles: {
@@ -407,18 +408,19 @@ const SliderBase = kind({
 
 			return value;
 		},
-		className: ({activateOnFocus, active, noFill, pressed, vertical, styler}) => styler.append({
-			activateOnFocus,
-			active,
-			noFill,
-			pressed,
-			vertical,
-			horizontal: !vertical
-		}),
+		className: ({activateOnFocus, active, noFill, orientation, pressed, styler}) => styler.append(
+			orientation,
+			{
+				activateOnFocus,
+				active,
+				noFill,
+				pressed
+			}
+		),
 		proportionProgress: computeProportionProgress
 	},
 
-	render: ({backgroundProgress, children, css, disabled, focused, inputRef, knobAfterMidpoint, max, min, onBlur, onChange, onKeyDown, onMouseMove, onMouseUp, proportionProgress, scrubbing, sliderBarRef, sliderRef, step, tooltip, tooltipForceSide, tooltipSide, value, vertical, ...rest}) => {
+	render: ({backgroundProgress, children, css, disabled, focused, inputRef, knobAfterMidpoint, max, min, onBlur, onChange, onKeyDown, onMouseMove, onMouseUp, orientation, proportionProgress, scrubbing, sliderBarRef, sliderRef, step, tooltip, tooltipForceSide, tooltipSide, value, ...rest}) => {
 		delete rest.activateOnFocus;
 		delete rest.active;
 		delete rest.detachedKnob;
@@ -440,9 +442,9 @@ const SliderBase = kind({
 			tooltipComponent = <SliderTooltip
 				knobAfterMidpoint={knobAfterMidpoint}
 				forceSide={tooltipForceSide}
+				orientation={orientation}
 				proportion={proportionProgress}
 				side={tooltipSide}
-				vertical={vertical}
 			>
 				{children}
 			</SliderTooltip>;
@@ -460,10 +462,10 @@ const SliderBase = kind({
 			>
 				<SliderBar
 					css={css}
+					orientation={orientation}
 					proportionBackgroundProgress={backgroundProgress}
 					proportionProgress={proportionProgress}
 					ref={sliderBarRef}
-					vertical={vertical}
 					scrubbing={scrubbing}
 				>
 					{tooltipComponent}
@@ -479,8 +481,8 @@ const SliderBase = kind({
 					step={step}
 					onChange={onChange}
 					onMouseMove={onMouseMove}
+					orient={orientation}
 					value={value}
-					orient={vertical ? 'vertical' : 'horizontal'}
 				/>
 			</div>
 		);

--- a/packages/moonstone/Slider/SliderBar.js
+++ b/packages/moonstone/Slider/SliderBar.js
@@ -47,6 +47,15 @@ class SliderBar extends React.Component {
 		detachedKnob: PropTypes.bool,
 
 		/**
+		 * Sets the orientation of the slider, whether the slider moves left and right or up and
+		 * down. Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * The background progress as a proportion.
 		 *
 		 * @type {Number}
@@ -70,24 +79,7 @@ class SliderBar extends React.Component {
 		 * @type {Boolean}
 		 * @public
 		 */
-		scrubbing: PropTypes.bool,
-
-		/**
-		 * If `true` the slider will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		vertical: PropTypes.bool,
-
-		/**
-		 * Height, in standard CSS units, of the vertical slider. Only takes
-		 * effect on a vertical oriented slider, and will be `null` otherwise.
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		verticalHeight: PropTypes.object
+		scrubbing: PropTypes.bool
 	}
 
 	getBarNode = (node) => {
@@ -107,13 +99,13 @@ class SliderBar extends React.Component {
 	}
 
 	render () {
-		const {children, css, detachedKnob, proportionBackgroundProgress, proportionProgress, scrubbing, vertical, ...rest} = this.props;
+		const {children, css, detachedKnob, orientation, proportionBackgroundProgress, proportionProgress, scrubbing, ...rest} = this.props;
 
 		return (
 			<div {...rest} className={css.sliderBar} ref={this.getNode}>
-				<div className={css.load} ref={this.getLoaderNode} style={{transform: computeBarTransform(proportionBackgroundProgress, vertical)}} />
-				<div className={css.fill} ref={this.getBarNode} style={{transform: computeBarTransform(proportionProgress, vertical)}} />
-				<div className={css.knob} ref={this.getKnobNode} style={(detachedKnob && !scrubbing) ? {transform: computeKnobTransform(proportionProgress, vertical, this.node)} : null}>
+				<div className={css.load} ref={this.getLoaderNode} style={{transform: computeBarTransform(proportionBackgroundProgress, (orientation === 'vertical'))}} />
+				<div className={css.fill} ref={this.getBarNode} style={{transform: computeBarTransform(proportionProgress, (orientation === 'vertical'))}} />
+				<div className={css.knob} ref={this.getKnobNode} style={(detachedKnob && !scrubbing) ? {transform: computeKnobTransform(proportionProgress, (orientation === 'vertical'), this.node)} : null}>
 					{children}
 				</div>
 			</div>

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -46,6 +46,7 @@ const SliderTooltipBase = kind({
 		 * Must be either `'horizontal'` or `'vertical'`.
 		 *
 		 * @type {String}
+		 * @default 'horizontal'
 		 * @public
 		 */
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -77,9 +77,9 @@ const SliderTooltipBase = kind({
 	defaultProps: {
 		knobAfterMidpoint: false,
 		forceSide: false,
+		orientation: 'horizontal',
 		proportion: 0,
-		side: 'before',
-		vertical: false
+		side: 'before'
 	},
 
 	styles: {

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -41,6 +41,16 @@ const SliderTooltipBase = kind({
 		knobAfterMidpoint: PropTypes.bool,
 
 		/**
+		 * Sets the orientation of the tooltip based on the orientation of the Slider, 'vertical'
+		 * sends the tooltip to one of the sides, 'horizontal'  positions it above the Slider.
+		 * Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * The proportion of progress across the bar. Should be a number between 0 and 1.
 		 *
 		 * @type {Number}
@@ -61,15 +71,7 @@ const SliderTooltipBase = kind({
 		 * @default 'before'
 		 * @public
 		 */
-		side: PropTypes.oneOf(['before', 'after']),
-
-		/**
-		 * If `true` the slider will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		vertical: PropTypes.bool
+		side: PropTypes.oneOf(['before', 'after'])
 	},
 
 	defaultProps: {
@@ -88,14 +90,14 @@ const SliderTooltipBase = kind({
 	contextTypes,
 
 	computed: {
-		className: ({forceSide, side, vertical, styler}) => styler.append({ignoreLocale: forceSide, vertical, horizontal: !vertical}, side),
-		arrowAnchor: ({knobAfterMidpoint, vertical}) => {
-			if (vertical) return 'middle';
+		className: ({forceSide, orientation, side, styler}) => styler.append(orientation, {ignoreLocale: forceSide}, side),
+		arrowAnchor: ({knobAfterMidpoint, orientation}) => {
+			if (orientation === 'vertical') return 'middle';
 			return knobAfterMidpoint ? 'left' : 'right';
 		},
-		direction: ({forceSide, side, vertical}, context) => {
+		direction: ({forceSide, orientation, side}, context) => {
 			let dir = 'right';
-			if (vertical) {
+			if (orientation === 'vertical') {
 				if (
 					// LTR before (Both force and nonforce cases)
 					(!context.rtl && side === 'before') ||
@@ -118,9 +120,9 @@ const SliderTooltipBase = kind({
 	render: ({children, ...rest}) => {
 		delete rest.knobAfterMidpoint;
 		delete rest.forceSide;
+		delete rest.orientation;
 		delete rest.proportion;
 		delete rest.side;
-		delete rest.vertical;
 
 		return (
 			<Tooltip {...rest}>

--- a/packages/moonstone/Slider/tests/Slider-specs.js
+++ b/packages/moonstone/Slider/tests/Slider-specs.js
@@ -320,7 +320,7 @@ describe('Slider Specs', () => {
 	it('should set "aria-valuetext" to hint string when knob is active and vertical is true', function () {
 		const Comp = SliderDecorator(SliderBase);
 		const slider = mount(
-			<Comp vertical />
+			<Comp orientation="vertical" />
 		);
 
 		slider.find('Slider').prop('onActivate')();

--- a/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
+++ b/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
@@ -172,6 +172,15 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			onKnobMove: PropTypes.func,
 
 			/**
+			 * Sets the orientation of the slider, whether the slider moves left and right or up and
+			 * down. Must be either `'horizontal'` or `'vertical'`.
+			 *
+			 * @type {String}
+			 * @public
+			 */
+			orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+			/**
 			 * The amount to increment or decrement the value.
 			 *
 			 * @type {Number}
@@ -195,22 +204,14 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * @default 0
 			 * @public
 			 */
-			value: PropTypes.number,
-
-			/**
-			 * If `true` the slider will be oriented vertically.
-			 *
-			 * @type {Boolean}
-			 * @public
-			 */
-			vertical: PropTypes.bool
+			value: PropTypes.number
 		};
 
 		static defaultProps = {
 			max: 100,
 			min: 0,
-			step: 1,
-			vertical: false
+			orientation: 'horizontal',
+			step: 1
 		};
 
 		constructor (props) {
@@ -382,7 +383,8 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		updateUI = () => {
 			// intentionally breaking encapsulation to avoid having to specify multiple refs
 			const {barNode, knobNode, loaderNode, node} = this.sliderBarNode;
-			const {backgroundProgress, vertical} = this.props;
+			const {backgroundProgress, orientation} = this.props;
+			const vertical = orientation === 'vertical';
 			const {value} = this.state;
 			const proportionProgress = computeProportionProgress({value, max: this.normalizedMax, min: this.normalizedMin});
 			const knobProgress = this.knobPosition != null ? this.knobPosition : proportionProgress;
@@ -457,7 +459,7 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		handleMouseEnter = (ev) => {
 			forwardMouseEnter(ev, this.props);
 
-			if (!this.props.detachedKnob || this.props.disabled || this.props.vertical) return;
+			if (!this.props.detachedKnob || this.props.disabled || this.props.orientation === 'vertical') return;
 
 			this.moveKnobByPointer(ev.clientX);
 		}
@@ -466,7 +468,7 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forwardMouseMove(ev, this.props);
 			this.willChange = Boolean(ev.buttons); // if detached knob is dragging, it fires onChange
 
-			if (!this.props.detachedKnob || this.props.disabled || this.props.vertical) return;
+			if (!this.props.detachedKnob || this.props.disabled || this.props.orientation === 'vertical') return;
 
 			this.moveKnobByPointer(ev.clientX);
 		}
@@ -507,7 +509,7 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleActivate = () => {
-			const {'aria-valuetext': ariaValueText, detachedKnob, disabled, vertical} = this.props;
+			const {'aria-valuetext': ariaValueText, detachedKnob, disabled, orientation} = this.props;
 
 			if (disabled) return;
 
@@ -523,7 +525,7 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				let valueText = ariaValueText != null ? ariaValueText : this.state.value;
 				if (active) {
-					valueText = vertical ? verticalHint : horizontalHint;
+					valueText = (orientation === 'vertical') ? verticalHint : horizontalHint;
 				}
 
 				this.setState({active, valueText});

--- a/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
+++ b/packages/moonstone/internal/SliderDecorator/SliderDecorator.js
@@ -177,6 +177,7 @@ const SliderDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			 *
 			 * @type {String}
 			 * @public
+			 * @default 'horizontal'
 			 */
 			orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 

--- a/packages/sampler/stories/moonstone-stories/IncrementSlider.js
+++ b/packages/sampler/stories/moonstone-stories/IncrementSlider.js
@@ -28,12 +28,12 @@ storiesOf('Moonstone', module)
 				min={number('min', IncrementSliderBase.defaultProps.min)}
 				noFill={boolean('noFill', false)}
 				onChange={action('onChange')}
+				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				step={number('step', IncrementSliderBase.defaultProps.step)}
 				tooltip={nullify(boolean('tooltip', false))}
 				tooltipAsPercent={nullify(boolean('tooltipAsPercent', false))}
 				tooltipForceSide={nullify(boolean('tooltipForceSide', false))}
 				tooltipSide={select('tooltipSide', ['before', 'after'], 'after')}
-				vertical={nullify(boolean('vertical', false))}
 			/>
 		))
 	);

--- a/packages/sampler/stories/moonstone-stories/ProgressBar.js
+++ b/packages/sampler/stories/moonstone-stories/ProgressBar.js
@@ -1,7 +1,7 @@
 import ProgressBar, {ProgressBarBase} from '@enact/moonstone/ProgressBar';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {boolean, number} from '@storybook/addon-knobs';
+import {boolean, number, select} from '@storybook/addon-knobs';
 import {withInfo} from '@storybook/addon-info';
 
 import nullify from '../../src/utils/nullify.js';
@@ -19,7 +19,7 @@ storiesOf('Moonstone', module)
 			<ProgressBar
 				backgroundProgress={number('backgroundProgress', 0.5, {range: true, min: 0, max: 1, step: 0.01})}
 				progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
-				vertical={boolean('vertical', false)}
+				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				disabled={nullify(boolean('disabled', false))}
 			/>
 		))

--- a/packages/sampler/stories/moonstone-stories/Slider.js
+++ b/packages/sampler/stories/moonstone-stories/Slider.js
@@ -29,12 +29,12 @@ storiesOf('Moonstone', module)
 				noFill={boolean('noFill', false)}
 				onChange={action('onChange')}
 				onKnobMove={action('onKnobMove')}
+				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				step={number('step', SliderBase.defaultProps.step)}
 				tooltip={nullify(boolean('tooltip', false))}
 				tooltipAsPercent={nullify(boolean('tooltipAsPercent', false))}
 				tooltipForceSide={nullify(boolean('tooltipForceSide', false))}
 				tooltipSide={select('tooltipSide', ['before', 'after'], 'after')}
-				vertical={nullify(boolean('vertical', false))}
 			/>
 		))
 	);

--- a/packages/sampler/stories/qa-stories/ProgressBar.js
+++ b/packages/sampler/stories/qa-stories/ProgressBar.js
@@ -1,7 +1,7 @@
 import ProgressBar, {ProgressBarBase} from '@enact/moonstone/ProgressBar';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {boolean, number} from '@storybook/addon-knobs';
+import {boolean, number, select} from '@storybook/addon-knobs';
 
 import nullify from '../../src/utils/nullify.js';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
@@ -15,7 +15,7 @@ storiesOf('ProgressBar', module)
 			<ProgressBar
 				backgroundProgress={number('backgroundProgress', ProgressBarBase.defaultProps.backgroundProgress, {range: true, min: 0, max: 1, step: 0.01})}
 				progress={number('progress', ProgressBarBase.defaultProps.progress, {range: true, min: 0, max: 1, step: 0.1})}
-				vertical={boolean('vertical', false)}
+				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				disabled={nullify(boolean('disabled', false))}
 			/>
 		),

--- a/packages/sampler/stories/qa-stories/Slider.js
+++ b/packages/sampler/stories/qa-stories/Slider.js
@@ -82,7 +82,6 @@ class SliderList extends React.Component {
 					onChange={this.handleChange}
 					step={1}
 					tooltip={false}
-					vertical={false}
 					value={this.state.value}
 				/>
 				<VirtualList

--- a/packages/sampler/stories/qa-stories/Slider.js
+++ b/packages/sampler/stories/qa-stories/Slider.js
@@ -85,7 +85,7 @@ class SliderList extends React.Component {
 					value={this.state.value}
 				/>
 				<VirtualList
-					component={this.renderItem(this.props.itemSize)}
+					itemRenderer={this.renderItem(this.props.itemSize)}
 					data={this.state.selectedItems}
 					dataSize={this.state.selectedItems.length}
 					itemSize={this.props.itemSize}

--- a/packages/sampler/stories/qa-stories/components/IncrementSliderDelayValue/IncrementSliderDelayValue.js
+++ b/packages/sampler/stories/qa-stories/components/IncrementSliderDelayValue/IncrementSliderDelayValue.js
@@ -13,8 +13,7 @@ class IncrementSliderDelayValue extends React.Component {
 		max: PropTypes.number,
 		min: PropTypes.number,
 		step: PropTypes.number,
-		value: PropTypes.number,
-		vertical: PropTypes.bool
+		value: PropTypes.number
 	}
 
 	static defaultProps = {
@@ -22,8 +21,7 @@ class IncrementSliderDelayValue extends React.Component {
 		max: 100,
 		min: 0,
 		step: 1,
-		value: 0,
-		vertical: false
+		value: 0
 	}
 
 	constructor (props) {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,10 +7,12 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Removed
 
 - `ui/Transition` property `clipHeight`
+- `ui/ProgressBar` property `vertical` and replaced it with `orientation`
 
 ### Added
 
 - `ui/Scrollable` support for scrolling by touch
+- `ui/ProgressBar` property orientation to accept orientation strings like "vertical" and "horizontal"
 
 ### Changed
 

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -57,6 +57,16 @@ const ProgressBar = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Sets the orientation of the slider, whether the progress-bar depicts its progress value
+		 * in a left and right orientation or up and down onientation.
+		 * Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * The proportion of the filled portion of the progress bar. Valid values are
 		 * between `0` and `1`.
 		 *
@@ -64,22 +74,12 @@ const ProgressBar = kind({
 		 * @default 0
 		 * @public
 		 */
-		progress: PropTypes.number,
-
-		/**
-		 * If `true` the progress bar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		vertical: PropTypes.bool
+		progress: PropTypes.number
 	},
 
 	defaultProps: {
 		backgroundProgress: 0,
-		progress: 0,
-		vertical: false
+		progress: 0
 	},
 
 	styles: {
@@ -89,12 +89,12 @@ const ProgressBar = kind({
 	},
 
 	computed: {
-		className: ({vertical, styler}) => styler.append({vertical}),
-		progressCssProp: ({vertical}) => (vertical ? 'height' : 'width')
+		className: ({orientation, styler}) => styler.append(orientation),
+		progressCssProp: ({orientation}) => ((orientation === 'vertical') ? 'height' : 'width')
 	},
 
 	render: ({backgroundProgress, css, progress, progressCssProp, ...rest}) => {
-		delete rest.vertical;
+		delete rest.orientation;
 
 		if (__DEV__) {
 			validateRange(backgroundProgress, 0, 1, 'ProgressBar', 'backgroundProgress', 'min', 'max');

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -79,6 +79,7 @@ const ProgressBar = kind({
 
 	defaultProps: {
 		backgroundProgress: 0,
+		orientation: 'horizontal',
 		progress: 0
 	},
 

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -49,7 +49,8 @@ const ProgressBar = kind({
 		 * * `progressBar` - The root component class
 		 * * `fill` - The foreground node of the progress bar
 		 * * `load` - The background node of the progress bar
-		 * * `vertical` - Applied when `vertical` prop is `true`
+		 * * `horizontal` - Applied when `orientation` is `'horizontal'`
+		 * * `vertical` - Applied when `orientation` is `'vertical'`
 		 *
 		 * @type {Object}
 		 * @public
@@ -62,6 +63,7 @@ const ProgressBar = kind({
 		 * Must be either `'horizontal'` or `'vertical'`.
 		 *
 		 * @type {String}
+		 * @default 'horizontal'
 		 * @public
 		 */
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/packages/ui/ProgressBar/ProgressBar.less
+++ b/packages/ui/ProgressBar/ProgressBar.less
@@ -19,4 +19,8 @@
 			bottom: 0;
 		}
 	}
+
+	&.horizontal {
+		/* Exported for theme customization */
+	}
 }

--- a/packages/ui/ProgressBar/tests/ProgressBar-specs.js
+++ b/packages/ui/ProgressBar/tests/ProgressBar-specs.js
@@ -28,7 +28,7 @@ describe('ProgressBar Specs', () => {
 		const progressBar = mount(
 			<ProgressBar
 				progress={0.5}
-				vertical
+				orientation="vertical"
 			/>
 		);
 
@@ -40,7 +40,7 @@ describe('ProgressBar Specs', () => {
 			<ProgressBar
 				progress={0.5}
 				backgroundProgress={0.75}
-				vertical
+				orientation="vertical"
 			/>
 		);
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
`vertical` is a 1-dimensional property without room for extension over time.


### Resolution
`vertical` has been replaced with `orientation` in all Slider and ProgressBar iterations. `orientation` accepts a customizable string, which will allow for easy future development.