### PR TITLE
ENYO-5186: Fix memoize to forward all args to provided function

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/util.memoize` to forward all args to memoized function
+
 ## [2.0.0-alpha.8] - 2018-04-17
 
 ### Added

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -107,7 +107,7 @@ const kind = (config) => {
 		 */
 		prepareHandler (prop, handler) {
 			this.handlers[prop] = (ev) => {
-				handler(ev, this.props, this.context);
+				return handler(ev, this.props, this.context);
 			};
 		}
 

--- a/packages/core/util/tests/memoize-specs.js
+++ b/packages/core/util/tests/memoize-specs.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 import {memoize} from '..';
 
 describe('memoize', function () {
@@ -14,5 +16,16 @@ describe('memoize', function () {
 		memoizedTest('a');
 		memoizedTest('a');
 		expect(obj).to.have.property('a', 1);
+	});
+
+	it('should forward all args to memoized function', function () {
+		const spy = sinon.spy();
+		const memoized = memoize(spy);
+		memoized(1, 2);
+
+		const expected = [1, 2];
+		const actual = spy.firstCall.args;
+
+		expect(expected).to.deep.equal(actual);
 	});
 });

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -191,7 +191,7 @@ const memoize = (fn) => {
 		if (n in cache) {
 			return cache[n];
 		} else {
-			let result = fn(n);
+			let result = fn(...args);
 			cache[n] = result;
 			return result;
 		}

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -177,7 +177,8 @@ const mergeClassNameMaps = (baseMap, additiveMap, allowedClassNames) => {
 };
 
 /**
- * Creates a function that memoizes the result of `fn`.
+ * Creates a function that memoizes the result of `fn`. Note that this function is a naive
+ * implementation and only checks the first argument for memoization.
  *
  * @method
  * @memberof core/util


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
While experimenting with using memoized event handlers with `core/kind`, I discovered that `core/util.memoize` doesn't send all args to provided function.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Fixed `core/util.memoize` pass all args to provided function
* Added test for the above
* Changed the generated handlers from `core/kind` to return the result of the handler. This won't affect the majority of cases because returned values are ignored by React (afaik) but will enable the memoized handlers with which I was experimenting.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)