### PR TITLE
PLAT-49780: Optimize localized font loading performance

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
 - `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
 - `moonstone/MoonstoneDecorator.I18nDecorator` to optimize localized font loading performance
+- `moonstone/styles/fonts.less` to remove specified unicode range definitions
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
 - `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
+- `moonstone/MoonstoneDecorator.I18nDecorator` to optimize localized font loading performance
 
 ## [2.0.0-alpha.6] - 2018-03-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,6 +17,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/TimePicker` to show `meridiem` correctly in all locales
 - `moonstone/Scrollable/ScrollButtons` to read out out audio guidance when button down.
+- `moonstone/MoonstoneDecorator.I18nDecorator` to optimize localized font loading performance
+- `moonstone/styles/fonts.less` to remove specified unicode range definitions
 
 ## [2.0.0-alpha.7 - 2018-04-03]
 
@@ -45,8 +47,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to hide more icon when right components are removed
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
 - `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
-- `moonstone/MoonstoneDecorator.I18nDecorator` to optimize localized font loading performance
-- `moonstone/styles/fonts.less` to remove specified unicode range definitions
 - `moonstone/Notification` to display when it's opened
 - `moonstone/VirtualList` and `moonstone/VirtualGridList` to show Spotlight properly while navigating with page up and down keys
 - `moonstone/Input` to allow navigating via left or right to other components when the input is active and the selection is at start or end of the text, respectively

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,9 +17,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/TimePicker` to show `meridiem` correctly in all locales
 - `moonstone/Scrollable/ScrollButtons` to read out out audio guidance when button down.
+- `moonstone/ExpandableItem` to show label properly when open and disabled
 - `moonstone/MoonstoneDecorator.I18nDecorator` to optimize localized font loading performance
 - `moonstone/styles/fonts.less` to remove specified unicode range definitions
-- `moonstone/ExpandableItem` to show label properly when open and disabled
 
 ## [2.0.0-alpha.7 - 2018-04-03]
 
@@ -47,7 +47,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to display custom thumbnail node
 - `moonstone/VideoPlayer` to hide more icon when right components are removed
 - `moonstone/Picker` to correctly update pressed state when dragging off buttons
-- `moonstone/VirtualList` and `moonstone/VirtualGridList`, to show Spotlight properly while navigating them with page up and down keys
 - `moonstone/Notification` to display when it's opened
 - `moonstone/VirtualList` and `moonstone/VirtualGridList` to show Spotlight properly while navigating with page up and down keys
 - `moonstone/Input` to allow navigating via left or right to other components when the input is active and the selection is at start or end of the text, respectively

--- a/packages/moonstone/MoonstoneDecorator/I18nFontDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/I18nFontDecorator.js
@@ -1,20 +1,47 @@
 import hoc from '@enact/core/hoc';
 import ilib from '@enact/i18n';
-import kind from '@enact/core/kind';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import fontGenerator from './fontGenerator';
 
-const I18nFontDecorator = hoc((config, Wrapped) => kind({
-	name: 'I18nFontDecorator',
+const I18nFontDecorator = hoc((config, Wrapped) => {
+	return class I18nDecorator extends React.Component {
+		static displayName = 'I18nFontDecorator'
 
-	render: (props) => {
-		fontGenerator(ilib.getLocale());
-		return (
-			<Wrapped {...props} />
-		);
-	}
-}));
+		static propTypes = {
+			locale: PropTypes.string
+		}
+
+		constructor (props) {
+			super(props);
+
+			this.state = {
+				locale: props.locale || ilib.getLocale()
+			};
+		}
+
+		componentDidMount () {
+			fontGenerator(this.state.locale);
+		}
+
+		componentWillReceiveProps (newProps) {
+			if (newProps.locale !== this.state.locale) {
+				this.setState({locale: newProps.locale});
+			}
+		}
+
+		componentDidUpdate (_, prevState) {
+			fontGenerator(this.state.locale, prevState.locale !== this.state.locale);
+		}
+
+		render () {
+			return (
+				<Wrapped {...this.props} />
+			);
+		}
+	};
+});
 
 export default I18nFontDecorator;
 export {I18nFontDecorator};

--- a/packages/moonstone/styles/fonts.less
+++ b/packages/moonstone/styles/fonts.less
@@ -22,8 +22,6 @@
 
 /* ----- MISO ------ */
 
-@font-unicode-range-miso: U+0, U+9-107, U+10C-113, U+116-11B, U+11E-11F, U+122-123, U+128-12B, U+12E-133, U+136-137, U+139-148, U+14C-14D, U+150-15B, U+15E-165, U+168-16B, U+16E-173, U+178-17E, U+181, U+18A, U+18F, U+192, U+198-199, U+1A0-1A1, U+1AF-1B0, U+1B3-1B4, U+1C4-1DC, U+1F1, U+1F3, U+1F8-1F9, U+218-21B, U+237, U+253, U+257, U+259, U+2C6-2C7, U+2D8-2DD, U+300-304, U+306-30C, U+312, U+31B, U+323, U+326-328, U+1E44-1E45, U+1E62-1E63, U+1EA0-1EF9, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+203E, U+20AB-20AC, U+2122, U+2205, U+2302;
-
 @font-face {
 	font-family: "Moonstone Miso";
 	src: @font-system-src-non-latin;
@@ -35,7 +33,6 @@
 	src: @font-system-src-miso-400;
 	font-weight: normal;
 	font-style: normal;
-	unicode-range: @font-unicode-range-miso;
 }
 
 @font-face {
@@ -49,7 +46,6 @@
 	src: @font-system-src-miso-700;
 	font-weight: 700;
 	font-style: normal;
-	unicode-range: @font-unicode-range-miso;
 }
 
 @font-face {
@@ -63,12 +59,9 @@
 	src: @font-system-src-miso-300;
 	font-weight: 300;
 	font-style: normal;
-	unicode-range: @font-unicode-range-miso;
 }
 
 /* ----- Museo Sans ------ */
-
-@font-unicode-range-museosans: U+0, U+9-17F, U+181, U+18A, U+18F, U+192, U+198-199, U+1A0-1A1, U+1AF-1B0, U+1B3-1B4, U+1C4-1DC, U+1F1, U+1F3, U+1F8-1F9, U+218-21B, U+237, U+253, U+257, U+259, U+2C6-2C7, U+2D8-2DD, U+300-304, U+306-30C, U+31B, U+323, U+326-328, U+3BC, U+1E44-1E45, U+1E62-1E63, U+1E9E, U+1EA0-1EF9, U+2009, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2070, U+2074-2079, U+2080-2089, U+20AB-20AC, U+2122, U+2212, U+221E, U+2248, U+2260, U+2264-2265, U+FB00-FB04, U+FD00;
 
 @font-face {
 	font-family: "MuseoSans";
@@ -81,7 +74,6 @@
 	src: @font-system-src-museosans-500;
 	font-weight: normal;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -95,7 +87,6 @@
 	src: @font-system-src-museosans-100;
 	font-weight: 100;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -109,7 +100,6 @@
 	src: @font-system-src-museosans-300;
 	font-weight: 300;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -123,7 +113,6 @@
 	src: @font-system-src-museosans-500;
 	font-weight: 500;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -137,7 +126,6 @@
 	src: @font-system-src-museosans-500-i;
 	font-weight: 500;
 	font-style: italic;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -151,7 +139,6 @@
 	src: @font-system-src-museosans-700;
 	font-weight: 700;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -165,7 +152,6 @@
 	src: @font-system-src-museosans-700-i;
 	font-weight: 700;
 	font-style: italic;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -179,7 +165,6 @@
 	src: @font-system-src-museosans-900;
 	font-weight: 900;
 	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
@@ -193,7 +178,6 @@
 	src: @font-system-src-museosans-900-i;
 	font-weight: 900;
 	font-style: italic;
-	unicode-range: @font-unicode-range-museosans;
 }
 
 /* ----- Moonstone (Icons) ------ */

--- a/packages/ui/internal/localized-fonts/localized-fonts.js
+++ b/packages/ui/internal/localized-fonts/localized-fonts.js
@@ -53,13 +53,19 @@ const buildFontSet = function (fontName, fonts, strLang, bitDefault) {
 	return strOut;
 };
 
-function fontGenerator (locale) {
+function fontGenerator (locale, localeChanged) {
+	const styleId = 'localized-fonts';
+	let styleElem = document.getElementById(styleId);
+
+	if (styleElem && !localeChanged) {
+		return;
+	}
+
 	const
 		matchLang = locale.match(/\b([a-z]{2})\b/),
 		language = matchLang && matchLang[1],
 		matchReg = locale.match(/\b([A-Z]{2}|[0-9]{3})\b/),
-		region = matchReg && matchReg[1],
-		styleId = 'localized-fonts';
+		region = matchReg && matchReg[1];
 
 	let fontDefinitionCss = '';
 
@@ -83,8 +89,6 @@ function fontGenerator (locale) {
 
 	if (typeof document !== 'undefined') {
 		// Normal execution in a browser window
-		let styleElem = document.getElementById(styleId);
-
 		if (!styleElem) {
 			styleElem = document.createElement('style');
 			styleElem.setAttribute('id', styleId);

--- a/packages/ui/internal/localized-fonts/localized-fonts.js
+++ b/packages/ui/internal/localized-fonts/localized-fonts.js
@@ -54,8 +54,10 @@ const buildFontSet = function (fontName, fonts, strLang, bitDefault) {
 };
 
 function fontGenerator (locale, localeChanged) {
-	const styleId = 'localized-fonts';
-	let styleElem = document.getElementById(styleId);
+	const
+		isDocumentAccessible = typeof document !== 'undefined',
+		styleId = 'localized-fonts';
+	let styleElem = isDocumentAccessible && document.getElementById(styleId);
 
 	if (styleElem && !localeChanged) {
 		return;
@@ -87,7 +89,7 @@ function fontGenerator (locale, localeChanged) {
 		}
 	}
 
-	if (typeof document !== 'undefined') {
+	if (isDocumentAccessible) {
 		// Normal execution in a browser window
 		if (!styleElem) {
 			styleElem = document.createElement('style');


### PR DESCRIPTION
### Issue Resolved / Feature Added
Currently too much (unnecessary) work is happening when attempting to load localized fonts into the dom. Localized font definitions are being generated on render regardless of whether they are already inserted in the dom. Also we're needlessly specifying miso-museo font unicode-range definitions, which add to overall load time bloat.


### Resolution
1) Optimize font loading by only generating font definitions when necessary: when they have not been loaded already or the locale has changed.
2) Remove the miso-museo font unicode-range definition rules.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>