### PR TITLE
ENYO-4747: Fix spotlight handling 5-way events when in pointer mode

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,8 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight/Spottable` to not set its focused state when disabled
-- handling 5-way events after the pointer hides
-
+- `spotlight` handling of 5-way events after the pointer hides
 
 ## [2.0.0-beta.1] - 2018-04-29
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight/Spottable` to not set its focused state when disabled
+- handling 5-way events after the pointer hides
 
 
 ## [2.0.0-beta.1] - 2018-04-29

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -358,11 +358,7 @@ const Spotlight = (function () {
 		const direction = getDirection(keyCode);
 		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
 
-		if (pointerHandled) {
-			return;
-		}
-
-		if (!(direction || isEnter(keyCode))) {
+		if (pointerHandled || !(direction || isEnter(keyCode))) {
 			return;
 		}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -359,7 +359,6 @@ const Spotlight = (function () {
 		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
 
 		if (pointerHandled) {
-			_pointerMoveDuringKeyPress = true;
 			return;
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed case where spotlight focus was erroneously remaining on the incorrect spottable item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Spotlight no longer forces `_pointerMoveDuringKeyPress = true;` when handling pointer events because wheeling isn't necessarily moving.

### Links
[//]: # (Related issues, references)
ENYO-4747

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)