### PR TITLE
ENYO-5089: Check pointer mode before handling key events in Scrollable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -334,7 +334,7 @@ class ScrollableBase extends Component {
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && spotItem) {
+		if (spotItem) {
 			// Should skip scroll by page when spotItem is paging control button of Scrollbar
 			if (!childRef.containerRef.contains(spotItem)) {
 				return;
@@ -389,7 +389,7 @@ class ScrollableBase extends Component {
 
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
-		if ((isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) && !ev.repeat && this.hasFocus()) {
+		if (!Spotlight.getPointerMode() && (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) && !ev.repeat && this.hasFocus()) {
 			this.scrollByPage(ev.keyCode);
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -380,7 +380,7 @@ class ScrollableBaseNative extends Component {
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
-		if (spotItem) {
+		if (!Spotlight.getPointerMode() && spotItem) {
 			// Should skip scroll by page when spotItem is paging control button of Scrollbar
 			if (!childRef.containerRef.contains(spotItem)) {
 				return;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -433,7 +433,7 @@ class ScrollableBaseNative extends Component {
 
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
-		if (!Spotlight.getPointerMode() && (isPageUp(ev.keyCode) || isPageDown(ev.keyCode))) {
+		if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
 			ev.preventDefault();
 			if (!ev.repeat && this.hasFocus()) {
 				this.scrollByPage(ev.keyCode);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -380,7 +380,7 @@ class ScrollableBaseNative extends Component {
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && spotItem) {
+		if (spotItem) {
 			// Should skip scroll by page when spotItem is paging control button of Scrollbar
 			if (!childRef.containerRef.contains(spotItem)) {
 				return;
@@ -434,14 +434,11 @@ class ScrollableBaseNative extends Component {
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
 		if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
+			ev.preventDefault();
 			if (Spotlight.getPointerMode()) {
 				ev.stopPropagation();
-				ev.preventDefault();
-			} else {
-				ev.preventDefault();
-				if (!ev.repeat && this.hasFocus()) {
-					this.scrollByPage(ev.keyCode);
-				}
+			} else if (!ev.repeat && this.hasFocus()) {
+				this.scrollByPage(ev.keyCode);
 			}
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -434,9 +434,14 @@ class ScrollableBaseNative extends Component {
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
 		if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
-			ev.preventDefault();
-			if (!ev.repeat && this.hasFocus()) {
-				this.scrollByPage(ev.keyCode);
+			if (Spotlight.getPointerMode()) {
+				ev.stopPropagation();
+				ev.preventDefault();
+			} else {
+				ev.preventDefault();
+				if (!ev.repeat && this.hasFocus()) {
+					this.scrollByPage(ev.keyCode);
+				}
 			}
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -380,7 +380,7 @@ class ScrollableBaseNative extends Component {
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && spotItem) {
+		if (spotItem) {
 			// Should skip scroll by page when spotItem is paging control button of Scrollbar
 			if (!childRef.containerRef.contains(spotItem)) {
 				return;
@@ -433,7 +433,7 @@ class ScrollableBaseNative extends Component {
 
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
-		if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
+		if (!Spotlight.getPointerMode() && (isPageUp(ev.keyCode) || isPageDown(ev.keyCode))) {
 			ev.preventDefault();
 			if (!ev.repeat && this.hasFocus()) {
 				this.scrollByPage(ev.keyCode);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing a page up/down key in VirtualList with pointer mode, the VirtualList scrolls. It should not do.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I checked pointer mode before handling key events in Scrollable.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

ENYO-5089

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)