### PR TITLE
ENYO-5194: Fix VideoPlayer to render bottom controls after playing

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -18,6 +18,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
 - `moonstone/MoonstoneDecorator` to optimize localized font loading performance
+- `moonstone/VideoPlayer` to render bottom controls at idle after mounting
 
 ## [2.0.0-alpha.8] - 2018-04-17
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1222,7 +1222,7 @@ const VideoPlayerBase = class extends React.Component {
 	//
 	// Media Interaction Methods
 	//
-	updateMainState = () => {
+	handleEvent = () => {
 		const el = this.video;
 		const updatedState = {
 			// Standard media properties
@@ -1255,6 +1255,16 @@ const VideoPlayerBase = class extends React.Component {
 
 		this.setState(updatedState);
 	}
+
+	handlePlayEvent = () => {
+		if (!this.state.bottomControlsRendered) {
+			this.renderBottomControl.idle();
+		}
+	}
+
+	renderBottomControl = new Job(() => {
+		this.setState({bottomControlsRendered: true});
+	});
 
 	/**
 	 * Returns an object with the current state of the media including `currentTime`, `duration`,
@@ -1642,18 +1652,6 @@ const VideoPlayerBase = class extends React.Component {
 		};
 	}
 
-	handleEvent = (ev) => {
-		this.updateMainState();
-
-		if (ev.type === 'onLoadStart') {
-			this.handleLoadStart();
-		}
-
-		if (ev.type === 'play') {
-			this.mayRenderBottomControls();
-		}
-	}
-
 	disablePointerMode = () => {
 		Spotlight.setPointerMode(false);
 		return true;
@@ -1851,22 +1849,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.announceRef = node;
 	}
 
-	handleLoadStart = () => {
-		if (!this.props.noAutoPlay) {
-			this.video.play();
-		}
-	}
-
-	mayRenderBottomControls = () => {
-		if (!this.state.bottomControlsRendered) {
-			this.renderBottomControl.idle();
-		}
-	}
-
-	renderBottomControl = new Job(() => {
-		this.setState({bottomControlsRendered: true});
-	});
-
 	getControlsAriaProps () {
 		if (this.state.announce === AnnounceState.TITLE) {
 			return {
@@ -1968,6 +1950,7 @@ const VideoPlayerBase = class extends React.Component {
 					component={videoComponent}
 					controls={false}
 					onUpdate={this.handleEvent}
+					onPlay={this.handlePlayEvent}
 					ref={this.setVideoRef}
 				>
 					{source}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ui/Media` forwards events by the type and not all included in `onUpdate`. This results in not properly handling the `onPlay` event to start rendering the bottom controls after playing the video.

One of the symptoms we can identify is that mini feedback does not appear until `MediaControls` gets rendered at any given time.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Handle `onPlay` event in `<Media>` directly to render the bottom controls.

### Additional Consideration
`onLoadStart` doesn't seem to give any meaning as `load()` starts the video, and the value of `noAutoPlay` attribute is respected when it does.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
