### PR TITLE
ENYO-5191: Add core/snapshot module

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 ### Added
 
 - `core/snapshot` module with `isWindowReady` method to check the window state and `onWindowReady` method to queue window-dependent callbacks for snapshot builds
+
 ### Fixed
 
 - `core/util.memoize` to forward all args to memoized function

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/snapshot` module with `isWindowReady` method to check the window state and `onWindowReady` method to queue window-dependent callbacks for snapshot builds
+
 ## [2.0.0-alpha.8] - 2018-04-17
 
 ### Added

--- a/packages/core/snapshot/package.json
+++ b/packages/core/snapshot/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "snapshot.js"
+}

--- a/packages/core/snapshot/snapshot.js
+++ b/packages/core/snapshot/snapshot.js
@@ -21,18 +21,18 @@ function isWindowReady () {
 }
 
 /**
- * Registers a callback that requires a valid window before execution such as event handlers.
+ * Executes a callback, such as registering event handlers, when a valid `window` is available.
  *
- * During development, the callback will be executed immediately. When using pre-rendering, the
- * callbacks would not be executed at all. When using snapshot, the callbacks are queued up and
- * executed in order once the window is available.
+ * During normal operation, the callback will be executed immediately. During a pre-rendering pass,
+ * the callback is not be executed at all. When using snapshot, the callback is added to a queued
+ * and is executed in order once the window is available.
  *
  * *Important Notes*
- * * Callbacks should not alter the initial HTML state. If it does, it will invalidate the pre-render
- *   state and interfere with React rehydration.
- * * Callbacks should be limited to module-scoped actions and not component instance actions. If the
- *   action is tied to a component, it should be invoked from within the component's lifecycle
- *   methods,
+ * * The callback should not alter the initial HTML state. If it does, it will invalidate the
+ * pre-render state and interfere with React rehydration.
+ * * The callback should be limited to module-scoped actions and not component instance actions. If
+ * the action is tied to a component, it should be invoked from within the component's lifecycle
+ * methods.
  *
  * @param   {Function} callback Function to run when the window is ready
  * @memberof core/snapshot
@@ -49,7 +49,7 @@ function onWindowReady (callback) {
 /**
  * Executes all queued window callbacks.
  *
- * Requires that the window be, in fact, available and will throw an Error if not.
+ * Requires that the window be, in fact, available and will throw an `Error` if not.
  *
  * @memberof core/snapshot
  * @public

--- a/packages/core/snapshot/snapshot.js
+++ b/packages/core/snapshot/snapshot.js
@@ -1,0 +1,71 @@
+/**
+ * Utilities to facilitate integration with v8 snapshot builds
+ *
+ * @module core/snapshot
+ * @public
+ */
+
+import invariant from 'invariant';
+
+const windowCallbacks = [];
+
+/**
+ * Determines if the `window` is available
+ *
+ * @returns {Boolean} `true` when `window` is ready
+ * @memberof core/snapshot
+ * @public
+ */
+function isWindowReady () {
+	return typeof window !== 'undefined';
+}
+
+/**
+ * Registers a callback that requires a valid window before execution such as event handlers.
+ *
+ * During development, the callback will be executed immediately. When using pre-rendering, the
+ * callbacks would not be executed at all. When using snapshot, the callbacks are queued up and
+ * executed in order once the window is available.
+ *
+ * *Important Notes*
+ * * Callbacks should not alter the initial HTML state. If it does, it will invalidate the pre-render
+ *   state and interfere with React rehydration.
+ * * Callbacks should be limited to module-scoped actions and not component instance actions. If the
+ *   action is tied to a component, it should be invoked from within the component's lifecycle
+ *   methods,
+ *
+ * @param   {Function} callback Function to run when the window is ready
+ * @memberof core/snapshot
+ * @public
+ */
+function onWindowReady (callback) {
+	if (isWindowReady()) {
+		callback();
+	} else {
+		windowCallbacks.push(callback);
+	}
+}
+
+/**
+ * Executes all queued window callbacks.
+ *
+ * Requires that the window be, in fact, available and will throw an Error if not.
+ *
+ * @memberof core/snapshot
+ * @public
+ */
+function windowReady () {
+	invariant(
+		isWindowReady(),
+		'windowReady cannot be run until the window is available'
+	);
+
+	windowCallbacks.forEach(f => f());
+}
+
+export default onWindowReady;
+export {
+	isWindowReady,
+	onWindowReady,
+	windowReady
+};


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Would be good to have a utility for enqueuing window-dependent callbacks in a snapshot-compatible way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* add `core/snapshot` module with `onWindowReady` and `windowReady` methods to enqueue callbacks and flush the queue, respectively

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Also need a CLI and dev-utils PR to complete the feature.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)