### PR TITLE
Simplify the disabled selector logic

### DIFF
--- a/packages/moonstone/Button/Button.less
+++ b/packages/moonstone/Button/Button.less
@@ -183,16 +183,22 @@
 			background-color: @moon-remote-button-blue-color;
 		}
 
-		&:not([disabled]) {
-			.focus({
-				color: @moon-spotlight-text-color;
-				background-color: transparent;
+		.focus({
+			color: @moon-spotlight-text-color;
+			background-color: transparent;
 
-				.bg {
-					background-color: @moon-spotlight-border-color;
+			.bg {
+				background-color: @moon-spotlight-border-color;
+			}
+
+			.disabled({
+				opacity: 1;  // override the default disabled-opacity
+
+				.client {
+					opacity: @moon-disabled-translucent-opacity;
 				}
 			});
-		}
+		});
 
 		// 'Selected' state
 		&.selected {
@@ -210,19 +216,6 @@
 				}
 			});
 		}
-
-		.disabled({
-			.focus({
-				&.translucent,
-				&.transparent {
-					opacity: 1;
-					div {
-						color: @moon-spotlight-text-color;
-						opacity: @moon-disabled-translucent-opacity;
-					}
-				}
-			});
-		});
 	});
 }
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
The selectors were targeting only a subset of the states of Button. This removes older code that targeted non-disabled state and allows disabled and non-disabled to share color rules.