### PR TITLE
ENYO-5076: Remove webOS media event from storybook

### DIFF
--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -68,7 +68,6 @@ const prop = {
 		'onStalled',
 		'onSuspend',
 		// 'onTimeUpdate',	// Disabled due to Storybook Actions-reporting having an adverse effect on VideoPlayer performance. Uncomment to view this event.
-		'onUMSMediaInfo',	// Custom webOS media event
 		'onVolumeChange',
 		'onWaiting'
 	]


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the sampler is run locally, VideoPlayer sample throws an unknown event handler warning. This is related to the recent change in #1459.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove webOS media event handler from the sampler.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
