### PR TITLE
PLAT-49776: Allow more flexible usage of Notification and SwitchItem

### DIFF
--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -48,6 +48,19 @@ const NotificationBase = kind({
 		children: PropTypes.node,
 
 		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal Elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `notification` - The root class name
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object,
+
+		/**
 		 * When `true`, the popup will not close when the user presses `ESC` key.
 		 *
 		 * @type {Boolean}

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -12,7 +12,7 @@ import Slottable from '@enact/ui/Slottable';
 
 import Popup from '../Popup';
 
-import css from './Notification.less';
+import componentCss from './Notification.less';
 
 /**
  * {@link moonstone/Notification.NotificationBase} is a toast-like minimal popup that comes up
@@ -32,13 +32,12 @@ const NotificationBase = kind({
 		 * `small` property set and will be coerced to `small` if not specified.
 		 *
 		 * @type {Node}
-		 * @required
 		 * @public
 		 */
 		buttons: PropTypes.oneOfType([
 			PropTypes.arrayOf(PropTypes.element),
 			PropTypes.element
-		]).isRequired,
+		]),
 
 		/**
 		 * The contents to be displayed in the body of the Notification.
@@ -92,13 +91,14 @@ const NotificationBase = kind({
 	},
 
 	styles: {
-		css,
-		className: 'notification'
+		css: componentCss,
+		className: 'notification',
+		publicClassNames: ['notification']
 	},
 
 	computed: {
 		className: ({className, buttons, styler}) => {
-			if (buttons.length > 3) {
+			if (buttons && buttons.length > 3) {
 				return styler.append({wide: true});
 			} else {
 				return className;
@@ -113,15 +113,15 @@ const NotificationBase = kind({
 		})
 	},
 
-	render: ({buttons, children, ...rest}) => {
+	render: ({buttons, children, css, ...rest}) => {
 		return (
 			<Popup noAnimation {...rest}>
 				<div className={css.body}>
 					{children}
 				</div>
-				<div className={css.buttons}>
+				{buttons ? <div className={css.buttons}>
 					{buttons}
-				</div>
+				</div> : null}
 			</Popup>
 		);
 	}

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -39,7 +39,12 @@ const SwitchItemBase = kind({
 		 * @type {Object}
 		 * @public
 		 */
-		css: PropTypes.object
+		css: PropTypes.object,
+		iconComponent: PropTypes.object
+	},
+
+	defaultProps: {
+		iconComponent: <Switch className={componentCss.switch} />
 	},
 
 	styles: {
@@ -53,9 +58,6 @@ const SwitchItemBase = kind({
 			data-webos-voice-intent="SelectToggleItem"
 			{...props}
 			css={props.css}
-			iconComponent={
-				<Switch className={componentCss.switch} />
-			}
 			iconPosition="after"
 		/>
 	)

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -7,9 +7,9 @@
  */
 
 import kind from '@enact/core/kind';
+import ComponentOverride from '@enact/ui/ComponentOverride';
 import React from 'react';
 import PropTypes from 'prop-types';
-import ComponentOverride from '@enact/ui/ComponentOverride';
 
 import Switch from '../Switch';
 import ToggleItem from '../ToggleItem';

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -9,6 +9,7 @@
 import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
+import ComponentOverride from '@enact/ui/ComponentOverride';
 
 import Switch from '../Switch';
 import ToggleItem from '../ToggleItem';
@@ -40,17 +41,34 @@ const SwitchItemBase = kind({
 		 * @public
 		 */
 		css: PropTypes.object,
-		iconComponent: PropTypes.object
+
+		/**
+		 * Customize the component used as the switch.
+		 *
+		 * @type {Component}
+		 * @default {@link moonstone/Switch.Switch}
+		 * @private
+		 */
+		iconComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
 	},
 
 	defaultProps: {
-		iconComponent: <Switch className={componentCss.switch} />
+		iconComponent: Switch
 	},
 
 	styles: {
 		css: componentCss,
 		className: 'switchItem',
 		publicClassNames: ['switchItem']
+	},
+
+	computed: {
+		iconComponent: ({css, iconComponent}) => (
+			<ComponentOverride
+				component={iconComponent}
+				className={css.switch}
+			/>
+		)
 	},
 
 	render: (props) => (

--- a/packages/moonstone/SwitchItem/SwitchItem.less
+++ b/packages/moonstone/SwitchItem/SwitchItem.less
@@ -11,7 +11,6 @@
 // Interally theme our implementation using published classes from ToggleItem and ToggleIcon
 .toggleItem {
 	.switch {
-		display: block;
 		.margin-start-end(@moon-toggle-item-icon-margin, 0);
 
 		&::before {


### PR DESCRIPTION
### Issue Resolved / Feature Added
`Notification` requires the `buttons` prop, which may not be necessary in all cases. Requiring it adds unnecessary restriction.

`SwitchItem` is restrictive in its implementation and should be expanded to support other use cases.


### Resolution
`Notification` no longer requires `buttons` and `SwitchItem` has a default-assigned, but overridable, `Switch` component to allow for more flexible usage.