### PR TITLE
ENYO-5252: Add fallback focus attempt on window focus

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,8 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` to always set focus when the window is activated after the window has been previously blurred
-
+- `spotlight` to retry setting focus when the window is activated
 
 ## [2.0.0-beta.2] - 2018-05-07
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to always set focus when the window is activated after the window has been previously blurred
+
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -328,7 +328,11 @@ const Spotlight = (function () {
 			// If the window was previously blurred while in pointer mode, the last active containerId may
 			// not have yet set focus to its spottable elements. For this reason we can't rely on setting focus
 			// to the last focused element of the last active containerId, so we use rootContainerId instead
-			Spotlight.focus(getContainerLastFocusedElement(rootContainerId));
+			if (!Spotlight.focus(getContainerLastFocusedElement(rootContainerId))) {
+				// If the last focused element was previously also disabled (or no longer exists), we
+				// need to set focus somewhere
+				Spotlight.focus();
+			}
 			_spotOnWindowFocus = false;
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
There are edge-cases where spotlight cannot set focus during the window focus event, because the last focused element (prior to the window blurring) is disabled (or perhaps missing).


### Resolution
Allow spotlight to set focus as a failsafe, in case the previously focused element cannot gain focus.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>