### PR TITLE
ENYO-5088: Refactor ProgressBarTooltip to use CSS variables for positioning

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/VideoPlayer` property `moreButtonColor` to allow setting underline colors for more button
 - `moonstone/Panels.Header` support for `headerInput` so the Header can be used as an Input. See documentation for usage examples.
-- `moonstone/ProgressBar` prop `tooltipSide` to configure tooltip position relative to the progres bar
+- `moonstone/ProgressBar` prop `tooltipSide` to configure tooltip position relative to the progress bar
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/VideoPlayer` property `moreButtonColor` to allow setting underline colors for more button
 - `moonstone/Panels.Header` support for `headerInput` so the Header can be used as an Input. See documentation for usage examples.
+- `moonstone/ProgressBar` prop `tooltipSide` to configure tooltip position relative to the progres bar
 
 ### Fixed
 

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
@@ -10,6 +10,10 @@
 @import '../styles/rules.less';
 
 .root {
+	// Global base-level initial CSS variable definitions.
+	// Anything set here should be acceptable as the basis for everything that references them
+	--moon-tooltip-offset: 0px;
+
 	.moon-text-base(@moon-sub-header-font-size);
 	font-weight: normal;
 	font-style: normal;

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
@@ -10,10 +10,6 @@
 @import '../styles/rules.less';
 
 .root {
-	// Global base-level initial CSS variable definitions.
-	// Anything set here should be acceptable as the basis for everything that references them
-	--moon-tooltip-offset: 0px;
-
 	.moon-text-base(@moon-sub-header-font-size);
 	font-weight: normal;
 	font-style: normal;

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -16,7 +16,6 @@ import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import React from 'react';
-import ri from '@enact/ui/resolution';
 
 import Skinnable from '../Skinnable';
 import {ProgressBarTooltip} from './ProgressBarTooltip';
@@ -87,7 +86,28 @@ const ProgressBarBase = kind({
 		 * @type {Boolean}
 		 * @public
 		 */
-		tooltipForceSide: PropTypes.bool
+		tooltipForceSide: PropTypes.bool,
+
+		/**
+		 * Specify where the tooltip should appear in relation to the ProgressBar. Options are
+		 * `'before'` and `'after'`. `before` renders above a `horizontal` slider and to the
+		 * left of a `vertical` ProgressBar. `after` renders below a `horizontal` slider and to the
+		 * right of a `vertical` ProgressBar. In the `vertical` case, the rendering position is
+		 * automatically reversed when rendering in an RTL locale. This can be overridden by
+		 * using the [tooltipForceSide]{@link moonstone/ProgressBar.ProgressBar.tooltipForceSide}
+		 * prop.
+		 *
+		 * @type {String}
+		 * @default 'before'
+		 * @public
+		 */
+		tooltipSide: PropTypes.string
+	},
+
+	defaultProps: {
+		tooltip: false,
+		tooltipSide: 'before',
+		tooltipForceSide: false
 	},
 
 	styles: {
@@ -96,35 +116,19 @@ const ProgressBarBase = kind({
 	},
 
 	computed: {
-		tooltipComponent: ({progress, tooltip, tooltipForceSide, orientation}) => {
+		tooltipComponent: ({orientation, progress, tooltip, tooltipForceSide, tooltipSide}) => {
 			if (tooltip) {
 				const progressAfterMidpoint = progress > 0.5;
 				const progressPercentage = Math.min(parseInt(progress * 100), 100);
 				const percentageText = `${progressPercentage}%`;
 
-				let tooltipPosition;
-				if (orientation === 'vertical') {
-					tooltipPosition = {
-						top: `${100 - progressPercentage}%`,
-						right: tooltipForceSide ? 'auto' : ri.unit(ri.scale(-36), 'rem'),
-						left: tooltipForceSide ? ri.unit(ri.scale(72), 'rem') : null
-					};
-				} else {
-					tooltipPosition = progressAfterMidpoint ? {
-						right: `${100 - progressPercentage}%`,
-						bottom: ri.unit(ri.scale(24), 'rem')
-					} : {
-						left: percentageText,
-						bottom: ri.unit(ri.scale(24), 'rem')
-					};
-				}
-
 				return (
 					<ProgressBarTooltip
 						forceSide={tooltipForceSide}
 						knobAfterMidpoint={progressAfterMidpoint}
-						style={tooltipPosition}
+						proportion={progress}
 						orientation={orientation}
+						side={tooltipSide}
 					>
 						{percentageText}
 					</ProgressBarTooltip>
@@ -137,6 +141,7 @@ const ProgressBarBase = kind({
 
 	render: ({css, tooltipComponent, ...rest}) => {
 		delete rest.tooltip;
+		delete rest.tooltipSide;
 		delete rest.tooltipForceSide;
 
 		return (

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -108,7 +108,9 @@ const ProgressBarTooltipBase = kind({
 					// RTL after
 					(context.rtl && !forceSide && side === 'after') ||
 					// RTL before FORCE
-					(context.rtl && forceSide && side === 'before')
+					(context.rtl && forceSide && side === 'before') ||
+					// LTR before FORCE
+					(!context.rtl && forceSide && side === 'before')
 				) {
 					dir = 'left';
 				} else {

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -94,7 +94,7 @@ const ProgressBarTooltipBase = kind({
 	contextTypes,
 
 	computed: {
-		className: ({forceSide, orientation, side, styler}) => styler.append(orientation, {ignoreLocale: forceSide}, side),
+		className: ({forceSide, knobAfterMidpoint, orientation, side, styler}) => styler.append(orientation, {ignoreLocale: forceSide, knobAfterMidpoint}, side),
 		arrowAnchor: ({knobAfterMidpoint, orientation}) => {
 			if (orientation === 'vertical') return 'middle';
 			return knobAfterMidpoint ? 'left' : 'right';
@@ -118,7 +118,11 @@ const ProgressBarTooltipBase = kind({
 				dir = (side === 'before' ? 'above' : 'below');
 			}
 			return dir;
-		}
+		},
+		style: ({proportion, style}) => ({
+			...style,
+			'--tooltip-progress-proportion': proportion
+		})
 	},
 
 	render: ({children, ...rest}) => {

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.less
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.less
@@ -6,7 +6,7 @@
 .tooltip {
 	--tooltip-progress-proportion: 0;
 	--tooltip-progress-percent: ~"calc(var(--tooltip-progress-proportion) * 100%)";
-	--tooltip-calculated-offset: ~"calc(var(--moon-tooltip-offset) + " @moon-tooltip-point-width ~")";
+	--tooltip-calculated-offset: ~"calc(var(--moon-tooltip-offset, 0px) + " @moon-tooltip-point-width ~")";
 
 	@offset-large: 0;
 

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.less
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.less
@@ -15,7 +15,7 @@
 
 		&.before {
 			top: 0;
-			transform: translateY(calc(-100% - var(--tooltip-calculated-offset)));
+			transform: translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
 
 			.moon-custom-text({
 				bottom: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
@@ -23,7 +23,7 @@
 		}
 		&.after {
 			bottom: 0;
-			transform: translateY(calc(100% + var(--tooltip-calculated-offset)));
+			transform: translateY(~"calc(100% + var(--tooltip-calculated-offset))");
 
 			.moon-custom-text({
 				top: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
@@ -33,11 +33,11 @@
 		&.knobAfterMidpoint,
 		[data-knob-after-midpoint="true"] & {
 			&.before {
-				transform: translateX(-100%) translateY(calc(-100% - var(--tooltip-calculated-offset)));
+				transform: translateX(-100%) translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
 			}
 
 			&.after {
-				transform: translateX(-100%) translateY(calc(100% + var(--tooltip-calculated-offset)));
+				transform: translateX(-100%) translateY(~"calc(100% + var(--tooltip-calculated-offset))");
 			}
 		}
 	}
@@ -50,7 +50,7 @@
 		:global(.enact-locale-right-to-left) &.before.ignoreLocale,
 		:global(.enact-locale-right-to-left) &.after {
 			right: 0;
-			transform: translate(calc(var(--tooltip-calculated-offset) * -1), 50%);
+			transform: translate(~"calc(var(--tooltip-calculated-offset) * -1)", 50%);
 
 			.moon-custom-text({
 				transform: translate(~"calc(var(--tooltip-calculated-offset) * -1 - " @offset-large ~")", 50%);

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.less
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.less
@@ -4,39 +4,56 @@
 @import '../styles/text.less';
 
 .tooltip {
-	@offset-large: 0px;
+	--tooltip-progress-proportion: 0;
+	--tooltip-progress-percent: ~"calc(var(--tooltip-progress-proportion) * 100%)";
+	--tooltip-calculated-offset: ~"calc(var(--moon-tooltip-offset) + " @moon-tooltip-point-width ~")";
+
+	@offset-large: 0;
 
 	&.horizontal {
+		left: var(--tooltip-progress-percent);
+
 		&.before {
-			bottom: @moon-slider-tooltip-offset;
+			top: 0;
+			transform: translateY(calc(-100% - var(--tooltip-calculated-offset)));
 
 			.moon-custom-text({
-				bottom: (@moon-slider-tooltip-offset + @offset-large);
+				bottom: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
 			});
 		}
 		&.after {
-			top: @moon-slider-tooltip-offset;
+			bottom: 0;
+			transform: translateY(calc(100% + var(--tooltip-calculated-offset)));
 
 			.moon-custom-text({
-				top: (@moon-slider-tooltip-offset + @offset-large);
+				top: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
 			});
 		}
 
+		&.knobAfterMidpoint,
 		[data-knob-after-midpoint="true"] & {
-			transform: translateX(-100%);
+			&.before {
+				transform: translateX(-100%) translateY(calc(-100% - var(--tooltip-calculated-offset)));
+			}
+
+			&.after {
+				transform: translateX(-100%) translateY(calc(100% + var(--tooltip-calculated-offset)));
+			}
 		}
 	}
 
 	&.vertical {
+		bottom: var(--tooltip-progress-percent);
+
 		// Left side
 		&.before,
 		:global(.enact-locale-right-to-left) &.before.ignoreLocale,
 		:global(.enact-locale-right-to-left) &.after {
 			right: 0;
-			transform: translate(-54px, -50%);
+			transform: translate(calc(var(--tooltip-calculated-offset) * -1), 50%);
 
 			.moon-custom-text({
-				transform: translate((-54px - @offset-large), -50%);
+				transform: translate(~"calc(var(--tooltip-calculated-offset) * -1 - " @offset-large ~")", 50%);
 			});
 		}
 
@@ -45,10 +62,10 @@
 		:global(.enact-locale-right-to-left) &.after.ignoreLocale,
 		:global(.enact-locale-right-to-left) &.before {
 			right: auto;
-			transform: translate(54px, -50%);
+			transform: translate(var(--tooltip-calculated-offset), 50%);
 
 			.moon-custom-text({
-				transform: translate((54px + @offset-large), -50%);
+				transform: translate(~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")", 50%);
 			});
 		}
 	}

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -444,7 +444,6 @@ const SliderBase = kind({
 				knobAfterMidpoint={knobAfterMidpoint}
 				forceSide={tooltipForceSide}
 				orientation={orientation}
-				proportion={proportionProgress}
 				side={tooltipSide}
 			>
 				{children}

--- a/packages/moonstone/Slider/Slider.less
+++ b/packages/moonstone/Slider/Slider.less
@@ -33,6 +33,8 @@
 	}
 
 	.knob {
+		--moon-tooltip-offset: @moon-slider-tooltip-offset;
+
 		position: absolute;
 		will-change: transform;
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -285,7 +285,7 @@
 @moon-slider-knob-width-large: @moon-button-small-height-large;
 @moon-slider-knob-height: @moon-button-small-height;
 @moon-slider-knob-height-large: @moon-button-small-height-large;
-@moon-slider-tooltip-offset: 54px;
+@moon-slider-tooltip-offset: (@moon-slider-knob-height / 2);
 @moon-slider-knob-resting-state-scale: 0.8;
 
 // IntegerPicker


### PR DESCRIPTION
### Issue Resolved / Feature Added
`ProgressBarTooltip` (formerly `SliderTooltip`) used some pretty outdated and non-functional techniques.


### Resolution
Essentially now, the `ProgressBarTooltip` component just transmits its proportion value directly to CSS. CSS then does calculations and positioning for every orientation of the tooltip. `Slider` can define a moonstone CSS "offset" variable which is then factored into the `ProgressBarTooltip` positioning calculation so it too is properly positioned.


### Additional Considerations
Does Storybook not support CSS variables? My Storybook was erroring and it didn't make sense as to why. My installation may be out of date.