### PR TITLE
ENYO-5250: ContextualPopupDecorator to not steal focus on close

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/IconButton` to allow external customization of the `Icon` vertical alignment (by setting `line-height`)
+- `moonstone/ContextualPopupDecorator` to not set focus to activator when closing if focus was set elsewhere
 
 ## [2.0.0-beta.3] - 2018-05-14
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -234,7 +234,8 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				arrowPosition: {top: 0, left: 0},
 				containerPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				activator: null
+				activator: null,
+				shouldSpotActivator: true
 			};
 
 			this.overflow = {};
@@ -253,21 +254,26 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillReceiveProps (nextProps) {
+			const current = Spotlight.getCurrent();
+
 			if (this.props.direction !== nextProps.direction) {
 				this.adjustedDirection = nextProps.direction;
 				this.setContainerPosition();
 			}
 
 			if (!this.props.open && nextProps.open) {
-				const activator = Spotlight.getCurrent();
-				this.updateLeaveFor(activator);
+				this.updateLeaveFor(current);
 				this.setState({
-					activator
+					activator: current
 				});
 			} else if (this.props.open && !nextProps.open) {
+
 				this.updateLeaveFor(null);
 				this.setState({
-					activator: null
+					activator: null,
+					// only spot the activator on close if spotlight isn't set or if the current
+					// focus is within the popup
+					shouldSpotActivator: !current || this.containerNode.contains(current)
 				});
 			}
 		}
@@ -280,7 +286,10 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (!this.props.open && prevProps.open) {
 				off('keydown', this.handleKeyDown);
 				off('keyup', this.handleKeyUp);
-				this.spotActivator(prevState.activator);
+
+				if (this.state.shouldSpotActivator) {
+					this.spotActivator(prevState.activator);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ContextualPopupDecorator` was indiscriminately setting focus to its activator on close regardless of where the focus may have been set under the assumption it had captured focus. If an app had programmatically set the focus elsewhere, the focus would be stolen. :sadpanda:

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Since focusing the activator occurs in `componentDidUpdate` (good) but the container has already been unmounted then, I added a new state member, `shouldFocusActivator` which is calculated in `componentWillReceiveProps` to determine the focus behavior after update.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)