### PR TITLE
ENYO-5006: Spotlight Hides on Page Down/Up

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
+- `moonstone/VirtualList` and `moonstone/VirtualGridList`, to navigate properly with page up and down keys
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
-- `moonstone/VirtualList` and `moonstone/VirtualGridList`, to navigate properly with page up and down keys
+- `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -310,8 +310,8 @@ const VirtualListBaseFactory = (type) => {
 		scrollToNextItem = ({direction, focusedItem}) => {
 			const
 				{data} = this.uiRef.props,
-				focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute)),
-				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo;
+				{firstIndex, numOfItems} = this.uiRef.state,
+				focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute));
 			let indexToScroll = -1;
 
 			if (Array.isArray(data) && data.some((item) => item.disabled)) {
@@ -325,7 +325,7 @@ const VirtualListBaseFactory = (type) => {
 					isRtl = this.props.rtl,
 					isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right');
 
-				if (firstVisibleIndex <= indexToScroll && indexToScroll <= lastVisibleIndex) {
+				if (firstIndex <= indexToScroll && indexToScroll < firstIndex + numOfItems) {
 					const node = this.uiRef.containerRef.querySelector(`[data-index='${indexToScroll}'].spottable`);
 
 					if (node) {
@@ -337,8 +337,8 @@ const VirtualListBaseFactory = (type) => {
 						Spotlight.pause();
 					}
 					focusedItem.blur();
+					this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
 				}
-				this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
 				this.uiRef.props.cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
 			}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Spotlight in `VirtualList` and `VirtualGridList` Hides on Page Down/Up

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

In some edge cases, Spotlight in `VirtualList` did not show properly after hiding it. So I fixed the condition to hide it.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

ENYO-5006

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)