### PR TITLE
PLAT-53652: Change ui/Cancelable to use stopPropagation instead of return values

### DIFF
--- a/packages/moonstone/ExpandableItem/Expandable.js
+++ b/packages/moonstone/ExpandableItem/Expandable.js
@@ -17,10 +17,10 @@ import ExpandableSpotlightDecorator from './ExpandableSpotlightDecorator';
  * @returns {undefined}
  * @private
  */
-const handleCancel = function (props) {
+const handleCancel = function (ev, props) {
 	if (props.open) {
 		props.onClose();
-		return true;
+		ev.stopPropagation();
 	}
 };
 

--- a/packages/moonstone/Panels/CancelDecorator.js
+++ b/packages/moonstone/Panels/CancelDecorator.js
@@ -11,7 +11,7 @@ const defaultConfig = {
 const CancelDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {cancel} = config;
 
-	function handleCancel (props) {
+	function handleCancel (ev, props) {
 		const {index, [cancel]: handler} = props;
 
 		if (index > 0 && handler && !document.querySelector(`.${css.transitioning}`)) {
@@ -25,7 +25,7 @@ const CancelDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				index: index - 1
 			});
 
-			return true;
+			ev.stopPropagation();
 		}
 	}
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Changed
+
+- `ui/Cancelable` default behavior when using a string value for `onCancel` to allow propagation up the component tree. Event propagation can be prevented using the `stopPropagation` method added to the event payload passed to the `onCancel` callback.
+
 ### Fixed
 
 - `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` to support RTL by dynamic language changes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Cancelable` default behavior when using a string value for `onCancel` to allow propagation up the component tree. Event propagation can be prevented using the `stopPropagation` method added to the event payload passed to the `onCancel` callback.
+- `ui/Cancelable` callback `onCancel` to accept an event with a `stopPropagation` method to prevent upstream instances from handling the event instead of using the return value from the callback to prevent propagation. When a function is passed to `onCancel`, it will now receive an event and a props object instead of only the props object. When a string is passed to `onCancel`, it will now receive an event instead of no arguments. Also when a string is passed, the event will now propagate to upstream instances unless `stopPropagation` is called.
 
 ### Fixed
 

--- a/packages/ui/Cancelable/Cancelable.js
+++ b/packages/ui/Cancelable/Cancelable.js
@@ -4,7 +4,7 @@
  * @module ui/Cancelable
  */
 
-import {forward, handle, stopImmediate} from '@enact/core/handle';
+import {forward, handle, stop, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {add} from '@enact/core/keymap';
 import invariant from 'invariant';
@@ -88,8 +88,16 @@ const Cancelable = hoc(defaultConfig, (config, Wrapped) => {
 	const onCancelIsFunction = typeof onCancel === 'function';
 	const dispatchCancelToConfig = function (ev, props) {
 		if (onCancelIsString && typeof props[onCancel] === 'function') {
-			props[onCancel]();
-			return true;
+			let stopped = false;
+
+			props[onCancel]({
+				type: onCancel,
+				stopPropagation: () => {
+					stopped = true;
+				}
+			});
+
+			return stopped;
 		} else if (onCancelIsFunction) {
 			return onCancel(props);
 		}
@@ -120,6 +128,7 @@ const Cancelable = hoc(defaultConfig, (config, Wrapped) => {
 			forCancel,
 			forward('onCancel'),
 			dispatchCancelToConfig,
+			stop,
 			stopImmediate
 		)
 

--- a/packages/ui/Cancelable/tests/Cancelable-specs.js
+++ b/packages/ui/Cancelable/tests/Cancelable-specs.js
@@ -25,7 +25,6 @@ describe('Cancelable', () => {
 
 	/* eslint-disable react/jsx-no-bind */
 	const returnsTrue = () => true;
-	const returnsFalse = () => false;
 	const stop = (ev) => ev.stopPropagation();
 
 	it('should call onCancel from prop for escape key', function () {
@@ -85,8 +84,8 @@ describe('Cancelable', () => {
 		expect(actual).to.equal(expected);
 	});
 
-	it('should stop propagation for escape key', function () {
-		const handleCancel = sinon.spy(returnsTrue);
+	it('should stop propagation when handled', function () {
+		const handleCancel = sinon.spy(stop);
 		const keyEvent = makeKeyEvent(27);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
@@ -105,7 +104,7 @@ describe('Cancelable', () => {
 		expect(actual).to.equal(expected);
 	});
 
-	it('should not stop propagation for non-escape key', function () {
+	it('should not stop propagation for not handled', function () {
 		const handleCancel = sinon.spy(returnsTrue);
 		const keyEvent = makeKeyEvent(42);
 		const Comp = Cancelable(
@@ -129,7 +128,7 @@ describe('Cancelable', () => {
 		const handleKeyUp = sinon.spy();
 		const keyEvent = makeKeyEvent(42);
 		const Comp = Cancelable(
-			{onCancel: () => true},
+			{onCancel: returnsTrue},
 			Component
 		);
 
@@ -168,8 +167,8 @@ describe('Cancelable', () => {
 		expect(actual).to.equal(expected);
 	});
 
-	it('should bubble up the component tree when config handler returns false', function () {
-		const handleCancel = sinon.spy(returnsFalse);
+	it('should bubble up the component tree when config handler does not call stopPropagation', function () {
+		const handleCancel = sinon.spy(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
 			Component
@@ -190,8 +189,8 @@ describe('Cancelable', () => {
 	});
 
 
-	it('should not bubble up the component tree when config handler returns true', function () {
-		const handleCancel = sinon.spy(returnsTrue);
+	it('should not bubble up the component tree when config handler calls stopPropagation', function () {
+		const handleCancel = sinon.spy(stop);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
 			Component
@@ -211,7 +210,7 @@ describe('Cancelable', () => {
 		expect(actual).to.equal(expected);
 	});
 
-	it('should bubble up the component tree when prop handler returns false', function () {
+	it('should bubble up the component tree when prop handler does not call stopPropagation', function () {
 		const handleCancel = sinon.spy();
 		const Comp = Cancelable(
 			{onCancel: 'onCustomEvent'},
@@ -220,7 +219,7 @@ describe('Cancelable', () => {
 
 		const subject = mount(
 			<Comp onCustomEvent={handleCancel}>
-				<Comp className="second" onCustomEvent={returnsFalse} />
+				<Comp className="second" onCustomEvent={returnsTrue} />
 			</Comp>
 		);
 
@@ -317,7 +316,7 @@ describe('Cancelable', () => {
 			expect(actual).to.deep.equal(expected);
 		});
 
-		it('should not invoke modal handlers after one returns true', function () {
+		it('should not invoke modal handlers after one calls stopPropagation', function () {
 			const handleCancel = sinon.spy(returnsTrue);
 
 			const First = Cancelable(
@@ -325,7 +324,7 @@ describe('Cancelable', () => {
 				Component
 			);
 			const Second = Cancelable(
-				{modal: true, onCancel: returnsTrue},
+				{modal: true, onCancel: stop},
 				Component
 			);
 

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -208,10 +208,12 @@ class FloatingLayerBase extends React.Component {
 	}
 }
 
-const handleCancel = (props) => {
-	if (props.open && !props.noAutoDismiss && props.onDismiss) {
-		props.onDismiss({});
-		return true;
+const handleCancel = (ev, {noAutoDismiss, onDismiss, open}) => {
+	if (open && !noAutoDismiss && onDismiss) {
+		onDismiss({
+			type: 'onDismiss'
+		});
+		ev.stopPropagation();
 	}
 };
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Current logic uses return values to mark a cancel event "handled" and prevent other upstream or modal handlers for being called. That's inconsistent with other event handlers and was incompatible with the prop-based approach which didn't receive an event payload and could never stop propagation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Add a consistent event payload to all `onCancel` handlers that includes `type` and `stopPropagation()` the latter which can be called to indicate the cancel was "handled" and no further handlers should be called.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

The change affects `moonstone/Panels` and all variants of `moonstone/ExpandableItem` and `moonstone/Popup`

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)