### PR TITLE
ENYO-5054: Update ProgressBar and Slider colors

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` property `moreButtonColor` to allow setting underline colors for more button
 - `moonstone/Panels.Header` support for `headerInput` so the Header can be used as an Input. See documentation for usage examples.
 
+### Changed
+
+- `moonstone/ProgressBar` colors (affecting `moonstone/Slider` as well) for light and dark theme to match the latest designs and make them more visible when drawn over arbitrary background colors
+
 ### Fixed
 
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -161,9 +161,9 @@
 
 // Progress Bar
 // ---------------------------------------
-@moon-progress-bar-bg-color: rgba(128, 128, 128, 0.3);
-@moon-progress-bar-loaded-bg-color: rgba(86, 86, 86, 0.2);
-@moon-progress-bar-fill-bg-color: #808080;
+@moon-progress-bar-bg-color: fade(@moon-gray, 50%);
+@moon-progress-bar-loaded-bg-color: fade(@moon-text-color, 40%);
+@moon-progress-bar-fill-bg-color: @moon-text-color;
 @moon-progress-bar-tooltip-text-color: @moon-white;
 
 // RadioItem

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -166,8 +166,8 @@
 // Progress Bar
 // ---------------------------------------
 @moon-progress-bar-bg-color: rgba(128, 128, 128, 0.3);
-@moon-progress-bar-loaded-bg-color: rgba(86, 86, 86, 0.2);
-@moon-progress-bar-fill-bg-color: #808080;
+@moon-progress-bar-loaded-bg-color: rgba(200, 200, 200, 0.5);
+@moon-progress-bar-fill-bg-color: #f5f5f5;
 @moon-progress-bar-tooltip-text-color: @moon-white;
 
 // RadioItem


### PR DESCRIPTION
### Issue Resolved / Feature Added
The colors for ProgressBar make it difficult to differentiate the stages of progress, as well as they don't look very good on random background colors, like photos or videos.


### Resolution
Update the colors to match the requirements and make the affected components more visually "contrasty".


### Additional Considerations
This affects both ProgressBar *and* Slider, since Slider uses these color values.