### PR TITLE
ENYO-5251: Handle `data-spotlight-container-disabled` prop properly in Scrollable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to ignore any user key events in pointer mode
+- `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` to pass `data-spotlight-container-disabled` prop to their outer DOM element
 - `moonstone/Image` so it automatically swaps the `src` to the appropriate resolution dynamically as the screen resizes
 - `moonstone/Popup` to support all `spotlightRestrict` options
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -96,6 +96,15 @@ class ScrollableBase extends Component {
 		'data-spotlight-container': PropTypes.bool,
 
 		/**
+		 * `false` if the content of the list or the scroller could get focus
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		'data-spotlight-container-disabled': PropTypes.bool,
+
+		/**
 		 * This is passed onto the wrapped component to allow
 		 * it to customize the spotlight container for its use case.
 		 *
@@ -166,6 +175,7 @@ class ScrollableBase extends Component {
 	}
 
 	static defaultProps = {
+		'data-spotlight-container-disabled': false,
 		focusableScrollbar: false
 	}
 
@@ -506,6 +516,7 @@ class ScrollableBase extends Component {
 			{
 				childRenderer,
 				'data-spotlight-container': spotlightContainer,
+				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
 				scrollRightAriaLabel,
 				scrollLeftAriaLabel,
@@ -550,6 +561,7 @@ class ScrollableBase extends Component {
 					<div
 						className={className}
 						data-spotlight-container={spotlightContainer}
+						data-spotlight-container-disabled={spotlightContainerDisabled}
 						data-spotlight-id={spotlightId}
 						ref={initUiContainerRef}
 						style={style}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -76,6 +76,15 @@ class ScrollableBaseNative extends Component {
 		'data-spotlight-container': PropTypes.bool,
 
 		/**
+		 * `false` if the content of the list or the scroller could get focus
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		'data-spotlight-container-disabled': PropTypes.bool,
+
+		/**
 		 * This is passed onto the wrapped component to allow
 		 * it to customize the spotlight container for its use case.
 		 *
@@ -146,6 +155,7 @@ class ScrollableBaseNative extends Component {
 	}
 
 	static defaultProps = {
+		'data-spotlight-container-disabled': false,
 		focusableScrollbar: false
 	}
 
@@ -555,6 +565,7 @@ class ScrollableBaseNative extends Component {
 			{
 				childRenderer,
 				'data-spotlight-container': spotlightContainer,
+				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
 				scrollRightAriaLabel,
 				scrollLeftAriaLabel,
@@ -599,6 +610,7 @@ class ScrollableBaseNative extends Component {
 					<div
 						className={className}
 						data-spotlight-container={spotlightContainer}
+						data-spotlight-container-disabled={spotlightContainerDisabled}
 						data-spotlight-id={spotlightId}
 						ref={initUiContainerRef}
 						style={style}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If `data-spotlight-container-disabled` prop was defined in VirtualList, VirtualList, or Scroller, it was passed to their internal DOM element instead of their outer DOM element.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`data-spotlight-container-disabled` prop is passed to their outer DOM element.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5251

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)