### PR TITLE
PLAT-52106: Add closeButtonAriaLabel prop to moonstone/Panels

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/Panels` property `exitAppAriaLabel` to configure the label set on application close button 
+
 ### Changes
 
 - `moonstone/VideoPlayer` property `title` to accept node type

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `moonstone/Panels` property `exitAppAriaLabel` to configure the label set on application close button 
+- `moonstone/Panels` property `closeButtonAriaLabel` to configure the label set on application close button 
 
 ### Changes
 

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -59,14 +59,13 @@ const ApplicationCloseButton = kind({
 	},
 
 	computed: {
-		closeButtonAriaLabel: ({'aria-label': ariaLabel}) => (ariaLabel == null) ? $L('Exit app') : ariaLabel
+		'aria-label': ({'aria-label': ariaLabel}) => ariaLabel == null ? $L('Exit app') : ariaLabel
 	},
 
-	render: ({backgroundOpacity, closeButtonAriaLabel, onApplicationClose, ...rest}) => {
+	render: ({backgroundOpacity, onApplicationClose, ...rest}) => {
 		return (
 			<IconButton
 				{...rest}
-				aria-label={closeButtonAriaLabel}
 				backgroundOpacity={backgroundOpacity}
 				onTap={onApplicationClose}
 				small

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -23,6 +23,15 @@ const ApplicationCloseButton = kind({
 
 	propTypes: /** @lends moonstone/Panels.ApplicationCloseButton.prototype */ {
 		/**
+		* Sets the hint string read when focusing the application close button.
+		*
+		* @type {String}
+		* @default 'Exit app'
+		* @public
+		*/
+		'aria-label': PropTypes.string,
+
+		/**
 		 * The background-color opacity of this button; valid values are `'opaque'`, `'translucent'`,
 		 * `'lightTranslucent'` and `'transparent'`.
 		 *
@@ -49,11 +58,15 @@ const ApplicationCloseButton = kind({
 		className: 'applicationCloseButton'
 	},
 
-	render: ({backgroundOpacity, onApplicationClose, ...rest}) => {
+	computed: {
+		exitAppAriaLabel: ({'aria-label': ariaLabel}) => (ariaLabel == null) ? $L('Exit app') : ariaLabel
+	},
+
+	render: ({backgroundOpacity, exitAppAriaLabel, onApplicationClose, ...rest}) => {
 		return (
 			<IconButton
 				{...rest}
-				aria-label={$L('Exit app')}
+				aria-label={exitAppAriaLabel}
 				backgroundOpacity={backgroundOpacity}
 				onTap={onApplicationClose}
 				small

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -59,14 +59,14 @@ const ApplicationCloseButton = kind({
 	},
 
 	computed: {
-		exitAppAriaLabel: ({'aria-label': ariaLabel}) => (ariaLabel == null) ? $L('Exit app') : ariaLabel
+		closeButtonAriaLabel: ({'aria-label': ariaLabel}) => (ariaLabel == null) ? $L('Exit app') : ariaLabel
 	},
 
-	render: ({backgroundOpacity, exitAppAriaLabel, onApplicationClose, ...rest}) => {
+	render: ({backgroundOpacity, closeButtonAriaLabel, onApplicationClose, ...rest}) => {
 		return (
 			<IconButton
 				{...rest}
-				aria-label={exitAppAriaLabel}
+				aria-label={closeButtonAriaLabel}
 				backgroundOpacity={backgroundOpacity}
 				onTap={onApplicationClose}
 				small

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {shape} from '@enact/ui/ViewManager';
 
+import $L from '../internal/$L';
 import IdProvider from '../internal/IdProvider';
 import Skinnable from '../Skinnable';
 
@@ -68,6 +69,15 @@ const PanelsBase = kind({
 		 * @public
 		 */
 		closeButtonBackgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'lightTranslucent', 'transparent']),
+
+		/**
+		* Sets the hint string read when focusing the application close button.
+		*
+		* @type {String}
+		* @default 'Exit app'
+		* @public
+		*/
+		exitAppAriaLabel: PropTypes.string,
 
 		/**
 		 * Unique identifier for the Panels instance
@@ -137,12 +147,14 @@ const PanelsBase = kind({
 		className: ({noCloseButton, styler}) => styler.append({
 			hasCloseButton: !noCloseButton
 		}),
-		applicationCloseButton: ({closeButtonBackgroundOpacity, id, noCloseButton, onApplicationClose}) => {
+		exitAppAriaLabel: ({exitAppAriaLabel}) => (exitAppAriaLabel == null) ? $L('Exit app') : exitAppAriaLabel,
+		applicationCloseButton: ({closeButtonBackgroundOpacity, exitAppAriaLabel, id, noCloseButton, onApplicationClose}) => {
 			if (!noCloseButton) {
 				const closeId = id ? `${id}_close` : null;
 
 				return (
 					<ApplicationCloseButton
+						aria-label={exitAppAriaLabel}
 						backgroundOpacity={closeButtonBackgroundOpacity}
 						className={css.close}
 						id={closeId}
@@ -172,6 +184,7 @@ const PanelsBase = kind({
 
 	render: ({noAnimation, arranger, childProps, children, generateId, index, applicationCloseButton, ...rest}) => {
 		delete rest.closeButtonBackgroundOpacity;
+		delete rest.exitAppAriaLabel;
 		delete rest.noCloseButton;
 		delete rest.onApplicationClose;
 		delete rest.onBack;

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {shape} from '@enact/ui/ViewManager';
 
-import $L from '../internal/$L';
 import IdProvider from '../internal/IdProvider';
 import Skinnable from '../Skinnable';
 
@@ -61,6 +60,15 @@ const PanelsBase = kind({
 		children: PropTypes.node,
 
 		/**
+		* Sets the hint string read when focusing the application close button.
+		*
+		* @type {String}
+		* @default 'Exit app'
+		* @public
+		*/
+		closeButtonAriaLabel: PropTypes.string,
+
+		/**
 		 * The background-color opacity of the application close button; valid values are `'opaque'`,
 		 * `'translucent'`, `'lightTranslucent'`, and `'transparent'`.
 		 *
@@ -69,15 +77,6 @@ const PanelsBase = kind({
 		 * @public
 		 */
 		closeButtonBackgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'lightTranslucent', 'transparent']),
-
-		/**
-		* Sets the hint string read when focusing the application close button.
-		*
-		* @type {String}
-		* @default 'Exit app'
-		* @public
-		*/
-		exitAppAriaLabel: PropTypes.string,
 
 		/**
 		 * Unique identifier for the Panels instance
@@ -147,14 +146,13 @@ const PanelsBase = kind({
 		className: ({noCloseButton, styler}) => styler.append({
 			hasCloseButton: !noCloseButton
 		}),
-		exitAppAriaLabel: ({exitAppAriaLabel}) => (exitAppAriaLabel == null) ? $L('Exit app') : exitAppAriaLabel,
-		applicationCloseButton: ({closeButtonBackgroundOpacity, exitAppAriaLabel, id, noCloseButton, onApplicationClose}) => {
+		applicationCloseButton: ({closeButtonAriaLabel, closeButtonBackgroundOpacity, id, noCloseButton, onApplicationClose}) => {
 			if (!noCloseButton) {
 				const closeId = id ? `${id}_close` : null;
 
 				return (
 					<ApplicationCloseButton
-						aria-label={exitAppAriaLabel}
+						aria-label={closeButtonAriaLabel}
 						backgroundOpacity={closeButtonBackgroundOpacity}
 						className={css.close}
 						id={closeId}
@@ -184,7 +182,7 @@ const PanelsBase = kind({
 
 	render: ({noAnimation, arranger, childProps, children, generateId, index, applicationCloseButton, ...rest}) => {
 		delete rest.closeButtonBackgroundOpacity;
-		delete rest.exitAppAriaLabel;
+		delete rest.closeButtonAriaLabel;
 		delete rest.noCloseButton;
 		delete rest.onApplicationClose;
 		delete rest.onBack;

--- a/packages/moonstone/Panels/tests/Panels-specs.js
+++ b/packages/moonstone/Panels/tests/Panels-specs.js
@@ -49,6 +49,18 @@ describe('Panels Specs', () => {
 		expect(expected).to.equal(actual);
 	});
 
+	it('should set application close button "aria-label" to closeButtonAriaLabel', function () {
+		const label = 'custom close button label';
+		const panels = mount(
+			<Panels closeButtonAriaLabel={label} />
+		);
+
+		const expected = label;
+		const actual = panels.find('IconButton').prop('aria-label');
+
+		expect(actual).to.equal(expected);
+	});
+
 	describe('computed', () => {
 		describe('childProps', () => {
 			it('should not add aria-owns when noCloseButton is true', () => {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's no way to override a11y string on Exit App button of Panels

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add Panels property `exitAppAriaLabel` to override readout string on 


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
PLAT-52106

### Comments
Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>