### PR TITLE
ENYO-5236: Fix vertical scroll bar button aria-label in RTL

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -203,28 +203,14 @@ class ScrollButtons extends Component {
 	handlePrevDown = () => {
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
-
-			if (vertical) {
-				this.announce($L('UP'));
-			} else if (rtl) {
-				this.announce($L('RIGHT'));
-			} else {
-				this.announce($L('LEFT'));
-			}
+			this.announce(vertical ? $L('UP') : $L(rtl ? 'RIGHT' : 'LEFT'));
 		}
 	}
 
 	handleNextDown = () => {
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
-
-			if (vertical) {
-				this.announce($L('DOWN'));
-			} else if (rtl) {
-				this.announce($L('LEFT'));
-			} else {
-				this.announce($L('RIGHT'));
-			}
+			this.announce(vertical ? $L('DOWN') : $L(rtl ? 'LEFT' : 'RIGHT'));
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -203,14 +203,14 @@ class ScrollButtons extends Component {
 	handlePrevDown = () => {
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
-			this.announce(vertical ? $L('UP') : $L(rtl ? 'RIGHT' : 'LEFT'));
+			this.announce(vertical && $L('UP') || rtl && $L('RIGHT') || $L('LEFT'));
 		}
 	}
 
 	handleNextDown = () => {
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
-			this.announce(vertical ? $L('DOWN') : $L(rtl ? 'LEFT' : 'RIGHT'));
+			this.announce(vertical && $L('DOWN') || rtl && $L('LEFT') || $L('RIGHT'));
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -201,18 +201,30 @@ class ScrollButtons extends Component {
 	}
 
 	handlePrevDown = () => {
-		const {vertical} = this.props;
-
 		if (this.announce) {
-			this.announce(vertical ? $L('UP') : $L('LEFT'));
+			const {rtl, vertical} = this.props;
+
+			if (vertical) {
+				this.announce($L('UP'));
+			} else if (rtl) {
+				this.announce($L('RIGHT'));
+			} else {
+				this.announce($L('LEFT'));
+			}
 		}
 	}
 
 	handleNextDown = () => {
-		const {vertical} = this.props;
-
 		if (this.announce) {
-			this.announce(vertical ? $L('DOWN') : $L('RIGHT'));
+			const {rtl, vertical} = this.props;
+
+			if (vertical) {
+				this.announce($L('DOWN'));
+			} else if (rtl) {
+				this.announce($L('LEFT'));
+			} else {
+				this.announce($L('RIGHT'));
+			}
 		}
 	}
 
@@ -321,7 +333,7 @@ class ScrollButtons extends Component {
 
 		return [
 			<ScrollButton
-				aria-label={rtl ? nextButtonAriaLabel : previousButtonAriaLabel}
+				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
 				key="prevButton"
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'up' : 'left'}
@@ -341,7 +353,7 @@ class ScrollButtons extends Component {
 			</ScrollButton>,
 			thumbRenderer(),
 			<ScrollButton
-				aria-label={rtl ? previousButtonAriaLabel : nextButtonAriaLabel}
+				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				key="nextButton"
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'down' : 'right'}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The aria-labels in vertical Scroll bar buttons with RTL mode are switched each other.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Fix the aria-labels in vertical scroll bar buttons.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When pressing the buttons, Scroller announce the wrong text because we passed it incorrectly in RTL mode.

### Links
[//]: # (Related issues, references)

ENYO-5236

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)