### PR TITLE
ENYO-5160: Fix VideoPlayer to show controls on 5-way select

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scrollable/ScrollButtons` to read out out audio guidance when button down.
 - `moonstone/ExpandableItem` to show label properly when open and disabled
 - `moonstone/Notification` to position properly in RTL locales
+- `moonstone/VideoPlayer` to show controls when pressing 5-way select
 
 ## [2.0.0-alpha.7 - 2018-04-03]
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -2099,6 +2099,7 @@ const VideoPlayerBase = class extends React.Component {
 					// This captures spotlight focus for use with 5-way.
 					// It's non-visible but lives at the top of the VideoPlayer.
 					className={css.controlsHandleAbove}
+					onClick={this.showControls}
 					onKeyDown={this.handleKeyDown}
 					onSpotlightDown={this.showControls}
 					spotlightDisabled={this.state.mediaControlsVisible || spotlightDisabled}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the media controls are hidden, pressing 5-way select does not show them

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Add back call to `showControls()` when the spotlight placeholder is "clicked" (triggered by the simulated click by spottable)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

We could change this to be a key handler instead but this was the prior behavior and simpler to add back. Open for debate :)

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)