### PR TITLE
ENYO-5092: Fix navigating out of moonstone/Input via 5-way

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
 - `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
+- `moonstone/Input` to allow navigating via left or right to other components when the input is active and the selection is at start or end of the text, respectively
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -281,9 +281,12 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 					preventSpotlightNavigation(ev);
 					this.paused.resume();
 
-					// Move spotlight in the keypress direction, if there is no other spottable elements,
-					// focus `InputDecorator` instead
-					if (!move(direction)) {
+					// Move spotlight in the keypress direction
+					if (move(direction)) {
+						// if successful, reset the internal state
+						this.blur();
+					} else {
+						// if there is no other spottable elements, focus `InputDecorator` instead
 						this.focusDecorator(currentTarget);
 					}
 				} else if (isLeft || isRight) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After the changes made in #1473, Input no longer allowed directly navigating to adjacent components via 5-way when the input is active and the cursor is at the start or end of the text. This was caused by the internal state of `InputSpotlightDecorator` being out of sync with the desired state.

When pressing left or right at the start or end, respectively, of the text, `InputSpotlightDecorator` would focus the next control. When the internal `<input>` was blurred while still in 5-way mode, `InputSpotlightDecorator` would then try to focus the decorator assuming that was the expected next target. As a result, focus would move to an external component and then immediately pulled back to the input decorator.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
After successfully moving to another target, reset the internal state of `InputSpotlightDecorator` to show that no part of the input is focused.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I also considered revising the logic within `updateFocus` to not steal focus when set externally. That's not easily achievable right now because we don't maintain node references to both the input and the decorator to use to compare with `Spotlight.getCurrent()`. We may consider that later but this change should be valid in either case in order to best maintain the correct internal state.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)