### PR TITLE
ENYO-5024: Fix Picker Fingernail Hang

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -41,6 +41,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to highlight knob when selected
 - `moonstone/Slider` to handle updates to its `value` prop correctly
 - `moonstone/ToggleItem` to accept HTML DOM node tag names as strings for its `component` property
+- `moonstone/Picker` state on onMouseLeave
 
 ## [2.0.0-alpha.5] - 2018-03-07
 

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -763,6 +763,7 @@ const PickerBase = class extends React.Component {
 				onKeyDown={this.handleKeyDown}
 				onKeyUp={this.handleKeyUp}
 				onUp={this.handleUp}
+				onMouseLeave={this.handleUp}
 				ref={this.initContainerRef}
 			>
 				<PickerButton

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -457,11 +457,13 @@ const PickerBase = class extends React.Component {
 		}
 	}
 
-	emulateMouseUp = new Job(() => {
+	clearPressedState = () => {
 		this.setState({
 			pressed: 0
 		});
-	}, 175)
+	}
+
+	emulateMouseUp = new Job(this.clearPressedState, 175)
 
 	handleUp = () => {
 		const {joined} = this.props;
@@ -763,7 +765,7 @@ const PickerBase = class extends React.Component {
 				onKeyDown={this.handleKeyDown}
 				onKeyUp={this.handleKeyUp}
 				onUp={this.handleUp}
-				onMouseLeave={this.handleUp}
+				onMouseLeave={this.clearPressedState}
 				ref={this.initContainerRef}
 			>
 				<PickerButton


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added `onMouseLeave` to clear `Picker`'s `pressed` state.

### Links
[//]: # (Related issues, references)
ENYO-5024

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
