### PR TITLE
PLAT-49776: Layout fixes and docs improvements

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` showing blank when `direction` prop changed after scroll position changed
 - `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` to support RTL by dynamic language changes
+- `ui/Layout` to correctly support two `align` values, allowing horizontal and vertical in one property. Previously, the transverse alignment was ignored, only allowing perpendicular alignment.
+- `ui/Layout.Cell` to no longer overflow when both `size` and `shrink` are set together
 
 ## [2.0.0-alpha.8] - 2018-04-17
 

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -69,14 +69,19 @@ const CellBase = kind({
 		shrink: PropTypes.bool,
 
 		/**
-		 * Sets the requested size, possibly overflowing if the contents are too large for the space.
-		 * When used in conjunction with [shrink]{@link ui/Layout.Cell#shrink}, the size will be set
-		 * as close to the requested size as is possible, given the dimensions of the contents of
-		 * this cell. E.g. If your content is `40px` tall and you set `size` to "30px", the Cell will
-		 * render `30px` tall. If [shrink]{@link ui/Layout.Cell#shrink} was used also, the rendered
-		 * Cell would be `40px` tall.
-		 * This accepts any valid CSS measurement and overrules the
-		 * [shrink]{@link ui/Layout.Cell#shrink} property.
+		 * Set the desired size of the Cell using any valid CSS measurement value.
+		 * When used in conjunction with [shrink]{@link ui/Layout.Cell#shrink}, the size will be
+		 * the maximum size, shrinking as necessary, to fit the content.
+		 *
+		 * E.g.
+		 * * `size="400px"` -> cell will be 400px, regardless of the dimensions of your content
+		 * * `size="400px" shrink` -> cell will be 400px if your content is greater than 400px,
+		 *   and will match your contents size if it's smaller
+		 *
+		 * This accepts any valid CSS measurement value string. If a numeric value is used, it will
+		 * be treated as a pixel value and converted to a
+		 * [relative unit]{@link ui/resolution.unit} based on the rules of
+		 * [resolution independence]{@link ui/resolution}.
 		 *
 		 * @type {String|Number}
 		 * @public
@@ -102,10 +107,9 @@ const CellBase = kind({
 			return {
 				...style,
 				alignSelf: toFlexAlign(align),
-				flexBasis: size,
-				// shrink and size uses just basis, size without shrink forcibly sets the size,
-				// allowing overflow.
-				'--cell-size': (shrink || !size) ? 'none' : size
+				flexBasis: (shrink ? null : size),
+				// Setting 100% below in the presence of `shrink`` and absense of `size` prevents overflow
+				'--cell-size': (shrink && !size) ? '100%' : size
 			};
 		}
 	},

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -162,7 +162,7 @@ const LayoutBase = kind({
 			return {
 				...style,
 				alignItems: toFlexAlign(alignParts[0]),
-				justifyItems: toFlexAlign(alignParts[1])
+				justifyContent: toFlexAlign(alignParts[1])
 			};
 		}
 	},


### PR DESCRIPTION
### Issue Resolved / Feature Added
I discovered a bug with `ui/Layout.Cell` which needed to be addressed to facilitate other work.


### Resolution
A long-standing layout issue occurring when `size` and `shrink` were set and the content extended beyond the bounds of the `Layout` component. `Cell` contents no longer overflow, even if they are too large. The documentation was also updated, and is less confusing now.