### PR TITLE
ENYO-5195: Fix to not fire onChange event when 5-ways out of boundary

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Slider` not to fire `onChange` event when 5-ways out of boundary
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Removed

--- a/packages/moonstone/Slider/utils.js
+++ b/packages/moonstone/Slider/utils.js
@@ -25,7 +25,15 @@ const isDecrement = ({keyCode}, {orientation}) => {
 	return orientation === 'vertical' ? is('down', keyCode) : is('left', keyCode);
 };
 
-const emitChange = (direction) => adaptEvent(
+const isNotMax = (ev, {value, max}) => {
+	return value !== max;
+};
+
+const isNotMin = (ev, {value, min}) => {
+	return value !== min;
+};
+
+const emitChange = (direction) =>  adaptEvent(
 	(ev, {knobStep, max, min, step, value = min}) => {
 		const newValue = clamp(min, max, value + (calcStep(knobStep, step) * direction));
 
@@ -45,16 +53,16 @@ const isActive = (ev, props) => {
 const handleIncrement = handle(
 	isActive,
 	isIncrement,
-	emitChange(1),
-	stopImmediate
-);
+	isNotMax,
+	emitChange(1)
+).finally(stopImmediate);
 
 const handleDecrement = handle(
 	isActive,
 	isDecrement,
-	emitChange(-1),
-	stopImmediate
-);
+	isNotMin,
+	emitChange(-1)
+).finally(stopImmediate);
 
 const either = (a, b) => (...args) => a(...args) || b(...args);
 const atMinimum = (ev, {min, value = min}) => value <= min;

--- a/packages/moonstone/Slider/utils.js
+++ b/packages/moonstone/Slider/utils.js
@@ -53,16 +53,18 @@ const isActive = (ev, props) => {
 const handleIncrement = handle(
 	isActive,
 	isIncrement,
+	stopImmediate,
 	isNotMax,
 	emitChange(1)
-).finally(stopImmediate);
+);
 
 const handleDecrement = handle(
 	isActive,
 	isDecrement,
+	stopImmediate,
 	isNotMin,
 	emitChange(-1)
-).finally(stopImmediate);
+);
 
 const either = (a, b) => (...args) => a(...args) || b(...args);
 const atMinimum = (ev, {min, value = min}) => value <= min;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`onChange` fires on every key down event even if when it reaches the boundary and 5-way out of it. Fixed by checking the value with min/max value prior to firing `onChange` event.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
