### PR TITLE
PLAT-54708: Support over 1000 items in VirtualList story sampler

### DIFF
--- a/packages/sampler/stories/moonstone-stories/VirtualGridList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualGridList.js
@@ -23,10 +23,20 @@ const
 	prop = {
 		direction: {'horizontal': 'horizontal', 'vertical': 'vertical'}
 	},
-	items = [],
+	dataSize = 1000,
+	getItem = (index) => {
+		const
+			count = ('00' + index).slice(-3),
+			text = `Item ${count}`,
+			subText = `SubItem ${count}`,
+			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
+			source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${index}`;
+
+		return {text, subText, source};
+	},
 	// eslint-disable-next-line enact/prop-types
 	uiRenderItem = ({index, ...rest}) => {
-		const {text, subText, source} = items[index];
+		const {text, subText, source} = getItem(index);
 
 		return (
 			<UiGridListImageItem
@@ -39,7 +49,7 @@ const
 	},
 	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
-		const {text, subText, source} = items[index];
+		const {text, subText, source} = getItem(index);
 
 		return (
 			<GridListImageItem
@@ -51,17 +61,6 @@ const
 		);
 	};
 
-for (let i = 0; i < 1000; i++) {
-	const
-		count = ('00' + i).slice(-3),
-		text = `Item ${count}`,
-		subText = `SubItem ${count}`,
-		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
-		source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`;
-
-	items.push({text, subText, source});
-}
-
 storiesOf('UI', module)
 	.add(
 		'VirtualList.VirtualGridList',
@@ -70,7 +69,7 @@ storiesOf('UI', module)
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<UiVirtualGridList
-				dataSize={number('dataSize', items.length)}
+				dataSize={number('dataSize', dataSize)}
 				direction={select('direction', prop.direction, 'vertical')}
 				itemRenderer={uiRenderItem}
 				itemSize={{
@@ -95,7 +94,7 @@ storiesOf('Moonstone', module)
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<VirtualGridList
-				dataSize={number('dataSize', items.length)}
+				dataSize={number('dataSize', dataSize)}
 				direction={select('direction', prop.direction, 'vertical')}
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
 				itemRenderer={renderItem}

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -19,7 +19,8 @@ const
 		'true': true,
 		"'noAnimation'": 'noAnimation'
 	},
-	items = [],
+	dataSize = 1000,
+	getItem = (index) => ('Item ' + ('00' + index).slice(-3)),
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {
@@ -30,14 +31,10 @@ const
 
 		return (
 			<Item {...rest} style={itemStyle}>
-				{items[index]}
+				{getItem(index)}
 			</Item>
 		);
 	};
-
-for (let i = 0; i < 1000; i++) {
-	items.push('Item ' + ('00' + i).slice(-3));
-}
 
 storiesOf('UI', module)
 	.add(
@@ -49,7 +46,7 @@ storiesOf('UI', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<UiVirtualList
-					dataSize={number('dataSize', items.length)}
+					dataSize={number('dataSize', dataSize)}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
@@ -73,7 +70,7 @@ storiesOf('Moonstone', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<VirtualList
-					dataSize={number('dataSize', items.length)}
+					dataSize={number('dataSize', dataSize)}
 					focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}

--- a/packages/sampler/stories/qa-stories/VirtualGridList.js
+++ b/packages/sampler/stories/qa-stories/VirtualGridList.js
@@ -13,10 +13,20 @@ import {mergeComponentMetadata} from '../../src/utils/propTables';
 const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
 
 const
-	items = [],
+	dataSize = 1000,
+	getItem = (index) => {
+		const
+			count = ('00' + index).slice(-3),
+			text = `Item ${count}`,
+			subText = `SubItem ${count}`,
+			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
+			source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${index}`;
+
+		return {text, subText, source};
+	},
 	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
-		const {text, subText, source} = items[index];
+		const {text, subText, source} = getItem(index);
 
 		return (
 			<GridListImageItem
@@ -28,23 +38,12 @@ const
 		);
 	};
 
-for (let i = 0; i < 1000; i++) {
-	const
-		count = ('00' + i).slice(-3),
-		text = `Item ${count}`,
-		subText = `SubItem ${count}`,
-		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
-		source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`;
-
-	items.push({text, subText, source});
-}
-
 storiesOf('VirtualList.VirtualGridList', module)
 	.add(
 		'Horizontal VirtualGridList',
 		() => (
 			<VirtualGridList
-				dataSize={number('dataSize', items.length)}
+				dataSize={number('dataSize', dataSize)}
 				direction="horizontal"
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
 				itemRenderer={renderItem}

--- a/packages/sampler/stories/qa-stories/VirtualList.js
+++ b/packages/sampler/stories/qa-stories/VirtualList.js
@@ -23,20 +23,18 @@ const
 			height: ri.unit(552, 'rem')
 		}
 	},
-	items = [],
+	dataSize = 1000,
+	getItem = (index) => ('Item ' + ('00' + index).slice(-3)),
+	selected = {},
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {height: size + 'px', ...style.item};
 		return (
 			<StatefulSwitchItem  index={index} style={itemStyle} {...rest}>
-				{items[index].item}
+				{getItem(index).item}
 			</StatefulSwitchItem>
 		);
 	};
-
-for (let i = 0; i < 1000; i++) {
-	items.push({item :'Item ' + ('00' + i).slice(-3), selected: false});
-}
 
 class StatefulSwitchItem extends React.Component {
 	static propTypes = {
@@ -46,18 +44,18 @@ class StatefulSwitchItem extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			selected: items[props.index].selected
+			selected: !!selected[props.index]
 		};
 	}
 
 	componentWillReceiveProps (nextProps) {
 		if (this.props.index !== nextProps.index) {
-			this.setState({selected: items[nextProps.index].selected});
+			this.setState({selected: !!selected[nextProps.index]});
 		}
 	}
 
 	onToggle = () => {
-		items[this.props.index].selected = !items[this.props.index].selected;
+		selected[this.props.index] = !selected[this.props.index];
 		this.setState({selected: !this.state.selected});
 	}
 
@@ -80,7 +78,7 @@ storiesOf('VirtualList', module)
 			const itemSize = ri.scale(number('itemSize', 72));
 			return (
 				<VirtualList
-					dataSize={number('dataSize', items.length)}
+					dataSize={number('dataSize', dataSize)}
 					focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If inserting over 1000 value for the `dataSize` knob in VirtualList, VirtualGridList story samplers, the 1000th item in the lists was not shown.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We defined only 1000 item data in the samplers. So instead of defining the data statically, I define the data dynamically depending on the data size that a user changes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I could limit the data size to 1000 by using range option. But we need to update all test steps not to insert a data size value, but to drag the slider knob to determine a data size value. To reduce the work, I tried to use this approach.

### Links
[//]: # (Related issues, references)

PLAT-54708

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)