### PR TITLE
PLAT-47085: Change moonstone/Input to lock pointer when focused

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` props `scrollRightAriaLabel`, `scrollLeftAriaLabel`, `scrollDownAriaLabel`, and `scrollUpAriaLabel` to configure the aria-label set on scroll buttons in the scrollbars
 - `moonstone/Popup` property `closeButtonAriaLabel` to configure the label set on popup close button
 
+### Changed
+
+- `moonstone/Input` to prevent pointer actions on other component when the input has focus
+
 ### Fixed
 
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -4,14 +4,14 @@
  * @module moonstone/Input
  */
 
-import {contextTypes} from '@enact/i18n/I18nDecorator';
-import Changeable from '@enact/ui/Changeable';
 import kind from '@enact/core/kind';
-import {isRtlText} from '@enact/i18n/util';
-import React from 'react';
-import PropTypes from 'prop-types';
-import Pure from '@enact/ui/internal/Pure';
 import {Subscription} from '@enact/core/internal/PubSub';
+import {contextTypes} from '@enact/i18n/I18nDecorator';
+import {isRtlText} from '@enact/i18n/util';
+import Changeable from '@enact/ui/Changeable';
+import Pure from '@enact/ui/internal/Pure';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import $L from '../internal/$L';
 import Skinnable from '../Skinnable';

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -1,0 +1,46 @@
+import {handle, preventDefault, returnsTrue, stop} from '@enact/core/handle';
+
+let active;
+let capturedDown = false;
+
+// if there is a focused input (there should be) and the target is not the input
+const shouldCapture = ({target}) => active && target !== active;
+const isCapturing = () => capturedDown && active;
+const setCapturing = (capturing) => returnsTrue(() => (capturedDown = capturing));
+
+const handlePointerDown = handle(
+	shouldCapture,				// If we should capture the click
+	preventDefault,				// prevent the down event bubbling
+	stop,						// (and stop propagation to support touch)
+	setCapturing(true)			// and flag that we've started capturing a down event
+);
+
+const handlePointerClick = handle(
+	isCapturing,				// if a down event was captured
+	stop,						// prevent the click event from propagating
+	setCapturing(false),		// clear the capturing flag
+	() => active.blur()			// and blur the active node
+);
+
+// Lock the pointer from emitting click events until released
+const lockPointer = (target) => {
+	active = target;
+	document.addEventListener('mousedown', handlePointerDown, {capture: true});
+	document.addEventListener('touchstart', handlePointerDown, {capture: true});
+	document.addEventListener('click', handlePointerClick, {capture: true});
+};
+
+// Release the pointer and allow subsequent click events
+const releasePointer = (target) => {
+	if (target === active) {
+		active = null;
+		document.removeEventListener('mousedown', handlePointerDown, {capture: true});
+		document.removeEventListener('touchstart', handlePointerDown, {capture: true});
+		document.removeEventListener('click', handlePointerClick, {capture: true});
+	}
+};
+
+export {
+	lockPointer,
+	releasePointer
+};


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

New UX requirement that in addition to pausing Spotlight, the user should not be able to click on other components but still select and position the carat within the input.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Added a pointer lock submodule to `moonstone/Input` which uses the capture phase and some module-scoped state to prevent click and "tap" actions when the input has focus.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)