### PR TITLE
ENYO-5228: Fix to scroll properly with all disabled items in VirtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to scroll properly with all disabled items
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
 
 ## [2.0.0-beta.1] - 2018-04-29

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -331,8 +331,7 @@ class ScrollableBase extends Component {
 			{childRef, containerRef, scrollToAccumulatedTarget} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
-			direction = isPageUp(keyCode) ? -1 : 1,
-			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
+			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
 		if (!Spotlight.getPointerMode() && spotItem) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -331,7 +331,8 @@ class ScrollableBase extends Component {
 			{childRef, containerRef, scrollToAccumulatedTarget} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
-			pageDistance = isPageUp(keyCode) ? (this.uiRef.pageDistance * -1) : this.uiRef.pageDistance,
+			direction = isPageUp(keyCode) ? -1 : 1,
+			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
 		if (!Spotlight.getPointerMode() && spotItem) {
@@ -397,16 +398,15 @@ class ScrollableBase extends Component {
 	onScrollbarButtonClick = ({isPreviousScrollButton, isVerticalScrollBar}) => {
 		const
 			bounds = this.uiRef.getScrollBounds(),
-			pageDistance = (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
-			delta = isPreviousScrollButton ? -pageDistance : pageDistance,
-			direction = Math.sign(delta);
+			direction = isPreviousScrollButton ? -1 : 1,
+			pageDistance = direction * (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		if (direction !== this.uiRef.wheelDirection) {
 			this.uiRef.isScrollAnimationTargetAccumulated = false;
 			this.uiRef.wheelDirection = direction;
 		}
 
-		this.uiRef.scrollToAccumulatedTarget(delta, isVerticalScrollBar);
+		this.uiRef.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar);
 	}
 
 	stop = () => {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -377,8 +377,7 @@ class ScrollableBaseNative extends Component {
 			{childRef, scrollToAccumulatedTarget} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
-			direction = isPageUp(keyCode) ? -1 : 1,
-			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
+			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
 		if (!Spotlight.getPointerMode() && spotItem) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -377,7 +377,8 @@ class ScrollableBaseNative extends Component {
 			{childRef, scrollToAccumulatedTarget} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
-			pageDistance = isPageUp(keyCode) ? (this.uiRef.pageDistance * -1) : this.uiRef.pageDistance,
+			direction = isPageUp(keyCode) ? -1 : 1,
+			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
 		if (!Spotlight.getPointerMode() && spotItem) {
@@ -449,16 +450,15 @@ class ScrollableBaseNative extends Component {
 	onScrollbarButtonClick = ({isPreviousScrollButton, isVerticalScrollBar}) => {
 		const
 			bounds = this.uiRef.getScrollBounds(),
-			pageDistance = (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
-			delta = isPreviousScrollButton ? -pageDistance : pageDistance,
-			direction = Math.sign(delta);
+			direction = isPreviousScrollButton ? -1 : 1,
+			pageDistance = direction * (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		if (direction !== this.uiRef.wheelDirection) {
 			this.uiRef.isScrollAnimationTargetAccumulated = false;
 			this.uiRef.wheelDirection = direction;
 		}
 
-		this.uiRef.scrollToAccumulatedTarget(delta, isVerticalScrollBar);
+		this.uiRef.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar);
 	}
 
 	scrollStopOnScroll = () => {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -596,8 +596,7 @@ class ScrollableBase extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			canScrollVertically = this.canScrollVertically(bounds),
-			direction = isPageUp(keyCode) ? -1 : 1,
-			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
+			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically);
 	}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -348,9 +348,6 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidMount () {
-		const bounds = this.getScrollBounds();
-
-		this.pageDistance = (this.canScrollVertically(bounds) ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 		this.addEventListeners();
 		this.updateScrollbars();
 
@@ -459,7 +456,6 @@ class ScrollableBase extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	pageDistance = 0
 
 	// bounds info
 	bounds = {
@@ -600,7 +596,8 @@ class ScrollableBase extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			canScrollVertically = this.canScrollVertically(bounds),
-			pageDistance = isPageUp(keyCode) ? (this.pageDistance * -1) : this.pageDistance;
+			direction = isPageUp(keyCode) ? -1 : 1,
+			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically);
 	}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -649,8 +649,7 @@ class ScrollableBaseNative extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			canScrollVertically = this.canScrollVertically(bounds),
-			direction = isPageUp(keyCode) ? -1 : 1,
-			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
+			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically);
 	}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -347,9 +347,6 @@ class ScrollableBaseNative extends Component {
 	}
 
 	componentDidMount () {
-		const bounds = this.getScrollBounds();
-
-		this.pageDistance = (this.canScrollVertically(bounds) ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 		this.addEventListeners();
 		this.updateScrollbars();
 
@@ -444,7 +441,6 @@ class ScrollableBaseNative extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	pageDistance = 0
 
 	// bounds info
 	bounds = {
@@ -653,7 +649,8 @@ class ScrollableBaseNative extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			canScrollVertically = this.canScrollVertically(bounds),
-			pageDistance = isPageUp(keyCode) ? (this.pageDistance * -1) : this.pageDistance;
+			direction = isPageUp(keyCode) ? -1 : 1,
+			pageDistance = direction * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
 		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically);
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though pressing a page up/down key in VirtualList with all disabled items, the list does not scroll.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We tried to cache the value of the scroll distance when mounting a VirtualList.
But at that time after updating React version, the list's client height equals 0 when `componentDidMount` called, then the cached value also equals 0 and finally the list does not scroll.

Sometimes the client size and scroll direction could be changed dynamically. So I think that it would be better not to cache it instead of checking if they are changed or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5228

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)