### PR TITLE
ENYO-5039:  Add flag to ignore to scroll on focus when jumping

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -35,14 +35,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` `role="list"`
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` prop `wrap` to support wrap-around spotlight navigation
 - `moonstone/VirtualList`, `moonstone/VirtualGridList` and `moonstone/Scroller` props `scrollRightAriaLabel`, `scrollLeftAriaLabel`, `scrollDownAriaLabel`, and `scrollUpAriaLabel` to configure the aria-label set on scroll buttons in the scrollbars
-- `moonstone/Popup` property `closeButtonAriaLabel` to configure the label set on popup close button
-- `moonstone/MediaOverlay` component
-
-### Fixed
-
-- `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
-- `moonstone/MoonstoneDecorator` to optimize localized font loading performance
-- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to give initial focus
 
 ### Changed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` and `moonstone/VirtualList` navigation via 5-way from paging controls
 - `moonstone/MoonstoneDecorator` to optimize localized font loading performance
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to give initial focus
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
 
 ### Changed
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -186,7 +186,7 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null && this.childRef.ignoreToScrollOnFocus === false) {
+		if (this.uiRef.scrollToInfo === null && !this.childRef.ignoreToScrollOnFocus) {
 			this.updateScrollOnFocus();
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -186,7 +186,7 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null && !this.childRef.ignoreToScrollOnFocus) {
+		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null) {
 			this.updateScrollOnFocus();
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -186,7 +186,7 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null) {
+		if (this.uiRef.scrollToInfo === null && this.childRef.ignoreToScrollOnFocus === false) {
 			this.updateScrollOnFocus();
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -166,7 +166,7 @@ class ScrollableBaseNative extends Component {
 	}
 
 	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null && !this.childRef.ignoreToScrollOnFocus) {
+		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null) {
 			this.updateScrollOnFocus();
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -166,7 +166,7 @@ class ScrollableBaseNative extends Component {
 	}
 
 	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null) {
+		if (this.uiRef.scrollToInfo === null && !this.childRef.ignoreToScrollOnFocus) {
 			this.updateScrollOnFocus();
 		}
 	}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -283,7 +283,6 @@ const VirtualListBaseFactory = (type) => {
 		isScrolledByJump = false
 		lastFocusedIndex = null
 		nodeIndexToBeFocused = null
-		ignoreToScrollOnFocus = false
 		preservedIndex = null
 		restoreLastFocused = false
 
@@ -502,7 +501,6 @@ const VirtualListBaseFactory = (type) => {
 					}
 					focusedItem.blur();
 					this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
-					this.ignoreToScrollOnFocus = true;
 				}
 				cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
 			}
@@ -633,7 +631,6 @@ const VirtualListBaseFactory = (type) => {
 					this.focusOnItem(nextIndex);
 				} else {
 					this.nodeIndexToBeFocused = this.lastFocusedIndex = nextIndex;
-					this.ignoreToScrollOnFocus = true;
 
 					if (!Spotlight.isPaused()) {
 						Spotlight.pause();
@@ -707,7 +704,6 @@ const VirtualListBaseFactory = (type) => {
 			}
 			this.focusOnNode(item);
 			this.nodeIndexToBeFocused = null;
-			this.ignoreToScrollOnFocus = false;
 			this.isScrolledByJump = false;
 		}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -259,6 +259,7 @@ const VirtualListBaseFactory = (type) => {
 		isScrolledByJump = false
 		lastFocusedIndex = null
 		nodeIndexToBeFocused = null
+		ignoreToScrollOnFocus = false
 		preservedIndex = null
 		restoreLastFocused = false
 
@@ -424,6 +425,7 @@ const VirtualListBaseFactory = (type) => {
 					}
 					focusedItem.blur();
 					this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
+					this.ignoreToScrollOnFocus = true;
 				}
 				cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
 			}
@@ -537,6 +539,7 @@ const VirtualListBaseFactory = (type) => {
 				}, 50);
 
 				this.nodeIndexToBeFocused = this.lastFocusedIndex = nextIndex;
+				this.ignoreToScrollOnFocus = true;
 
 				if (!Spotlight.isPaused()) {
 					Spotlight.pause();
@@ -590,6 +593,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 			this.focusOnNode(item);
 			this.nodeIndexToBeFocused = null;
+			this.ignoreToScrollOnFocus = false;
 			this.isScrolledByJump = false;
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When jumping over the disabled items in VirtualList, the focus in it gone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If calling `setState` or `forceUpdate` app side while jumping, the focus information that we have to give gone because we get focus, scroll the list, then initialize the focus information. So for the case, we add a flag  not to scroll on focus

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5039

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)