### PR TITLE
ENYO-5243: Add valid Input props

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,6 +5,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/Input` and `moonstone/ExpandableInput` support for `<input>` props
+
 ### Fixed
 
 - `moonstone/ExpandableItem` and related expandables to deal with disabled items and the `autoClose`, `lockBottom` and `noLockBottom` props

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `moonstone/Input` and `moonstone/ExpandableInput` support for `<input>` props
+- `moonstone/Input` and `moonstone/ExpandableInput` support for forwarding valid `<input>` props to the contained `<input>` node
 
 ### Fixed
 

--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import Pure from '@enact/ui/internal/Pure';
 import Pause from '@enact/spotlight/Pause';
 
-import {calcAriaLabel, Input} from '../Input';
+import {calcAriaLabel, extractInputProps, Input} from '../Input';
 import {Expandable, ExpandableItemBase} from '../ExpandableItem';
 
 import css from './ExpandableInput.less';
@@ -294,6 +294,7 @@ class ExpandableInputBase extends React.Component {
 			...rest
 		} = this.props;
 
+		const inputProps = extractInputProps(rest);
 		delete rest.onChange;
 		delete rest.onInputChange;
 
@@ -312,6 +313,7 @@ class ExpandableInputBase extends React.Component {
 				spotlightDisabled={spotlightDisabled}
 			>
 				<Input
+					{...inputProps}
 					autoFocus
 					className={css.decorator}
 					disabled={disabled}

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -245,7 +245,6 @@ const InputBase = kind({
 		},
 		className: ({focused, invalid, small, styler}) => styler.append({focused, invalid, small}),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
-		inputProps: ({autoComplete, list, maxLength, minLength, pattern, required, size}) => Object.assign({}, {autoComplete, list, maxLength, minLength, pattern, required, size}),
 		invalidTooltip: ({css, invalid, invalidMessage, rtl}) => {
 			if (invalid && invalidMessage) {
 				const direction = rtl ? 'left' : 'right';
@@ -260,7 +259,7 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({css, dir, disabled, iconAfter, iconBefore, inputProps, invalidTooltip, onChange, placeholder, small, type, value, ...rest}) => {
+	render: ({autoComplete, css, dir, disabled, iconAfter, iconBefore, invalidTooltip, list, maxLength, minLength, onChange, pattern, placeholder, required, size, small, type, value, ...rest}) => {
 		delete rest.dismissOnEnter;
 		delete rest.focused;
 		delete rest.invalid;
@@ -271,13 +270,19 @@ const InputBase = kind({
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" small={small}>{iconBefore}</InputDecoratorIcon>
 				<input
-					{...inputProps}
 					aria-disabled={disabled}
+					autoComplete={autoComplete}
 					className={css.input}
 					dir={dir}
 					disabled={disabled}
 					onChange={onChange}
+					list={list}
+					maxLength={maxLength}
+					minLength={minLength}
+					pattern={pattern}
 					placeholder={placeholder}
+					required={required}
+					size={size}
 					type={type}
 					value={value}
 				/>

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -20,18 +20,7 @@ import Tooltip from '../TooltipDecorator/Tooltip';
 import componentCss from './Input.less';
 import InputDecoratorIcon from './InputDecoratorIcon';
 import InputSpotlightDecorator from './InputSpotlightDecorator';
-import {extractInputProps} from './util';
-
-const calcAriaLabel = function (title, type, value = '') {
-	const hint = $L('Input field');
-
-	if (type === 'password' && value) {
-		const character = value.length > 1 ? $L('characters') : $L('character');
-		value = `${value.length} ${character}`;
-	}
-
-	return `${title} ${value} ${hint}`;
-};
+import {calcAriaLabel, extractInputProps} from './util';
 
 /**
  * {@link moonstone/Input.InputBase} is a Moonstone styled input component. It supports start and end
@@ -218,7 +207,6 @@ const InputBase = kind({
 		disabled: false,
 		dismissOnEnter: false,
 		invalid: false,
-		invalidMessage: $L('Please enter a valid value.'),
 		placeholder: '',
 		type: 'text'
 	},
@@ -246,7 +234,7 @@ const InputBase = kind({
 		},
 		className: ({focused, invalid, small, styler}) => styler.append({focused, invalid, small}),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
-		invalidTooltip: ({css, invalid, invalidMessage, rtl}) => {
+		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.'), rtl}) => {
 			if (invalid && invalidMessage) {
 				const direction = rtl ? 'left' : 'right';
 				return (

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -20,6 +20,7 @@ import Tooltip from '../TooltipDecorator/Tooltip';
 import componentCss from './Input.less';
 import InputDecoratorIcon from './InputDecoratorIcon';
 import InputSpotlightDecorator from './InputSpotlightDecorator';
+import {extractInputProps} from './util';
 
 const calcAriaLabel = function (title, type, value = '') {
 	const hint = $L('Input field');
@@ -259,7 +260,8 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({autoComplete, css, dir, disabled, iconAfter, iconBefore, invalidTooltip, list, maxLength, minLength, onChange, pattern, placeholder, required, size, small, type, value, ...rest}) => {
+	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, small, type, value, ...rest}) => {
+		const inputProps = extractInputProps(rest);
 		delete rest.dismissOnEnter;
 		delete rest.focused;
 		delete rest.invalid;
@@ -270,19 +272,13 @@ const InputBase = kind({
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" small={small}>{iconBefore}</InputDecoratorIcon>
 				<input
+					{...inputProps}
 					aria-disabled={disabled}
-					autoComplete={autoComplete}
 					className={css.input}
 					dir={dir}
 					disabled={disabled}
 					onChange={onChange}
-					list={list}
-					maxLength={maxLength}
-					minLength={minLength}
-					pattern={pattern}
 					placeholder={placeholder}
-					required={required}
-					size={size}
 					type={type}
 					value={value}
 				/>
@@ -325,6 +321,7 @@ const Input = Pure(
 export default Input;
 export {
 	calcAriaLabel,
+	extractInputProps,
 	Input,
 	InputBase
 };

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -245,6 +245,7 @@ const InputBase = kind({
 		},
 		className: ({focused, invalid, small, styler}) => styler.append({focused, invalid, small}),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
+		inputProps: ({autoComplete, list, maxLength, minLength, pattern, required, size}) => Object.assign({}, {autoComplete, list, maxLength, minLength, pattern, required, size}),
 		invalidTooltip: ({css, invalid, invalidMessage, rtl}) => {
 			if (invalid && invalidMessage) {
 				const direction = rtl ? 'left' : 'right';
@@ -259,7 +260,7 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, small, type, value, ...rest}) => {
+	render: ({css, dir, disabled, iconAfter, iconBefore, inputProps, invalidTooltip, onChange, placeholder, small, type, value, ...rest}) => {
 		delete rest.dismissOnEnter;
 		delete rest.focused;
 		delete rest.invalid;
@@ -270,6 +271,7 @@ const InputBase = kind({
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" small={small}>{iconBefore}</InputDecoratorIcon>
 				<input
+					{...inputProps}
 					aria-disabled={disabled}
 					className={css.input}
 					dir={dir}

--- a/packages/moonstone/Input/util.js
+++ b/packages/moonstone/Input/util.js
@@ -1,0 +1,27 @@
+const inputPropNames = ['autoComplete', 'list', 'maxLength', 'minLength', 'pattern', 'required', 'size'];
+
+/**
+ * Removes `<input>` related props from `props` and returns them in a new object.
+ * Useful when redirecting `<input>` related props from a non-input root element to the
+ * `<input>` element.
+ *
+ * @method
+ * @memberof moonstone/Input/util
+ * @param   {Object} props  Props object
+ * @returns {Object}        input related props
+ */
+const extractInputProps = function (props) {
+	const inputProps = {};
+	Object.keys(props).forEach(key => {
+		if (inputPropNames.indexOf(key) > -1) {
+			inputProps[key] = props[key];
+			delete props[key];
+		}
+	});
+
+	return inputProps;
+};
+
+export {
+	extractInputProps
+};

--- a/packages/moonstone/Input/util.js
+++ b/packages/moonstone/Input/util.js
@@ -1,21 +1,50 @@
-const inputPropNames = ['autoComplete', 'list', 'maxLength', 'minLength', 'pattern', 'required', 'size'];
+import $L from '../internal/$L';
+
+/**
+ * Determines the `aria-label` for an Input
+ *
+ * @method
+ * @memberof moonstone/Input
+ * @param   {String}  prefix   Text to precede the value in the aria-label
+ * @param   {String}  type     `type` of the Input
+ * @param   {String}  [value]  Current value of the input
+ * @returns {String}           `aria-label` value
+ */
+const calcAriaLabel = function (prefix, type, value = '') {
+	const hint = $L('Input field');
+
+	if (type === 'password' && value) {
+		const character = value.length > 1 ? $L('characters') : $L('character');
+		value = `${value.length} ${character}`;
+	}
+
+	return `${prefix} ${value} ${hint}`;
+};
 
 /**
  * Removes `<input>` related props from `props` and returns them in a new object.
- * Useful when redirecting `<input>` related props from a non-input root element to the
- * `<input>` element.
+ *
+ * Useful when redirecting `<input>` related props from a non-input root element to the `<input>`
+ * element.
  *
  * @method
- * @memberof moonstone/Input/util
+ * @memberof moonstone/Input
  * @param   {Object} props  Props object
  * @returns {Object}        input related props
  */
 const extractInputProps = function (props) {
 	const inputProps = {};
 	Object.keys(props).forEach(key => {
-		if (inputPropNames.indexOf(key) > -1) {
-			inputProps[key] = props[key];
-			delete props[key];
+		switch (key) {
+			case 'autoComplete':
+			case 'list':
+			case 'maxLength':
+			case 'minLength':
+			case 'pattern':
+			case 'required':
+			case 'size':
+				inputProps[key] = props[key];
+				delete props[key];
 		}
 	});
 
@@ -23,5 +52,6 @@ const extractInputProps = function (props) {
 };
 
 export {
+	calcAriaLabel,
 	extractInputProps
 };

--- a/packages/moonstone/Input/util.js
+++ b/packages/moonstone/Input/util.js
@@ -9,6 +9,7 @@ import $L from '../internal/$L';
  * @param   {String}  type     `type` of the Input
  * @param   {String}  [value]  Current value of the input
  * @returns {String}           `aria-label` value
+ * @private
  */
 const calcAriaLabel = function (prefix, type, value = '') {
 	const hint = $L('Input field');
@@ -31,6 +32,7 @@ const calcAriaLabel = function (prefix, type, value = '') {
  * @memberof moonstone/Input
  * @param   {Object} props  Props object
  * @returns {Object}        input related props
+ * @private
  */
 const extractInputProps = function (props) {
 	const inputProps = {};


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added support for `<input>` props `autoComplete, list, maxLength, minLength, pattern, required, size` to `moonstone/Input` and `moonstone/ExpandableInput`


### Links
[//]: # (Related issues, references)
ENYO-5243

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com