### PR TITLE
PLAT-53640: Allow to force to re-render VirtualList items if needed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/VirtualList.VirtualList` to re-render items when forceUpdate() called
 - `ui/ViewManager` to not initially pass the wrong value for `enteringProp` when a view initiates a transition into the viewport
 
 ## [2.0.0-alpha.7 - 2018-04-03]

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -243,6 +243,12 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
+		componentWillUpdate (nextProps, nextState) {
+			if (this.state.firstIndex === nextState.firstIndex) {
+				this.prevFirstIndex = -1; // force to re-render items
+			}
+		}
+
 		scrollBounds = {
 			clientWidth: 0,
 			clientHeight: 0,
@@ -626,10 +632,10 @@ const VirtualListBaseFactory = (type) => {
 				{firstIndex, numOfItems} = this.state,
 				{isPrimaryDirectionVertical, dimensionToExtent, primary, secondary, cc} = this,
 				diff = firstIndex - this.prevFirstIndex,
-				updateFrom = (cc.length === 0 || 0 >= diff || diff >= numOfItems) ? firstIndex : this.prevFirstIndex + numOfItems;
+				updateFrom = (cc.length === 0 || 0 >= diff || diff >= numOfItems || this.prevFirstIndex === -1) ? firstIndex : this.prevFirstIndex + numOfItems;
 			let
 				hideTo = 0,
-				updateTo = (cc.length === 0 || -numOfItems >= diff || diff > 0) ? firstIndex + numOfItems : this.prevFirstIndex;
+				updateTo = (cc.length === 0 || -numOfItems >= diff || diff > 0 || this.prevFirstIndex === -1) ? firstIndex + numOfItems : this.prevFirstIndex;
 
 			if (updateFrom >= updateTo) {
 				return;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though calling this.forceUpdate() app side, VirtualList items are not re-rendered because we cached them to enhance performance by blocking re-rendering them.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

While scrolling a VirtuslList, we still use the cached items. But while updating it, we re-render the items.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-53640

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)