### PR TITLE
Fixed VirtualList not to have two defaultProps

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -211,14 +211,11 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		static defaultProps = {
-			isItemDisabled: isItemDisabledDefault,
-			wrap: false
-		}
-
-		static defaultProps = {
 			dataSize: 0,
+			isItemDisabled: isItemDisabledDefault,
 			pageScroll: false,
-			spacing: 0
+			spacing: 0,
+			wrap: false
 		}
 
 		constructor (props) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a 5-way key is pressed on a list, an error occurs by trying to call a function variable which value is `undefined`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Currently, there are two `defaultProps`s in VirtualList by merging #1593 and #1551. If we merge them, this issue is resolved.

This PR is to merge two `defaultProps` into one.

### Links
[//]: # (Related issues, references)
PLAT-54727

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
