### PR TITLE
ENYO-5093: Guard against document to allow proper prerendering.

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -162,7 +162,7 @@ class FloatingLayerBase extends React.Component {
 		const {floatLayerClassName, open} = this.props;
 		const floatingLayer = this.context.getFloatingLayer();
 
-		if (!this.node && floatingLayer && open) {
+		if (!this.node && floatingLayer && open && typeof document !== 'undefined') {
 			invariant(
 				this.context.getFloatingLayer,
 				'FloatingLayer cannot be used outside the subtree of a FloatingLayerDecorator'

--- a/packages/ui/FloatingLayer/FloatingLayerDecorator.js
+++ b/packages/ui/FloatingLayer/FloatingLayerDecorator.js
@@ -70,7 +70,11 @@ const FloatingLayerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// as the floating layer, this.floatingLayer may not have been initialized yet since
 			// componentDidMount runs inside-out. As a fallback, we search by id but this could
 			// introduce issues (e.g. for duplicate layer ids).
-			return this.floatingLayer || document.getElementById(floatLayerId) || null;
+			return (
+				this.floatingLayer ||
+				(typeof document !== 'undefined' && document.getElementById(floatLayerId)) ||
+				null
+			);
 		}
 
 		getRootFloatingLayer = () => {


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Prerendering was failing due to usage of `document.createElement`

### Resolution
* Guard for existence of `document`.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>