### PR TITLE
ENYO-5223: Remove duplicate classNames in moonstone/Item family

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Item`, `moonstone/SlotItem`, `moonstone/ToggleItem` to properly apply `className`
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Removed

--- a/packages/moonstone/Item/Item.js
+++ b/packages/moonstone/Item/Item.js
@@ -51,7 +51,6 @@ const ItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		className: 'item',
 		publicClassNames: 'item'
 	},
 

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -56,7 +56,6 @@ const SlotItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		className: 'slotItem',
 		publicClassNames: ['slotItem']
 	},
 

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -78,7 +78,6 @@ const ToggleItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		className: 'toggleItem',
 		publicClassNames: ['toggleItem']
 	},
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Don’t need to apply `className` in `moonstone` when the same className is applied in `ui`. Removing `className` from `moonstone/Item` and other components.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
