### PR TITLE
PLAT-52105: Add props for overriding inner focusable component - Popup

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
-- `moonstone/Panels` property `closeButtonAriaLabel` to configure the label set on application close button 
+- `moonstone/Panels` property `closeButtonAriaLabel` to configure the label set on application close button
+- `moonstone/Popup` property `closeButtonAriaLabel` to configure the label set on popup close button
 
 ### Changed
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -60,12 +60,12 @@ const PopupBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
-		* Sets the hint string read when focusing the popup close button.
-		*
-		* @type {String}
-		* @default 'Close'
-		* @public
-		*/
+		 * Sets the hint string read when focusing the popup close button.
+		 *
+		 * @type {String}
+		 * @default 'Close'
+		 * @public
+		 */
 		closeButtonAriaLabel: PropTypes.string,
 
 		/**
@@ -153,9 +153,9 @@ const PopupBase = kind({
 
 	computed: {
 		className: ({showCloseButton, styler}) => styler.append({reserveClose: showCloseButton}),
-		closeButton: ({closeButtonAriaLabel, showCloseButton, onCloseButtonClick}) => {
+		closeButton: ({closeButtonAriaLabel, onCloseButtonClick, showCloseButton}) => {
 			if (showCloseButton) {
-				const ariaLabel =  (closeButtonAriaLabel == null) ? $L('Close') : closeButtonAriaLabel;
+				const ariaLabel = (closeButtonAriaLabel == null) ? $L('Close') : closeButtonAriaLabel;
 
 				return (
 					<IconButton
@@ -230,12 +230,12 @@ class Popup extends React.Component {
 
 	static propTypes = /** @lends moonstone/Popup.Popup.prototype */ {
 		/**
-		* Sets the hint string read when focusing the popup close button.
-		*
-		* @type {String}
-		* @default 'Close'
-		* @public
-		*/
+		 * Sets the hint string read when focusing the popup close button.
+		 *
+		 * @type {String}
+		 * @default 'Close'
+		 * @public
+		 */
 		closeButtonAriaLabel: PropTypes.string,
 
 		/**

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -60,6 +60,15 @@ const PopupBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
+		* Sets the hint string read when focusing the popup close button.
+		*
+		* @type {String}
+		* @default 'Close'
+		* @public
+		*/
+		closeButtonAriaLabel: PropTypes.string,
+
+		/**
 		 * When `true`, the popup will not animate on/off screen.
 		 *
 		 * @type {Boolean}
@@ -144,15 +153,17 @@ const PopupBase = kind({
 
 	computed: {
 		className: ({showCloseButton, styler}) => styler.append({reserveClose: showCloseButton}),
-		closeButton: ({showCloseButton, onCloseButtonClick}) => {
+		closeButton: ({closeButtonAriaLabel, showCloseButton, onCloseButtonClick}) => {
 			if (showCloseButton) {
+				const ariaLabel =  (closeButtonAriaLabel == null) ? $L('Close') : closeButtonAriaLabel;
+
 				return (
 					<IconButton
 						className={css.closeButton}
 						backgroundOpacity="transparent"
 						small
 						onTap={onCloseButtonClick}
-						aria-label={$L('Close')}
+						aria-label={ariaLabel}
 					>
 						closex
 					</IconButton>
@@ -162,6 +173,7 @@ const PopupBase = kind({
 	},
 
 	render: ({closeButton, children, noAnimation, open, onHide, onShow, spotlightId, spotlightRestrict, ...rest}) => {
+		delete rest.closeButtonAriaLabel;
 		delete rest.onCloseButtonClick;
 		delete rest.showCloseButton;
 		return (
@@ -217,6 +229,15 @@ const checkScrimNone = (props) => {
 class Popup extends React.Component {
 
 	static propTypes = /** @lends moonstone/Popup.Popup.prototype */ {
+		/**
+		* Sets the hint string read when focusing the popup close button.
+		*
+		* @type {String}
+		* @default 'Close'
+		* @public
+		*/
+		closeButtonAriaLabel: PropTypes.string,
+
 		/**
 		 * When `true`, the popup will not animate on/off screen.
 		 *

--- a/packages/moonstone/Popup/tests/Popup-specs.js
+++ b/packages/moonstone/Popup/tests/Popup-specs.js
@@ -50,6 +50,19 @@ describe('Popup specs', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	it('should set popup close button "aria-label" to closeButtonAriaLabel', () => {
+		const label = 'custom close button label';
+		const popup = mount(
+			<Popup open showCloseButton closeButtonAriaLabel={label}><div>popup</div></Popup>,
+			options
+		);
+
+		const expected = label;
+		const actual = popup.find('IconButton').prop('aria-label');
+
+		expect(actual).to.equal(expected);
+	});
+
 	it('should set role to alert by default', function () {
 		const popup = shallow(
 			<PopupBase><div>popup</div></PopupBase>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add prop to override a11y string of close button in popup

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
added `closeButtonAriaLabel`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>
