### PR TITLE
ENYO-5143: IconButton is now visually customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Fixed
 
 - `core/dispatcher.on` to not add duplicate event handlers
+- `moonstone/IconButton` to allow theme-style customization, like it claimed was possible
 - `moonstone/ExpandableItem` and related expandables to deal with disabled items and the `autoClose`, `lockBottom` and `noLockBottom` props
 - `moonstone/Slider` not to fire `onChange` event when 5-ways out of boundary
 - `moonstone/ToggleButton` layout for RTL locales

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
+- `moonstone/IconButton` to allow theme-style customization, like it claimed was possible
 
 ## [2.0.0-beta.1] - 2018-04-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
 - `moonstone/IconButton` to allow theme-style customization, like it claimed was possible
 - `moonstone/ExpandableItem` and related expandables to deal with disabled items and the `autoClose`, `lockBottom` and `noLockBottom` props
 - `moonstone/Slider` not to fire `onChange` event when 5-ways out of boundary

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -103,7 +103,7 @@ const IconButtonBase = kind({
 			<UiIconButtonBase
 				data-webos-voice-intent="Select"
 				{...rest}
-				buttonComponent={ButtonBase}
+				buttonComponent={<ButtonBase css={css} />}
 				css={css}
 				icon={children}
 				iconComponent={Icon}

--- a/packages/moonstone/IconButton/IconButton.less
+++ b/packages/moonstone/IconButton/IconButton.less
@@ -43,4 +43,10 @@
 			line-height: 30px;
 		}
 	}
+
+	// Include the classes that we explicitly said are customizable in the publicClassNames
+	.bg,
+	.selected {
+		/* Exported for customization*/
+	}
 }

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Touchable from '../Touchable';
+import ComponentOverride from '../ComponentOverride';
 
 import componentCss from './IconButton.less';
 
@@ -147,7 +148,7 @@ const IconButtonBase = kind({
 		className: ({small, styler}) => styler.append({small})
 	},
 
-	render: ({buttonComponent: Button, children, css, icon, iconComponent: Icon, small, ...rest}) => {
+	render: ({buttonComponent, children, css, icon, iconComponent: Icon, small, ...rest}) => {
 
 		// To support the simpler use case of only specifying the icon as the children within
 		// <IconButton>, this falls back on using children if icon isn't specified.
@@ -156,11 +157,17 @@ const IconButtonBase = kind({
 			children = null;
 		}
 
+		console.log('css:', css);
 		return (
-			<Button {...rest} small={small} minWidth={false}>
+			<ComponentOverride
+				{...rest}
+				component={buttonComponent}
+				small={small}
+				minWidth={false}
+			>
 				<Icon small={small} className={css.icon}>{icon}</Icon>
 				{children}
-			</Button>
+			</ComponentOverride>
 		);
 	}
 });

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -14,8 +14,8 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Touchable from '../Touchable';
 import ComponentOverride from '../ComponentOverride';
+import Touchable from '../Touchable';
 
 import componentCss from './IconButton.less';
 
@@ -36,11 +36,11 @@ const IconButtonBase = kind({
 		 *
 		 * This is the root component and will receive all props except `icon`.
 		 *
-		 * @type {Function}
+		 * @type {Function|Element}
 		 * @required
 		 * @public
 		 */
-		buttonComponent: PropTypes.func.isRequired,
+		buttonComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
 
 		/**
 		 * The component used to render the [icon]{@link ui/IconButton.IconButtonBase.icon}.
@@ -157,7 +157,6 @@ const IconButtonBase = kind({
 			children = null;
 		}
 
-		console.log('css:', css);
 		return (
 			<ComponentOverride
 				{...rest}


### PR DESCRIPTION
### Issue Resolved / Feature Added
IconButton isn't visually customizable the way Button is, which is _just wrong_.


### Resolution
Added ComponentOverride to ui/IconButton so moonstone/IconButton could send its `css` into the Button component for customization. Also had to include the two customizable classes in the moonstone/IconButton.less file so they're available for override externally.