### PR TITLE
ENYO-5134: Fix ExpandableItem from Applying Open Class When Disabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scrollable/ScrollButtons` to read out out audio guidance when button down.
+- `moonstone/ExpandableItem` to show label properly when open and disabled
 
 ## [2.0.0-alpha.7 - 2018-04-03]
 

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -271,7 +271,7 @@ const ExpandableItemBase = kind({
 	},
 
 	computed: {
-		className: ({open, styler}) => (styler.append({open})),
+		className: ({disabled, open, styler}) => disabled ? null : (styler.append({open})),
 		label: ({label, noneText}) => (label || noneText),
 		labeledItemClassName: ({showLabel, styler}) => (styler.join(css.labeledItem, css[showLabel])),
 		open: ({disabled, open}) => (open && !disabled),

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -271,7 +271,7 @@ const ExpandableItemBase = kind({
 	},
 
 	computed: {
-		className: ({disabled, open, styler}) => disabled ? null : (styler.append({open})),
+		className: ({disabled, open, styler}) => (styler.append({open: open && !disabled})),
 		label: ({label, noneText}) => (label || noneText),
 		labeledItemClassName: ({showLabel, styler}) => (styler.join(css.labeledItem, css[showLabel])),
 		open: ({disabled, open}) => (open && !disabled),

--- a/packages/moonstone/ExpandableItem/ExpandableItem.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.less
@@ -24,8 +24,10 @@
 	&.open {
 		.labeledItem {
 			&.auto {
-				.label {
-					display: none;
+				&:not([disabled]) {
+					.label {
+						display: none;
+					}
 				}
 			}
 

--- a/packages/moonstone/ExpandableItem/ExpandableItem.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.less
@@ -24,11 +24,9 @@
 	&.open {
 		.labeledItem {
 			&.auto {
-				&:not([disabled]) {
 					.label {
 						display: none;
 					}
-				}
 			}
 
 			.icon {

--- a/packages/moonstone/ExpandableItem/ExpandableItem.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.less
@@ -24,9 +24,9 @@
 	&.open {
 		.labeledItem {
 			&.auto {
-					.label {
-						display: none;
-					}
+				.label {
+					display: none;
+				}
 			}
 
 			.icon {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Prevent applying `open` class when `disabled`


### Links
[//]: # (Related issues, references)
ENYO-5134 ENYO-5119

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com