### PR TITLE
ENYO-5221: Automatic Image src swapping during resolution change

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Removed

--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -98,11 +98,15 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 		}
 
 		handleResize = () => {
-			const src = selectSrc(this.props.src);
-			if (src !== this.state.src) {
+			this.setState((state, props) => {
+				const src = selectSrc(props.src);
 				// Trigger a render and save the currently selected src for later comparisons
-				this.setState({src});
-			}
+				if (src !== state.src) {
+					return {src};
+				}
+
+				return null;
+			});
 		}
 
 		render () {

--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -11,8 +11,10 @@
  */
 
 import kind from '@enact/core/kind';
+import hoc from '@enact/core/hoc';
 import UiImage from '@enact/ui/Image';
 import Pure from '@enact/ui/internal/Pure';
+import {selectSrc} from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import React from 'react';
@@ -62,6 +64,53 @@ const ImageBase = kind({
 	}
 });
 
+
+// This induces a render when there is a screen size change that has a corosponding image src value
+// associated with the new screen size. The render is kicked off by remembering the new image src.
+//
+// This hoc could (should) be rewritten at a later time to use a smarter context API and callbacks,
+// or something like pub/sub; each of which would be hooked together from the resolution.js that
+// would coordinate any screen size/orientation changes and emit events from there.
+//
+// This is ripe for refactoring, and could probably move into UI to be generalized, but that's for
+// another time. -B 2018-05-01
+const ResponsiveImageDecorator = hoc((config, Wrapped) => {
+	return class extends React.Component {
+		static displayName = 'ResponsiveImageDecorator'
+
+		static propTypes = {
+			src: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
+		}
+
+		constructor (props) {
+			super(props);
+			this.state = {
+				src: selectSrc(this.props.src)
+			};
+		}
+
+		componentDidMount () {
+			window.addEventListener('resize', this.handleResize);
+		}
+
+		componentWillUnmount () {
+			window.removeEventListener('resize', this.handleResize);
+		}
+
+		handleResize = () => {
+			const src = selectSrc(this.props.src);
+			if (src !== this.state.src) {
+				// Trigger a render and save the currently selected src for later comparisons
+				this.setState({src});
+			}
+		}
+
+		render () {
+			return <Wrapped {...this.props} />;
+		}
+	};
+});
+
 /**
  * Moonstone-specific behaviors to apply to [Image]{@link moonstone/Image.ImageBase}.
  *
@@ -72,6 +121,7 @@ const ImageBase = kind({
  */
 const ImageDecorator = compose(
 	Pure,
+	ResponsiveImageDecorator,
 	Skinnable
 );
 

--- a/packages/moonstone/Image/Image.less
+++ b/packages/moonstone/Image/Image.less
@@ -4,6 +4,6 @@
 
 .image {
 	margin: 0 @moon-spotlight-outset;
-	width: 320px;
+	width: 360px;
 	height: 240px;
 }

--- a/packages/sampler/stories/moonstone-stories/Image.js
+++ b/packages/sampler/stories/moonstone-stories/Image.js
@@ -6,20 +6,42 @@ import {select} from '@storybook/addon-knobs';
 import {withInfo} from '@storybook/addon-info';
 
 const src = {
-	'hd': 'http://lorempixel.com/128/128/city/1/',
-	'fhd': 'http://lorempixel.com/256/256/city/1/',
-	'uhd': 'http://lorempixel.com/512/512/city/1/'
+	'hd':  'http://via.placeholder.com/200x200',
+	'fhd': 'http://via.placeholder.com/300x300',
+	'uhd': 'http://via.placeholder.com/600x600'
 };
 
 storiesOf('Moonstone', module)
 	.add(
 		'Image',
 		withInfo('The basic Image')(() => (
+
 			<Image
 				src={src}
 				sizing={select('sizing', ['fill', 'fit', 'none'], 'fill')}
 				onError={action('error')}
 				onLoad={action('loaded')}
-			/>
+				style={{
+					border: '#ffa500 dashed 1px'
+				}}
+			>
+				<label
+					style={{
+						border: '#ffa500 dashed 1px',
+						borderBottomWidth: 0,
+						borderRadius: '6px 6px 0 0',
+						backgroundColor: 'rgba(255, 165, 0, 0.5)',
+						color: '#fff',
+						position: 'absolute',
+						transform: 'translateX(-1px) translateY(-100%)',
+						padding: '0.1em 1em',
+						fontWeight: 100,
+						fontStyle: 'italic',
+						fontSize: '16px'
+					}}
+				>
+					Image Boundry
+				</label>
+			</Image>
 		))
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
An image on the screen doesn't update when the screen is resized and new imagery should be swapped in for the source. A refresh is required.


### Resolution
Images now automatically detect when a screen size change occurs and re-renders only if a new image source (src) is available and appropriate.

### Additional Considerations
The Sample was also updated to be more helpful. It now has a border and uses appropriate scaling of images (1x,2x,4x -> 2x,3x,6x) to more accurately represent the relative scale between 720, 1080, and 4k