### PR TITLE
ENYO-5264: Fix Touchable to only send one tap on emulated mouse click

### DIFF
--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -11,7 +11,7 @@ class ClickAllow {
 
 	shouldAllowTap (ev) {
 		const {type, timeStamp} = ev;
-		return !(type === 'click' && this.lastMouseUpTime === timeStamp);
+		return type === 'click' && this.lastMouseUpTime !== timeStamp;
 	}
 }
 

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -11,6 +11,9 @@ class ClickAllow {
 
 	shouldAllowTap (ev) {
 		const {type, timeStamp} = ev;
+
+		// Allow the custom tap event for a “click” when it’s actually a click and it’s not from the
+		// last mouseup event which would have fired the click for us
 		return type === 'click' && this.lastMouseUpTime !== timeStamp;
 	}
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Selecting a component via 5-way would emit 2 `onTap` events.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Suppress any non-`click` event from emitting an `onTap` event.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)