### PR TITLE
Prevent blurring on state update

### DIFF
--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -160,14 +160,14 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			}
 
 			const focusChanged = this.state.focused !== prevState.focused;
-			if (focusChanged && this.state.focused === 'input') {
-				forward('onActivate', {type: 'onActivate'}, this.props);
-				this.paused.pause();
-			} else {
-				if (focusChanged && prevState.focused === 'input') {
+			if (focusChanged) {
+				if (this.state.focused === 'input') {
+					forward('onActivate', {type: 'onActivate'}, this.props);
+					this.paused.pause();
+				} else if (prevState.focused === 'input') {
 					forward('onDeactivate', {type: 'onDeactivate'}, this.props);
+					this.paused.resume();
 				}
-				this.paused.resume();
 			}
 		}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
InputSpotlightDecorator would restart spotlight whenever the state updated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Only unpause spotlight if the focus target changes

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5085

### Comments
