### PR TITLE
ENYO-5041: Check before blurring for self-only type contextual popup

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -507,9 +507,10 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {spotlightRestrict} = this.props;
 			const {containerId} = this.state;
 			const spottableDescendants = Spotlight.getSpottableDescendants(containerId);
-			if (spotlightRestrict === 'self-only' && spottableDescendants.length) {
+			if (spotlightRestrict === 'self-only' && spottableDescendants.length && Spotlight.getCurrent()) {
 				Spotlight.getCurrent().blur();
 			}
+
 			if (!Spotlight.focus(containerId)) {
 				Spotlight.setActiveContainer(containerId);
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ContextualPopupDecorator` with `spotlightRestrict: 'self-only'` tries to blur before if there is a spottable component inside the popup. However, there's a case where there's no focused element prior to opening the popup. Adding a check before blur can solve the problem.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
