### PR TITLE
ENYO-5069: Fix the timing to read a11y for ScrollButton

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -191,22 +191,32 @@ class ScrollButtons extends Component {
 		return current === this.prevButtonNodeRef || current === this.nextButtonNodeRef;
 	}
 
+	handlePrevDown = () => {
+		const {vertical} = this.props;
+
+		if (this.announce) {
+			this.announce(vertical ? $L('UP') : $L('LEFT'));
+		}
+	}
+
+	handleNextDown = () => {
+		const {vertical} = this.props;
+
+		if (this.announce) {
+			this.announce(vertical ? $L('DOWN') : $L('RIGHT'));
+		}
+	}
+
 	handlePrevScroll = (ev) => {
 		const {onPrevScroll, vertical} = this.props;
 
 		onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
-		if (this.announce) {
-			this.announce(vertical ? $L('UP') : $L('LEFT'));
-		}
 	}
 
 	handleNextScroll = (ev) => {
 		const {onNextScroll, vertical} = this.props;
 
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
-		if (this.announce) {
-			this.announce(vertical ? $L('DOWN') : $L('RIGHT'));
-		}
 	}
 
 	handlePrevHoldPulse = (ev) => {
@@ -281,6 +291,7 @@ class ScrollButtons extends Component {
 				direction={vertical ? 'up' : 'left'}
 				disabled={disabled || prevButtonDisabled}
 				onClick={this.handlePrevScroll}
+				onDown={this.handlePrevDown}
 				onHoldPulse={this.handlePrevHoldPulse}
 				onKeyDown={this.depressButton}
 				onKeyUp={this.releaseButton}
@@ -297,6 +308,7 @@ class ScrollButtons extends Component {
 				direction={vertical ? 'down' : 'right'}
 				disabled={disabled || nextButtonDisabled}
 				onClick={this.handleNextScroll}
+				onDown={this.handleNextDown}
 				onHoldPulse={this.handleNextHoldPulse}
 				onKeyDown={this.depressButton}
 				onKeyUp={this.releaseButton}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fix the timing to read a11y when the scroll 'down' or 'up' button was pressed.
Expected: Press the button and the 'down' should be heard immediately.
Actual: Release the button and the 'down' is heard.

### Links
ENYO-5069

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)