### PR TITLE
ENYO-5231: Fix the wrong spotlight ID in Scrollable

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -342,7 +342,7 @@ class ScrollableBase extends Component {
 
 			const
 				// VirtualList and Scroller have a spotlightId on containerRef
-				spotlightId = this.uiRef.containerRef.dataset.spotlightId,
+				spotlightId = containerRef.dataset.spotlightId,
 				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -342,7 +342,7 @@ class ScrollableBase extends Component {
 
 			const
 				// VirtualList and Scroller have a spotlightId on containerRef
-				spotlightId = childRef.containerRef.dataset.spotlightId,
+				spotlightId = this.uiRef.containerRef.dataset.spotlightId,
 				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -374,7 +374,7 @@ class ScrollableBaseNative extends Component {
 		if (!this.uiRef.state.isVerticalScrollbarVisible) return;
 
 		const
-			{childRef, scrollToAccumulatedTarget} = this.uiRef,
+			{childRef, containerRef, scrollToAccumulatedTarget} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
@@ -386,12 +386,7 @@ class ScrollableBaseNative extends Component {
 				return;
 			}
 			const
-				spotlightId = (
-					// ScrollerNative has a spotlightId on containerRef
-					childRef.containerRef.dataset.spotlightId ||
-					// VirtualListNative has a spotlightId on contentRef
-					childRef.contentRef.dataset.spotlightId
-				),
+				spotlightId = containerRef.dataset.spotlightId,
 				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = this.uiRef.containerRef.getBoundingClientRect(),


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

While doing UI migration, I get the spotlight ID from the wrong DOM element.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I use the right DOM element to get the spotlight ID in Scrollable.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5231

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)