### PR TITLE
ENYO-5197: Fix slider tooltip visibility condition

### DIFF
--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -251,12 +251,13 @@ const SliderBase = kind({
 			activateOnFocus,
 			active
 		}),
-		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
+		tooltip: ({focused, tooltip}) => tooltip === true ? <ProgressBarTooltip visible={focused} /> : tooltip
 	},
 
-	render: ({css, focused, tooltip, ...rest}) => {
+	render: ({css, tooltip, ...rest}) => {
 		delete rest.activateOnFocus;
 		delete rest.active;
+		delete rest.focused;
 		delete rest.knobStep;
 		delete rest.onActivate;
 
@@ -267,7 +268,6 @@ const SliderBase = kind({
 				tooltipComponent={
 					<ComponentOverride
 						component={tooltip}
-						visible={focused}
 					/>
 				}
 			/>

--- a/packages/moonstone/Slider/tests/Slider-specs.js
+++ b/packages/moonstone/Slider/tests/Slider-specs.js
@@ -422,4 +422,19 @@ describe('Slider', () => {
 
 		expect(actual).to.equal(expected);
 	});
+
+	it('should set the custom tooltip to not visible when focused', () => {
+		const subject = mount(
+			<Slider
+				tooltip={<div id="customtooltip">tooltip</div>}
+			/>
+		);
+
+		focus(subject);
+
+		const expected = 'not visible';
+		const actual = subject.find('#customtooltip').prop('visible') ? 'visible' : 'not visible';
+
+		expect(actual).to.equal(expected);
+	});
 });


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/Slider`'s tooltip visible condition is dictated by `focused` prop. `moonstone/VideoPlayer.MediaSlider` which uses `moonstone/Slider` as a base has its own visibility condition but gets ignored. Fixed it to only apply `focused` condition for the default tooltip.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>