### PR TITLE
ENYO-5146: Fix spotlight handling when leaving ExpandableInput

### DIFF
--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -7,7 +7,7 @@
  */
 
 import Changeable from '@enact/ui/Changeable';
-import {forKey, forward, oneOf, preventDefault, stopImmediate} from '@enact/core/handle';
+import {adaptEvent, call, forKey, forward, handle, oneOf, preventDefault, stopImmediate} from '@enact/core/handle';
 import deprecate from '@enact/core/internal/deprecate';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -18,6 +18,24 @@ import {calcAriaLabel, Input} from '../Input';
 import {Expandable, ExpandableItemBase} from '../ExpandableItem';
 
 import css from './ExpandableInput.less';
+
+const handleDeactivate = handle(
+	call('shouldClose'),
+	adaptEvent(
+		() => ({type: 'onClose'}),
+		forward('onClose')
+	)
+);
+
+// Special onKeyDown handle for up and down key events
+const handleUpDown = handle(
+	// prevent InputSpotlightDecorator from attempting to move focus up/down
+	preventDefault,
+	// prevent Spotlight handling up/down since closing the expandable will spot the label
+	stopImmediate,
+	// trigger close to resume spotlight and emit onClose
+	handleDeactivate
+);
 
 /**
  * {@link moonstone/ExpandableInput.ExpandableInputBase} is a stateless component that
@@ -192,6 +210,9 @@ class ExpandableInputBase extends React.Component {
 		if (props.onInputChange) {
 			deprecate({name: 'onInputChange', since: '1.0.0', message: 'Use `onChange` instead', until: '2.0.0'});
 		}
+
+		this.handleUpDown = handleUpDown.bind(this);
+		this.handleDeactivate = handleDeactivate.bind(this);
 	}
 
 	componentWillReceiveProps (nextProps) {
@@ -220,14 +241,6 @@ class ExpandableInputBase extends React.Component {
 		}
 	}
 
-	fireCloseEvent = () => {
-		const {onClose} = this.props;
-
-		if (onClose) {
-			onClose();
-		}
-	}
-
 	resetValue = () => {
 		this.paused.resume();
 		forward('onChange', {
@@ -235,13 +248,13 @@ class ExpandableInputBase extends React.Component {
 		}, this.props);
 	}
 
+	shouldClose () {
+		return this.paused.resume() && !this.pointer;
+	}
+
 	handleInputKeyDown = oneOf(
-		// prevent Enter onKeyPress which would re-open the expandable when the label
-		// receives focus
-		[forKey('enter'), preventDefault],
-		// prevent Spotlight handling up/down since closing the expandable will spot the label
-		[forKey('up'), stopImmediate],
-		[forKey('down'), stopImmediate],
+		[forKey('up'), handleUpDown],
+		[forKey('down'), handleUpDown],
 		[forKey('left'), forward('onSpotlightLeft')],
 		[forKey('right'), forward('onSpotlightRight')],
 		[forKey('cancel'), this.resetValue]
@@ -249,12 +262,6 @@ class ExpandableInputBase extends React.Component {
 
 	handleActivate = () => {
 		this.paused.pause();
-	}
-
-	handleDeactivate = () => {
-		if (this.paused.resume() && !this.pointer) {
-			this.fireCloseEvent();
-		}
 	}
 
 	handleChange = (val) => {

--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -226,6 +226,10 @@ class ExpandableInputBase extends React.Component {
 		this.setState({initialValue});
 	}
 
+	componentWillUnmount () {
+		this.paused.resume();
+	}
+
 	calcAriaLabel () {
 		const {noneText, title, type, value} = this.props;
 		const returnVal = (type === 'password') ? value : (value || noneText);

--- a/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
+++ b/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
@@ -109,13 +109,21 @@ const ExpandableSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const current = Spotlight.getCurrent();
 			if (this.containerNode.contains(current)) {
 				Spotlight.focus(this.containerNode.querySelector('[data-expandable-label]'));
-			} else if (!current) {
-				// when focus is not currently set during close (due to a cancel event or the close
-				// on blur from ExpandableInput), we need to fix the last focused element for the
-				// container tree to be the labeled item so that focus can be restored to it rather
-				// than spotlight getting lost
+			} else {
 				const label = this.containerNode.querySelector('[data-expandable-label]');
 				const containerIds = getContainersForNode(label);
+
+				// when focus is not within the expandable (due to a cancel event or the close
+				// on blur from ExpandableInput, or some quick key presses), we need to fix the last
+				// focused element config so that focus can be restored to the label rather than
+				// spotlight getting lost.
+				//
+				// If there is focus somewhere else, then we only need to fix the nearest container
+				// to be the label. If there isn't focus, we need to update the entire container
+				// tree.
+				if (current) {
+					containerIds.splice(containerIds.length - 1);
+				}
 
 				setContainerLastFocusedElement(label, containerIds);
 			}

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -1,5 +1,5 @@
 import deprecate from '@enact/core/internal/deprecate';
-import {forward, stopImmediate} from '@enact/core/handle';
+import {call, forward, forwardWithPrevent, handle, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
 import {getDirection, Spotlight} from '@enact/spotlight';
@@ -23,6 +23,11 @@ const isSelectionAtLocation = (target, location) => {
 	}
 };
 
+const handleKeyDown = handle(
+	forwardWithPrevent('onKeyDown'),
+	call('onKeyDown')
+);
+
 /**
  * {@link moonstone/Input.InputSpotlightDecorator} is a Higher-order Component that manages the
  * spotlight behavior for an {@link moonstone/Input.Input}
@@ -37,7 +42,6 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 	const forwardBlur = forward('onBlur');
 	const forwardMouseDown = forward('onMouseDown');
 	const forwardFocus = forward('onFocus');
-	const forwardKeyDown = forward('onKeyDown');
 	const forwardKeyUp = forward('onKeyUp');
 
 	return class extends React.Component {
@@ -128,6 +132,7 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			};
 
 			this.paused = new Pause('InputSpotlightDecorator');
+			this.handleKeyDown = handleKeyDown.bind(this);
 
 			if (props.noDecorator) {
 				deprecate({name: 'noDecorator', since: '1.3.0', replacedBy: 'autoFocus'});
@@ -242,7 +247,7 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			}
 		}
 
-		onKeyDown = (ev) => {
+		onKeyDown (ev) {
 			const {currentTarget, keyCode, preventDefault, target} = ev;
 
 			// cache the target if this is the first keyDown event to ensure the component had focus
@@ -296,7 +301,6 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 					stopImmediate(ev);
 				}
 			}
-			forwardKeyDown(ev, this.props);
 		}
 
 		onKeyUp = (ev) => {
@@ -342,7 +346,7 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 					onBlur={this.onBlur}
 					onMouseDown={this.onMouseDown}
 					onFocus={this.onFocus}
-					onKeyDown={this.onKeyDown}
+					onKeyDown={this.handleKeyDown}
 					onKeyUp={this.onKeyUp}
 				/>
 			);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There were several lingering issues with navigating from the `Input` within `ExpandableInput` via 5-way:

* Pressing down would result in the element below `ExpandableInput` receiving focus instead of the label (ENYO-5146)
* Unmounting an `ExpandableInput` while the `Input` has focus would result in the pointer being locked (ENYO-5249)
* Pressing left or right to navigate out of an `ExpandableInput` inside a "last focused" container (such as `moonstone/Panels.Panel`) would correctly navigate but would not update the last focused causing spotlight to land inside the `Input` when the container obtained focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Change `moonstone/Input` to allow consumers to call `ev.preventDefault()` from `onKeyDown` handlers to prevent its default behavior (in this case, calling `Spotlight.move()` on 5-way up and down)
* Add `componentWillUnmount` callback to resume spotlight in `ExpandableInput`
* Refactor logic in `moonstone/ExpandableItem.ExpandableSpotlightDecorator` to fix the last focused element for either the entire tree (when nothing is focused) or just the immediate expandable spotlight container (when something else is focused) to ensure focus restores correctly.

### Additional Considerations

* Also removed the "enter" handler in `ExpandableInput` since the `preventDefault` was now preventing `Input`'s `dismissOnEnter` handling (which was needed) and the "problem" it was avoiding was no longer reproducing (I think because of changes in Input to not blur when `dismissOnEnter` until keyup).

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)