### PR TITLE
PLAT-52790: Fix the a11y property of VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -731,7 +731,7 @@ VirtualListBase.displayName = 'VirtualListBase';
 const VirtualListBaseNative = VirtualListBaseFactory(Native);
 VirtualListBaseNative.displayName = 'VirtualListBaseNative';
 
-const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
+const ScrollableVirtualList = ({...rest}) => ( // eslint-disable-line react/jsx-no-bind
 	<Scrollable
 		{...rest}
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
@@ -739,7 +739,7 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 				{...props}
 				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
 					[
-						cc.length ? <div key="0" ref={initItemContainerRef} role={role}>{cc}</div> : null,
+						cc.length ? <div key="0" ref={initItemContainerRef} role="list">{cc}</div> : null,
 						primary ?
 							null :
 							<SpotlightPlaceholder
@@ -747,7 +747,6 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 								data-vl-placeholder
 								key="1"
 								onFocus={handlePlaceholderFocus}
-								role="region"
 							/>,
 						needsScrollingPlaceholder ? <SpotlightPlaceholder key="2" /> : null
 					]
@@ -757,17 +756,7 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 	/>
 );
 
-ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualList.prototype */ {
-	/**
-	 * Aria role.
-	 *
-	 * @type {String}
-	 * @private
-	 */
-	role: PropTypes.string
-};
-
-const ScrollableVirtualListNative = ({role, ...rest}) => (
+const ScrollableVirtualListNative = ({...rest}) => (
 	<ScrollableNative
 		{...rest}
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
@@ -775,7 +764,7 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 				{...props}
 				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
 					[
-						cc.length ? <div key="0" ref={initItemContainerRef} role={role}>{cc}</div> : null,
+						cc.length ? <div key="0" ref={initItemContainerRef} role="list">{cc}</div> : null,
 						primary ?
 							null :
 							<SpotlightPlaceholder
@@ -783,7 +772,6 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 								data-vl-placeholder
 								key="1"
 								onFocus={handlePlaceholderFocus}
-								role="region"
 							/>,
 						needsScrollingPlaceholder ? <SpotlightPlaceholder key="2" /> : null
 					]
@@ -792,16 +780,6 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 		)}
 	/>
 );
-
-ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.VirtualListNative.prototype */ {
-	/**
-	 * Aria role.
-	 *
-	 * @type {String}
-	 * @private
-	 */
-	role: PropTypes.string
-};
 
 const SpottableVirtualList = SpotlightContainerDecorator(SpotlightContainerConfig, ScrollableVirtualList);
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -803,7 +803,7 @@ const ScrollableVirtualList = (props) => (
 			<VirtualListBase
 				{...virtualListProps}
 				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
+					cc.length ? <div ref={initItemContainerRef} role="list">{cc}</div> : null
 				)}
 				ref={initUiChildRef}
 			/>
@@ -818,7 +818,7 @@ const ScrollableVirtualListNative = (props) => (
 			<VirtualListBaseNative
 				{...virtualListProps}
 				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
+					cc.length ? <div ref={initItemContainerRef} role="list">{cc}</div> : null
 				)}
 				ref={initUiChildRef}
 			/>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Add 'role=list' in VirtualList
Remove 'role=region' in SpotlightPlaceholder

Reasons to add 'role=list' to VirtualList
- The list role is a semantic role, so putting it in the list does not change the behavior. However, for the XofY feature, we need 'role=list' just above the 'aria-posinset' and 'aria-setsize' properties.
I will include the list role in the VirtualList so that the App does not have to pass the list role to the VirtualList as prop.

Reasons to remove 'role=region' from spotlightPlaceholder
- Currently, in the 1553 Master Image, there is no issue in the existing behavior even if there is no region role in the spotlightPlaceholder.
This is because Chethan has modified Blink to not read an empty div. (Related ticket: https://jira2.lgsvl.com/browse/PLAT-44268)

### Links
PLAT-52790

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)