### PR TITLE
ENYO-5188: Deprecate tooltipHideDelay in VideoPlayer

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Deprecated
 
+- `moonstone/VideoPlayer` prop `tooltipHideDelay`, to be removed in 2.0.0
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `data`, to be removed in 2.0.0
 
 ## [1.15.0] - 2018-02-28

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -7,6 +7,7 @@
  */
 import Announce from '@enact/ui/AnnounceDecorator/Announce';
 import ApiDecorator from '@enact/core/internal/ApiDecorator';
+import deprecate from '@enact/core/internal/deprecate';
 import equals from 'ramda/src/equals';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -670,6 +671,7 @@ const VideoPlayerBase = class extends React.Component {
 		 * @type {Number}
 		 * @default 3000
 		 * @public
+		 * @deprecated
 		 */
 		tooltipHideDelay: PropTypes.number
 	}
@@ -756,6 +758,10 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (props.setApiProvider) {
 			props.setApiProvider(this);
+		}
+
+		if (props.tooltipHideDelay) {
+			deprecate({name: 'tooltipHideDelay', since: '1.16.0', until: '2.0.0'});
 		}
 	}
 

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -155,7 +155,6 @@ storiesOf('VideoPlayer')
 						spotlightDisabled={boolean('spotlightDisabled', false)}
 						thumbnailSrc={poster}
 						thumbnailUnavailable={boolean('thumbnailUnavailable', false)}
-						tooltipHideDelay={number('tooltipHideDelay', 3000)}
 						title={text('title', 'Moonstone VideoPlayer Sample Video')}
 						titleHideDelay={number('titleHideDelay', 4000)}
 						{...prop.eventActions}


### PR DESCRIPTION
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Deprecate `tooltipHideDelay` prop in `moonstone/VideoPlayer`. Seems like it's a cruft leftover from #815

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
