### PR TITLE
PLAT-52108: Accessibility: Add props for overriding inner focusable component - VirtualList, Scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,8 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
-- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` props 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the aria-label set on scroll buttons in the scrollbars
-- `moonstone/Panels` property `closeButtonAriaLabel` to configure the label set on application close button 
+- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` props `scrollRightAriaLabel`, `scrollLeftAriaLabel`, `scrollDownAriaLabel`, and `scrollUpAriaLabel` to configure the aria-label set on scroll buttons in the scrollbars
+- `moonstone/Panels` property `closeButtonAriaLabel` to configure the label set on application close button
 
 ### Changed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
+- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` property 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the label set on scroll buttons in the scrollbars
 
 ### Changed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
-- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` property 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the label set on scroll buttons in the scrollbars
+- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` property 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the aria-label set on scroll buttons in the scrollbars
 
 ### Changed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
-- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` property 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the aria-label set on scroll buttons in the scrollbars
+- `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` props 'horizontalScrollbarNextButtonAriaLabel', 'horizontalScrollbarPreviousButtonAriaLabel', 'verticalScrollbarNextButtonAriaLabel', and 'verticalScrollbarPreviousButtonAriaLabel' to configure the aria-label set on scroll buttons in the scrollbars
 
 ### Changed
 

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -2,7 +2,6 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import $L from '../internal/$L';
 import IconButton from '../IconButton';
 
 import css from './Scrollbar.less';
@@ -53,6 +52,14 @@ const ScrollButton = kind({
 		direction: PropTypes.oneOf(['down', 'left', 'right', 'up']).isRequired,
 
 		/**
+		* Sets the hint string read when focusing the scroll bar button.
+		*
+		* @type {String}
+		* @public
+		*/
+		'aria-label': PropTypes.string,
+
+		/**
 		 * When `true`, the `aria-label` is set.
 		 *
 		 * @type {Boolean}
@@ -77,22 +84,7 @@ const ScrollButton = kind({
 	},
 
 	computed: {
-		'aria-label': ({active, direction}) => {
-			if (active) {
-				return null;
-			}
-
-			switch (direction) {
-				case 'up':
-					return $L('scroll up');
-				case 'down':
-					return $L('scroll down');
-				case 'left':
-					return $L('scroll left');
-				case 'right':
-					return $L('scroll right');
-			}
-		},
+		'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel),
 		className: ({direction, styler}) => styler.append(classNameMap[direction])
 	},
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -67,6 +67,14 @@ class ScrollButtons extends Component {
 		disabled: PropTypes.bool,
 
 		/**
+		* Sets the hint string read when focusing the next button in the scroll bar.
+		*
+		* @type {String}
+		* @public
+		*/
+		nextButtonAriaLabel: PropTypes.string,
+
+		/**
 		 * Called when the scrollbar's down/right button is pressed.
 		 *
 		 * @type {Function}
@@ -97,6 +105,14 @@ class ScrollButtons extends Component {
 		 * @private
 		 */
 		onPrevSpotlightDisappear: PropTypes.func,
+
+		/**
+		* Sets the hint string read when focusing the previous button in the scroll bar.
+		*
+		* @type {String}
+		* @public
+		*/
+		previousButtonAriaLabel: PropTypes.string,
 
 		/**
 		 * If `true`, the scrollbar will be oriented vertically.
@@ -280,13 +296,14 @@ class ScrollButtons extends Component {
 
 	render () {
 		const
-			{disabled, onNextSpotlightDisappear, onPrevSpotlightDisappear, thumbRenderer, vertical} = this.props,
+			{disabled, nextButtonAriaLabel, onNextSpotlightDisappear, onPrevSpotlightDisappear, previousButtonAriaLabel, thumbRenderer, vertical} = this.props,
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
 			prevIcon = preparePrevButton(vertical),
 			nextIcon = prepareNextButton(vertical);
 
 		return [
 			<ScrollButton
+				aria-label={previousButtonAriaLabel}
 				key="prevButton"
 				data-scroll-button="previous"
 				direction={vertical ? 'up' : 'left'}
@@ -304,6 +321,7 @@ class ScrollButtons extends Component {
 			</ScrollButton>,
 			thumbRenderer(),
 			<ScrollButton
+				aria-label={nextButtonAriaLabel}
 				key="nextButton"
 				data-scroll-button="next"
 				direction={vertical ? 'down' : 'right'}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -122,7 +122,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll right')
+		* @default $L('scroll right')
 		* @public
 		*/
 		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -131,7 +131,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll left')
+		* @default $L('scroll left')
 		* @public
 		*/
 		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
@@ -140,7 +140,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll down')
+		* @default $L('scroll down')
 		* @public
 		*/
 		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -149,7 +149,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll up')
+		* @default $L('scroll up')
 		* @public
 		*/
 		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -122,7 +122,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll right'
+		* @default $('scroll right')
 		* @public
 		*/
 		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -131,7 +131,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll left'
+		* @default $('scroll left')
 		* @public
 		*/
 		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
@@ -140,7 +140,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll down'
+		* @default $('scroll down')
 		* @public
 		*/
 		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -149,7 +149,7 @@ class Scrollable extends Component {
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll up'
+		* @default $('scroll up')
 		* @public
 		*/
 		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
@@ -493,8 +493,8 @@ class Scrollable extends Component {
 	render () {
 		const
 			{
-				focusableScrollbar,
 				childRenderer,
+				focusableScrollbar,
 				horizontalScrollbarNextButtonAriaLabel,
 				horizontalScrollbarPreviousButtonAriaLabel,
 				verticalScrollbarNextButtonAriaLabel,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -119,13 +119,13 @@ class Scrollable extends Component {
 		focusableScrollbar: PropTypes.bool,
 
 		/**
-		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
+		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $L('scroll right')
+		* @default $L('scroll down')
 		* @public
 		*/
-		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
+		scrollDownAriaLabel: PropTypes.string,
 
 		/**
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
@@ -134,16 +134,16 @@ class Scrollable extends Component {
 		* @default $L('scroll left')
 		* @public
 		*/
-		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
+		scrollLeftAriaLabel: PropTypes.string,
 
 		/**
-		* Sets the hint string read when focusing the next button in the vertical scroll bar.
+		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $L('scroll down')
+		* @default $L('scroll right')
 		* @public
 		*/
-		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
+		scrollRightAriaLabel: PropTypes.string,
 
 		/**
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
@@ -152,15 +152,11 @@ class Scrollable extends Component {
 		* @default $L('scroll up')
 		* @public
 		*/
-		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
+		scrollUpAriaLabel: PropTypes.string
 	}
 
 	static defaultProps = {
-		focusableScrollbar: false,
-		horizontalScrollbarNextButtonAriaLabel: $L('scroll right'),
-		horizontalScrollbarPreviousButtonAriaLabel: $L('scroll left'),
-		verticalScrollbarNextButtonAriaLabel: $L('scroll down'),
-		verticalScrollbarPreviousButtonAriaLabel: $L('scroll up')
+		focusableScrollbar: false
 	}
 
 	constructor (props) {
@@ -495,20 +491,16 @@ class Scrollable extends Component {
 			{
 				childRenderer,
 				focusableScrollbar,
-				horizontalScrollbarNextButtonAriaLabel,
-				horizontalScrollbarPreviousButtonAriaLabel,
-				verticalScrollbarNextButtonAriaLabel,
-				verticalScrollbarPreviousButtonAriaLabel,
+				scrollRightAriaLabel,
+				scrollLeftAriaLabel,
+				scrollDownAriaLabel,
+				scrollUpAriaLabel,
 				...rest
 			} = this.props,
-			horizontalScrollbarA11yProps = {
-				nextButtonAriaLabel: horizontalScrollbarNextButtonAriaLabel,
-				previousButtonAriaLabel: horizontalScrollbarPreviousButtonAriaLabel
-			},
-			verticalScrollbarA11yProps = {
-				nextButtonAriaLabel: verticalScrollbarNextButtonAriaLabel,
-				previousButtonAriaLabel: verticalScrollbarPreviousButtonAriaLabel
-			};
+			downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
+			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
+			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
+			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
 		return (
 			<UiScrollableBase
@@ -556,9 +548,10 @@ class Scrollable extends Component {
 							{isVerticalScrollbarVisible ?
 								<Scrollbar
 									{...verticalScrollbarProps}
-									{...verticalScrollbarA11yProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
+									nextButtonAriaLabel={downButtonAriaLabel}
+									previousButtonAriaLabel={upButtonAriaLabel}
 								/> :
 								null
 							}
@@ -566,10 +559,11 @@ class Scrollable extends Component {
 						{isHorizontalScrollbarVisible ?
 							<Scrollbar
 								{...horizontalScrollbarProps}
-								{...horizontalScrollbarA11yProps}
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
+								nextButtonAriaLabel={rightButtonAriaLabel}
+								previousButtonAriaLabel={leftButtonAriaLabel}
 							/> :
 							null
 						}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -15,6 +15,8 @@ import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Touchable from '@enact/ui/Touchable';
 
+import $L from '../internal/$L';
+
 import Scrollbar from './Scrollbar';
 
 import scrollbarCss from './Scrollbar.less';
@@ -114,11 +116,51 @@ class Scrollable extends Component {
 		 * @default false
 		 * @public
 		 */
-		focusableScrollbar: PropTypes.bool
+		focusableScrollbar: PropTypes.bool,
+
+		/**
+		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll right'
+		* @public
+		*/
+		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll left'
+		* @public
+		*/
+		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the next button in the vertical scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll down'
+		* @public
+		*/
+		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll up'
+		* @public
+		*/
+		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
 	}
 
 	static defaultProps = {
-		focusableScrollbar: false
+		focusableScrollbar: false,
+		horizontalScrollbarNextButtonAriaLabel: $L('scroll right'),
+		horizontalScrollbarPreviousButtonAriaLabel: $L('scroll left'),
+		verticalScrollbarNextButtonAriaLabel: $L('scroll down'),
+		verticalScrollbarPreviousButtonAriaLabel: $L('scroll up')
 	}
 
 	constructor (props) {
@@ -449,7 +491,24 @@ class Scrollable extends Component {
 	}
 
 	render () {
-		const {focusableScrollbar, childRenderer, ...rest} = this.props;
+		const
+			{
+				focusableScrollbar,
+				childRenderer,
+				horizontalScrollbarNextButtonAriaLabel,
+				horizontalScrollbarPreviousButtonAriaLabel,
+				verticalScrollbarNextButtonAriaLabel,
+				verticalScrollbarPreviousButtonAriaLabel,
+				...rest
+			} = this.props,
+			horizontalScrollbarA11yProps = {
+				nextButtonAriaLabel: horizontalScrollbarNextButtonAriaLabel,
+				previousButtonAriaLabel: horizontalScrollbarPreviousButtonAriaLabel
+			},
+			verticalScrollbarA11yProps = {
+				nextButtonAriaLabel: verticalScrollbarNextButtonAriaLabel,
+				previousButtonAriaLabel: verticalScrollbarPreviousButtonAriaLabel
+			};
 
 		return (
 			<UiScrollableBase
@@ -494,9 +553,26 @@ class Scrollable extends Component {
 									ref: this.initChildRef
 								})}
 							</TouchableDiv>
-							{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} {...this.scrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}
+							{isVerticalScrollbarVisible ?
+								<Scrollbar
+									{...verticalScrollbarProps}
+									{...verticalScrollbarA11yProps}
+									{...this.scrollbarProps}
+									disabled={!isVerticalScrollbarVisible}
+								/> :
+								null
+							}
 						</div>
-						{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} {...this.scrollbarProps} corner={isVerticalScrollbarVisible} disabled={!isHorizontalScrollbarVisible} /> : null}
+						{isHorizontalScrollbarVisible ?
+							<Scrollbar
+								{...horizontalScrollbarProps}
+								{...horizontalScrollbarA11yProps}
+								{...this.scrollbarProps}
+								corner={isVerticalScrollbarVisible}
+								disabled={!isHorizontalScrollbarVisible}
+							/> :
+							null
+						}
 					</ScrollableSpotlightContainer>
 				)}
 			/>

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -103,7 +103,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll right'
+		* @default $('scroll right')
 		* @public
 		*/
 		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -112,7 +112,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll left'
+		* @default $('scroll left')
 		* @public
 		*/
 		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
@@ -121,7 +121,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll down'
+		* @default $('scroll down')
 		* @public
 		*/
 		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -130,7 +130,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default 'scroll up'
+		* @default $('scroll up')
 		* @public
 		*/
 		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
@@ -546,8 +546,8 @@ class ScrollableNative extends Component {
 	render () {
 		const
 			{
-				focusableScrollbar,
 				childRenderer,
+				focusableScrollbar,
 				horizontalScrollbarNextButtonAriaLabel,
 				horizontalScrollbarPreviousButtonAriaLabel,
 				verticalScrollbarNextButtonAriaLabel,

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -103,7 +103,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll right')
+		* @default $L('scroll right')
 		* @public
 		*/
 		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -112,7 +112,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll left')
+		* @default $L('scroll left')
 		* @public
 		*/
 		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
@@ -121,7 +121,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll down')
+		* @default $L('scroll down')
 		* @public
 		*/
 		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
@@ -130,7 +130,7 @@ class ScrollableNative extends Component {
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $('scroll up')
+		* @default $L('scroll up')
 		* @public
 		*/
 		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -6,6 +6,8 @@ import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Touchable from '@enact/ui/Touchable';
 
+import $L from '../internal/$L';
+
 import Scrollbar from './Scrollbar';
 
 import scrollbarCss from './Scrollbar.less';
@@ -95,11 +97,51 @@ class ScrollableNative extends Component {
 		 * @default false
 		 * @public
 		 */
-		focusableScrollbar: PropTypes.bool
+		focusableScrollbar: PropTypes.bool,
+
+		/**
+		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll right'
+		* @public
+		*/
+		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll left'
+		* @public
+		*/
+		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the next button in the vertical scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll down'
+		* @public
+		*/
+		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
+
+		/**
+		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
+		*
+		* @type {String}
+		* @default 'scroll up'
+		* @public
+		*/
+		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
 	}
 
 	static defaultProps = {
-		focusableScrollbar: false
+		focusableScrollbar: false,
+		horizontalScrollbarNextButtonAriaLabel: $L('scroll right'),
+		horizontalScrollbarPreviousButtonAriaLabel: $L('scroll left'),
+		verticalScrollbarNextButtonAriaLabel: $L('scroll down'),
+		verticalScrollbarPreviousButtonAriaLabel: $L('scroll up')
 	}
 
 	constructor (props) {
@@ -502,7 +544,24 @@ class ScrollableNative extends Component {
 	}
 
 	render () {
-		const {focusableScrollbar, childRenderer, ...rest} = this.props;
+		const
+			{
+				focusableScrollbar,
+				childRenderer,
+				horizontalScrollbarNextButtonAriaLabel,
+				horizontalScrollbarPreviousButtonAriaLabel,
+				verticalScrollbarNextButtonAriaLabel,
+				verticalScrollbarPreviousButtonAriaLabel,
+				...rest
+			} = this.props,
+			horizontalScrollbarA11yProps = {
+				nextButtonAriaLabel: horizontalScrollbarNextButtonAriaLabel,
+				previousButtonAriaLabel: horizontalScrollbarPreviousButtonAriaLabel
+			},
+			verticalScrollbarA11yProps = {
+				nextButtonAriaLabel: verticalScrollbarNextButtonAriaLabel,
+				previousButtonAriaLabel: verticalScrollbarPreviousButtonAriaLabel
+			};
 
 		return (
 			<UiScrollableBaseNative
@@ -546,9 +605,26 @@ class ScrollableNative extends Component {
 									ref: this.initChildRef
 								})}
 							</TouchableDiv>
-							{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} {...this.scrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}
+							{isVerticalScrollbarVisible ?
+								<Scrollbar
+									{...verticalScrollbarProps}
+									{...verticalScrollbarA11yProps}
+									{...this.scrollbarProps}
+									disabled={!isVerticalScrollbarVisible}
+								/> :
+								null
+							}
 						</div>
-						{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} {...this.scrollbarProps} corner={isVerticalScrollbarVisible} disabled={!isHorizontalScrollbarVisible} /> : null}
+						{isHorizontalScrollbarVisible ?
+							<Scrollbar
+								{...horizontalScrollbarProps}
+								{...horizontalScrollbarA11yProps}
+								{...this.scrollbarProps}
+								corner={isVerticalScrollbarVisible}
+								disabled={!isHorizontalScrollbarVisible}
+							/> :
+							null
+						}
 					</ScrollableSpotlightContainer>
 				)}
 			/>

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -100,13 +100,13 @@ class ScrollableNative extends Component {
 		focusableScrollbar: PropTypes.bool,
 
 		/**
-		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
+		* Sets the hint string read when focusing the next button in the vertical scroll bar.
 		*
 		* @type {String}
-		* @default $L('scroll right')
+		* @default $L('scroll down')
 		* @public
 		*/
-		horizontalScrollbarNextButtonAriaLabel: PropTypes.string,
+		scrollDownAriaLabel: PropTypes.string,
 
 		/**
 		* Sets the hint string read when focusing the previous button in the horizontal scroll bar.
@@ -115,16 +115,16 @@ class ScrollableNative extends Component {
 		* @default $L('scroll left')
 		* @public
 		*/
-		horizontalScrollbarPreviousButtonAriaLabel: PropTypes.string,
+		scrollLeftAriaLabel: PropTypes.string,
 
 		/**
-		* Sets the hint string read when focusing the next button in the vertical scroll bar.
+		* Sets the hint string read when focusing the next button in the horizontal scroll bar.
 		*
 		* @type {String}
-		* @default $L('scroll down')
+		* @default $L('scroll right')
 		* @public
 		*/
-		verticalScrollbarNextButtonAriaLabel: PropTypes.string,
+		scrollRightAriaLabel: PropTypes.string,
 
 		/**
 		* Sets the hint string read when focusing the previous button in the vertical scroll bar.
@@ -133,15 +133,11 @@ class ScrollableNative extends Component {
 		* @default $L('scroll up')
 		* @public
 		*/
-		verticalScrollbarPreviousButtonAriaLabel: PropTypes.string
+		scrollUpAriaLabel: PropTypes.string
 	}
 
 	static defaultProps = {
-		focusableScrollbar: false,
-		horizontalScrollbarNextButtonAriaLabel: $L('scroll right'),
-		horizontalScrollbarPreviousButtonAriaLabel: $L('scroll left'),
-		verticalScrollbarNextButtonAriaLabel: $L('scroll down'),
-		verticalScrollbarPreviousButtonAriaLabel: $L('scroll up')
+		focusableScrollbar: false
 	}
 
 	constructor (props) {
@@ -548,20 +544,16 @@ class ScrollableNative extends Component {
 			{
 				childRenderer,
 				focusableScrollbar,
-				horizontalScrollbarNextButtonAriaLabel,
-				horizontalScrollbarPreviousButtonAriaLabel,
-				verticalScrollbarNextButtonAriaLabel,
-				verticalScrollbarPreviousButtonAriaLabel,
+				scrollRightAriaLabel,
+				scrollLeftAriaLabel,
+				scrollDownAriaLabel,
+				scrollUpAriaLabel,
 				...rest
 			} = this.props,
-			horizontalScrollbarA11yProps = {
-				nextButtonAriaLabel: horizontalScrollbarNextButtonAriaLabel,
-				previousButtonAriaLabel: horizontalScrollbarPreviousButtonAriaLabel
-			},
-			verticalScrollbarA11yProps = {
-				nextButtonAriaLabel: verticalScrollbarNextButtonAriaLabel,
-				previousButtonAriaLabel: verticalScrollbarPreviousButtonAriaLabel
-			};
+			downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
+			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
+			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
+			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
 		return (
 			<UiScrollableBaseNative
@@ -608,9 +600,10 @@ class ScrollableNative extends Component {
 							{isVerticalScrollbarVisible ?
 								<Scrollbar
 									{...verticalScrollbarProps}
-									{...verticalScrollbarA11yProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
+									nextButtonAriaLabel={downButtonAriaLabel}
+									previousButtonAriaLabel={upButtonAriaLabel}
 								/> :
 								null
 							}
@@ -618,10 +611,11 @@ class ScrollableNative extends Component {
 						{isHorizontalScrollbarVisible ?
 							<Scrollbar
 								{...horizontalScrollbarProps}
-								{...horizontalScrollbarA11yProps}
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
+								nextButtonAriaLabel={rightButtonAriaLabel}
+								previousButtonAriaLabel={leftButtonAriaLabel}
 							/> :
 							null
 						}

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -68,4 +68,74 @@ describe('Scroller', () => {
 			expect(actual).to.equal(expected);
 		});
 	});
+
+	describe('Scrollbar accessibility', () => {
+		it('should set "aria-label" to previous scroll button in the horizontal scroll bar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<Scroller
+					horizontalScrollbar="visible"
+					verticalScrollbar="visible"
+				>
+					{contents}
+				</Scroller>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(2).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to next scroll button in the horizontal scroll bar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<Scroller
+					horizontalScrollbar="visible"
+					verticalScrollbar="visible"
+				>
+					{contents}
+				</Scroller>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(3).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to previous scroll button in the vertical scroll bar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<Scroller
+					horizontalScrollbar="visible"
+					verticalScrollbar="visible"
+				>
+					{contents}
+				</Scroller>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(0).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to next scroll button in the vertical scroll bar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<Scroller
+					horizontalScrollbar="visible"
+					verticalScrollbar="visible"
+				>
+					{contents}
+				</Scroller>
+			);
+
+			const expected = 'label';
+			const actual = subject.find('ScrollButton').at(1).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+	});
 });

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -75,7 +75,7 @@ describe('Scroller', () => {
 			const subject = mount(
 				<Scroller
 					horizontalScrollbar="visible"
-					horizontalScrollbarPreviousButtonAriaLabel={label}
+					scrollLeftAriaLabel={label}
 					verticalScrollbar="visible"
 				>
 					{contents}
@@ -93,7 +93,7 @@ describe('Scroller', () => {
 			const subject = mount(
 				<Scroller
 					horizontalScrollbar="visible"
-					horizontalScrollbarNextButtonAriaLabel={label}
+					scrollRightAriaLabel={label}
 					verticalScrollbar="visible"
 				>
 					{contents}
@@ -112,7 +112,7 @@ describe('Scroller', () => {
 				<Scroller
 					horizontalScrollbar="visible"
 					verticalScrollbar="visible"
-					verticalScrollbarPreviousButtonAriaLabel={label}
+					scrollUpAriaLabel={label}
 				>
 					{contents}
 				</Scroller>
@@ -130,7 +130,7 @@ describe('Scroller', () => {
 				<Scroller
 					horizontalScrollbar="visible"
 					verticalScrollbar="visible"
-					verticalScrollbarNextButtonAriaLabel={label}
+					scrollDownAriaLabel={label}
 				>
 					{contents}
 				</Scroller>

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -75,8 +75,8 @@ describe('Scroller', () => {
 			const subject = mount(
 				<Scroller
 					horizontalScrollbar="visible"
-					verticalScrollbar="visible"
 					horizontalScrollbarPreviousButtonAriaLabel={label}
+					verticalScrollbar="visible"
 				>
 					{contents}
 				</Scroller>

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -76,6 +76,7 @@ describe('Scroller', () => {
 				<Scroller
 					horizontalScrollbar="visible"
 					verticalScrollbar="visible"
+					horizontalScrollbarPreviousButtonAriaLabel={label}
 				>
 					{contents}
 				</Scroller>
@@ -92,6 +93,7 @@ describe('Scroller', () => {
 			const subject = mount(
 				<Scroller
 					horizontalScrollbar="visible"
+					horizontalScrollbarNextButtonAriaLabel={label}
 					verticalScrollbar="visible"
 				>
 					{contents}
@@ -110,6 +112,7 @@ describe('Scroller', () => {
 				<Scroller
 					horizontalScrollbar="visible"
 					verticalScrollbar="visible"
+					verticalScrollbarPreviousButtonAriaLabel={label}
 				>
 					{contents}
 				</Scroller>
@@ -127,12 +130,13 @@ describe('Scroller', () => {
 				<Scroller
 					horizontalScrollbar="visible"
 					verticalScrollbar="visible"
+					verticalScrollbarNextButtonAriaLabel={label}
 				>
 					{contents}
 				</Scroller>
 			);
 
-			const expected = 'label';
+			const expected = label;
 			const actual = subject.find('ScrollButton').at(1).prop('aria-label');
 
 			expect(actual).to.equal(expected);

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -283,13 +283,51 @@ describe('VirtualList', () => {
 	});
 
 	describe('Scrollbar accessibility', () => {
-		it('should set "aria-label" to previous scroll button', function () {
+		it('should set "aria-label" to previous scroll button in the horizontal scrollbar', function () {
 			const label = 'custom button aria label';
 			const subject = mount(
 				<VirtualList
 					clientSize={clientSize}
 					dataSize={dataSize}
 					direction="horizontal"
+					itemRenderer={renderItem}
+					itemSize={30}
+					horizontalScrollbarPreviousButtonAriaLabel={label}
+				/>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(0).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to next scroll button in the horizontal scrollbar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<VirtualList
+					clientSize={clientSize}
+					dataSize={dataSize}
+					direction="horizontal"
+					itemRenderer={renderItem}
+					itemSize={30}
+					horizontalScrollbarNextButtonAriaLabel={label}
+				/>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(1).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to previous scroll button in the vertical scrollbar', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<VirtualList
+					clientSize={clientSize}
+					dataSize={dataSize}
+					direction="vertical"
 					itemRenderer={renderItem}
 					itemSize={30}
 					verticalScrollbarPreviousButtonAriaLabel={label}
@@ -302,13 +340,13 @@ describe('VirtualList', () => {
 			expect(actual).to.equal(expected);
 		});
 
-		it('should set "aria-label" to next scroll button', function () {
+		it('should set "aria-label" to next scroll button in the vertical scrollbar', function () {
 			const label = 'custom button aria label';
 			const subject = mount(
 				<VirtualList
 					clientSize={clientSize}
 					dataSize={dataSize}
-					direction="horizontal"
+					direction="vertical"
 					itemRenderer={renderItem}
 					itemSize={30}
 					verticalScrollbarNextButtonAriaLabel={label}

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -124,44 +124,6 @@ describe('VirtualList', () => {
 		expect(actual).to.equal(expected);
 	});
 
-	it('should set "aria-label" to previous scroll button', function () {
-		const label = 'custom button aria label';
-		const subject = mount(
-			<VirtualList
-				clientSize={clientSize}
-				dataSize={dataSize}
-				direction="horizontal"
-				itemRenderer={renderItem}
-				itemSize={30}
-				verticalScrollbarPreviousButtonAriaLabel={label}
-			/>
-		);
-
-		const expected = label;
-		const actual = subject.find('ScrollButton').first().prop('aria-label');
-
-		expect(actual).to.equal(expected);
-	});
-
-	it('should set "aria-label" to next scroll button', function () {
-		const label = 'custom button aria label';
-		const subject = mount(
-			<VirtualList
-				clientSize={clientSize}
-				dataSize={dataSize}
-				direction="horizontal"
-				itemRenderer={renderItem}
-				itemSize={30}
-				verticalScrollbarNextButtonAriaLabel={label}
-			/>
-		);
-
-		const expected = label;
-		const actual = subject.find('ScrollButton').last().prop('aria-label');
-
-		expect(actual).to.equal(expected);
-	});
-
 	describe('ScrollTo', () => {
 		it('should scroll to the specific item of a given index with scrollTo', () => {
 			mount(
@@ -317,6 +279,46 @@ describe('VirtualList', () => {
 				expect(actual).to.equal(expected);
 				done();
 			}, 0);
+		});
+	});
+
+	describe('Scrollbar accessibility', () => {
+		it('should set "aria-label" to previous scroll button', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<VirtualList
+					clientSize={clientSize}
+					dataSize={dataSize}
+					direction="horizontal"
+					itemRenderer={renderItem}
+					itemSize={30}
+					verticalScrollbarPreviousButtonAriaLabel={label}
+				/>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(0).prop('aria-label');
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set "aria-label" to next scroll button', function () {
+			const label = 'custom button aria label';
+			const subject = mount(
+				<VirtualList
+					clientSize={clientSize}
+					dataSize={dataSize}
+					direction="horizontal"
+					itemRenderer={renderItem}
+					itemSize={30}
+					verticalScrollbarNextButtonAriaLabel={label}
+				/>
+			);
+
+			const expected = label;
+			const actual = subject.find('ScrollButton').at(1).prop('aria-label');
+
+			expect(actual).to.equal(expected);
 		});
 	});
 });

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -124,6 +124,44 @@ describe('VirtualList', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	it('should set "aria-label" to previous scroll button', function () {
+		const label = 'custom button aria label';
+		const subject = mount(
+			<VirtualList
+				clientSize={clientSize}
+				dataSize={dataSize}
+				direction="horizontal"
+				itemRenderer={renderItem}
+				itemSize={30}
+				verticalScrollbarPreviousButtonAriaLabel={label}
+			/>
+		);
+
+		const expected = label;
+		const actual = subject.find('ScrollButton').first().prop('aria-label');
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should set "aria-label" to next scroll button', function () {
+		const label = 'custom button aria label';
+		const subject = mount(
+			<VirtualList
+				clientSize={clientSize}
+				dataSize={dataSize}
+				direction="horizontal"
+				itemRenderer={renderItem}
+				itemSize={30}
+				verticalScrollbarNextButtonAriaLabel={label}
+			/>
+		);
+
+		const expected = label;
+		const actual = subject.find('ScrollButton').last().prop('aria-label');
+
+		expect(actual).to.equal(expected);
+	});
+
 	describe('ScrollTo', () => {
 		it('should scroll to the specific item of a given index with scrollTo', () => {
 			mount(

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -290,7 +290,7 @@ describe('VirtualList', () => {
 					clientSize={clientSize}
 					dataSize={dataSize}
 					direction="horizontal"
-					horizontalScrollbarPreviousButtonAriaLabel={label}
+					scrollLeftAriaLabel={label}
 					itemRenderer={renderItem}
 					itemSize={30}
 				/>
@@ -309,7 +309,7 @@ describe('VirtualList', () => {
 					clientSize={clientSize}
 					dataSize={dataSize}
 					direction="horizontal"
-					horizontalScrollbarNextButtonAriaLabel={label}
+					scrollRightAriaLabel={label}
 					itemRenderer={renderItem}
 					itemSize={30}
 				/>
@@ -330,7 +330,7 @@ describe('VirtualList', () => {
 					direction="vertical"
 					itemRenderer={renderItem}
 					itemSize={30}
-					verticalScrollbarPreviousButtonAriaLabel={label}
+					scrollUpAriaLabel={label}
 				/>
 			);
 
@@ -349,7 +349,7 @@ describe('VirtualList', () => {
 					direction="vertical"
 					itemRenderer={renderItem}
 					itemSize={30}
-					verticalScrollbarNextButtonAriaLabel={label}
+					scrollDownAriaLabel={label}
 				/>
 			);
 

--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -290,9 +290,9 @@ describe('VirtualList', () => {
 					clientSize={clientSize}
 					dataSize={dataSize}
 					direction="horizontal"
+					horizontalScrollbarPreviousButtonAriaLabel={label}
 					itemRenderer={renderItem}
 					itemSize={30}
-					horizontalScrollbarPreviousButtonAriaLabel={label}
 				/>
 			);
 
@@ -309,9 +309,9 @@ describe('VirtualList', () => {
 					clientSize={clientSize}
 					dataSize={dataSize}
 					direction="horizontal"
+					horizontalScrollbarNextButtonAriaLabel={label}
 					itemRenderer={renderItem}
 					itemSize={30}
-					horizontalScrollbarNextButtonAriaLabel={label}
 				/>
 			);
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There's no way to override a11y string on scrollbar scroll buttons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Add Scrollable/ScrollableNative props - horizontalScrollbarNextButtonAriaLabel, horizontalScrollbarPreviousButtonAriaLabel, verticalScrollbarNextButtonAriaLabel, verticalScrollbarPreviousButtonAriaLabel to override readout string on

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-52108

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)