### PR TITLE
ENYO-5253: Fix Spottable to prevent making component spottable when disabled

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` making a component as spottable when `spotlightDisabled` is set
+
 ## [2.0.0-beta.3] - 2018-05-14
 
 ### Fixed

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -182,13 +182,11 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillReceiveProps (nextProps) {
-			const becomingDisabled = nextProps.disabled && !this.props.disabled;
+			const spottableDisabled = this.isFocused && nextProps.disabled && !this.props.disabled;
 
-			if (!this.state.spottableDisabled && this.isFocused && becomingDisabled) {
-				this.setState({
-					spottableDisabled: true
-				});
-			}
+			this.setState({
+				spottableDisabled
+			});
 		}
 
 		componentDidUpdate (prevProps, prevState) {

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -182,10 +182,12 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillReceiveProps (nextProps) {
-			const spottableDisabled = this.isFocused && nextProps.disabled || nextProps.spotlightDisabled;
+			const becomingDisabled = nextProps.disabled && !this.props.disabled;
 
-			if (!this.state.spottableDisabled && spottableDisabled) {
-				this.setState({spottableDisabled});
+			if (!this.state.spottableDisabled && this.isFocused && becomingDisabled) {
+				this.setState({
+					spottableDisabled: true
+				});
 			}
 		}
 

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -10,6 +10,7 @@ import {forward, forwardWithPrevent, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
 import {getContainersForNode} from '../src/container';
@@ -43,6 +44,8 @@ const isKeyboardAccessible = (node) => {
 		)
 	);
 };
+
+const isSpottable = (props) => !props.disabled && !props.spotlightDisabled;
 
 // Last instance of spottable to be focused
 let lastSelectTarget = null;
@@ -177,21 +180,26 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			this.isHovered = false;
 
 			this.state = {
-				spottableDisabled: false
+				focusedWhenDisabled: false
 			};
 		}
 
+		componentDidMount () {
+			// eslint-disable-next-line react/no-find-dom-node
+			this.node = ReactDOM.findDOMNode(this);
+		}
+
 		componentWillReceiveProps (nextProps) {
-			const spottableDisabled = this.isFocused && nextProps.disabled && !this.props.disabled;
+			const focusedWhenDisabled = this.isFocused && nextProps.disabled && !this.props.disabled;
 
 			this.setState({
-				spottableDisabled
+				focusedWhenDisabled
 			});
 		}
 
 		componentDidUpdate (prevProps, prevState) {
 			// if the component is focused and became disabled
-			if (!prevState.spottableDisabled && this.state.spottableDisabled) {
+			if (!prevState.focusedWhenDisabled && this.state.focusedWhenDisabled) {
 				if (lastSelectTarget === this) {
 					selectCancelled = true;
 					forward('onMouseUp', null, this.props);
@@ -199,12 +207,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			// if the component became enabled, notify spotlight to enable restoring "lost" focus
-			if (
-				(!this.props.disabled && !this.props.spotlightDisabled) && (
-					(prevProps.disabled && !this.props.disabled) ||
-					(prevProps.spotlightDisabled && !this.props.spotlightDisabled)
-				)
-			) {
+			if (isSpottable(this.props) && !isSpottable(prevProps)) {
 				if (Spotlight.getPointerMode()) {
 					if (this.isHovered) {
 						Spotlight.setPointerMode(false);
@@ -278,9 +281,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			return notPrevented && allow;
 		}
 
-		isActionable = (ev, props) => {
-			return !props.disabled && !props.spotlightDisabled;
-		}
+		isActionable = (ev, props) => isSpottable(props)
 
 		handle = handle.bind(this)
 
@@ -305,8 +306,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			if (ev.currentTarget === ev.target) {
 				this.isFocused = false;
 
-				if (this.state.spottableDisabled) {
-					this.setState({spottableDisabled: false});
+				if (this.state.focusedWhenDisabled) {
+					this.setState({focusedWhenDisabled: false});
 				}
 			}
 
@@ -342,8 +343,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		render () {
-			const {disabled, spotlightDisabled, spotlightId, ...rest} = this.props;
-			const spottable = this.state.spottableDisabled || !disabled && !spotlightDisabled;
+			const {disabled, spotlightId, ...rest} = this.props;
+			const spottable = this.state.focusedWhenDisabled || isSpottable(this.props);
 			let tabIndex = rest.tabIndex;
 
 			delete rest.onSpotlightDisappear;
@@ -351,6 +352,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			delete rest.onSpotlightLeft;
 			delete rest.onSpotlightRight;
 			delete rest.onSpotlightUp;
+			delete rest.spotlightDisabled;
 
 			if (tabIndex == null) {
 				tabIndex = -1;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The logic in `componentWillReceiveProps` was incorrectly setting the `spottableDisabled` state to `true` for `spotlightDisabled` components

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Always (correctly) update the value of `spottableDisabled` on prop change so the state is accurate
* Do not consider `spotlightDisabled` in the value of `spottableDisabled` because it is included in the `spottable` determination in `render()`.
* Fixed a regression from #1570 which inadvertently dropped assignment of `this.node`

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)