### PR TITLE
ENYO-5241: Prevent adding duplicate handlers with core/dispatcher

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/dispatcher.on` to not add duplicate event handlers
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Added

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -6,7 +6,7 @@
 
 import curry from 'ramda/src/curry';
 
-import getListeners from './listeners';
+import {getListeners, addListener} from './listeners';
 
 /**
  * Checks if the default target of `document` exists before returning it, otherwise returns `false`.
@@ -58,7 +58,7 @@ const dispatcher = function (ev) {
 };
 
 /**
- * Adds a new global event listener
+ * Adds a new global event listener. Duplicate event handlers will be discarded.
  *
  * @function
  * @param	{String}	name				Event name
@@ -70,10 +70,9 @@ const dispatcher = function (ev) {
  */
 const on = function (name, fn, target = getDefaultTarget()) {
 	if (target) {
-		const listeners = getListeners(target, name);
+		const added = addListener(target, name, fn);
 
-		const length = listeners.push(fn);
-		if (length === 1) {
+		if (added && getListeners(target, name).length === 1) {
 			target.addEventListener(name, dispatcher);
 		}
 	}

--- a/packages/core/dispatcher/listeners.js
+++ b/packages/core/dispatcher/listeners.js
@@ -11,5 +11,15 @@ const getListeners = function (target, name) {
 	return (listeners[name] = listeners[name] || []);
 };
 
+const addListener = function (target, name, fn) {
+	const listeners = getListeners(target, name);
+
+	if (listeners.indexOf(fn) === -1) {
+		listeners.push(fn);
+		return true;
+	}
+	return false;
+};
+
 export default getListeners;
-export {getListeners};
+export {getListeners, addListener};

--- a/packages/core/dispatcher/tests/dispatcher-specs.js
+++ b/packages/core/dispatcher/tests/dispatcher-specs.js
@@ -20,6 +20,20 @@ describe('dispatcher', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	it('should not register duplicate handlers on target', function () {
+		const handler = sinon.spy();
+		on('localechange', handler, window);
+		on('localechange', handler, window);
+
+		const ev = new CustomEvent('localechange', {});
+		window.dispatchEvent(ev);
+
+		const expected = true;
+		const actual = handler.calledOnce;
+
+		expect(actual).to.equal(expected);
+	});
+
 	it('should unregister handlers on target', function () {
 		const handler = sinon.spy();
 		on('localechange', handler, window);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It was possible to duplicate event handlers

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Prevent adding the same handler twice to a target

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It could be argued that the root cause of duplicate handlers should be addressed.

### Links
[//]: # (Related issues, references)
ENYO-5241

### Comments
