### PR TITLE
ENYO-5210: Fix Marquee to always animate when marqueeOn="render"

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Item` to use its natural width rather than imposing a 100% width allowing inline Items to be the correct width.
 - `ui/Marquee` to always marquee when `marqueeOn` is set to `'render'`
 - `ui/Item` to use its natural width rather than imposing a 100% width allowing inline Items to be the correct width
 - `ui/MarqueeDecorator` to correctly reset animation when children updates

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Item` to use its natural width rather than imposing a 100% width allowing inline Items to be the correct width.
+- `ui/Marquee` to always marquee when `marqueeOn` is set to `'render'`
 
 ## [2.0.0-beta.1] - 2018-04-29
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -599,11 +599,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				return;
 			}
 
-			if (this.props.marqueeOn === 'render') {
-				this.restartAnimation();
-			} else {
-				this.stop();
-			}
+			this.stop();
 		}
 
 		handleResize = () => {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -294,7 +294,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillReceiveProps (next) {
-			const {marqueeOn, marqueeDisabled, marqueeSpeed} = this.props;
+			const {forceDirection, marqueeOn, marqueeDisabled, marqueeSpeed} = this.props;
 			this.validateTextDirection(next);
 			if ((this.props.children !== next.children) || (invalidateProps && didPropChange(invalidateProps, this.props, next))) {
 				// restart marqueeOn="render" marquees or synced marquees that were animating
@@ -305,7 +305,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.invalidateMetrics();
 				this.cancelAnimation();
 				this.textDirectionValidated = false;
-			} else if (next.marqueeOn !== marqueeOn || next.marqueeDisabled !== marqueeDisabled || next.marqueeSpeed !== marqueeSpeed) {
+			} else if (
+				next.marqueeOn !== marqueeOn ||
+				next.marqueeDisabled !== marqueeDisabled ||
+				next.marqueeSpeed !== marqueeSpeed ||
+				next.forceDirection !== forceDirection
+			) {
 				this.cancelAnimation();
 			} else if (next.disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
@@ -387,6 +392,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		shouldStartMarquee () {
 			const {disabled, marqueeOn} = this.props;
 			return (
+				marqueeOn === 'render' ||
 				this.forceRestartMarquee ||
 				!this.sync && (
 					(this.isFocused && marqueeOn === 'focus' && !disabled) ||
@@ -593,7 +599,11 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				return;
 			}
 
-			this.stop();
+			if (this.props.marqueeOn === 'render') {
+				this.restartAnimation();
+			} else {
+				this.stop();
+			}
 		}
 
 		handleResize = () => {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -754,6 +754,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const props = Object.assign({}, this.props);
 
 			delete props.alignment;
+			delete props.forceDirection;
 			delete props.marqueeCentered;
 			delete props.marqueeDelay;
 			delete props.marqueeDisabled;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Marquee` stops the animation when some of the props value updates, however it should always marquee if `marqueeOn` value is set to `render`. 
Updated condition to always start the animation for `marqueeOn="render"` and restart when `stop` is called.

### Additional consideration
I'm not 100% sure if marquee should restart when `forceDirection` is updated because of the rare chance of apps needing to change at runtime. Given that, some props change (e.g. `marqueeDelay`, `marqueeResetDelay`) won't update the animation state even with the fix. Should we check for them as well?

In regards to recent react 16.3.x update, we should consider refactoring animation check logic in `componentWillReceiveProps` to  `componentDidUpdate`.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
