### PR TITLE
ENYO-5196 Rename Tooltip exports

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -19,15 +19,17 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Popup` property `closeButtonAriaLabel` to configure the label set on popup close button
 - `moonstone/MediaOverlay` component
 
+### Changed
+
+- `moonstone/IncrementSlider` and `moonstone/Slider` prop `tooltip` to support either a boolean for
+- the default tooltip or an element or component for a custom tooltip
+- `moonstone/ProgressBar.ProgressBarTooltip`, `moonstone/Slider.SliderTooltip` and `moonstone/IncrementSlider/IncrementSliderTooltip` exports to be `moonstone/ProgressBar.Tooltip`, `moonstone/Slider.Tooltip` and `moonstone/IncrementSlider/Tooltip` respectively
+
 ### Fixed
 
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
 - `moonstone/MoonstoneDecorator` to optimize localized font loading performance
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to give initial focus
-
-### Changed
-
-- `moonstone/IncrementSlider` and `moonstone/Slider` prop `tooltip` to support either a boolean for the default tooltip or an element or component for a custom tooltip
 
 ## [2.0.0-alpha.8] - 2018-04-17
 

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -35,7 +35,7 @@ import React from 'react';
 import IdProvider from '../internal/IdProvider';
 import $L from '../internal/$L';
 import DisappearSpotlightDecorator from '../internal/DisappearSpotlightDecorator';
-import {ProgressBarTooltip} from '../ProgressBar';
+import {Tooltip} from '../ProgressBar';
 import Skinnable from '../Skinnable';
 import {SliderBase} from '../Slider';
 import {emitChange} from '../Slider/utils';
@@ -596,7 +596,7 @@ const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
  * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
  * [Slider]{@link moonstone/Slider.Slider}.
  *
- * See {@link moonstone/ProgressBar.ProgressBarTooltip}
+ * See {@link moonstone/ProgressBar.Tooltip}
  *
  * @class IncrementSliderTooltip
  * @memberof moonstone/IncrementSlider
@@ -609,5 +609,5 @@ export {
 	IncrementSlider,
 	IncrementSliderBase,
 	IncrementSliderDecorator,
-	ProgressBarTooltip as IncrementSliderTooltip
+	Tooltip
 };

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -17,7 +17,7 @@
  * @exports IncrementSlider
  * @exports IncrementSliderBase
  * @exports IncrementSliderDecorator
- * @exports IncrementSliderTooltip
+ * @exports Tooltip
  */
 
 import {forward} from '@enact/core/handle';
@@ -353,13 +353,13 @@ const IncrementSliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom Tooltip component or an instance of
-		 * [IncrementSliderTooltip]{@link moonstone/IncrementSlider.IncrementSliderTooltip} with
+		 * [Tooltip]{@link moonstone/IncrementSlider.Tooltip} with
 		 * additional props configured.
 		 *
 		 * ```
 		 * <IncrementSlider
 		 *   tooltip={
-		 *     <IncrementSliderTooltip percent side="after" />
+		 *     <Tooltip percent side="after" />
 		 *   }
 		 * />
 		 * ```
@@ -369,7 +369,7 @@ const IncrementSliderBase = kind({
 		 *
 		 * ```
 		 * <IncrementSlider>
-		 *   <IncrementSliderTooltip percent side="after" />
+		 *   <Tooltip percent side="after" />
 		 * </IncrementSlider>
 		 * ```
 		 *
@@ -598,7 +598,7 @@ const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
  *
  * See {@link moonstone/ProgressBar.Tooltip}
  *
- * @class IncrementSliderTooltip
+ * @class Tooltip
  * @memberof moonstone/IncrementSlider
  * @ui
  * @public

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -8,7 +8,7 @@
  * @exports ProgressBar
  * @exports ProgressBarBase
  * @exports ProgressBarDecorator
- * @exports ProgressBarTooltip
+ * @exports Tooltip
  */
 
 import kind from '@enact/core/kind';
@@ -19,7 +19,7 @@ import compose from 'ramda/src/compose';
 import React from 'react';
 
 import Skinnable from '../Skinnable';
-import {ProgressBarTooltip} from './ProgressBarTooltip';
+import {Tooltip} from './Tooltip';
 
 import componentCss from './ProgressBar.less';
 
@@ -123,7 +123,7 @@ const ProgressBarBase = kind({
 				const percentageText = `${progressPercentage}%`;
 
 				return (
-					<ProgressBarTooltip
+					<Tooltip
 						forceSide={tooltipForceSide}
 						proportion={progress}
 						orientation={orientation}
@@ -131,7 +131,7 @@ const ProgressBarBase = kind({
 						visible
 					>
 						{percentageText}
-					</ProgressBarTooltip>
+					</Tooltip>
 				);
 			} else {
 				return null;
@@ -186,5 +186,5 @@ export {
 	ProgressBar,
 	ProgressBarBase,
 	ProgressBarDecorator,
-	ProgressBarTooltip
+	Tooltip
 };

--- a/packages/moonstone/ProgressBar/Tooltip.js
+++ b/packages/moonstone/ProgressBar/Tooltip.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 
 import Tooltip from '../TooltipDecorator/Tooltip';
 
-import css from './ProgressBarTooltip.less';
+import css from './Tooltip.less';
 
 const memoizedPercentFormatter = memoize((/* locale */) => new NumFmt({
 	type: 'percentage',
@@ -21,15 +21,15 @@ const memoizedPercentFormatter = memoize((/* locale */) => new NumFmt({
  * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
  * [Slider]{@link moonstone/Slider.Slider}.
  *
- * @class ProgressBarTooltip
+ * @class Tooltip
  * @memberof moonstone/ProgressBar
  * @ui
  * @public
  */
-const ProgressBarTooltipBase = kind({
+const TooltipBase = kind({
 	name: 'ProgressBarTooltip',
 
-	propTypes: /** @lends moonstone/ProgressBar.ProgressBarTooltip.prototype */{
+	propTypes: /** @lends moonstone/ProgressBar.Tooltip.prototype */{
 		/**
 		 * Setting to `true` overrides the natural LTR->RTL tooltip side-flipping for locale changes
 		 * for `vertical` ProgressBars/Sliders. This may be useful if you have a static layout that does not
@@ -176,10 +176,10 @@ const ProgressBarTooltipBase = kind({
 	}
 });
 
-ProgressBarTooltipBase.defaultSlot = 'tooltip';
+TooltipBase.defaultSlot = 'tooltip';
 
-export default ProgressBarTooltipBase;
+export default TooltipBase;
 export {
-	ProgressBarTooltipBase,
-	ProgressBarTooltipBase as ProgressBarTooltip
+	TooltipBase,
+	TooltipBase as Tooltip
 };

--- a/packages/moonstone/ProgressBar/Tooltip.less
+++ b/packages/moonstone/ProgressBar/Tooltip.less
@@ -1,4 +1,4 @@
-// ProgressBarTooltip.less
+// ProgressBar/Tooltip.less
 //
 @import '../styles/variables.less';
 @import '../styles/text.less';

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -30,7 +30,7 @@ import anyPass from 'ramda/src/anyPass';
 import compose from 'ramda/src/compose';
 import React from 'react';
 
-import {ProgressBarTooltip} from '../ProgressBar';
+import {Tooltip} from '../ProgressBar';
 import Skinnable from '../Skinnable';
 
 import SliderBehaviorDecorator from './SliderBehaviorDecorator';
@@ -251,7 +251,7 @@ const SliderBase = kind({
 			activateOnFocus,
 			active
 		}),
-		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
+		tooltip: ({tooltip}) => tooltip === true ? Tooltip : tooltip
 	},
 
 	render: ({css, focused, tooltip, ...rest}) => {
@@ -330,7 +330,7 @@ const Slider = SliderDecorator(SliderBase);
  * [ProgressBar]{@link moonstone/ProgressBar.ProgressBar}, or
  * [Slider]{@link moonstone/Slider.Slider}.
  *
- * See {@link moonstone/ProgressBar.ProgressBarTooltip}
+ * See {@link moonstone/ProgressBar.Tooltip}
  *
  * @class SliderTooltip
  * @memberof moonstone/Slider
@@ -343,5 +343,5 @@ export {
 	Slider,
 	SliderBase,
 	SliderDecorator,
-	ProgressBarTooltip as SliderTooltip
+	Tooltip
 };

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -14,7 +14,7 @@
  * @exports Slider
  * @exports SliderBase
  * @exports SliderDecorator
- * @exports SliderTooltip
+ * @exports Tooltip
  */
 
 import {forKey, forProp, forward, forwardWithPrevent, handle} from '@enact/core/handle';
@@ -167,12 +167,12 @@ const SliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom Tooltip component or an instance of
-		 * [SliderTooltip]{@link moonstone/Slider.SliderTooltip} with additional props configured.
+		 * [Tooltip]{@link moonstone/Slider.Tooltip} with additional props configured.
 		 *
 		 * ```
 		 * <Slider
 		 *   tooltip={
-		 *     <SliderTooltip percent side="after" />
+		 *     <Tooltip percent side="after" />
 		 *   }
 		 * />
 		 * ```
@@ -182,7 +182,7 @@ const SliderBase = kind({
 		 *
 		 * ```
 		 * <Slider>
-		 *   <SliderTooltip percent side="after" />
+		 *   <Tooltip percent side="after" />
 		 * </Slider>
 		 * ```
 		 *
@@ -332,7 +332,7 @@ const Slider = SliderDecorator(SliderBase);
  *
  * See {@link moonstone/ProgressBar.Tooltip}
  *
- * @class SliderTooltip
+ * @class Tooltip
  * @memberof moonstone/Slider
  * @ui
  * @public

--- a/packages/sampler/stories/moonstone-stories/IncrementSlider.js
+++ b/packages/sampler/stories/moonstone-stories/IncrementSlider.js
@@ -1,4 +1,4 @@
-import IncrementSlider, {IncrementSliderBase, IncrementSliderTooltip} from '@enact/moonstone/IncrementSlider';
+import IncrementSlider, {IncrementSliderBase, Tooltip} from '@enact/moonstone/IncrementSlider';
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -38,7 +38,7 @@ storiesOf('Moonstone', module)
 					step={number('step', 1)}
 				>
 					{tooltip ? (
-						<IncrementSliderTooltip
+						<Tooltip
 							forceSide={forceSide}
 							percent={percent}
 							side={side}

--- a/packages/sampler/stories/moonstone-stories/Slider.js
+++ b/packages/sampler/stories/moonstone-stories/Slider.js
@@ -1,4 +1,4 @@
-import Slider, {SliderBase, SliderTooltip} from '@enact/moonstone/Slider';
+import Slider, {SliderBase, Tooltip} from '@enact/moonstone/Slider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -36,7 +36,7 @@ storiesOf('Moonstone', module)
 					step={number('step', 1)}
 				>
 					{tooltip ? (
-						<SliderTooltip
+						<Tooltip
 							percent={percent}
 							forceSide={forceSide}
 							side={side}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Renamed Tooltip exports from `ProgressBar` and the sliders

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I am not super happy about the 'name' of `ProgressBar/Tooltip` being `'ProgressBarTooltip'`.
I considered other names but recall that `/` and `.` don't work.  Considered `-`, which is OK
but not great.  Cannot set to `'Tooltip'` as this is ambiguous with its internal `Tooltip` component.

### Links
[//]: # (Related issues, references)
ENYO-5196

### Comments
