### PR TITLE
ENYO-5227: Updated the disabled color of items

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options
+- `disabled` component colors to match the most recent design guidelines (from 30% to 60% opacity)
 
 ## [2.0.0-beta.2] - 2018-05-07
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,7 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options
-- `disabled` component colors to match the most recent design guidelines (from 30% to 60% opacity)
+- `moonstone` component `disabled` colors to match the most recent design guidelines (from 30% to 60% opacity)
 
 ## [2.0.0-beta.2] - 2018-05-07
 

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -30,7 +30,7 @@
 
 // Disabled Opacity
 // ---------------------------------------
-@moon-disabled-opacity: 0.3;
+@moon-disabled-opacity: 0.6;
 @moon-disabled-translucent-opacity: 0.4;
 
 // Spotlight and State

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -28,7 +28,7 @@
 
 // Disabled Opacity
 // ---------------------------------------
-@moon-disabled-opacity: 0.3;
+@moon-disabled-opacity: 0.6;
 @moon-disabled-translucent-opacity: 0.4;
 
 // Spotlight and State


### PR DESCRIPTION
### Issue Resolved / Feature Added
The disabled color seems to have drifted toward more (too) transparent over time.


### Resolution
This corrects the value back to "normal" based on the latest iteration of the design visuals.