### PR TITLE
ENYO-5115: Fix to scroll properly with all enabled items via a page up or down key

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,7 +5,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [unreleased]
 
 ### Fixed
-
+- `moonstone/VirtualList.VirtualList`, and `moonstone/VirtualList.VirtualGridList` to scroll properly with all enabled items via a page up or down key
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,7 +5,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [unreleased]
 
 ### Fixed
-- `moonstone/VirtualList.VirtualList`, and `moonstone/VirtualList.VirtualGridList` to scroll properly with all enabled items via a page up or down key
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` to scroll properly with all enabled items via a page up or down key
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -459,8 +459,8 @@ const VirtualListBaseFactory = (type) => {
 			const
 				{cbScrollTo} = this.props,
 				{firstIndex, numOfItems} = this.uiRef.state,
-				focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute));
-			let indexToScroll = this.getIndexToScroll(direction, focusedIndex);
+				focusedIndex = Number.parseInt(focusedItem.getAttribute(dataIndexAttribute)),
+				indexToScroll = this.getIndexToScroll(direction, focusedIndex);
 
 			if (indexToScroll !== -1) {
 				const

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -313,15 +313,13 @@ const VirtualListBaseFactory = (type) => {
 				{dataSize, isItemDisabled} = this.props,
 				safeIndexFrom = clamp(0, dataSize - 1, indexFrom),
 				safeIndexTo = clamp(-1, dataSize, indexTo),
-				noDisabledItem = (isItemDisabled === isItemDisabledDefault);
+				delta = (indexFrom < indexTo) ? 1 : -1;
 
 			if (indexFrom < 0 && indexTo < 0 || indexFrom >= dataSize && indexTo >= dataSize) {
 				return -1;
-			} else if (noDisabledItem) {
+			} else if (isItemDisabled === isItemDisabledDefault) {
 				return safeIndexFrom;
 			}
-
-			const delta = (indexFrom < indexTo) ? 1 : -1;
 
 			if (safeIndexFrom !== safeIndexTo) {
 				for (let i = safeIndexFrom; i !== safeIndexTo; i += delta) {
@@ -410,8 +408,7 @@ const VirtualListBaseFactory = (type) => {
 				{findSpottableItem} = this,
 				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo,
 				numOfItemsInPage = (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent),
-				isPageDown = (direction === 'down' || direction === 'right') ? 1 : -1,
-				noDisabledItem = (isItemDisabled === isItemDisabledDefault);
+				isPageDown = (direction === 'down' || direction === 'right') ? 1 : -1;
 			let candidateIndex = -1;
 
 			/* First, find a spottable item in this page */
@@ -449,7 +446,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/* For grid lists, find the nearest item from the current item */
 			if (candidateIndex !== -1) {
-				return noDisabledItem ? candidateIndex : this.findNearestSpottableItemInExtent(candidateIndex, this.getExtentIndex(candidateIndex));
+				return (isItemDisabled === isItemDisabledDefault) ? candidateIndex : this.findNearestSpottableItemInExtent(currentIndex, this.getExtentIndex(candidateIndex));
 			} else {
 				return -1;
 			}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -449,11 +449,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/* For grid lists, find the nearest item from the current item */
 			if (candidateIndex !== -1) {
-				if (!noDisabledItem) {
-					return candidateIndex;
-				} else {
-					return this.findNearestSpottableItemInExtent(candidateIndex, this.getExtentIndex(candidateIndex));
-				}
+				return noDisabledItem ? candidateIndex : this.findNearestSpottableItemInExtent(candidateIndex, this.getExtentIndex(candidateIndex));
 			} else {
 				return -1;
 			}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -403,7 +403,7 @@ const VirtualListBaseFactory = (type) => {
 
 		getIndexToScroll = (direction, currentIndex) => {
 			const
-				{dataSize, isItemDisabled, spacing} = this.props,
+				{dataSize, spacing} = this.props,
 				{dimensionToExtent, primary} = this.uiRef,
 				{findSpottableItem} = this,
 				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo,
@@ -413,13 +413,13 @@ const VirtualListBaseFactory = (type) => {
 
 			/* First, find a spottable item in this page */
 			if (isPageDown === 1) { // Page Down
-				if ((lastVisibleIndex - (lastVisibleIndex % dimensionToExtent || dimensionToExtent)) >= currentIndex) {
+				if ((lastVisibleIndex - (lastVisibleIndex % dimensionToExtent)) > currentIndex) { // If a current focused item is in the last visible line.
 					candidateIndex = findSpottableItem(
 						lastVisibleIndex,
 						currentIndex - (currentIndex % dimensionToExtent) + dimensionToExtent - 1
 					);
 				}
-			} else if (firstVisibleIndex + dimensionToExtent <= currentIndex) { // Page Up
+			} else if (firstVisibleIndex + dimensionToExtent <= currentIndex) { // Page Up,  if a current focused item is in the first visible line.
 				candidateIndex = findSpottableItem(
 					firstVisibleIndex,
 					currentIndex - (currentIndex % dimensionToExtent)
@@ -446,7 +446,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/* For grid lists, find the nearest item from the current item */
 			if (candidateIndex !== -1) {
-				return (isItemDisabled === isItemDisabledDefault) ? candidateIndex : this.findNearestSpottableItemInExtent(currentIndex, this.getExtentIndex(candidateIndex));
+				return this.findNearestSpottableItemInExtent(currentIndex, this.getExtentIndex(candidateIndex));
 			} else {
 				return -1;
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If the items from the 2nd to 5th in VirtualList are visible, and the 3rd item get focus, the first item get focus if pressing a page up key. The 2nd item should get focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

There are missing page up/down key requirements in VirtualList if it has all enabled items. So I implemented them as we did with some disabled items.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5115

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)