### PR TITLE
ENYO-5220: Inline Item is too wide

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Item` to use its natural width rather than imposing a 100% width. This allows in-line Items to be the correct width.
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Changed

--- a/packages/ui/Item/Item.less
+++ b/packages/ui/Item/Item.less
@@ -2,7 +2,6 @@
 //
 
 .item {
-	width: 100%;
 	box-sizing: border-box;
 	display: block;
 	align-items: center;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Items, set to `inline` are the wrong width

### Resolution
They were being told to be 100% wide, which doesn't cooperate with the way an in-line element lays itself out.

_(This rule was vestigial from back when we laid-out `Item` using `flex`.)_