### PR TITLE
ENYO-5156: Change ToggleItem to forward native events for onFocus and onBlur

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,6 +5,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `moonstone/ToggleItem` to forward native events on `onFocus` and `onBlur`
+
 ### Fixed
 
 - `moonstone/ExpandableItem` and related expandables to deal with disabled items and the `autoClose`, `lockBottom` and `noLockBottom` props

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/ToggleItem` to forward native events on `onFocus` and `onBlur`
 - `moonstone/Input` and `moonstone/ExpandableInput` support for forwarding valid `<input>` props to the contained `<input>` node
+- `moonstone/ToggleButton` to fire `onToggle` when toggled
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,6 +5,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/SelectableItem.SelectableItemDecorator`
+
 ### Changed
 
 - `moonstone/ToggleItem` to forward native events on `onFocus` and `onBlur`

--- a/packages/moonstone/SelectableItem/SelectableItem.js
+++ b/packages/moonstone/SelectableItem/SelectableItem.js
@@ -64,8 +64,8 @@ const SelectableItemBase = kind({
  * Adds interactive functionality to `SelectableItemBase`
  *
  * @class SelectableItemDecorator
- * @memberof moostone/SelectableItem
- * @mixes moostone/ToggleItem.ToggleItemDecorator
+ * @memberof moonstone/SelectableItem
+ * @mixes moonstone/ToggleItem.ToggleItemDecorator
  * @hoc
  * @public
  */

--- a/packages/moonstone/SelectableItem/SelectableItem.js
+++ b/packages/moonstone/SelectableItem/SelectableItem.js
@@ -4,13 +4,14 @@
  * @module moonstone/SelectableItem
  * @exports SelectableItem
  * @exports SelectableItemBase
+ * @exports SelectableItemDecorator
  */
 
 import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import ToggleItem from '../ToggleItem';
+import {ToggleItemBase, ToggleItemDecorator} from '../ToggleItem';
 
 import SelectableIcon from './SelectableIcon';
 
@@ -21,7 +22,7 @@ import componentCss from './SelectableItem.less';
  *
  * @class SelectableItem
  * @memberof moonstone/SelectableItem
- * @extends moonstone/ToggleItem.ToggleItem
+ * @extends moonstone/ToggleItem.ToggleItemBase
  * @ui
  * @public
  */
@@ -50,7 +51,7 @@ const SelectableItemBase = kind({
 	},
 
 	render: (props) => (
-		<ToggleItem
+		<ToggleItemBase
 			data-webos-voice-intent="SelectCheckItem"
 			{...props}
 			css={props.css}
@@ -59,8 +60,38 @@ const SelectableItemBase = kind({
 	)
 });
 
-export default SelectableItemBase;
+/**
+ * Adds interactive functionality to `SelectableItemBase`
+ *
+ * @class SelectableItemDecorator
+ * @memberof moostone/SelectableItem
+ * @mixes moostone/ToggleItem.ToggleItemDecorator
+ * @hoc
+ * @public
+ */
+const SelectableItemDecorator = ToggleItemDecorator({invalidateProps: ['inline', 'selected']});
+
+/**
+ * A Moonstone-styled item with circle shaped component with built-in support for toggling,
+ * marqueed text, and `Spotlight` focus.
+ *
+ * Usage:
+ * ```
+ * <SelectableItem>Toggle Me</SelectableItem>
+ * ```
+ *
+ * @class SelectableItem
+ * @memberof moonstone/SelectableItem
+ * @extends moonstone/SelectableItem.SelectableItemBase
+ * @mixes moonstone/SelectableItem.SelectableItemDecorator
+ * @ui
+ * @public
+ */
+const SelectableItem = SelectableItemDecorator(SelectableItemBase);
+
+export default SelectableItem;
 export {
-	SelectableItemBase as SelectableItem,
-	SelectableItemBase
+	SelectableItem,
+	SelectableItemBase,
+	SelectableItemDecorator
 };

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -12,7 +12,6 @@
 import kind from '@enact/core/kind';
 import Spottable from '@enact/spotlight/Spottable';
 import Pure from '@enact/ui/internal/Pure';
-import {RemeasurableDecorator} from '@enact/ui/Remeasurable';
 import {SlotItemBase as UiSlotItemBase, SlotItemDecorator as UiSlotItemDecorator} from '@enact/ui/SlotItem';
 import {ItemDecorator as UiItemDecorator} from '@enact/ui/Item';
 import Toggleable from '@enact/ui/Toggleable';
@@ -78,7 +77,6 @@ const SlotItemBase = kind({
  * @mixes ui/SlotItem.SlotItemDecorator
  * @mixes ui/Toggleable
  * @mixes spotlight.Spottable
- * @mixes ui/Remeasurable.RemeasurableDecorator
  * @mixes moonstone/Marquee.MarqueeDecorator
  * @mixes moonstone/Skinnable
  * @hoc
@@ -92,7 +90,6 @@ const SlotItemDecorator = compose(
 	),
 	UiItemDecorator, // (Touchable)
 	Spottable,
-	RemeasurableDecorator({trigger: 'remeasure'}),
 	MarqueeDecorator({className: componentCss.content, invalidateProps: ['inline', 'autoHide', 'remeasure']}),
 	Skinnable
 );

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -175,7 +175,7 @@ const ToggleButtonBase = kind({
  */
 const ToggleButton = Pure(
 	Toggleable(
-		{prop: 'selected', toggle: 'onTap'},
+		{prop: 'selected', toggleProp: 'onTap'},
 		Skinnable(
 			ToggleButtonBase
 		)

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -9,11 +9,12 @@
  * @exports ToggleItemDecorator
  */
 
+import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import Pure from '@enact/ui/internal/Pure';
 import React from 'react';
 import PropTypes from 'prop-types';
-import UiToggleItem from '@enact/ui/ToggleItem';
+import {ToggleItemBase as UiToggleItem, ToggleItemDecorator as UiToggleItemDecorator} from '@enact/ui/ToggleItem';
 import Spottable from '@enact/spotlight/Spottable';
 import compose from 'ramda/src/compose';
 
@@ -99,22 +100,44 @@ const ToggleItemBase = kind({
 });
 
 /**
+ * Default config for {@link moonstone/ToggleItem.ToggleItemDecorator}.
+ *
+ * @memberof moonstone/ToggleItem.ToggleItemDecorator
+ * @hocconfig
+ */
+const defaultConfig = {
+	/**
+	 * Invalidate the distance of marquee text if any property (like 'inline') changes.
+	 * Expects an array of props which on change trigger invalidateMetrics.
+	 *
+	 * @type {Array}
+	 * @default ['inline']
+	 * @memberof moonstone/ToggleItem.ToggleItemDecorator.defaultConfig
+	 */
+	invalidateProps: ['inline']
+};
+
+/**
  * Adds interactive functionality to `ToggleItemBase`
  *
  * @class ToggleItemDecorator
  * @memberof moonstone/ToggleItem
+ * @mixes ui/ToggleItem.ToggleItemDecorator
  * @mixes spotlight/Spottable.Spottable
  * @mixes moonstone/Marquee.MarqueeDecorator
  * @mixes moonstone/Skinnable
  * @hoc
  * @public
  */
-const ToggleItemDecorator = compose(
-	Pure,
-	Spottable,
-	MarqueeDecorator({className: componentCss.content, invalidateProps: ['inline', 'autoHide']}),
-	Skinnable
-);
+const ToggleItemDecorator = hoc(defaultConfig, ({invalidateProps}, Wrapped) => {
+	return compose(
+		Pure,
+		UiToggleItemDecorator,
+		Spottable,
+		MarqueeDecorator({className: componentCss.content, invalidateProps}),
+		Skinnable
+	)(Wrapped);
+});
 
 /**
  * A Moonstone-styled item with built-in support for toggling, marqueed text, and `Spotlight` focus.

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -14,8 +14,12 @@ import Pure from '@enact/ui/internal/Pure';
 import React from 'react';
 import PropTypes from 'prop-types';
 import UiToggleItem from '@enact/ui/ToggleItem';
+import Spottable from '@enact/spotlight/Spottable';
+import compose from 'ramda/src/compose';
 
-import SlotItem from '../SlotItem';
+import {MarqueeDecorator} from '../Marquee';
+import Skinnable from '../Skinnable';
+import {SlotItemBase} from '../SlotItem';
 
 import componentCss from './ToggleItem.less';
 
@@ -87,7 +91,7 @@ const ToggleItemBase = kind({
 			<UiToggleItem
 				role="checkbox"
 				{...props}
-				component={SlotItem}
+				component={SlotItemBase}
 				css={props.css}
 			/>
 		);
@@ -99,10 +103,18 @@ const ToggleItemBase = kind({
  *
  * @class ToggleItemDecorator
  * @memberof moonstone/ToggleItem
+ * @mixes spotlight/Spottable.Spottable
+ * @mixes moonstone/Marquee.MarqueeDecorator
+ * @mixes moonstone/Skinnable
  * @hoc
  * @public
  */
-const ToggleItemDecorator = Pure;
+const ToggleItemDecorator = compose(
+	Pure,
+	Spottable,
+	MarqueeDecorator({className: componentCss.content}),
+	Skinnable
+);
 
 /**
  * A Moonstone-styled item with built-in support for toggling, marqueed text, and `Spotlight` focus.

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -112,7 +112,7 @@ const ToggleItemBase = kind({
 const ToggleItemDecorator = compose(
 	Pure,
 	Spottable,
-	MarqueeDecorator({className: componentCss.content}),
+	MarqueeDecorator({className: componentCss.content, invalidateProps: ['inline', 'autoHide']}),
 	Skinnable
 );
 

--- a/packages/moonstone/ToggleItem/ToggleItem.less
+++ b/packages/moonstone/ToggleItem/ToggleItem.less
@@ -1,3 +1,6 @@
 .toggleItem {
-	/* Placeholder for CSS overrides */
+	// Apply to the marquee content area to tell it to expand to the available width of the container
+	.content {
+		flex: 1 1 auto;
+	}
 }

--- a/packages/sampler/stories/moonstone-stories/ToggleButton.js
+++ b/packages/sampler/stories/moonstone-stories/ToggleButton.js
@@ -24,13 +24,13 @@ storiesOf('Moonstone', module)
 		})(() => (
 			<ToggleButton
 				aria-label="toggle button"
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
-				onClick={action('onClick')}
 				backgroundOpacity={nullify(select('backgroundOpacity', prop.backgroundOpacity))}
+				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
 				disabled={boolean('disabled', false)}
+				onToggle={action('onToggle')}
 				small={nullify(boolean('small', false))}
-				toggleOnLabel={text('toggleOnLabel', 'On')}
 				toggleOffLabel={text('toggleOffLabel', 'Off')}
+				toggleOnLabel={text('toggleOnLabel', 'On')}
 			>
 				Missing Toggle Label
 			</ToggleButton>

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [2.0.0-beta.2] - 2018-05-07
 
-### Changed
-
-- `ui/ToggleItem` to to be slottable
-
 ### Fixed
 
 - `ui/Marquee` to always marquee when `marqueeOn` is set to `'render'`

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Changed
+
+- `ui/ToggleItem` to to be slottable
+
 ### Fixed
 
 - `ui/Marquee` to always marquee when `marqueeOn` is set to `'render'`

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Toggleable` to forward events on `acitvate` and `deactivate` instead of firing toggled payload. Use `toggle` to handle toggled payload from the event
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,11 +4,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
-### Changed
-
-- `ui/Toggleable` to forward events on `acitvate` and `deactivate` instead of firing toggled payload. Use `toggle` to handle toggled payload from the event
-## [Unreleased]
-
 ### Added
 
 - `ui/Touchable` support to fire `onTap` when a `click` event occurs
@@ -16,6 +11,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Changed
 
 - `ui/Touchable` custom events `onDown`, `onUp`, `onMove`, and `onTap` to use the event name as the `type` rather than the shorter name (e.g. `onTap` rather than `tap`)
+- `ui/Toggleable` to forward events on `activate` and `deactivate` instead of firing toggled payload. Use `toggle` to handle toggled payload from the event
 
 ## [2.0.0-beta.2] - 2018-05-07
 

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -13,6 +13,7 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
+import {SlotItemDecorator as UiSlotItemDecorator} from '@enact/ui/SlotItem';
 
 import ComponentOverride from '../ComponentOverride';
 import Toggleable from '../Toggleable';
@@ -175,7 +176,7 @@ const ToggleItemBase = kind({
 		slotAfter: iconCreator('after')
 	},
 
-	render: ({component: Component, css, children, onToggle, selected, ...rest}) => {
+	render: ({component: Component, css, children, selected, ...rest}) => {
 		delete rest.iconComponent;
 		delete rest.iconPosition;
 		delete rest.value;
@@ -186,7 +187,6 @@ const ToggleItemBase = kind({
 				{...rest}
 				css={css}
 				aria-checked={selected}
-				onTap={onToggle}
 			>
 				{children}
 			</Component>
@@ -199,6 +199,7 @@ const ToggleItemBase = kind({
  *
  * @class ToggleItemDecorator
  * @memberof ui/ToggleItem
+ * @mixes ui/SlotItem.SlotItemDecorator
  * @mixes ui/Remeasurable.RemeasurableDecorator
  * @mixes ui/Touchable.Touchable
  * @mixes ui/Toggleable.Toggleable
@@ -206,9 +207,10 @@ const ToggleItemBase = kind({
  * @public
  */
 const ToggleItemDecorator = compose(
+	UiSlotItemDecorator, // Slottable
 	RemeasurableDecorator({trigger: 'selected'}),
-	Touchable,
-	Toggleable
+	Toggleable({toggle: 'onTap'}),
+	Touchable
 );
 
 /**

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -13,11 +13,9 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {SlotItemDecorator as UiSlotItemDecorator} from '../SlotItem';
 
 import ComponentOverride from '../ComponentOverride';
 import Toggleable from '../Toggleable';
-import {RemeasurableDecorator} from '../Remeasurable';
 import Touchable from '../Touchable';
 
 import componentCss from './ToggleItem.less';
@@ -199,16 +197,12 @@ const ToggleItemBase = kind({
  *
  * @class ToggleItemDecorator
  * @memberof ui/ToggleItem
- * @mixes ui/SlotItem.SlotItemDecorator
- * @mixes ui/Remeasurable.RemeasurableDecorator
  * @mixes ui/Touchable.Touchable
  * @mixes ui/Toggleable.Toggleable
  * @hoc
  * @public
  */
 const ToggleItemDecorator = compose(
-	UiSlotItemDecorator, // Slottable
-	RemeasurableDecorator({trigger: 'selected'}),
 	Toggleable({toggleProp: 'onTap'}),
 	Touchable
 );

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -13,7 +13,7 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {SlotItemDecorator as UiSlotItemDecorator} from '@enact/ui/SlotItem';
+import {SlotItemDecorator as UiSlotItemDecorator} from '../SlotItem';
 
 import ComponentOverride from '../ComponentOverride';
 import Toggleable from '../Toggleable';

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -209,7 +209,7 @@ const ToggleItemBase = kind({
 const ToggleItemDecorator = compose(
 	UiSlotItemDecorator, // Slottable
 	RemeasurableDecorator({trigger: 'selected'}),
-	Toggleable({toggle: 'onTap'}),
+	Toggleable({toggleProp: 'onTap'}),
 	Touchable
 );
 

--- a/packages/ui/ToggleItem/tests/ToggleItem-specs.js
+++ b/packages/ui/ToggleItem/tests/ToggleItem-specs.js
@@ -22,9 +22,9 @@ describe('ToggleItem Specs', () => {
 	it('should call onToggle, onClick, or both when clicked', function () {
 		const handleToggle = sinon.spy();
 		const subject = mount(
-			<ToggleItemBase component={SlottedItem} onToggle={handleToggle} iconComponent={CustomIcon}>
+			<ToggleItem component={SlottedItem} onToggle={handleToggle} iconComponent={CustomIcon}>
 				Toggle Item
-			</ToggleItemBase>
+			</ToggleItem>
 		);
 
 		tap(subject);

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -177,13 +177,15 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleActivate = this.handle(
 			forProp('disabled', false),
-			this.forwardWithState(activate),
+			forward(activate),
+			this.forwardWithState(toggle),
 			() => this.updateActive(true)
 		)
 
 		handleDeactivate = this.handle(
 			forProp('disabled', false),
-			this.forwardWithState(deactivate),
+			forward(deactivate),
+			this.forwardWithState(toggle),
 			() => this.updateActive(false)
 		)
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -22,8 +22,19 @@ const defaultConfig = {
 	/**
 	 * Configures the event name that activates the component.
 	 *
-	 * Note: When using `activate`/`deactivate` instead of `toggle`, set `toggle` to `null` to
-	 * prevent passing the default `onToggle` prop to the wrapped component.
+	 * Note: When using `activate`/`deactivate`, the event payload will only forward the original
+	 * event and not include toggled `prop` value. Use `toggle` to receive toggled value from the
+	 * event payload.
+	 *
+	 * Example:
+	 * ```
+	 * const ToggleItem = Toggleable({activate: 'onFocus', deactivate: 'onBlur'}, Item);
+	 *
+	 * handleEvent = (ev) => {
+	 * 	// do something with `ev.selected` here
+	 * }
+	 *
+	 * <ToggleItem onToggle={handleEvent}>This is a toggle item</Item>
 	 *
 	 * @type {String}
 	 * @memberof ui/Toggleable.Toggleable.defaultConfig
@@ -33,9 +44,20 @@ const defaultConfig = {
 	/**
 	 * Configures the event name that deactivates the component.
 	 *
-	 * Note: When using `activate`/`deactivate` instead of `toggle`, set `toggle` to `null` to
-	 * prevent passing the default `onToggle` prop to the wrapped component.
+	 * Note: When using `activate`/`deactivate`, the event payload will only forward the original
+	 * event and not include toggled `prop` value. Use `toggle` to receive toggled value from the
+	 * event payload.
 	 *
+	 * Example:
+	 * ```
+	 * const ToggleItem = Toggleable({activate: 'onFocus', deactivate: 'onBlur'}, Item);
+	 *
+	 * handleEvent = (ev) => {
+	 * 	// do something with `ev.selected` here
+	 * }
+	 *
+	 * <ToggleItem onToggle={handleEvent}>This is a toggle item</Item>
+	 * ```
 	 * @type {String}
 	 * @memberof ui/Toggleable.Toggleable.defaultConfig
 	 */
@@ -51,7 +73,11 @@ const defaultConfig = {
 	prop: 'selected',
 
 	/**
-	 * Configures the event name that toggles the component.
+	 * Configures the event name that toggles the component. The payload includes a toggled boolean
+	 * value of `prop`.
+	 *
+	 * Note: The payload will override the original event. If a native event is set, then the native
+	 * event payload will be lost.
 	 *
 	 * @type {String}
 	 * @default 'onToggle'
@@ -73,9 +99,12 @@ const defaultConfig = {
 
 /**
  * {@link ui/Toggleable.Toggleable} is a Higher-order Component that applies a 'Toggleable' behavior
- * to its wrapped component.  Its default event and property can be configured when applied to a component.
+ * to its wrapped component. Its default event and property can be configured when applied to a component.
  *
- * By default, Toggleable applies the `active` property on click events.
+ * Example:
+ * ```
+ * 	const ToggleItem = Toggleable({toggleProp: 'onClick'}, Item);
+ * ```
  *
  * @class Toggleable
  * @memberof ui/Toggleable


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/ToggleItem` forwards custom events (i.e. `{remeasure: true}`) when `onFocus`/`onBlur`. This is due to `moonstone/SlotItem`, a base component for `moonstone/ToggleItem`, being wrapped in `Toggleable` which activates/deactivates `onFocus` and `onBlur` respectively to notify `Remeasurable`. This behavior is not applicable to `moonstone/ToggleItem` as toggled "selected" states do not appear or disappear on focus/blur. Proposing to clean up HOCs in `ToggleItem`.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
