### PR TITLE
ENYO-5013: Fix ui/Transition to handle empty children

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,8 +6,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Transition` property `children` not to be required
+- `ui/Transition` property `children` to not be required
 - `ui/Transition` to fire `onShow` and `onHide` even when there are no `children`
+
 ## [2.0.0-alpha.7 - 2018-04-03]
 
 ### Removed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Transition` property `children` not to be required
+- `ui/Transition` to fire `onShow` and `onHide` even when there are no `children`
+
 ## [2.0.0-alpha.6] - 2018-03-22
 
 ### Removed

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -369,7 +369,7 @@ class Transition extends React.Component {
 			this.measureInner();
 		}
 
-		if (initialHeight === null && prevState.initialHeight === null) {
+		if (!this.childNode) {
 			if (!prevProps.visible && visible) {
 				forwardOnShow({}, this.props);
 			} else if (prevProps.visible && !visible) {

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -15,6 +15,8 @@ import PropTypes from 'prop-types';
 import css from './Transition.less';
 
 const forwardTransitionEnd = forward('onTransitionEnd');
+const forwardOnShow = forward('onShow');
+const forwardOnHide = forward('onHide');
 
 /**
  * {@link ui/Transition.TransitionBase} is a stateless component that allows for applying
@@ -29,8 +31,6 @@ const TransitionBase = kind({
 	name: 'TransitionBase',
 
 	propTypes: /** @lends ui/Transition.TransitionBase.prototype */ {
-		children: PropTypes.node.isRequired,
-
 		/**
 		 * Provide a function to get the reference to the child node (the one with the content) at
 		 * render time. Useful if you need to measure or interact with the node directly.
@@ -40,6 +40,14 @@ const TransitionBase = kind({
 		 * @public
 		 */
 		childRef: PropTypes.func,
+
+		/**
+		 * The node to be transitioned.
+		 *
+		 * @type {Node}
+		 * @public
+		 */
+		children: PropTypes.node,
 
 		/**
 		 * The height of the transition when `type` is set to `'clip'`, used when direction is
@@ -217,7 +225,13 @@ class Transition extends React.Component {
 	static contextTypes = contextTypes
 
 	static propTypes = /** @lends ui/Transition.Transition.prototype */ {
-		children: PropTypes.node.isRequired,
+		/**
+		 * The node to be transitioned.
+		 *
+		 * @type {Node}
+		 * @public
+		 */
+		children: PropTypes.node,
 
 		/**
 		 * The direction of transition (i.e. where the component will move *to*; the destination).
@@ -353,6 +367,14 @@ class Transition extends React.Component {
 			renderState !== TRANSITION_STATE.INIT) ||
 			(initialHeight == null && visible)) {
 			this.measureInner();
+		}
+
+		if (initialHeight === null && prevState.initialHeight === null) {
+			if (!prevProps.visible && visible) {
+				forwardOnShow({}, this.props);
+			} else if (prevProps.visible && !visible) {
+				forwardOnHide({}, this.props);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`mooonstone/ExpandableItem.ExpandableSpotlightDecorator` depends on pausing and resuming spotlight from `ui/Transition`'s `onShow` and `onHide` events. However, when there are no children provided, then `Transition` never fires those events, resulting in indefinite spotlight pause.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change `Transition` to handle empty `children` and fire events when `visible` prop changes.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>