### PR TITLE
PLAT-52825: Refactoring to reduce ref usage in VirtualList, Scrollable

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -101,7 +101,6 @@ class Scrollable extends Component {
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
-		 * @default 'vertical'
 		 * @private
 		 */
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -93,16 +93,18 @@ class Scrollable extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
+		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
 		 *
 		 * Valid values are:
+		 * * `'both'`,
 		 * * `'horizontal'`, and
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
 		 * @default 'vertical'
-		 * @public
+		 * @private
 		 */
-		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
 		 * When `true`, allows 5-way navigation to the scrollbar controls. By default, 5-way will
@@ -116,7 +118,6 @@ class Scrollable extends Component {
 	}
 
 	static defaultProps = {
-		direction: 'vertical',
 		focusableScrollbar: false
 	}
 
@@ -462,13 +463,13 @@ class Scrollable extends Component {
 				scrollTo={this.scrollTo}
 				stop={this.stop}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childUiComponentProps,
+					childComponentProps: childUiComponentProps,
 					className,
 					componentCss,
 					handleScroll,
 					horizontalScrollbarProps,
-					initUiChildRef,
-					initUiContainerRef,
+					initChildRef: initUiChildRef,
+					initContainerRef: initUiContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -193,7 +193,7 @@ class Scrollable extends Component {
 	onFocus = (ev) => {
 		const
 			{direction} = this.props,
-			{isDragging, animator} = this.uiRef,
+			{animator, isDragging} = this.uiRef,
 			shouldPreventScrollByFocus = this.childRef.shouldPreventScrollByFocus ?
 				this.childRef.shouldPreventScrollByFocus() :
 				false;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -92,7 +92,7 @@ class Scrollable extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
-		 * Direction of the list.
+		 * Direction of the list or the scroller.
 		 *
 		 * Valid values are:
 		 * * `'horizontal'`, and

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -92,6 +92,19 @@ class Scrollable extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
+		 * Direction of the list.
+		 *
+		 * Valid values are:
+		 * * `'horizontal'`, and
+		 * * `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'vertical'
+		 * @public
+		 */
+		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * When `true`, allows 5-way navigation to the scrollbar controls. By default, 5-way will
 		 * not move focus to the scrollbar controls.
 		 *
@@ -103,6 +116,7 @@ class Scrollable extends Component {
 	}
 
 	static defaultProps = {
+		direction: 'vertical',
 		focusableScrollbar: false
 	}
 
@@ -178,7 +192,8 @@ class Scrollable extends Component {
 
 	onFocus = (ev) => {
 		const
-			{isDragging, animator, direction} = this.uiRef,
+			{direction} = this.props,
+			{isDragging, animator} = this.uiRef,
 			shouldPreventScrollByFocus = this.childRef.shouldPreventScrollByFocus ?
 				this.childRef.shouldPreventScrollByFocus() :
 				false;
@@ -219,8 +234,8 @@ class Scrollable extends Component {
 
 	getPageDirection = (keyCode) => {
 		const
+			{direction} = this.props,
 			isRtl = this.uiRef.state.rtl,
-			{direction} = this.uiRef,
 			isVertical = (direction === 'vertical' || direction === 'both');
 
 		return isPageUp(keyCode) ?

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -452,8 +452,8 @@ class Scrollable extends Component {
 					componentCss,
 					handleScroll,
 					horizontalScrollbarProps,
-					initContainerRef,
 					initUiChildRef,
+					initUiContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,
@@ -463,7 +463,7 @@ class Scrollable extends Component {
 				}) => (
 					<ScrollableSpotlightContainer
 						className={className}
-						containerRef={initContainerRef}
+						containerRef={initUiContainerRef}
 						focusableScrollbar={focusableScrollbar}
 						style={style}
 					>

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -462,7 +462,7 @@ class Scrollable extends Component {
 				scrollTo={this.scrollTo}
 				stop={this.stop}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
+					childUiComponentProps,
 					className,
 					componentCss,
 					handleScroll,
@@ -485,7 +485,7 @@ class Scrollable extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childComponentProps,
+									...childUiComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -462,7 +462,7 @@ class Scrollable extends Component {
 				scrollTo={this.scrollTo}
 				stop={this.stop}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps: childUiComponentProps,
+					childComponentProps,
 					className,
 					componentCss,
 					handleScroll,
@@ -485,7 +485,7 @@ class Scrollable extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childUiComponentProps,
+									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -504,8 +504,8 @@ class ScrollableNative extends Component {
 					className,
 					componentCss,
 					horizontalScrollbarProps,
-					initContainerRef,
 					initUiChildRef,
+					initUiContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,
@@ -515,7 +515,7 @@ class ScrollableNative extends Component {
 				}) => (
 					<ScrollableSpotlightContainer
 						className={className}
-						containerRef={initContainerRef}
+						containerRef={initUiContainerRef}
 						focusableScrollbar={focusableScrollbar}
 						style={style}
 					>

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -82,7 +82,6 @@ class ScrollableNative extends Component {
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
-		 * @default 'vertical'
 		 * @private
 		 */
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -74,7 +74,7 @@ class ScrollableNative extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
-		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
+		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
 		 *
 		 * Valid values are:
 		 * * `'both'`,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -74,16 +74,18 @@ class ScrollableNative extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
+		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
 		 *
 		 * Valid values are:
+		 * * `'both'`,
 		 * * `'horizontal'`, and
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
 		 * @default 'vertical'
-		 * @public
+		 * @private
 		 */
-		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
 		 * When `true`, allows 5-way navigation to the scrollbar controls. By default, 5-way will
@@ -97,7 +99,6 @@ class ScrollableNative extends Component {
 	}
 
 	static defaultProps = {
-		direction: 'vertical',
 		focusableScrollbar: false
 	}
 
@@ -516,12 +517,12 @@ class ScrollableNative extends Component {
 				scrollTo={this.scrollTo}
 				start={this.start}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childUiComponentProps,
+					childComponentProps: childUiComponentProps,
 					className,
 					componentCss,
 					horizontalScrollbarProps,
-					initUiChildRef,
-					initUiContainerRef,
+					initChildRef: initUiChildRef,
+					initContainerRef: initUiContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -516,7 +516,7 @@ class ScrollableNative extends Component {
 				scrollTo={this.scrollTo}
 				start={this.start}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
+					childUiComponentProps,
 					className,
 					componentCss,
 					horizontalScrollbarProps,
@@ -538,7 +538,7 @@ class ScrollableNative extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childComponentProps,
+									...childUiComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -516,7 +516,7 @@ class ScrollableNative extends Component {
 				scrollTo={this.scrollTo}
 				start={this.start}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps: childUiComponentProps,
+					childComponentProps,
 					className,
 					componentCss,
 					horizontalScrollbarProps,
@@ -538,7 +538,7 @@ class ScrollableNative extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childUiComponentProps,
+									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -73,6 +73,19 @@ class ScrollableNative extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
+		 * Direction of the list.
+		 *
+		 * Valid values are:
+		 * * `'horizontal'`, and
+		 * * `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'vertical'
+		 * @public
+		 */
+		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * When `true`, allows 5-way navigation to the scrollbar controls. By default, 5-way will
 		 * not move focus to the scrollbar controls.
 		 *
@@ -84,6 +97,7 @@ class ScrollableNative extends Component {
 	}
 
 	static defaultProps = {
+		direction: 'vertical',
 		focusableScrollbar: false
 	}
 
@@ -230,9 +244,11 @@ class ScrollableNative extends Component {
 	}
 
 	onFocus = (ev) => {
-		const shouldPreventScrollByFocus = this.childRef.shouldPreventScrollByFocus ?
-			this.childRef.shouldPreventScrollByFocus() :
-			false;
+		const
+			{direction} = this.props,
+			shouldPreventScrollByFocus = this.childRef.shouldPreventScrollByFocus ?
+				this.childRef.shouldPreventScrollByFocus() :
+				false;
 
 		if (!Spotlight.getPointerMode()) {
 			this.alertThumb();
@@ -251,7 +267,7 @@ class ScrollableNative extends Component {
 				// If scroll animation is ongoing, we need to pass last target position to
 				// determine correct scroll position.
 				if (this.uiRef.scrolling && lastPos) {
-					pos = positionFn({item, scrollPosition: (this.uiRef.direction !== 'horizontal') ? lastPos.top : lastPos.left});
+					pos = positionFn({item, scrollPosition: (direction !== 'horizontal') ? lastPos.top : lastPos.left});
 				} else {
 					pos = positionFn({item});
 				}
@@ -265,8 +281,8 @@ class ScrollableNative extends Component {
 
 	getPageDirection = (keyCode) => {
 		const
+			{direction} = this.props,
 			isRtl = this.uiRef.state.rtl,
-			{direction} = this.uiRef,
 			isVertical = (direction === 'vertical' || direction === 'both');
 
 		return isPageUp(keyCode) ?

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -73,7 +73,7 @@ class ScrollableNative extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
-		 * Direction of the list.
+		 * Direction of the list or the scroller.
 		 *
 		 * Valid values are:
 		 * * `'horizontal'`, and

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -359,6 +359,26 @@ const ScrollableScroller = (props) => (
 	/>
 );
 
+ScrollableScroller.propTypes = /** @lends moonstone/Scroller.Scroller.prototype */ {
+	/**
+	 * Direction of the scroller.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'both'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
+};
+
+ScrollableScroller.defaultProps = {
+	direction: 'both'
+};
+
 const ScrollableScrollerNative = (props) => (
 	<ScrollableNative
 		{...props}
@@ -367,6 +387,26 @@ const ScrollableScrollerNative = (props) => (
 		)}
 	/>
 );
+
+ScrollableScrollerNative.propTypes = /** @lends moonstone/Scroller.ScrollerNative.prototype */ {
+	/**
+	 * Direction of the scroller.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'both'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
+};
+
+ScrollableScrollerNative.defaultProps = {
+	direction: 'both'
+};
 
 /**
  * A Moonstone-styled Scroller, SpotlightContainerDecorator and Scrollable applied.

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -829,12 +829,29 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 
 ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
 	/**
+	 * Direction of the list.
+	 *
+	 * Valid values are:
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'vertical'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+	/**
 	 * Aria role.
 	 *
 	 * @type {String}
 	 * @public
 	 */
 	role: PropTypes.string
+};
+
+ScrollableVirtualList.defaultProps = {
+	direction: 'vertical'
 };
 
 const ScrollableVirtualListNative = ({role, ...rest}) => (
@@ -865,12 +882,29 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 
 ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.VirtualListBaseNative.prototype */ {
 	/**
+	 * Direction of the list.
+	 *
+	 * Valid values are:
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'vertical'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+	/**
 	 * Aria role.
 	 *
 	 * @type {String}
 	 * @private
 	 */
 	role: PropTypes.string
+};
+
+ScrollableVirtualListNative.defaultProps = {
+	direction: 'vertical'
 };
 
 const SpottableVirtualList = SpotlightContainerDecorator(SpotlightContainerConfig, ScrollableVirtualList);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -80,8 +80,6 @@ const VirtualListBaseFactory = (type) => {
 			 * Usage:
 			 * ```
 			 * renderItem = ({index, ...rest}) => {
-			 * 	delete rest.data;
-			 *
 			 * 	return (
 			 * 		<MyComponent index={index} {...rest} />
 			 * 	);
@@ -107,6 +105,24 @@ const VirtualListBaseFactory = (type) => {
 			 * @private
 			 */
 			itemsRenderer: PropTypes.func.isRequired,
+
+			/**
+			 * Callback method of scrollTo.
+			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+			 *
+			 * @type {Function}
+			 * @private
+			 */
+			cbScrollTo: PropTypes.func,
+
+			/**
+			 * Size of the data.
+			 *
+			 * @type {Number}
+			 * @default 0
+			 * @public
+			 */
+			dataSize: PropTypes.number,
 
 			/**
 			 * Spotlight container Id.
@@ -151,6 +167,15 @@ const VirtualListBaseFactory = (type) => {
 			 */
 			isItemDisabled: PropTypes.func,
 
+			/*
+			 * It scrolls by page when `true`, by item when `false`.
+			 *
+			 * @type {Boolean}
+			 * @default false
+			 * @private
+			 */
+			pageScroll: PropTypes.bool,
+
 			/**
 			 * `true` if rtl, `false` if ltr.
 			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
@@ -158,7 +183,16 @@ const VirtualListBaseFactory = (type) => {
 			 * @type {Boolean}
 			 * @private
 			 */
-			rtl: PropTypes.bool
+			rtl: PropTypes.bool,
+
+			/**
+			 * Spacing between items.
+			 *
+			 * @type {Number}
+			 * @default 0
+			 * @public
+			 */
+			spacing: PropTypes.number
 		}
 
 		componentDidMount () {
@@ -230,8 +264,7 @@ const VirtualListBaseFactory = (type) => {
 
 		findSpottableItem = (indexFrom, indexTo) => {
 			const
-				{isItemDisabled} = this.props,
-				{dataSize} = this.uiRef.props,
+				{dataSize, isItemDisabled} = this.props,
 				safeIndexFrom = clamp(0, dataSize - 1, indexFrom),
 				safeIndexTo = clamp(-1, dataSize, indexTo),
 				delta = (indexFrom < indexTo) ? 1 : -1;
@@ -253,8 +286,7 @@ const VirtualListBaseFactory = (type) => {
 
 		getIndexToScrollDisabled = (direction, currentIndex) => {
 			const
-				{isItemDisabled} = this.props,
-				{dataSize, spacing} = this.uiRef.props,
+				{dataSize, isItemDisabled, spacing} = this.props,
 				{dimensionToExtent, primary} = this.uiRef,
 				{findSpottableItem} = this,
 				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo,
@@ -323,7 +355,7 @@ const VirtualListBaseFactory = (type) => {
 
 		getIndexToScroll = (direction, currentIndex) => {
 			const
-				{dataSize, spacing} = this.uiRef.props,
+				{dataSize, spacing} = this.props,
 				{dimensionToExtent, primary} = this.uiRef,
 				numOfItemsInPage = Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent,
 				factor = (direction === 'down' || direction === 'right') ? 1 : -1;
@@ -343,7 +375,7 @@ const VirtualListBaseFactory = (type) => {
 
 		scrollToNextItem = ({direction, focusedItem}) => {
 			const
-				{isItemDisabled} = this.props,
+				{cbScrollTo, isItemDisabled} = this.props,
 				{firstIndex, numOfItems} = this.uiRef.state,
 				focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute));
 			let indexToScroll = -1;
@@ -373,7 +405,7 @@ const VirtualListBaseFactory = (type) => {
 					focusedItem.blur();
 					this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
 				}
-				this.uiRef.props.cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
+				cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
 			}
 
 			return true;
@@ -389,7 +421,7 @@ const VirtualListBaseFactory = (type) => {
 
 		setSpotlightContainerRestrict = (keyCode, target) => {
 			const
-				{dataSize} = this.uiRef.props,
+				{dataSize} = this.props,
 				{isPrimaryDirectionVertical, dimensionToExtent} = this.uiRef,
 				index = Number.parseInt(target.getAttribute(dataIndexAttribute)),
 				canMoveBackward = index >= dimensionToExtent,
@@ -409,8 +441,7 @@ const VirtualListBaseFactory = (type) => {
 
 		jumpToSpottableItem = (keyCode, target) => {
 			const
-				{isItemDisabled} = this.props,
-				{cbScrollTo, dataSize} = this.uiRef.props,
+				{cbScrollTo, dataSize, isItemDisabled} = this.props,
 				{firstIndex, numOfItems} = this.uiRef.state,
 				{isPrimaryDirectionVertical} = this.uiRef,
 				rtl = this.props.rtl,
@@ -631,7 +662,7 @@ const VirtualListBaseFactory = (type) => {
 
 		calculatePositionOnFocus = ({item, scrollPosition = this.uiRef.scrollPosition}) => {
 			const
-				{pageScroll} = this.uiRef.props,
+				{pageScroll} = this.props,
 				{numOfItems} = this.uiRef.state,
 				{primary} = this.uiRef,
 				offsetToClientEnd = primary.clientSize - primary.itemSize,

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -776,9 +776,9 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
 				{...props}
-				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initUiItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
 					[
-						cc.length ? <div key="0" ref={initItemContainerRef} role={role}>{cc}</div> : null,
+						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?
 							null :
 							<SpotlightPlaceholder
@@ -812,9 +812,9 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
 				{...props}
-				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initUiItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
 					[
-						cc.length ? <div key="0" ref={initItemContainerRef} role={role}>{cc}</div> : null,
+						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?
 							null :
 							<SpotlightPlaceholder

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -807,7 +807,7 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
 				{...props}
-				itemsRenderer={({cc, handlePlaceholderFocus, initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, handlePlaceholderFocus, initItemContainerRef: initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
 					[
 						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?
@@ -843,7 +843,7 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
 				{...props}
-				itemsRenderer={({cc, handlePlaceholderFocus, initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, handlePlaceholderFocus, initItemContainerRef: initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
 					[
 						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -807,7 +807,7 @@ const ScrollableVirtualList = ({role, ...rest}) => ( // eslint-disable-line reac
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
 				{...props}
-				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initUiItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, handlePlaceholderFocus, initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
 					[
 						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?
@@ -843,7 +843,7 @@ const ScrollableVirtualListNative = ({role, ...rest}) => (
 		childRenderer={(props) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
 				{...props}
-				itemsRenderer={({cc, primary, needsScrollingPlaceholder, initUiItemContainerRef, handlePlaceholderFocus}) => ( // eslint-disable-line react/jsx-no-bind
+				itemsRenderer={({cc, handlePlaceholderFocus, initUiItemContainerRef, needsScrollingPlaceholder, primary}) => ( // eslint-disable-line react/jsx-no-bind
 					[
 						cc.length ? <div key="0" ref={initUiItemContainerRef} role={role}>{cc}</div> : null,
 						primary ?

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -110,16 +110,18 @@ class ScrollableBase extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
+		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
 		 *
 		 * Valid values are:
+		 * * `'both'`,
 		 * * `'horizontal'`, and
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
 		 * @default 'vertical'
-		 * @public
+		 * @private
 		 */
-		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
 		 * Specifies how to show horizontal scrollbar.
@@ -291,7 +293,6 @@ class ScrollableBase extends Component {
 
 	static defaultProps = {
 		cbScrollTo: nop,
-		direction: 'vertical',
 		horizontalScrollbar: 'auto',
 		onScroll: nop,
 		onScrollStart: nop,
@@ -978,6 +979,18 @@ class ScrollableBase extends Component {
 
 	// render
 
+	initChildRef = (ref) => {
+		if (ref) {
+			this.childRef = ref;
+		}
+	}
+
+	initContainerRef = (ref) => {
+		if (ref) {
+			this.containerRef = ref;
+		}
+	}
+
 	initHorizontalScrollbarRef = (ref) => {
 		if (ref) {
 			this.horizontalScrollbarRef = ref;
@@ -987,18 +1000,6 @@ class ScrollableBase extends Component {
 	initVerticalScrollbarRef = (ref) => {
 		if (ref) {
 			this.verticalScrollbarRef = ref;
-		}
-	}
-
-	initUiChildRef = (ref) => {
-		if (ref) {
-			this.childRef = ref;
-		}
-	}
-
-	initUiContainerRef = (ref) => {
-		if (ref) {
-			this.containerRef = ref;
 		}
 	}
 
@@ -1033,13 +1034,13 @@ class ScrollableBase extends Component {
 		delete rest.verticalScrollbar;
 
 		return containerRenderer({
-			childUiComponentProps: {...rest, rtl},
+			childComponentProps: {...rest, rtl},
 			className: scrollableClasses,
 			componentCss: css,
 			handleScroll: this.handleScroll,
 			horizontalScrollbarProps: this.horizontalScrollbarProps,
-			initUiChildRef: this.initUiChildRef,
-			initUiContainerRef: this.initUiContainerRef,
+			initChildRef: this.initChildRef,
+			initContainerRef: this.initContainerRef,
 			isHorizontalScrollbarVisible,
 			isVerticalScrollbarVisible,
 			scrollTo: this.scrollTo,
@@ -1085,13 +1086,13 @@ class Scrollable extends Component {
 			<ScrollableBase
 				{...rest}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childUiComponentProps,
+					childComponentProps,
 					className,
 					componentCss,
 					handleScroll,
 					horizontalScrollbarProps,
-					initUiChildRef,
-					initUiContainerRef,
+					initChildRef,
+					initContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,
@@ -1101,16 +1102,16 @@ class Scrollable extends Component {
 				}) => (
 					<div
 						className={className}
-						ref={initUiContainerRef}
+						ref={initContainerRef}
 						style={style}
 					>
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childUiComponentProps,
+									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
-									initUiChildRef,
+									initChildRef,
 									onScroll: handleScroll
 								})}
 							</TouchableDiv>

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -966,18 +966,6 @@ class ScrollableBase extends Component {
 
 	// render
 
-	initChildRef = (ref) => {
-		if (ref) {
-			this.childRef = ref;
-		}
-	}
-
-	initContainerRef = (ref) => {
-		if (ref) {
-			this.containerRef = ref;
-		}
-	}
-
 	initHorizontalScrollbarRef = (ref) => {
 		if (ref) {
 			this.horizontalScrollbarRef = ref;
@@ -987,6 +975,18 @@ class ScrollableBase extends Component {
 	initVerticalScrollbarRef = (ref) => {
 		if (ref) {
 			this.verticalScrollbarRef = ref;
+		}
+	}
+
+	initUiChildRef = (ref) => {
+		if (ref) {
+			this.childRef = ref;
+		}
+	}
+
+	initUiContainerRef = (ref) => {
+		if (ref) {
+			this.containerRef = ref;
 		}
 	}
 
@@ -1026,8 +1026,8 @@ class ScrollableBase extends Component {
 			componentCss: css,
 			handleScroll: this.handleScroll,
 			horizontalScrollbarProps: this.horizontalScrollbarProps,
-			initContainerRef: this.initContainerRef,
-			initUiChildRef: this.initChildRef,
+			initUiChildRef: this.initUiChildRef,
+			initUiContainerRef: this.initUiContainerRef,
 			isHorizontalScrollbarVisible,
 			isVerticalScrollbarVisible,
 			scrollTo: this.scrollTo,
@@ -1078,8 +1078,8 @@ class Scrollable extends Component {
 					componentCss,
 					handleScroll,
 					horizontalScrollbarProps,
-					initContainerRef,
 					initUiChildRef,
+					initUiContainerRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,
@@ -1089,7 +1089,7 @@ class Scrollable extends Component {
 				}) => (
 					<div
 						className={className}
-						ref={initContainerRef}
+						ref={initUiContainerRef}
 						style={style}
 					>
 						<div className={componentCss.container}>

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -118,7 +118,6 @@ class ScrollableBase extends Component {
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
-		 * @default 'vertical'
 		 * @private
 		 */
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -109,7 +109,7 @@ class ScrollableBase extends Component {
 		cbScrollTo: PropTypes.func,
 
 		/**
-		 * Direction of the list.
+		 * Direction of the list or the scroller.
 		 *
 		 * Valid values are:
 		 * * `'horizontal'`, and

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1033,7 +1033,7 @@ class ScrollableBase extends Component {
 		delete rest.verticalScrollbar;
 
 		return containerRenderer({
-			childComponentProps: {...rest, rtl},
+			childUiComponentProps: {...rest, rtl},
 			className: scrollableClasses,
 			componentCss: css,
 			handleScroll: this.handleScroll,
@@ -1085,7 +1085,7 @@ class Scrollable extends Component {
 			<ScrollableBase
 				{...rest}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
+					childUiComponentProps,
 					className,
 					componentCss,
 					handleScroll,
@@ -1107,7 +1107,7 @@ class Scrollable extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childComponentProps,
+									...childUiComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -109,6 +109,19 @@ class ScrollableBase extends Component {
 		cbScrollTo: PropTypes.func,
 
 		/**
+		 * Direction of the list.
+		 *
+		 * Valid values are:
+		 * * `'horizontal'`, and
+		 * * `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'vertical'
+		 * @public
+		 */
+		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * Specifies how to show horizontal scrollbar.
 		 *
 		 * Valid values are:
@@ -278,6 +291,7 @@ class ScrollableBase extends Component {
 
 	static defaultProps = {
 		cbScrollTo: nop,
+		direction: 'vertical',
 		horizontalScrollbar: 'auto',
 		onScroll: nop,
 		onScrollStart: nop,
@@ -336,7 +350,6 @@ class ScrollableBase extends Component {
 		const bounds = this.getScrollBounds();
 
 		this.pageDistance = (this.canScrollVertically(bounds) ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
-		this.direction = this.childRef.props.direction;
 		this.addEventListeners();
 		this.updateScrollbars();
 
@@ -363,7 +376,6 @@ class ScrollableBase extends Component {
 
 		this.clampScrollPosition();
 
-		this.direction = this.childRef.props.direction;
 		this.addEventListeners();
 		if (
 			hasDataSizeChanged === false &&
@@ -444,7 +456,6 @@ class ScrollableBase extends Component {
 
 	// status
 	deferScrollTo = true
-	direction = 'vertical'
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 	pageDistance = 0
@@ -493,9 +504,11 @@ class ScrollableBase extends Component {
 	}
 
 	onDrag = (ev) => {
+		const {direction} = this.props;
+
 		this.start({
-			targetX: (this.direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
-			targetY: (this.direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
+			targetX: (direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
+			targetY: (direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
 			animate: false
 		});
 	}
@@ -817,13 +830,12 @@ class ScrollableBase extends Component {
 	}
 
 	canScrollHorizontally = (bounds) => {
-		const {direction} = this;
-
+		const {direction} = this.props;
 		return (direction === 'horizontal' || direction === 'both') && (bounds.scrollWidth > bounds.clientWidth) && !isNaN(bounds.scrollWidth);
 	}
 
 	canScrollVertically = (bounds) => {
-		const {direction} = this;
+		const {direction} = this.props;
 		return (direction === 'vertical' || direction === 'both') && (bounds.scrollHeight > bounds.clientHeight) && !isNaN(bounds.scrollHeight);
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -100,6 +100,19 @@ class ScrollableBaseNative extends Component {
 		cbScrollTo: PropTypes.func,
 
 		/**
+		 * Direction of the list.
+		 *
+		 * Valid values are:
+		 * * `'horizontal'`, and
+		 * * `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'vertical'
+		 * @public
+		 */
+		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
 		 * Specifies how to show horizontal scrollbar.
 		 *
 		 * Valid values are:
@@ -277,6 +290,7 @@ class ScrollableBaseNative extends Component {
 
 	static defaultProps = {
 		cbScrollTo: nop,
+		direction: 'vertical',
 		horizontalScrollbar: 'auto',
 		onScroll: nop,
 		onScrollStart: nop,
@@ -335,7 +349,6 @@ class ScrollableBaseNative extends Component {
 		const bounds = this.getScrollBounds();
 
 		this.pageDistance = (this.canScrollVertically(bounds) ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
-		this.direction = this.childRef.props.direction;
 		this.addEventListeners();
 		this.updateScrollbars();
 
@@ -360,7 +373,6 @@ class ScrollableBaseNative extends Component {
 			}
 		}
 
-		this.direction = this.childRef.props.direction;
 		this.addEventListeners();
 		if (
 			hasDataSizeChanged === false &&
@@ -429,7 +441,6 @@ class ScrollableBaseNative extends Component {
 
 	// status
 	deferScrollTo = true
-	direction = 'vertical'
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 	pageDistance = 0
@@ -486,10 +497,12 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onDrag = (ev) => {
+		const {direction} = this.props;
+
 		if (!this.isTouching) {
 			this.start(
-				(this.direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
-				(this.direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
+				(direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
+				(direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
 				false
 			);
 		}
@@ -861,13 +874,12 @@ class ScrollableBaseNative extends Component {
 	}
 
 	canScrollHorizontally = (bounds) => {
-		const {direction} = this;
-
+		const {direction} = this.props;
 		return (direction === 'horizontal' || direction === 'both') && (bounds.scrollWidth > bounds.clientWidth) && !isNaN(bounds.scrollWidth);
 	}
 
 	canScrollVertically = (bounds) => {
-		const {direction} = this;
+		const {direction} = this.props;
 		return (direction === 'vertical' || direction === 'both') && (bounds.scrollHeight > bounds.clientHeight) && !isNaN(bounds.scrollHeight);
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -109,7 +109,6 @@ class ScrollableBaseNative extends Component {
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
-		 * @default 'vertical'
 		 * @private
 		 */
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1071,7 +1071,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.verticalScrollbar;
 
 		return containerRenderer({
-			childComponentProps: {...rest, rtl},
+			childUiComponentProps: {...rest, rtl},
 			className: scrollableClasses,
 			componentCss: css,
 			horizontalScrollbarProps: this.horizontalScrollbarProps,
@@ -1123,7 +1123,7 @@ class ScrollableNative extends Component {
 			<ScrollableBaseNative
 				{...rest}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
+					childUiComponentProps,
 					className,
 					componentCss,
 					horizontalScrollbarProps,
@@ -1144,7 +1144,7 @@ class ScrollableNative extends Component {
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childComponentProps,
+									...childUiComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
 									initUiChildRef

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -101,16 +101,18 @@ class ScrollableBaseNative extends Component {
 
 		/**
 		 * Direction of the list or the scroller.
+		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
 		 *
 		 * Valid values are:
+		 * * `'both'`,
 		 * * `'horizontal'`, and
 		 * * `'vertical'`.
 		 *
 		 * @type {String}
 		 * @default 'vertical'
-		 * @public
+		 * @private
 		 */
-		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
 		 * Specifies how to show horizontal scrollbar.
@@ -290,7 +292,6 @@ class ScrollableBaseNative extends Component {
 
 	static defaultProps = {
 		cbScrollTo: nop,
-		direction: 'vertical',
 		horizontalScrollbar: 'auto',
 		onScroll: nop,
 		onScrollStart: nop,
@@ -1025,6 +1026,18 @@ class ScrollableBaseNative extends Component {
 
 	// render
 
+	initChildRef = (ref) => {
+		if (ref) {
+			this.childRef = ref;
+		}
+	}
+
+	initContainerRef = (ref) => {
+		if (ref) {
+			this.containerRef = ref;
+		}
+	}
+
 	initHorizontalScrollbarRef = (ref) => {
 		if (ref) {
 			this.horizontalScrollbarRef = ref;
@@ -1034,18 +1047,6 @@ class ScrollableBaseNative extends Component {
 	initVerticalScrollbarRef = (ref) => {
 		if (ref) {
 			this.verticalScrollbarRef = ref;
-		}
-	}
-
-	initUiChildRef = (ref) => {
-		if (ref) {
-			this.childRef = ref;
-		}
-	}
-
-	initUiContainerRef = (ref) => {
-		if (ref) {
-			this.containerRef = ref;
 		}
 	}
 
@@ -1071,12 +1072,12 @@ class ScrollableBaseNative extends Component {
 		delete rest.verticalScrollbar;
 
 		return containerRenderer({
-			childUiComponentProps: {...rest, rtl},
+			childComponentProps: {...rest, rtl},
 			className: scrollableClasses,
 			componentCss: css,
 			horizontalScrollbarProps: this.horizontalScrollbarProps,
-			initUiContainerRef: this.initUiContainerRef,
-			initUiChildRef: this.initUiChildRef,
+			initContainerRef: this.initContainerRef,
+			initChildRef: this.initChildRef,
 			isHorizontalScrollbarVisible,
 			isVerticalScrollbarVisible,
 			scrollTo: this.scrollTo,
@@ -1123,12 +1124,12 @@ class ScrollableNative extends Component {
 			<ScrollableBaseNative
 				{...rest}
 				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childUiComponentProps,
+					childComponentProps,
 					className,
 					componentCss,
 					horizontalScrollbarProps,
-					initUiContainerRef,
-					initUiChildRef,
+					initContainerRef,
+					initChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
 					scrollTo,
@@ -1138,16 +1139,16 @@ class ScrollableNative extends Component {
 				}) => (
 					<div
 						className={className}
-						ref={initUiContainerRef}
+						ref={initContainerRef}
 						style={style}
 					>
 						<div className={componentCss.container}>
 							<TouchableDiv {...touchableProps}>
 								{childRenderer({
-									...childUiComponentProps,
+									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
-									initUiChildRef
+									initChildRef
 								})}
 							</TouchableDiv>
 							{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -100,7 +100,7 @@ class ScrollableBaseNative extends Component {
 		cbScrollTo: PropTypes.func,
 
 		/**
-		 * Direction of the list.
+		 * Direction of the list or the scroller.
 		 *
 		 * Valid values are:
 		 * * `'horizontal'`, and

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1013,18 +1013,6 @@ class ScrollableBaseNative extends Component {
 
 	// render
 
-	initChildRef = (ref) => {
-		if (ref) {
-			this.childRef = ref;
-		}
-	}
-
-	initContainerRef = (ref) => {
-		if (ref) {
-			this.containerRef = ref;
-		}
-	}
-
 	initHorizontalScrollbarRef = (ref) => {
 		if (ref) {
 			this.horizontalScrollbarRef = ref;
@@ -1034,6 +1022,18 @@ class ScrollableBaseNative extends Component {
 	initVerticalScrollbarRef = (ref) => {
 		if (ref) {
 			this.verticalScrollbarRef = ref;
+		}
+	}
+
+	initUiChildRef = (ref) => {
+		if (ref) {
+			this.childRef = ref;
+		}
+	}
+
+	initUiContainerRef = (ref) => {
+		if (ref) {
+			this.containerRef = ref;
 		}
 	}
 
@@ -1063,8 +1063,8 @@ class ScrollableBaseNative extends Component {
 			className: scrollableClasses,
 			componentCss: css,
 			horizontalScrollbarProps: this.horizontalScrollbarProps,
-			initContainerRef: this.initContainerRef,
-			initUiChildRef: this.initChildRef,
+			initUiContainerRef: this.initUiContainerRef,
+			initUiChildRef: this.initUiChildRef,
 			isHorizontalScrollbarVisible,
 			isVerticalScrollbarVisible,
 			scrollTo: this.scrollTo,
@@ -1115,7 +1115,7 @@ class ScrollableNative extends Component {
 					className,
 					componentCss,
 					horizontalScrollbarProps,
-					initContainerRef,
+					initUiContainerRef,
 					initUiChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
@@ -1126,7 +1126,7 @@ class ScrollableNative extends Component {
 				}) => (
 					<div
 						className={className}
-						ref={initContainerRef}
+						ref={initUiContainerRef}
 						style={style}
 					>
 						<div className={componentCss.container}>

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -202,8 +202,8 @@ class ScrollerBase extends Component {
 const Scroller = (props) => (
 	<Scrollable
 		{...props}
-		childRenderer={({initChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
-			<ScrollerBase {...scrollerProps} ref={initChildRef} />
+		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
+			<ScrollerBase {...rest} ref={initChildRef} />
 		)}
 	/>
 );
@@ -229,8 +229,8 @@ const Scroller = (props) => (
 const ScrollerNative = (props) => (
 	<ScrollableNative
 		{...props}
-		childRenderer={({initChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
-			<ScrollerBase {...scrollerProps} ref={initChildRef} />
+		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
+			<ScrollerBase {...rest} ref={initChildRef} />
 		)}
 	/>
 );

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -202,8 +202,8 @@ class ScrollerBase extends Component {
 const Scroller = (props) => (
 	<Scrollable
 		{...props}
-		childRenderer={({initUiChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
-			<ScrollerBase {...scrollerProps} ref={initUiChildRef} />
+		childRenderer={({initChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
+			<ScrollerBase {...scrollerProps} ref={initChildRef} />
 		)}
 	/>
 );
@@ -229,8 +229,8 @@ const Scroller = (props) => (
 const ScrollerNative = (props) => (
 	<ScrollableNative
 		{...props}
-		childRenderer={({initUiChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
-			<ScrollerBase {...scrollerProps} ref={initUiChildRef} />
+		childRenderer={({initChildRef, ...scrollerProps}) => ( // eslint-disable-line react/jsx-no-bind
+			<ScrollerBase {...scrollerProps} ref={initChildRef} />
 		)}
 	/>
 );

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -29,7 +29,7 @@ import css from './Scroller.less';
 class ScrollerBase extends Component {
 	static displayName = 'ui:ScrollerBase'
 
-	static propTypes = /** @lends ui/Scroller.Scroller.prototype */ {
+	static propTypes = /** @lends ui/Scroller.ScrollerBase.prototype */ {
 		children: PropTypes.node.isRequired,
 
 		/**
@@ -208,6 +208,26 @@ const Scroller = (props) => (
 	/>
 );
 
+Scroller.propTypes = /** @lends ui/Scroller.Scroller.prototype */ {
+	/**
+	 * Direction of the scroller.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'both'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
+};
+
+Scroller.defaultProps = {
+	direction: 'both'
+};
+
 /**
  * An unstyled native scroller, [ScrollableNative]{@link ui/Scrollable.ScrollableNative} applied.
  * For smooth native scrolling, web engine with below Chromium 61, should be launched
@@ -234,6 +254,26 @@ const ScrollerNative = (props) => (
 		)}
 	/>
 );
+
+ScrollerNative.propTypes = /** @lends ui/Scroller.ScrollerNative.prototype */ {
+	/**
+	 * Direction of the scroller.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'both'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
+};
+
+ScrollerNative.defaultProps = {
+	direction: 'both'
+};
 
 export default Scroller;
 export {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -714,7 +714,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		initItemContainerRef = (ref) => {
+		initUiItemContainerRef = (ref) => {
 			if (ref) {
 				this.itemContainerRef = ref;
 			}
@@ -733,7 +733,7 @@ const VirtualListBaseFactory = (type) => {
 		render () {
 			const
 				{className, itemsRenderer, style, ...rest} = this.props,
-				{cc, initItemContainerRef, primary} = this,
+				{cc, initUiItemContainerRef, primary} = this,
 				containerClasses = this.mergeClasses(className);
 
 			delete rest.cbScrollTo;
@@ -756,7 +756,7 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<div className={containerClasses} ref={this.initContainerRef} style={style}>
 					<div {...rest} ref={this.initContentRef}>
-						{itemsRenderer({cc, initItemContainerRef, primary})}
+						{itemsRenderer({cc, initUiItemContainerRef, primary})}
 					</div>
 				</div>
 			);
@@ -794,8 +794,8 @@ const ScrollableVirtualList = (props) => (
 		childRenderer={({initUiChildRef, ...virtualListProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
 				{...virtualListProps}
-				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
+				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
+					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}
 				ref={initUiChildRef}
 			/>
@@ -809,8 +809,8 @@ const ScrollableVirtualListNative = (props) => (
 		childRenderer={({initUiChildRef, ...virtualListProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
 				{...virtualListProps}
-				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
+				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
+					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}
 				ref={initUiChildRef}
 			/>

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -267,7 +267,7 @@ const VirtualListBaseFactory = (type) => {
 		threshold = 0
 		maxFirstIndex = 0
 		prevFirstIndex = 0
-		curDataSize = 0
+		prevDataSize = 0
 		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
@@ -383,11 +383,11 @@ const VirtualListBaseFactory = (type) => {
 				{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 				numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
 				wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
-				dataSizeDiff = dataSize - this.curDataSize;
+				dataSizeDiff = dataSize - this.prevDataSize;
 			let newFirstIndex = firstIndex;
 
 			this.maxFirstIndex = Math.ceil((dataSize - numOfItems) / dimensionToExtent) * dimensionToExtent;
-			this.curDataSize = dataSize;
+			this.prevDataSize = dataSize;
 
 			// reset children
 			this.cc = [];
@@ -671,10 +671,10 @@ const VirtualListBaseFactory = (type) => {
 
 		getVirtualScrollDimension = () => {
 			const
-				{dimensionToExtent, primary, curDataSize} = this,
+				{dimensionToExtent, primary, prevDataSize} = this,
 				{spacing} = this.props;
 
-			return (Math.ceil(curDataSize / dimensionToExtent) * primary.gridSize) - spacing;
+			return (Math.ceil(prevDataSize / dimensionToExtent) * primary.gridSize) - spacing;
 		}
 
 		syncClientSize = () => {
@@ -791,9 +791,9 @@ VirtualListBaseNative.displayName = 'ui:VirtualListBaseNative';
 const ScrollableVirtualList = (props) => (
 	<Scrollable
 		{...props}
-		childRenderer={({initUiChildRef, ...virtualListProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initUiChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
-				{...virtualListProps}
+				{...scrollableProps}
 				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
 					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}
@@ -806,9 +806,9 @@ const ScrollableVirtualList = (props) => (
 const ScrollableVirtualListNative = (props) => (
 	<ScrollableNative
 		{...props}
-		childRenderer={({initUiChildRef, ...virtualListProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initUiChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
-				{...virtualListProps}
+				{...scrollableProps}
 				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
 					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -803,6 +803,25 @@ const ScrollableVirtualList = (props) => (
 	/>
 );
 
+ScrollableVirtualList.propTypes = /** @lends ui/VirtualList.VirtualListBase.prototype */ {
+	/**
+	 * Direction of the list.
+	 *
+	 * Valid values are:
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'vertical'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['horizontal', 'vertical'])
+};
+
+ScrollableVirtualList.defaultProps = {
+	direction: 'vertical'
+};
+
 const ScrollableVirtualListNative = (props) => (
 	<ScrollableNative
 		{...props}
@@ -817,6 +836,25 @@ const ScrollableVirtualListNative = (props) => (
 		)}
 	/>
 );
+
+ScrollableVirtualListNative.propTypes = /** @lends ui/VirtualList.VirtualListBaseNative.prototype */ {
+	/**
+	 * Direction of the list.
+	 *
+	 * Valid values are:
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @default 'vertical'
+	 * @public
+	 */
+	direction: PropTypes.oneOf(['horizontal', 'vertical'])
+};
+
+ScrollableVirtualListNative.defaultProps = {
+	direction: 'vertical'
+};
 
 export default VirtualListBase;
 export {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -714,7 +714,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		initUiItemContainerRef = (ref) => {
+		initItemContainerRef = (ref) => {
 			if (ref) {
 				this.itemContainerRef = ref;
 			}
@@ -733,7 +733,7 @@ const VirtualListBaseFactory = (type) => {
 		render () {
 			const
 				{className, itemsRenderer, style, ...rest} = this.props,
-				{cc, initUiItemContainerRef, primary} = this,
+				{cc, initItemContainerRef, primary} = this,
 				containerClasses = this.mergeClasses(className);
 
 			delete rest.cbScrollTo;
@@ -756,7 +756,7 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<div className={containerClasses} ref={this.initContainerRef} style={style}>
 					<div {...rest} ref={this.initContentRef}>
-						{itemsRenderer({cc, initUiItemContainerRef, primary})}
+						{itemsRenderer({cc, initItemContainerRef, primary})}
 					</div>
 				</div>
 			);
@@ -791,11 +791,11 @@ VirtualListBaseNative.displayName = 'ui:VirtualListBaseNative';
 const ScrollableVirtualList = (props) => (
 	<Scrollable
 		{...props}
-		childRenderer={({initChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
-				{...scrollableProps}
-				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
+				{...rest}
+				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
+					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
 				)}
 				ref={initChildRef}
 			/>
@@ -806,11 +806,11 @@ const ScrollableVirtualList = (props) => (
 const ScrollableVirtualListNative = (props) => (
 	<ScrollableNative
 		{...props}
-		childRenderer={({initChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
-				{...scrollableProps}
-				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
+				{...rest}
+				itemsRenderer={({cc, initItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
+					cc.length ? <div ref={initItemContainerRef}>{cc}</div> : null
 				)}
 				ref={initChildRef}
 			/>

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -267,7 +267,7 @@ const VirtualListBaseFactory = (type) => {
 		threshold = 0
 		maxFirstIndex = 0
 		prevFirstIndex = 0
-		prevDataSize = 0
+		curDataSize = 0
 		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
@@ -383,11 +383,11 @@ const VirtualListBaseFactory = (type) => {
 				{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 				numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
 				wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
-				dataSizeDiff = dataSize - this.prevDataSize;
+				dataSizeDiff = dataSize - this.curDataSize;
 			let newFirstIndex = firstIndex;
 
 			this.maxFirstIndex = Math.ceil((dataSize - numOfItems) / dimensionToExtent) * dimensionToExtent;
-			this.prevDataSize = dataSize;
+			this.curDataSize = dataSize;
 
 			// reset children
 			this.cc = [];
@@ -671,10 +671,10 @@ const VirtualListBaseFactory = (type) => {
 
 		getVirtualScrollDimension = () => {
 			const
-				{dimensionToExtent, primary, prevDataSize} = this,
+				{dimensionToExtent, primary, curDataSize} = this,
 				{spacing} = this.props;
 
-			return (Math.ceil(prevDataSize / dimensionToExtent) * primary.gridSize) - spacing;
+			return (Math.ceil(curDataSize / dimensionToExtent) * primary.gridSize) - spacing;
 		}
 
 		syncClientSize = () => {
@@ -791,13 +791,13 @@ VirtualListBaseNative.displayName = 'ui:VirtualListBaseNative';
 const ScrollableVirtualList = (props) => (
 	<Scrollable
 		{...props}
-		childRenderer={({initUiChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
 				{...scrollableProps}
 				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
 					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}
-				ref={initUiChildRef}
+				ref={initChildRef}
 			/>
 		)}
 	/>
@@ -806,13 +806,13 @@ const ScrollableVirtualList = (props) => (
 const ScrollableVirtualListNative = (props) => (
 	<ScrollableNative
 		{...props}
-		childRenderer={({initUiChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
+		childRenderer={({initChildRef, ...scrollableProps}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
 				{...scrollableProps}
 				itemsRenderer={({cc, initUiItemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
 					cc.length ? <div ref={initUiItemContainerRef}>{cc}</div> : null
 				)}
-				ref={initUiChildRef}
+				ref={initChildRef}
 			/>
 		)}
 	/>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Sometimes we referred the child or the grandchild's props even though those props could be referred from the current component.

e.g
AS-IS
```
const {direction} = this.uiRef.props;
```
TO-BE
```
const {direction} = this.props;
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Refer the props efficiently between Moonstone and UI libraries and between Scrollable and VirtualList from this.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Renamed the following variables
```
childComponentProps as childUiComponentProps
initContainerRef as initUiContainerRef
initItemContainerRef as initUiItemContainerRef
initChildRef as initUiChildRef
virtualListProps as scrollableProps
```

### Links
[//]: # (Related issues, references)

PLAT-52825

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)