### PR TITLE
ENYO-4977: Add missing min-height support to ExpandableItem

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -273,7 +273,7 @@ const ExpandableItemBase = kind({
 	computed: {
 		className: ({disabled, label, noneText, open, showLabel, styler}) => (styler.append({
 			open: open && !disabled,
-			autoLabel: showLabel === 'auto' && label || noneText
+			autoLabel: showLabel === 'auto' && (label || noneText)
 		})),
 		label: ({label, noneText}) => (label || noneText),
 		labeledItemClassName: ({showLabel, styler}) => (styler.join(css.labeledItem, css[showLabel])),

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -271,9 +271,9 @@ const ExpandableItemBase = kind({
 	},
 
 	computed: {
-		className: ({disabled, open, showLabel, styler}) => (styler.append({
+		className: ({disabled, label, noneText, open, showLabel, styler}) => (styler.append({
 			open: open && !disabled,
-			autoLabel: showLabel === 'auto'
+			autoLabel: showLabel === 'auto' && label || noneText
 		})),
 		label: ({label, noneText}) => (label || noneText),
 		labeledItemClassName: ({showLabel, styler}) => (styler.join(css.labeledItem, css[showLabel])),

--- a/packages/moonstone/ExpandableItem/ExpandableItem.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.less
@@ -1,10 +1,15 @@
 // ExpandableItem.less
 //
 @import '../styles/variables.less';
+@import "../styles/text.less";
 
 .expandableItem {
 	&.autoLabel {
 		min-height: @moon-body-line-height + @moon-item-line-height + (@moon-item-vertical-padding * 2);
+
+		.moon-custom-text({
+			min-height: @moon-body-line-height + @moon-item-line-height-large + (@moon-item-vertical-padding * 2);
+		});
 	}
 
 	.labeledItem {
@@ -39,4 +44,10 @@
 			}
 		}
 	}
+
+	.moon-custom-text({
+		&.autoLabel {
+			min-height: @moon-body-line-height + @moon-item-line-height-large + (@moon-item-vertical-padding * 2);
+		}
+	});
 }

--- a/packages/moonstone/ExpandableItem/ExpandableItem.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.less
@@ -44,10 +44,4 @@
 			}
 		}
 	}
-
-	.moon-custom-text({
-		&.autoLabel {
-			min-height: @moon-body-line-height + @moon-item-line-height-large + (@moon-item-vertical-padding * 2);
-		}
-	});
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
Add missing `noneText` and `.enact-text-large` support for `ExpandableItem` min-height change.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>