### PR TITLE
ENYO-5144: Fix ui/ViewManager to send the correct enteringProp value

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/Transition` property `children` to not be required
 - `ui/Transition` to fire `onShow` and `onHide` even when there are no `children`
 
+### Fixed
+
+- `ui/ViewManager` to not initially pass the wrong value for `enteringProp` when a view initiates a transition into the viewport
+
 ## [2.0.0-alpha.7 - 2018-04-03]
 
 ### Removed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -69,10 +69,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/Toggleable` to use `'selected'` as its default `prop`, rather than `'active'`, since `'selected'` is by far the most common use case
 - `ui/Touchable` to use global gesture configuration with instance override rather than component-level configuration via HOC configs with instance override
 
-### Fixed
-
-- `ui/ViewManager` to suppress `enteringProp` for views that are rendered at mount
-
 ## [2.0.0-alpha.3] - 2018-01-18
 
 ### Added

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -214,9 +214,8 @@ class TransitionGroup extends React.Component {
 		this.state = {
 			children: mapChildren(this.props.children)
 		};
-	}
 
-	componentWillMount () {
+		this.hasMounted = false;
 		this.currentlyTransitioningKeys = {};
 		this.keysToEnter = [];
 		this.keysToLeave = [];
@@ -224,6 +223,8 @@ class TransitionGroup extends React.Component {
 	}
 
 	componentDidMount () {
+		this.hasMounted = true;
+
 		// this isn't used by ViewManager or View at the moment but leaving it around for future
 		// flexibility
 		this.state.children.forEach(child => this.performAppear(child.key));
@@ -436,7 +437,7 @@ class TransitionGroup extends React.Component {
 
 			return React.cloneElement(
 				this.props.childFactory(child),
-				{key: child.key, ref: child.key, leaving: isLeaving}
+				{key: child.key, ref: child.key, leaving: isLeaving, appearing: !this.hasMounted}
 			);
 		});
 

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -9,6 +9,10 @@ import ReactDOM from 'react-dom';
 
 import {shape} from './Arranger';
 
+const clearEntering = ({entering}) => {
+	return entering ? {entering: false} : null;
+};
+
 /**
  * A `View` wraps a set of children for {@link ui/ViewManager.ViewManager}.
  * It is not intended to be used directly
@@ -30,6 +34,8 @@ class View extends React.Component {
 		 * @public
 		 */
 		duration: PropTypes.number.isRequired,
+
+		appearing: PropTypes.bool,
 
 		/**
 		 * Arranger to control the animation
@@ -119,7 +125,7 @@ class View extends React.Component {
 		this.animation = null;
 		this._raf = null;
 		this.state = {
-			entering: true
+			entering: !props.appearing
 		};
 	}
 
@@ -149,9 +155,7 @@ class View extends React.Component {
 	}
 
 	enteringJob = new Job(() => {
-		this.setState({
-			entering: false
-		});
+		this.setState(clearEntering);
 	})
 
 	componentWillAppear (callback) {
@@ -164,9 +168,7 @@ class View extends React.Component {
 	}
 
 	componentDidAppear () {
-		this.setState({
-			entering: false
-		});
+		this.setState(clearEntering);
 	}
 
 	// This is called at the same time as componentDidMount() for components added to an existing
@@ -310,12 +312,12 @@ class View extends React.Component {
 	}
 
 	render () {
-		const {enteringProp, children, childProps} = this.props;
+		const {appearing, enteringProp, children, childProps} = this.props;
 
 		if (enteringProp || childProps) {
 			const props = Object.assign({}, childProps);
 			if (enteringProp) {
-				props[enteringProp] = this.state.entering;
+				props[enteringProp] = !appearing && this.state.entering;
 			}
 
 			return React.cloneElement(children, props);

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -119,7 +119,7 @@ class View extends React.Component {
 		this.animation = null;
 		this._raf = null;
 		this.state = {
-			entering: false
+			entering: true
 		};
 	}
 
@@ -163,9 +163,9 @@ class View extends React.Component {
 		}
 	}
 
-	setEntering () {
+	componentDidAppear () {
 		this.setState({
-			entering: true
+			entering: false
 		});
 	}
 
@@ -174,8 +174,6 @@ class View extends React.Component {
 	// will not be called on the initial render of a TransitionGroup.
 	componentWillEnter (callback) {
 		const {arranger, reverseTransition} = this.props;
-		this.setEntering();
-
 		if (arranger) {
 			this.prepareTransition(reverseTransition ? arranger.leave : arranger.enter, callback);
 		} else {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Due to the changes in #1446, when a view was transitioning into the viewport, it would initially be rendered with `enteringProp` set to `false`, then changed to `true` in `componentWillEnter`, and back to `false` in `componentDidEnter`.

This interfered with `moonstone/Panels.Panel` which would restore focus after the first `false` value, then lose focus when the child was removed when `enteringProp` became `true`, and finally tries to restore focus again when it returns to `false` but had then lost the last focused key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Revert the changes from #1446 in favor of a new `appearing` prop for View that is only set for views rendered before the ViewManager is mounted

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)