### PR TITLE
ENYO-5084: webos/platform property description should be changed from…

### DIFF
--- a/packages/webos/platform/platform.js
+++ b/packages/webos/platform/platform.js
@@ -75,7 +75,7 @@ function detect () {
  * @type {object}
  * @property {?boolean} tv - Set true for LG webOS SmartTV
  * @property {?boolean} watch - Set true for LG webOS SmartWatch
- * @property {?boolean} open - Set true for Open webOS
+ * @property {?boolean} open - Set true for webOS OSE
  * @property {?boolean} legacy - Set true for legacy webOS (Palm and HP hardware)
  * @property {?boolean} unknown - Set true for any unknown system
  *


### PR DESCRIPTION
… Open webOS to webOS OSE

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The official name of open webOS is "webOS OSE". There's open webOS in the `open` description

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed to webOS OSE

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>
