### PR TITLE
ENYO-4981: Fix TimePicker to support variable length meridiems

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/TimePickerBase` to show `meridiem` correctly in all locales
+- `moonstone/TimePicker` to show `meridiem` correctly in all locales
 
 ## [2.0.0-alpha.7 - 2018-04-03]
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -32,6 +32,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
 - `moonstone/Input` to allow navigating via left or right to other components when the input is active and the selection is at start or end of the text, respectively
 - `moonstone/Panels.ActivityPanels` to correctly lay out the existing panel after adding additional panels
+- `moonstone/TimePickerBase` to show `meridiem` correctly in all locales
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/TimePicker/TimePickerBase.js
+++ b/packages/moonstone/TimePicker/TimePickerBase.js
@@ -239,7 +239,8 @@ const TimePickerBase = kind({
 	},
 
 	computed: {
-		hasMeridiem: ({order}) => order.indexOf('a') >= 0
+		hasMeridiem: ({order}) => order.indexOf('a') >= 0,
+		meridiemPickerWidth: ({meridiem, meridiems}) => meridiems[meridiem].length * 2
 	},
 
 	render: ({
@@ -248,6 +249,7 @@ const TimePickerBase = kind({
 		hour,
 		meridiem,
 		meridiemLabel,
+		meridiemPickerWidth,
 		meridiems,
 		minute,
 		noLabels,
@@ -338,7 +340,7 @@ const TimePickerBase = kind({
 											reverse
 											spotlightDisabled={spotlightDisabled}
 											value={meridiem}
-											width={4}
+											width={meridiemPickerWidth}
 											wrap
 										>
 											{meridiems}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/TimePickerBase` to show `meridiem` correctly in all locales by setting the `meridiem` picker width dynamically based on the length of the meridiem * 2



### Links
[//]: # (Related issues, references)
ENYO-4981

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com