### PR TITLE
PLAT-51932: Added AccessibilityDecorator and SpotlightRootDecorator functionality…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/Panels.ActivityPanels` to correctly lay out the existing panel after adding additional panels
 - `spotlight` to partition and prioritize next spottable elements for more natural 5-way behavior
 - `ui/Scroller` horizontal scrolling in RTL locales
+## Unreleased
+
+### Changed
+
+- `moonstone/moonstoneDecorator` to include functionality from AccessibilityDecorator and SpotlightRootDecorator to reduce startup time
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/MoonstoneDecorator/AccessibilityUtils.js
+++ b/packages/moonstone/MoonstoneDecorator/AccessibilityUtils.js
@@ -1,0 +1,86 @@
+import hoc from '@enact/core/hoc';
+import {contextTypes, Publisher} from '@enact/core/internal/PubSub';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes =  /** @lends moonstone/MoonstoneDecorator.AccessibilityDecorator.prototype */ {
+    /**
+     * Enables additional features to help users visually differentiate components.
+     * The UI library will be responsible for using this information to adjust
+     * the components' contrast to this preset.
+     *
+     * @type {Boolean}
+     * @public
+     */
+	highContrast: PropTypes.bool,
+
+    /**
+     * Set the goal size of the text. The UI library will be responsible for using this
+     * information to adjust the components' text sizes to this preset.
+     * Current presets are `'normal'` (default), and `'large'`.
+     *
+     * @type {String}
+     * @default 'normal'
+     * @public
+     */
+	textSize: PropTypes.oneOf(['normal', 'large'])
+};
+
+const defaultProps = {
+	highContrast: false,
+	textSize: 'normal'
+};
+
+const createResizePublisher = (subscriber) => Publisher.create('resize', subscriber);
+
+const onTextSizeChange = (props, prevProps, publisher) => {
+	if (prevProps.textSize !== props.textSize) {
+		publisher.publish({
+			horizontal: true,
+			vertical: true
+		});
+	}
+};
+
+const createClassName = (className, highContrast, textSize) => {
+	const accessibilityClassName = highContrast ? `enact-a11y-high-contrast enact-text-${textSize}` : `enact-text-${textSize}`;
+	return className ? `${className} ${accessibilityClassName}` : accessibilityClassName;
+};
+/**
+ * {@link moonstone/MoonstoneDecorator.AccessibilityDecorator} is a Higher-order Component that
+ * classifies an application with a target set of font sizing rules
+ *
+ * @class AccessibilityDecorator
+ * @memberof moonstone/MoonstoneDecorator
+ * @hoc
+ * @public
+ */
+// const AccessibilityDecorator = hoc((config, Wrapped) => {
+// 	return class extends React.Component {
+// 		static displayName = 'AccessibilityDecorator'
+
+// 		render () {
+// 			const {className, highContrast, textSize, ...props} = this.props;
+// 			const accessibilityClassName = highContrast ? `enact-a11y-high-contrast enact-text-${textSize}` : `enact-text-${textSize}`;
+// 			const combinedClassName = className ? `${className} ${accessibilityClassName}` : accessibilityClassName;
+
+// 			return <Wrapped className={combinedClassName} {...props} />;
+// 		}
+// 	};
+// });
+const Accessibility = {
+	propTypes,
+	defaultProps,
+	createResizePublisher,
+	onTextSizeChange,
+	createClassName
+};
+export default Accessibility;
+export {
+    Accessibility,
+    propTypes,
+    defaultProps,
+    createResizePublisher,
+    onTextSizeChange,
+    createClassName
+};

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 
 import {init, defineScreenTypes, getResolutionClasses} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
+import SpotlightRootDecorator from '@enact/spotlight/SpotlightRootDecorator';
 
 import Skinnable from '../Skinnable';
 
@@ -63,9 +64,9 @@ const defaultConfig = {
  * @public
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	
-	const {ri, i18n, float, overlay, skin, textSize, highContrast} = config;
-	
+
+	const {ri, i18n, spotlight, float, noAutoFocus, overlay, skin, textSize, highContrast} = config;
+
 	if (ri.screenTypes) {
 		defineScreenTypes(ri.screenTypes);
 	}
@@ -82,6 +83,8 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			)
 		);
 	}
+
+	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
 	// if (ri) App = ResolutionDecorator(ri, App);
 	if (skin) App = Skinnable({defaultSkin: 'dark'}, App);

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -17,11 +17,10 @@ import I18nFontDecorator from './I18nFontDecorator';
 import screenTypes from './screenTypes.json';
 import css from './MoonstoneDecorator.less';
 import {configure} from '@enact/ui/Touchable';
-import {contextTypes, Publisher} from '@enact/core/internal/PubSub';
-import PropTypes from 'prop-types';
-import Spotlight from '@enact/spotlight/src/spotlight';
-import {spottableClass} from '@enact/spotlight/Spottable';
-import {rootContainerId} from '@enact/spotlight/src/container';
+import {contextTypes} from '@enact/core/internal/PubSub';
+
+import Accessibility from './AccessibilityUtils';
+
 /**
  * Default config for {@link moonstone/MoonstoneDecorator.MoonstoneDecorator}.
  *
@@ -38,9 +37,7 @@ const defaultConfig = {
 	},
 	spotlight: true,
 	textSize: true,
-	skin: true,
-	dynamic: true,
-	screenTypes: null
+	skin: true
 };
 
 /**
@@ -63,7 +60,7 @@ const defaultConfig = {
  * @public
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {ri, i18n, float, noAutoFocus, overlay, skin, textSize, highContrast} = config;
+	const {ri, i18n, float, overlay, skin, textSize, highContrast} = config;
 
 	// Apply classes depending on screen type (overlay / fullscreen)
 	const bgClassName = 'enact-fit' + (overlay ? '' : ` ${css.bg}`);
@@ -124,92 +121,25 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static childContextTypes = contextTypes
 
-		static propTypes =  /** @lends moonstone/MoonstoneDecorator.AccessibilityDecorator.prototype */ {
-			/**
-			 * Enables additional features to help users visually differentiate components.
-			 * The UI library will be responsible for using this information to adjust
-			 * the components' contrast to this preset.
-			 *
-			 * @type {Boolean}
-			 * @public
-			 */
-			highContrast: PropTypes.bool,
+		static propTypes =  Accessibility.accessibilityPropTypes;
 
-			/**
-			 * Set the goal size of the text. The UI library will be responsible for using this
-			 * information to adjust the components' text sizes to this preset.
-			 * Current presets are `'normal'` (default), and `'large'`.
-			 *
-			 * @type {String}
-			 * @default 'normal'
-			 * @public
-			 */
-			textSize: PropTypes.oneOf(['normal', 'large'])
-		}
-
-		static defaultProps = {
-			highContrast: false,
-			textSize: 'normal'
-		}
+		static defaultProps = Accessibility.defaultProps
 
 		getChildContext () {
 			return {
-				Subscriber: this.publisher.getSubscriber()
+				Subscriber: this.publisher.accessibility.getSubscriber()
 			};
 		}
 
 		componentWillMount () {
+			this.publisher = {};
 			if (textSize || highContrast) {
-				this.publisher = Publisher.create('resize', this.context.Subscriber);
+				this.publisher.accessibility = Accessibility.createResizePublisher(this.context.Subscriber);
 			}
-
-			if (typeof window === 'object') {
-				const palmSystem = window.PalmSystem;
-
-				Spotlight.initialize({
-					selector: '.' + spottableClass,
-					restrict: 'none'
-				});
-
-				Spotlight.set(rootContainerId, {
-					overflow: true
-				});
-
-				if (palmSystem && palmSystem.cursor) {
-					Spotlight.setPointerMode(palmSystem.cursor.visibility);
-				}
-			}
-		}
-
-		componentDidMount () {
-			if (!noAutoFocus) {
-				Spotlight.focus();
-			}
-			if (config.dynamic) window.addEventListener('resize', this.handleResize);
-			// eslint-disable-next-line react/no-find-dom-node
-			// this.rootNode = ReactDOM.findDOMNode(this);
 		}
 
 		componentDidUpdate (prevProps) {
-			if (prevProps.textSize !== this.props.textSize) {
-				this.publisher.publish({
-					horizontal: true,
-					vertical: true
-				});
-			}
-		}
-
-
-		componentWillUnmount () {
-			Spotlight.terminate();
-			if (config.dynamic) window.removeEventListener('resize', this.handleResize);
-		}
-
-		navigableFilter = (elem) => {
-			while (elem && elem !== document && elem.nodeType === 1) {
-				if (elem.getAttribute('data-container-disabled') === 'true') return false;
-				elem = elem.parentNode;
-			}
+			Accessibility.onTextSizeChange(this.props, prevProps, this.publisher);
 		}
 
 		render () {
@@ -222,8 +152,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			const {highContrast: contrast, textSize: size, ...props} = this.props;
-			const accessibilityClassName = contrast ? `enact-a11y-high-contrast enact-text-${size}` : `enact-text-${size}`;
-			const combinedClassName = className ? `${className} ${accessibilityClassName}` : accessibilityClassName;
+			const combinedClassName = Accessibility.createClassName(className, contrast, size);
 
 			return (
 				<App {...props} className={combinedClassName} />

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -10,7 +10,7 @@ import I18nDecorator from '@enact/i18n/I18nDecorator';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import {ResolutionDecorator, init, defineScreenTypes, getResolutionClasses} from '@enact/ui/resolution';
+import {init, defineScreenTypes, getResolutionClasses} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
 
 import Skinnable from '../Skinnable';
@@ -35,13 +35,12 @@ const defaultConfig = {
 	noAutoFocus: false,
 	overlay: false,
 	ri: {
-		screenTypes
+		screenTypes,
+		dynamic: true
 	},
 	spotlight: true,
 	textSize: true,
-	skin: true,
-	dynamic: true,
-	screenTypes: null
+	skin: true
 };
 
 /**
@@ -64,12 +63,12 @@ const defaultConfig = {
  * @public
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	if (config.screenTypes) {
-		defineScreenTypes(config.screenTypes);
-	}
-
+	
 	const {ri, i18n, float, overlay, skin, textSize, highContrast} = config;
-
+	
+	if (ri.screenTypes) {
+		defineScreenTypes(ri.screenTypes);
+	}
 	// Apply classes depending on screen type (overlay / fullscreen)
 	const bgClassName = 'enact-fit' + (overlay ? '' : ` ${css.bg}`);
 
@@ -155,7 +154,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			if (config.dynamic) window.addEventListener('resize', this.handleResize);
+			if (ri.dynamic) window.addEventListener('resize', this.handleResize);
 			// eslint-disable-next-line react/no-find-dom-node
 			this.rootNode = ReactDOM.findDOMNode(this);
 		}
@@ -165,7 +164,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			if (config.dynamic) window.removeEventListener('resize', this.handleResize);
+			if (ri.dynamic) window.removeEventListener('resize', this.handleResize);
 		}
 
 		handleResize = () => {

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -86,7 +86,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
-	// if (ri) App = ResolutionDecorator(ri, App);
+
 	if (skin) App = Skinnable({defaultSkin: 'dark'}, App);
 
 	// add webOS-specific key maps


### PR DESCRIPTION
### Issue Resolved / Feature Added
`MoonstoneDecorator` has a lot of HOCs. Publisher and Subscriber in particular take a bit of time to setup on each component during the lifecycle methods.

### Resolution
Put `AccessibilityDecorator` and `SpotlightRootDecorator` inside `MoonstoneDecorator` directly we can save a bit of time.

### Additional Considerations
I left in `AccessibilityDecorator` and `SpotlightRootDecorator`. I'm didn't want to delete them because I think they can still be useful in other areas.

ALTERNATIVELY, React 16.3 should come with the new context API. We could wait on that and possibly eliminate the need for publisher and subscriber.

### Links
PLAT-51932

