### PR TITLE
ENYO-5136: Add tooltipSide knob for ProgressBar samples

### DIFF
--- a/packages/sampler/stories/moonstone-stories/ProgressBar.js
+++ b/packages/sampler/stories/moonstone-stories/ProgressBar.js
@@ -22,6 +22,7 @@ storiesOf('Moonstone', module)
 				progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
 				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				tooltipForceSide={boolean('tooltipForceSide', false)}
+				tooltipSide={select('tooltipSide', ['before', 'after'], 'before')}
 				disabled={nullify(boolean('disabled', false))}
 			/>
 		))

--- a/packages/sampler/stories/qa-stories/ProgressBar.js
+++ b/packages/sampler/stories/qa-stories/ProgressBar.js
@@ -18,6 +18,7 @@ storiesOf('ProgressBar', module)
 				progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
 				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				tooltipForceSide={boolean('tooltipForceSide', false)}
+				tooltipSide={select('tooltipSide', ['before', 'after'], 'before')}
 				disabled={nullify(boolean('disabled', false))}
 			/>
 		),


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add `tooltipSide` to `ProgressBar` sampler


### Links
[//]: # (Related issues, references)
ENYO-5136

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com