### PR TITLE
PLAT-57884: Limit voice control area when popup is open

### DIFF
--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -517,6 +517,7 @@ class Popup extends React.Component {
 					onShow={this.handlePopupShow}
 					open={this.state.popupOpen}
 					spotlightRestrict="self-only"
+					data-webos-voice-exclusive
 				/>
 			</FloatingLayer>
 		);


### PR DESCRIPTION
In current status, Web Engine search all DOM node when voice control is requested.
But when popup is open, voice control scope has to limited.
Relate to this behavior, data-webos-voice-exclusive attribute is defined.
When  this attribute is exist, web engine will be search for only the node's children.

Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
