### PR TITLE
PLAT-52443: Add the log to deprecate `data` prop in `VirtualList` (release 1.x)

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Deprecated
+
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `data`, to be removed in 2.0.0
+
 ## [1.15.0] - 2018-02-28
 
 ### Deprecated

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -51,6 +51,11 @@ const deprecateComponent = deprecate(
 	{name: 'component', replacedBy: 'itemRenderer', until: '2.0.0'}
 );
 
+const deprecateData = deprecate(
+	() => {},
+	{name: 'data', until: '2.0.0'}
+);
+
 /**
  * {@link moonstone/VirtualList.VirtualListBase} is a base component for
  * {@link moonstone/VirtualList.VirtualList} and
@@ -137,6 +142,7 @@ class VirtualListCore extends Component {
 		 *
 		 * @type {Any}
 		 * @default []
+		 * @deprecated will be removed in 2.0.0
 		 * @public
 		 */
 		data: PropTypes.any,
@@ -675,6 +681,7 @@ class VirtualListCore extends Component {
 			style = {};
 
 		deprecateComponent();
+		deprecateData();
 
 		this.composeStyle(style, ...rest);
 

--- a/packages/moonstone/VirtualList/VirtualListBaseNative.js
+++ b/packages/moonstone/VirtualList/VirtualListBaseNative.js
@@ -53,6 +53,11 @@ const deprecateComponent = deprecate(
 	{name: 'component', replacedBy: 'itemRenderer', until: '2.0.0'}
 );
 
+const deprecateData = deprecate(
+	() => {},
+	{name: 'data', until: '2.0.0'}
+);
+
 /**
  * {@link moonstone/VirtualList.VirtualListBaseNative} is a base component for
  * {@link moonstone/VirtualList.VirtualList} and
@@ -140,6 +145,7 @@ class VirtualListCoreNative extends Component {
 		 *
 		 * @type {Any}
 		 * @default []
+		 * @deprecated will be removed in 2.0.0
 		 * @public
 		 */
 		data: PropTypes.any,
@@ -645,6 +651,7 @@ class VirtualListCoreNative extends Component {
 			style = {};
 
 		deprecateComponent();
+		deprecateData();
 
 		this.composeStyle(style, ...rest);
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In Enact 2.0 (https://github.com/enactjs/enact/pull/1524), we'd like to remove the `data` prop in a `VirtualList`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Add the log to deprecate `data` prop in `VirtualList`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-52443

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)
