### PR TITLE
ENYO-5133: Fix Babel configuration in Sampler

### DIFF
--- a/packages/sampler/.qa-storybook/.babelrc
+++ b/packages/sampler/.qa-storybook/.babelrc
@@ -3,7 +3,7 @@
 	"plugins": ["dev-expression"],
 	"env": {
 		"production": {
-			"plugins": ["transform-react-inline-elements","transform-react-constant-elements"]
+			"plugins": ["transform-react-inline-elements"]
 		}
 	}
 }

--- a/packages/sampler/.storybook/.babelrc
+++ b/packages/sampler/.storybook/.babelrc
@@ -3,7 +3,7 @@
 	"plugins": ["dev-expression"],
 	"env": {
 		"production": {
-			"plugins": ["transform-react-inline-elements","transform-react-constant-elements"]
+			"plugins": ["transform-react-inline-elements"]
 		}
 	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Babel configs were referencing an removed/nonexistent plugin.

### Resolution
* Remove broken plugin references.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>