### PR TITLE
ENYO-5242: use webOSLocaleChange event instead of languagechange on webos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/I18nDecorator` to listen correct event on webOS platform to check language changes.
+
 ## [2.0.0-beta.1] - 2018-04-29
 
 ### Removed

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -84,7 +84,11 @@ const IntlHoc = hoc((config, Wrapped) => {
 
 		componentDidMount () {
 			if (typeof window === 'object') {
-				on('languagechange', this.handleLocaleChange, window);
+				if (ilib._platform === 'webos') {
+					on('webOSLocaleChange', this.handleLocaleChange, document);
+				} else {
+					on('languagechange', this.handleLocaleChange, window);
+				}
 			}
 		}
 
@@ -96,7 +100,11 @@ const IntlHoc = hoc((config, Wrapped) => {
 
 		componentWillUnmount () {
 			if (typeof window === 'object') {
-				off('languagechange', this.handleLocaleChange, window);
+				if (ilib._platform === 'webos') {
+					off('webOSLocaleChange', this.handleLocaleChange, document);
+				} else {
+					off('languagechange', this.handleLocaleChange, window);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

It's not enough to get navigator.language on languagechange event callback.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

There is a precise event that named webOSLocaleChange. I use it for webOS platform.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5242

### Comments

Enact-DCO-1.0-Signed-off-by: Yeram Choi <yeram.choi@lge.com>