### PR TITLE
PLAT-52582: Change media title to accept node type

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Panels.Header` support for `headerInput` so the Header can be used as an Input. See documentation for usage examples.
 - `moonstone/ProgressBar` prop `tooltipSide` to configure tooltip position relative to the progress bar
 - `moonstone/ProgressBar` colors (affecting `moonstone/Slider` as well) for light and dark theme to match the latest designs and make them more visible when drawn over arbitrary background colors
+- `moonstone/VideoPlayer` property `title` to accept node type
 
 ### Fixed
 

--- a/packages/moonstone/VideoPlayer/MediaTitle.js
+++ b/packages/moonstone/VideoPlayer/MediaTitle.js
@@ -49,10 +49,10 @@ const MediaTitleBase = kind({
 		/**
 		 * A title string to identify the media's title.
 		 *
-		 * @type {String}
+		 * @type {String|Node}
 		 * @public
 		 */
-		title: PropTypes.string,
+		title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
 		/**
 		 * Setting this to false effectively hides the entire component. Setting it to `false` after

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -614,10 +614,10 @@ const VideoPlayerBase = class extends React.Component {
 		/**
 		 * Set a title for the video being played.
 		 *
-		 * @type {String}
+		 * @type {String|Node}
 		 * @public
 		 */
-		title: PropTypes.string,
+		title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
 		/**
 		 * The amount of time in milliseconds that should pass before the title disappears from the


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/VideoPlayer` only accepts string as title the proptype. In case of app wanting to use a image or an `Icon` as part of the title, it will throw a proptype warning.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change propType declaration to accept node type for `title` prop.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
