### PR TITLE
ENYO-5213: Fix Popup spotlightRestrict handling

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to ignore to scroll on focus when jumping
+- `moonstone/Popup` to support all `spotlightRestrict` options
 
 ## [2.0.0-beta.1] - 2018-04-29
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -358,7 +358,7 @@ class Popup extends React.Component {
 	}
 
 	componentDidMount () {
-		if (this.props.open && this.props.noAnimation) {
+		if (this.props.open) {
 			on('keydown', this.handleKeyDown);
 			this.spotPopupContent();
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Popup` would seem to ignore the `spotlightRestrict` setting if it was open on mount

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`onShow` is not fired for `Transition` that is open at start anymore, regardless of animation
setting.  Always attach keyboard handler when open at mount.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Due to some strangeness with Sampler, it is possible for `onTransitionEnd` to fire when
refreshing a page with an open-at-the-start transition in it.  I was not able to diagnose why
but this will result in two event handlers being attached.  I will address this by modifying
`on()` to discard duplicate handlers in a separate PR.

### Links
[//]: # (Related issues, references)
ENYO-5213

### Comments
