### PR TITLE
ENYO-5130: Fixed not showing proper placeholder and selectionOverlay in GridListImageItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,7 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
 - `moonstone/MoonstoneDecorator` to optimize localized font loading performance
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to give initial focus
-- `moonstone/GridListImageitem` to show proper `placeholder` and `selectionOverlay`
+- `moonstone/GridListImageItem` to show proper `placeholder` and `selectionOverlay`
 
 ### Changed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
 - `moonstone/MoonstoneDecorator` to optimize localized font loading performance
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to give initial focus
+- `moonstone/GridListImageitem` to show proper `placeholder` and `selectionOverlay`
 
 ### Changed
 

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -33,6 +33,7 @@ const
  * A moonstone-styled base component for [GridListImageItem]{@link moonstone/GridListImageItem.GridListImageItem}.
  *
  * @class GridListImageItemBase
+ * @extends ui/GridListImageItem.GridListImageItem
  * @memberof moonstone/GridListImageItem
  * @ui
  * @public

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -59,6 +59,15 @@ const GridListImageItemBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Placeholder image used while [source]{@link ui/GridListImageItem.GridListImageItem#source}
+		 * is loaded.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		placeholder: PropTypes.string,
+
+		/**
 		 * When `true`, applies a selected visual effect to the image, but only if `selectionOverlayShowing`
 		 * is also `true`.
 		 *
@@ -93,7 +102,7 @@ const GridListImageItemBase = kind({
 		publicClassNames: ['icon', 'image', 'selected', 'caption', 'subCaption']
 	},
 
-	render: ({css, selectionOverlay, ...rest}) => {
+	render: ({css, placeholder, selectionOverlay, ...rest}) => {
 		if (selectionOverlay) {
 			rest['role'] = 'checkbox';
 			rest['aria-checked'] = rest.selected;
@@ -106,7 +115,8 @@ const GridListImageItemBase = kind({
 				css={css}
 				iconComponent={Icon}
 				imageComponent={Image}
-				placeholder={defaultPlaceholder}
+				placeholder={placeholder || defaultPlaceholder}
+				selectionOverlay={selectionOverlay}
 			/>
 		);
 	}

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -64,6 +64,10 @@ const GridListImageItemBase = kind({
 		 * is loaded.
 		 *
 		 * @type {String}
+		 * @default 'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
+		 * '9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
+		 * 'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
+		 * '4NCg==';
 		 * @public
 		 */
 		placeholder: PropTypes.string,
@@ -98,12 +102,17 @@ const GridListImageItemBase = kind({
 		selectionOverlay: PropTypes.func
 	},
 
+	defaultProps: {
+		placeholder: defaultPlaceholder,
+		selected: false
+	},
+
 	styles: {
 		css: componentCss,
 		publicClassNames: ['icon', 'image', 'selected', 'caption', 'subCaption']
 	},
 
-	render: ({css, placeholder, selectionOverlay, ...rest}) => {
+	render: ({css, selectionOverlay, ...rest}) => {
 		if (selectionOverlay) {
 			rest['role'] = 'checkbox';
 			rest['aria-checked'] = rest.selected;
@@ -116,7 +125,6 @@ const GridListImageItemBase = kind({
 				css={css}
 				iconComponent={Icon}
 				imageComponent={Image}
-				placeholder={placeholder || defaultPlaceholder}
 				selectionOverlay={selectionOverlay}
 			/>
 		);

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -67,7 +67,7 @@ const GridListImageItemBase = kind({
 		 * @default 'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
 		 * '9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
 		 * 'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
-		 * '4NCg==';
+		 * '4NCg=='
 		 * @public
 		 */
 		placeholder: PropTypes.string,


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We didn't pass `placeholder` and `selectionOverlay` prop to ui/GridListImageItem properly in moonstone/GridListImageItem.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed not passing props

### Links
[//]: # (Related issues, references)
ENYO-5130

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)