### PR TITLE
PLAT-52586: Fix ProgressBar tooltip in vertical orientation

### DIFF
--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -101,20 +101,23 @@ const ProgressBarBase = kind({
 				const progressAfterMidpoint = progress > 0.5;
 				const progressPercentage = Math.min(parseInt(progress * 100), 100);
 				const percentageText = `${progressPercentage}%`;
-				const tooltipVerticalPosition = {
-					top: `${100 - progressPercentage}%`,
-					right: tooltipForceSide ? 'auto' : ri.unit(-36, 'rem'),
-					left: tooltipForceSide ? ri.unit(72, 'rem') : null
-				};
-				const tooltipHorizontalPosition = progressAfterMidpoint ? {
-					right: `${100 - progressPercentage}%`,
-					bottom: ri.unit(24, 'rem')
-				} : {
-					left: percentageText,
-					bottom: ri.unit(24, 'rem')
-				};
 
-				const tooltipPosition = orientation === 'vertical' ? tooltipVerticalPosition : tooltipHorizontalPosition;
+				let tooltipPosition;
+				if (orientation === 'vertical') {
+					tooltipPosition = {
+						top: `${100 - progressPercentage}%`,
+						right: tooltipForceSide ? 'auto' : ri.unit(ri.scale(-36), 'rem'),
+						left: tooltipForceSide ? ri.unit(ri.scale(72), 'rem') : null
+					};
+				} else {
+					tooltipPosition = progressAfterMidpoint ? {
+						right: `${100 - progressPercentage}%`,
+						bottom: ri.unit(ri.scale(24), 'rem')
+					} : {
+						left: percentageText,
+						bottom: ri.unit(ri.scale(24), 'rem')
+					};
+				}
 
 				return (
 					<ProgressBarTooltip

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -49,6 +49,17 @@ const ProgressBarBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Sets the orientation of the slider, whether the progress-bar depicts its progress value
+		 * in a left and right orientation or up and down onientation.
+		 * Must be either `'horizontal'` or `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'horizontal'
+		 * @public
+		 */
+		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * The proportion of the filled portion of the progress bar. Valid values are
 		 * between `0` and `1`.
 		 *
@@ -76,16 +87,7 @@ const ProgressBarBase = kind({
 		 * @type {Boolean}
 		 * @public
 		 */
-		tooltipForceSide: PropTypes.bool,
-
-		/**
-		 * If `true` the progress bar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		vertical: PropTypes.bool
+		tooltipForceSide: PropTypes.bool
 	},
 
 	styles: {
@@ -94,7 +96,7 @@ const ProgressBarBase = kind({
 	},
 
 	computed: {
-		tooltipComponent: ({progress, tooltip, tooltipForceSide, vertical}) => {
+		tooltipComponent: ({progress, tooltip, tooltipForceSide, orientation}) => {
 			if (tooltip) {
 				const progressAfterMidpoint = progress > 0.5;
 				const progressPercentage = Math.min(parseInt(progress * 100), 100);
@@ -112,14 +114,14 @@ const ProgressBarBase = kind({
 					bottom: ri.unit(24, 'rem')
 				};
 
-				const tooltipPosition = vertical ? tooltipVerticalPosition : tooltipHorizontalPosition;
+				const tooltipPosition = orientation === 'vertical' ? tooltipVerticalPosition : tooltipHorizontalPosition;
 
 				return (
 					<ProgressBarTooltip
 						forceSide={tooltipForceSide}
 						knobAfterMidpoint={progressAfterMidpoint}
 						style={tooltipPosition}
-						vertical={vertical}
+						orientation={orientation}
 					>
 						{percentageText}
 					</ProgressBarTooltip>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ProgressBar needs to accept `orientation` to set `vertical` to apply vertical styles correctly.



### Links
[//]: # (Related issues, references)
PLAT-52586

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
