### PR TITLE
ENYO-5154 Account for disabled items in ExpandableItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/ExpandableItem` and related expandables to deal with disabled items and the `autoClose`, `lockBottom` and `noLockBottom` props
+-
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Removed

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -7,15 +7,15 @@
  * @module moonstone/ExpandableItem
  */
 
+import {is} from '@enact/core/keymap';
+import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
 import {getContainersForNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
-import {is} from '@enact/core/keymap';
-import kind from '@enact/core/kind';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import PropTypes from 'prop-types';
 import last from 'ramda/src/last';
 import React from 'react';
-import PropTypes from 'prop-types';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import LabeledItem from '../LabeledItem';
 
@@ -256,16 +256,13 @@ const ExpandableItemBase = kind({
 				// case here in which the children of the container are spottable and the
 				// ExpandableList use case which has an intermediate child (Group) between the
 				// spottable components and the container.
-				if (autoClose && isUp(keyCode) && onClose) {
-					if (wouldDirectionLeaveContainer('up', target)) {
-						onClose();
+				if (autoClose && onClose && isUp(keyCode) && wouldDirectionLeaveContainer('up', target)) {
+					onClose();
+					ev.nativeEvent.stopImmediatePropagation();
+				} else if (isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) {
+					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
-					}
-				} else if (isDown(keyCode)) {
-					const leaving = wouldDirectionLeaveContainer('down', target);
-					if (lockBottom && leaving) {
-						ev.nativeEvent.stopImmediatePropagation();
-					} else if (onSpotlightDown && leaving) {
+					} else if (onSpotlightDown) {
 						onSpotlightDown(ev);
 					}
 				}

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -29,6 +29,9 @@ const isDown = is('down');
 
 const ContainerDiv = SpotlightContainerDecorator({continue5WayHold: true}, 'div');
 
+// Returns `true` if a directional movement would leave the same container as `srcNode` is in.
+// For a more generalized implementation, there'd need to be some way to specify an upper-most
+// container for dealing with cases of components that are themselves wrapped in containers.
 function wouldDirectionLeaveContainer (dir, srcNode) {
 	const target = getTargetByDirectionFromElement(dir, srcNode);
 

--- a/packages/sampler/stories/qa-stories/ExpandableList.js
+++ b/packages/sampler/stories/qa-stories/ExpandableList.js
@@ -79,8 +79,14 @@ storiesOf('ExpandableList', module)
 				<ExpandableList title="First">
 					{['One', 'Two', 'Three']}
 				</ExpandableList>
-				<ExpandableList title="Second">
-					{['Fourth', 'Fifth', 'Sixth']}
+				<ExpandableList title="Second (with disabled items)">
+					{[
+						{key: 1, children: 'a', disabled: true},
+						{key: 2, children: 'b'},
+						{key: 3, children: 'c', disabled: true},
+						{key: 4, children: 'd'},
+						{key: 5, children: 'e', disabled: true}
+					]}
 				</ExpandableList>
 				<ExpandableList title="Third">
 					{['Seventh', 'Eighth', 'Ninth']}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -191,7 +191,7 @@ const isContainerEnabled = (node) => {
 const getContainerId = (node) => node.dataset[containerKey];
 
 /**
- * Generates a CSS selector string for a currrent container if `node` is a container
+ * Generates a CSS selector string for a current container if `node` is a container
  *
  * @param   {Node}    node  Container Node
  *


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If disabled items appeared at the top/bottom of Expandables, the `autoClose`,
`lockBottom` and `noLockBottom` props could be ignored

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Used some internal spotlight-fu to ensure focus stays within the inner container
when navigating up/down

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5154

### Comments
