### PR TITLE
ENYO-4978: Fix sliderTooltip Deprecation in 1.x

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Deprecated
 
-- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
+- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/ProgressBar.ProgressBarTooltip` in 2.0.0
 
 ## [1.15.0] - 2018-02-28
 

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -132,7 +132,7 @@ const SliderTooltipBase = kind({
 	}
 });
 
-const deprecatedSliderTooltipBase = deprecate(SliderTooltipBase, {name: 'moonstone/Slider.SliderTooltip', since: '1.15.0', until: '2.0.0', message: 'Use `moonstone/Tooltip.ProgressBarTooltip` instead when using 2.0.0'});
+const deprecatedSliderTooltipBase = deprecate(SliderTooltipBase, {name: 'moonstone/Slider.SliderTooltip', since: '1.15.0', until: '2.0.0', message: 'Use `moonstone/ProgressBar.ProgressBarTooltip` instead when using 2.0.0'});
 
 export default deprecatedSliderTooltipBase;
 export {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Slider.sliderTooltip` is moving to `ProgressBar.ProgressBarTooltip` in #1467 
Fixing the typo in #1478 from `Tooltip.ProgressBarTooltip` to `ProgressBar.ProgressBarTooltip`



### Links
[//]: # (Related issues, references)
ENYO-4978

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com