### PR TITLE
ENYO-5271: Add debugging utilities to core/handle

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/handle.handle` utility `bindAs` to facilitate debugging and binding handlers to component instances
+
 ## [2.0.0-beta.2] - 2018-05-07
 
 ### Fixed

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -90,11 +90,15 @@ const hasPropsAndContext = (obj) => {
 
 const named = (fn, name) => {
 	if (__DEV__) {
-		Object.defineProperty(fn, 'name', {
-			value: name,
-			writeable: false,
-			enumerable: false
-		});
+		try {
+			Object.defineProperty(fn, 'name', {
+				value: name,
+				writeable: false,
+				enumerable: false
+			});
+		} catch (err) {
+			// unable to set name of function
+		}
 	}
 
 	return fn;

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -33,22 +33,17 @@
  *
  * class MyComponent extends React.Component {
  *   // bind handle() to the instance
- *   handle = handle.bind(this)
+ *   constructor () {
+ *     super();
  *
- *   // then create handlers using the bound function
- *   logEnter = this.handle(
- *     forward('onKeyDown'),  // forwards the event to the function passed in the onKeyDown prop
- *     forKey('enter'),       // if the event.keyCode maps to the enter key, allows event processing to continue
- *     preventDefault,        // calls event.preventDefault() to prevent the `keypress` event
- *     (ev, props) => {       // custom event handler -- in this case, logging some text
- *       // In the bound version, `props` will contain a reference to this.props
- *       // since it doesn't return `true`, no further input functions would be called after this one
- *       console.log('The Enter key was pressed down');
- *     }
- *   )
+ *     // logEnter will be bound to `this` and set as this.handleKeyDown
+ *     logEnter.bindAs(this, 'handleKeyDown');
+ *   }
  *
  *   render () {
- *     // ...
+ *     return (
+ *       <div onKeyDown={this.handleKeyDown} />
+ *     );
  *   }
  * }
  * ```

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -27,6 +27,9 @@
  * `props` and `context`. This allows you to write consistent event handlers for components created
  * either with `kind()` or ES6 classes without worrying about from where the props are sourced.
  *
+ * Handlers can either be bound directly using the native `bind()` method or using the `bindAs()`
+ * utility method that is appended to the handler.
+ *
  * ```
  * import {forKey, forward, handle, preventDefault} from '@enact/core/handle';
  * import React from 'react';
@@ -37,6 +40,11 @@
  *     super();
  *
  *     // logEnter will be bound to `this` and set as this.handleKeyDown
+ *     //
+ *     // Equivalent to the following with the advantage of set the function name to be displayed in
+ *     // development tool call stacks
+ *     //
+ *     //   this.handleKeyDown = logEnter.bind(this)
  *     logEnter.bindAs(this, 'handleKeyDown');
  *   }
  *

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -140,7 +140,7 @@ const handle = function (...handlers) {
 	// context if fn() doesn't have its own `this`.
 	const _outer = this;
 
-	const fn = function (ev, props, context) {
+	const fn = function prepareHandleArgs (ev, props, context) {
 		let caller = null;
 
 		// if handle() was bound to a class, use its props and context. otherwise, we accept
@@ -159,7 +159,7 @@ const handle = function (...handlers) {
 	};
 
 	fn.finally = function (cleanup) {
-		return decorateHandleFunction(function (ev, props, context) {
+		return decorateHandleFunction(function handleWithFinally (ev, props, context) {
 			let result = false;
 
 			if (hasPropsAndContext(this)) {
@@ -232,7 +232,7 @@ const returnsTrue = handle.returnsTrue = function (handler) {
 			handler.apply(this, args);
 
 			return true;
-		}, 'handle.returnsTrue');
+		}, 'returnsTrue');
 	}
 
 	return true;
@@ -319,7 +319,7 @@ const forward = handle.forward = curry(named((name, ev, props) => {
 	}
 
 	return true;
-}, 'handle.forward'));
+}, 'forward'));
 
 /**
  * Calls `event.preventDefault()` and returns `true`.
@@ -373,7 +373,7 @@ const forwardWithPrevent = handle.forwardWithPrevent = curry(named((name, ev, pr
 	forward(name, wrappedEvent, props);
 
 	return !prevented;
-}, 'handle.forwardWithPrevent'));
+}, 'forwardWithPrevent'));
 
 /**
  * Calls `event.stopPropagation()` and returns `true`
@@ -552,7 +552,7 @@ const call = function (method) {
 		}
 
 		return false;
-	}, 'handle.call');
+	}, 'call');
 };
 
 /**
@@ -585,7 +585,7 @@ const call = function (method) {
 const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
 	return named(function (ev, ...args) {
 		return handler.call(this, adapter.call(this, ev, ...args), ...args);
-	}, 'handle.adaptEvent');
+	}, 'adaptEvent');
 });
 
 export default handle;

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -85,6 +85,20 @@ const hasPropsAndContext = (obj) => {
 	return obj && obj.hasOwnProperty && obj.hasOwnProperty('props') && obj.hasOwnProperty('context');
 };
 
+const decorateHandleFunction = (fn) => {
+	fn.named = (name) => {
+		Object.defineProperty(fn, 'name', {
+			value: name,
+			writeable: false,
+			enumerable: false
+		});
+
+		return fn;
+	};
+
+	return fn;
+}
+
 /**
  * Allows generating event handlers by chaining input functions to filter or short-circuit the
  * handling flow. Any input function that returns a falsey value will stop the chain.
@@ -126,7 +140,7 @@ const handle = function (...handlers) {
 	};
 
 	fn.finally = function (cleanup) {
-		return function (ev, props, context) {
+		return decorateHandleFunction(function (ev, props, context) {
 			let result = false;
 
 			if (hasPropsAndContext(this)) {
@@ -141,10 +155,10 @@ const handle = function (...handlers) {
 			}
 
 			return result;
-		};
+		});
 	};
 
-	return fn;
+	return decorateHandleFunction(fn);
 };
 
 /**

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -393,9 +393,9 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 				}
 			}, 400);
 
-      this.clickAllow = new ClickAllow();
+			this.clickAllow = new ClickAllow();
 
-      handleClick.bindAs(this, 'handleClick');
+			handleClick.bindAs(this, 'handleClick');
 			handleMouseDown.bindAs(this, 'handleMouseDown');
 			handleMouseEnter.bindAs(this, 'handleMouseEnter');
 			handleMouseMove.bindAs(this, 'handleMouseMove');

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -63,7 +63,7 @@ const handleDown = handle(
 	adaptEvent(makeTouchableEvent('down'), forwardWithPrevent('onDown')),
 	call('activate'),
 	call('startGesture')
-);
+).named('handleDown');
 
 const handleUp = handle(
 	isEnabled,
@@ -71,7 +71,7 @@ const handleUp = handle(
 	call('isTracking'),
 	adaptEvent(makeTouchableEvent('up'), forwardWithPrevent('onUp')),
 	adaptEvent(makeTouchableEvent('tap'), forward('onTap'))
-).finally(call('deactivate'));
+).finally(call('deactivate')).named('handleUp');
 
 const handleEnter = handle(
 	isEnabled,
@@ -79,7 +79,7 @@ const handleEnter = handle(
 	call('enterGesture'),
 	call('isPaused'),
 	call('activate')
-);
+).named('handleEnter');
 
 const handleLeave = handle(
 	isEnabled,
@@ -88,7 +88,7 @@ const handleLeave = handle(
 		[forProp('noResume', false), call('pause')],
 		[returnsTrue, call('deactivate')]
 	)
-);
+).named('handleLeave');
 
 // Mouse event handlers
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Debugging `core/handle` usage can be frustrating when everything is named `anonymous`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Added some names to internal functions that show up in the call stack
* Added `named()` to handlers to provide a means to name them when dev tools can't figure it out
* Added `bindAs()` to handlers to combine binding and naming when using `core/handle` with ES6 classes
* Adopting naming in `ui/Touchable` which is used everyone and could benefit from the naming the most


Was | Now
-----|-----
![image](https://user-images.githubusercontent.com/788456/40085809-97d8eb48-5850-11e8-99ca-18fb23020310.png) | ![image](https://user-images.githubusercontent.com/788456/40086063-a9a0ac7a-5851-11e8-9244-a22794e2e981.png)

### Additional Considerations

See https://github.com/ariya/phantomjs/issues/14310 for why the `try`/`catch` block exists :( Its `__DEV__` only so a minor inconvenience.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)