### PR TITLE
ENYO-5112: Touchable End Gestures when Blurred

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Touchable` to end gestures when focus is lost
+
 ## [2.0.0-beta.3] - 2018-05-14
 
 ### Changed
@@ -16,9 +22,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Touchable` custom events `onDown`, `onUp`, `onMove`, and `onTap` to use the event name as the `type` rather than the shorter name (e.g. `onTap` rather than `tap`)
 - `ui/Toggleable` to forward events on `activate` and `deactivate` instead of firing toggled payload. Use `toggle` to handle toggled payload from the event.
-
-### Fixed
-- `ui/Touchable` to end gestures when blurred
 
 ## [2.0.0-beta.2] - 2018-05-07
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/Touchable` custom events `onDown`, `onUp`, `onMove`, and `onTap` to use the event name as the `type` rather than the shorter name (e.g. `onTap` rather than `tap`)
 - `ui/Toggleable` to forward events on `activate` and `deactivate` instead of firing toggled payload. Use `toggle` to handle toggled payload from the event
 
+### Fixed
+- `ui/Touchable` to end gestures when blurred
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -527,7 +527,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		onBlur () {
-			return this.endGesture();
+			return this.suspendGesture();
 		}
 
 		enterGesture () {
@@ -548,6 +548,14 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.hold.end();
 			this.flick.end();
 			this.drag.end();
+
+			return true;
+		}
+
+		suspendGesture () {
+			this.hold.suspend();
+			this.flick.suspend();
+			this.drag.suspend();
 
 			return true;
 		}

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -404,7 +404,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 
 			handleClick.bindAs(this, 'handleClick');
 			handleBlur.bindAs(this, 'handleBlur');
-      handleMouseDown.bindAs(this, 'handleMouseDown');
+			handleMouseDown.bindAs(this, 'handleMouseDown');
 			handleMouseEnter.bindAs(this, 'handleMouseEnter');
 			handleMouseMove.bindAs(this, 'handleMouseMove');
 			handleMouseLeave.bindAs(this, 'handleMouseLeave');

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -176,7 +176,8 @@ const handleGlobalMove = handle(
 );
 
 const handleOnBlur = handle(
-	call('onBlur')
+	forward('onBlur'),
+	handleLeave
 );
 
 /**
@@ -522,13 +523,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.hold.move(coords);
 			this.flick.move(coords);
 			this.drag.move(coords);
-
-			return true;
-		}
-
-		onBlur () {
-			this.hold.suspend();
-			this.drag.end();
 
 			return true;
 		}

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -527,7 +527,9 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		onBlur () {
-			return this.suspendGesture();
+			this.hold.suspend();
+
+			return true;
 		}
 
 		enterGesture () {
@@ -548,14 +550,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.hold.end();
 			this.flick.end();
 			this.drag.end();
-
-			return true;
-		}
-
-		suspendGesture () {
-			this.hold.suspend();
-			this.flick.suspend();
-			this.drag.suspend();
 
 			return true;
 		}

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -178,7 +178,7 @@ const handleGlobalMove = handle(
 const handleBlur = handle(
 	forward('onBlur'),
 	call('hasFocus'),
-	call('leaveGesture')
+	call('endGesture')
 );
 
 /**
@@ -539,8 +539,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		leaveGesture () {
-			this.targetHadFocus = false;
-
 			this.drag.leave();
 			this.hold.leave();
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -162,6 +162,10 @@ const handleGlobalMove = handle(
 	call('moveGesture')
 );
 
+const handleOnBlur = handle(
+	call('onBlur')
+);
+
 /**
  * Default config for {@link ui/Touchable.Touchable}.
  *
@@ -392,6 +396,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.handleTouchEnd = handleTouchEnd.bind(this);
 			this.handleGlobalUp = handleGlobalUp.bind(this);
 			this.handleGlobalMove = handleGlobalMove.bind(this);
+			this.handleOnBlur = handleOnBlur.bind(this);
 		}
 
 		componentDidMount () {
@@ -505,6 +510,10 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			return true;
 		}
 
+		onBlur () {
+			return this.endGesture();
+		}
+
 		enterGesture () {
 			this.drag.enter();
 			this.hold.enter();
@@ -558,6 +567,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			props.onMouseMove = this.handleMouseMove;
 			props.onMouseEnter = this.handleMouseEnter;
 			props.onMouseUp = this.handleMouseUp;
+			props.onBlur = this.handleOnBlur;
 
 			if (platform.touch) {
 				props.onTouchStart = this.handleTouchStart;

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -175,9 +175,10 @@ const handleGlobalMove = handle(
 	call('moveGesture')
 );
 
-const handleOnBlur = handle(
+const handleBlur = handle(
 	forward('onBlur'),
-	handleLeave
+	call('hasFocus'),
+	call('leaveGesture')
 );
 
 /**
@@ -390,6 +391,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			});
 
 			this.target = null;
+			this.targetHadFocus = false;
 			this.handle = handle.bind(this);
 			this.drag = new Drag();
 			this.flick = new Flick();
@@ -413,7 +415,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.handleTouchEnd = handleTouchEnd.bind(this);
 			this.handleGlobalUp = handleGlobalUp.bind(this);
 			this.handleGlobalMove = handleGlobalMove.bind(this);
-			this.handleOnBlur = handleOnBlur.bind(this);
+			this.handleBlur = handleBlur.bind(this);
 		}
 
 		componentDidMount () {
@@ -514,6 +516,8 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.flick.begin(flick, props, coords);
 			this.drag.begin(drag, props, coords, this.target);
 
+			this.targetHadFocus = this.target === document.activeElement;
+
 			return true;
 		}
 
@@ -535,6 +539,8 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		leaveGesture () {
+			this.targetHadFocus = false;
+
 			this.drag.leave();
 			this.hold.leave();
 
@@ -542,6 +548,8 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		endGesture () {
+			this.targetHadFocus = false;
+
 			this.hold.end();
 			this.flick.end();
 			this.drag.end();
@@ -558,6 +566,10 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 
 		isPaused () {
 			return this.state.active === States.Paused;
+		}
+
+		hasFocus () {
+			return this.targetHadFocus;
 		}
 
 		hasTouchLeftTarget (ev) {
@@ -586,7 +598,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			props.onMouseMove = this.handleMouseMove;
 			props.onMouseEnter = this.handleMouseEnter;
 			props.onMouseUp = this.handleMouseUp;
-			props.onBlur = this.handleOnBlur;
+			props.onBlur = this.handleBlur;
 
 			if (platform.touch) {
 				props.onTouchStart = this.handleTouchStart;

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -528,6 +528,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 
 		onBlur () {
 			this.hold.suspend();
+			this.drag.end();
 
 			return true;
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add a blur handler to end gestures when the focused component is blurred.


### Links
[//]: # (Related issues, references)
ENYO-5112

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com