### PR TITLE
ENYO-5071: Fix ActivityPanels layout after adding panels

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -41,6 +41,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to highlight knob when selected
 - `moonstone/Slider` to handle updates to its `value` prop correctly
 - `moonstone/ToggleItem` to accept HTML DOM node tag names as strings for its `component` property
+- `moonstone/Panels.ActivityPanels` to correctly lay out the existing panel after adding additional panels
 
 ## [2.0.0-alpha.5] - 2018-03-07
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,12 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Fixed
+
+- `moonstone/Panels.ActivityPanels` to correctly lay out the existing panel after adding additional panels
+
+## [2.0.0-alpha.6]
+
 ### Removed
 
 - `moonstone/Slider` exports `SliderFactory` and `SliderBaseFactory`
@@ -26,9 +32,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ContextualPopup` prop `popupContainerId` to `popupSpotlightId`
 - `moonstone/Popup` prop `containerId` to `spotlightId`
 - `moonstone/VideoPlayer` prop `containerId` to `spotlightId`
-
-### Changed
-
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `component` to be replaced by `itemRenderer`
 
 ### Fixed
@@ -41,7 +44,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to highlight knob when selected
 - `moonstone/Slider` to handle updates to its `value` prop correctly
 - `moonstone/ToggleItem` to accept HTML DOM node tag names as strings for its `component` property
-- `moonstone/Panels.ActivityPanels` to correctly lay out the existing panel after adding additional panels
 
 ## [2.0.0-alpha.5] - 2018-03-07
 

--- a/packages/moonstone/Panels/Arrangers.js
+++ b/packages/moonstone/Panels/Arrangers.js
@@ -96,5 +96,5 @@ export const ActivityArranger = {
 	leave: compose(panelLeave, offsetForBreadcrumbs),
 	// Need a stay arrangement in case the initial index for ActivityPanels is > 0 so the panel is
 	// correctly offset for the breadcrumbs.
-	stay: offsetForBreadcrumbs
+	stay: compose(clearTransform, offsetForBreadcrumbs)
 };

--- a/packages/moonstone/Panels/Viewport.js
+++ b/packages/moonstone/Panels/Viewport.js
@@ -117,10 +117,10 @@ const ViewportBase = class extends React.Component {
 	)
 
 	mapChildren = (children, generateId) => React.Children.map(children, (child, index) => {
-		return React.cloneElement(child, {
+		return child ? React.cloneElement(child, {
 			spotlightId: child.props.spotlightId || generateId(index, 'panel-container', Spotlight.remove),
 			'data-index': index
-		});
+		}) : null;
 	})
 
 	getEnteringProp = (noAnimation) => noAnimation ? null : 'hideChildren'


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When altering the children of ActivityPanels, the active panel will incorrectly be offset for breadcrumbs multiple times.

This is due to a logic error in the ActivityPanelsArranger which failed to clear the current transform before setting the offset.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add a `clearTransform` to the `stay` arranger
* Also fix a bug in Viewport to support `null` children

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)