### PR TITLE
PLAT-53067: Move dependencies to React 16.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,8 +32,8 @@
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "recompose": "^0.26.0"
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,8 +37,8 @@
     "@enact/core": "^2.0.0-alpha.8",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "xhr": "^2.4.1"
   }
 }

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -37,8 +37,8 @@
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "recompose": "^0.26.0",
     "warning": "^3.0.0"
   }

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -23,8 +23,8 @@
     "@enact/spotlight": "^2.0.0-alpha.8",
     "@enact/ui": "^2.0.0-alpha.8",
     "@enact/webos": "^2.0.0-alpha.8",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "devDependencies": {
     "@enact/dev-utils": "^0.4.0",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -24,8 +24,8 @@
     "@enact/core": "^2.0.0-alpha.8",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "warning": "^3.0.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,8 +34,8 @@
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "recompose": "^0.26.0",
     "warning": "^3.0.0"
   }


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Dependencies are at a loose `^16.2.0` for React/ReactDOM.


### Resolution
* Bump to an explicit `^16.3.2` dependency range for React/ReactDOM.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>