### PR TITLE
ENYO-5216: Fixed header layout

### DIFF
--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -244,7 +244,7 @@ const HeaderBase = kind({
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
 					{titleOrInput}
-					<Cell shrink size={78}>
+					<Cell shrink size={96}>
 						<Layout align="end">
 							<Cell>
 								{titleBelowComponent}

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -104,12 +104,21 @@ const CellBase = kind({
 		style: ({align, shrink, size, style}) => {
 			if (typeof size === 'number') size = ri.unit(ri.scale(size), 'rem');
 
+			let cellSize = size;
+			if (!size) {
+				if (shrink) {
+					cellSize = '100%';
+				} else {
+					cellSize = 'none';
+				}
+			}
+
 			return {
 				...style,
 				alignSelf: toFlexAlign(align),
 				flexBasis: (shrink ? null : size),
 				// Setting 100% below in the presence of `shrink`` and absense of `size` prevents overflow
-				'--cell-size': (shrink && !size) ? '100%' : size
+				'--cell-size': cellSize
 			};
 		}
 	},


### PR DESCRIPTION
### Issue Resolved / Feature Added
Header got *jacked up* with the latest Layout changes.


### Resolution
A child cell used a parent's cell as a measurement for itself, causing it to be far too small. The fix was to explicitly "blank out" the sizing if no sizing or shrink was set on the cell, so it didn't inherit from its ancestor.