### PR TITLE
Revert "ENYO-4978: Deprecate sliderTooltip in 1.x"

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [unreleased]
-
-### Deprecated
-
-- `moonstone/Slider.SliderTooltip`, to be moved to `moonstone/Tooltip.ProgressBarTooltip` in 2.0.0
-
 ## [1.15.0] - 2018-02-28
 
 ### Deprecated

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -19,7 +19,7 @@ import {computeProportionProgress} from '../internal/SliderDecorator/util';
 import Skinnable from '../Skinnable';
 
 import SliderBarFactory from './SliderBar';
-import {privateSliderTooltip as SliderTooltip} from './SliderTooltip';
+import SliderTooltip from './SliderTooltip';
 import componentCss from './Slider.less';
 
 const isActive = (ev, props) => props.active || props.activateOnFocus || props.detachedKnob;

--- a/packages/moonstone/Slider/SliderTooltip.js
+++ b/packages/moonstone/Slider/SliderTooltip.js
@@ -1,4 +1,3 @@
-import deprecate from '@enact/core/internal/deprecate';
 import kind from '@enact/core/kind';
 
 import {contextTypes} from '@enact/i18n/I18nDecorator';
@@ -16,7 +15,6 @@ import css from './SliderTooltip.less';
  * @memberof moonstone/Slider
  * @ui
  * @public
- * @deprecated
  */
 const SliderTooltipBase = kind({
 	name: 'SliderTooltip',
@@ -132,11 +130,5 @@ const SliderTooltipBase = kind({
 	}
 });
 
-const deprecatedSliderTooltipBase = deprecate(SliderTooltipBase, {name: 'moonstone/Slider.SliderTooltip', since: '1.15.0', until: '2.0.0', message: 'Use `moonstone/Tooltip.ProgressBarTooltip` instead when using 2.0.0'});
-
-export default deprecatedSliderTooltipBase;
-export {
-	deprecatedSliderTooltipBase as SliderTooltipBase,
-	SliderTooltipBase as privateSliderTooltip,
-	SliderTooltipBase as privateSliderTooltipBase
-};
+export default SliderTooltipBase;
+export {SliderTooltipBase, SliderTooltipBase as SliderTooltip};


### PR DESCRIPTION
Reverts enactjs/enact#1478 instead of merging #1513 