### PR TITLE
ENYO-5188: Remove tooltipHideDelay prop in VideoPlayer

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Removed
+
+- `moonstone/VideoPlayer` property `tooltipHideDelay`
+
 ### Added
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -630,16 +630,6 @@ const VideoPlayerBase = class extends React.Component {
 		titleHideDelay: PropTypes.number,
 
 		/**
-		 * The amount of time in milliseconds that should pass before the tooltip disappears from the
-		 * controls. Setting this to `0` disables the hiding.
-		 *
-		 * @type {Number}
-		 * @default 3000
-		 * @public
-		 */
-		tooltipHideDelay: PropTypes.number,
-
-		/**
 		 * Video component to use. The default (`'video'`) renders an `HTMLVideoElement`. Custom
 		 * video components must have a similar API structure, exposing the following APIs:
 		 *
@@ -685,7 +675,6 @@ const VideoPlayerBase = class extends React.Component {
 			slowRewind: ['-1/2', '-1']
 		},
 		titleHideDelay: 5000,
-		tooltipHideDelay: 3000,
 		videoComponent: 'video'
 	}
 
@@ -1955,7 +1944,6 @@ const VideoPlayerBase = class extends React.Component {
 		delete rest.setApiProvider;
 		delete rest.thumbnailUnavailable;
 		delete rest.titleHideDelay;
-		delete rest.tooltipHideDelay;
 		delete rest.videoPath;
 
 		// Handle some cases when the "more" button is pressed

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -158,7 +158,6 @@ storiesOf('Moonstone', module)
 						spotlightDisabled={boolean('spotlightDisabled', false)}
 						thumbnailSrc={poster}
 						thumbnailUnavailable={boolean('thumbnailUnavailable', false)}
-						tooltipHideDelay={number('tooltipHideDelay', 3000)}
 						title={text('title', 'Moonstone VideoPlayer Sample Video')}
 						titleHideDelay={number('titleHideDelay', 4000)}
 						{...prop.eventActions}


### PR DESCRIPTION
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `tooltipHideDelay` prop in `moonstone/VideoPlayer`. Seems like it's a cruft leftover from #815

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>