### PR TITLE
ENYO-5111: Update Group QA samples to apply disabled prop

### DIFF
--- a/packages/sampler/stories/qa-stories/SelectableItem.js
+++ b/packages/sampler/stories/qa-stories/SelectableItem.js
@@ -95,6 +95,7 @@ storiesOf('SelectableItem', module)
 					disabled: boolean('disabled', false)
 				}}
 				selectedProp="selected"
+				disabled={boolean('disabled', false)}
 				onSelect={action('onSelect')}
 			>
 

--- a/packages/sampler/stories/qa-stories/SelectableItem.js
+++ b/packages/sampler/stories/qa-stories/SelectableItem.js
@@ -94,12 +94,32 @@ storiesOf('SelectableItem', module)
 					inline: boolean('inline', false),
 					disabled: boolean('disabled', false)
 				}}
+				childSelect="onToggle"
 				selectedProp="selected"
 				disabled={boolean('disabled', false)}
 				onSelect={action('onSelect')}
 			>
 
 				{[text('Normal Text 1', inputData.normalText + 1), text('Normal Text 2', inputData.normalText + 2), text('Normal Text 3', inputData.normalText + 3)]}
+			</Group>
+		)
+	)
+	.add(
+		'that is grouped with individual disabled items',
+		() => (
+			<Group
+				childComponent={SelectableItem}
+				childSelect="onToggle"
+				selectedProp="selected"
+				onSelect={action('onSelect')}
+			>
+				{[
+					{children: '1', disabled: true},
+					{children: '2', disabled: false},
+					{children: '3', disabled: true},
+					{children: '4', disabled: false}
+
+				]}
 			</Group>
 		)
 	);

--- a/packages/sampler/stories/qa-stories/SwitchItem.js
+++ b/packages/sampler/stories/qa-stories/SwitchItem.js
@@ -63,6 +63,7 @@ storiesOf('SwitchItem', module)
 						disabled: boolean('disabled', false)
 					}}
 					selectedProp="selected"
+					disabled={boolean('disabled', false)}
 					defaultSelected={1}
 					onSelect={action('onSelect')}
 				>

--- a/packages/sampler/stories/qa-stories/SwitchItem.js
+++ b/packages/sampler/stories/qa-stories/SwitchItem.js
@@ -62,6 +62,7 @@ storiesOf('SwitchItem', module)
 						inline: boolean('ItemProps-Inline', false),
 						disabled: boolean('disabled', false)
 					}}
+					childSelect="onToggle"
 					selectedProp="selected"
 					disabled={boolean('disabled', false)}
 					defaultSelected={1}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Apply `disabled` prop to `<Group>` as well

### Links
[//]: # (Related issues, references)
ENYO-5111

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com