### PR TITLE
ENYO-5141: VirtualGridList: Fix showing blank when direction prop changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` showing blank when `direction` prop changed after scroll position changed
 - `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` to support RTL by dynamic language changes
 
 ## [2.0.0-alpha.8] - 2018-04-17

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -387,6 +387,10 @@ const VirtualListBaseFactory = (type) => {
 
 			// reset
 			this.scrollPosition = 0;
+			if (type === JS && this.contentRef) {
+				this.contentRef.style.transform = null;
+			}
+
 			// eslint-disable-next-line react/no-direct-mutation-state
 			this.state.firstIndex = 0;
 			// eslint-disable-next-line react/no-direct-mutation-state


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualGridList shows blank when `direction` prop changed after scroll.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This issue only occurs in "JS" version of VirtualLists.
After syncing the DOM structure of "JS" list with "Native" list, we made contentRef for "JS" list and transform it when the scroll occurs.
But when the `direction` prop changed after scroll position changed, we didn't reset the transform value for contentRef.
So added reset transform code for contentRef.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5141

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)