### PR TITLE
ENYO-5199: Fix ContextualPopupDecorator to properly stop keydown event propagation

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/IconButton` to allow external customization of the `Icon` vertical alignment (by setting `line-height`)
+- `moonstone/ContextualPopupDecorator` to properly stop propagating keydown event if fired from the popup container
 
 ## [2.0.0-beta.3] - 2018-05-14
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -479,6 +479,8 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				// set the pointer mode to false on keydown
 				Spotlight.setPointerMode(false);
 
+				// we guard against attempting a focus change by verifying the case where a spotlightModal
+				// popup contains no spottable components
 				if (!spotlessSpotlightModal && shouldSpotPopup) {
 					this.spotPopupContent();
 				}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -463,6 +463,7 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forward('onClose')
 		)
 
+		// handle key event from outside (i.e. the activator) to the popup container
 		handleKeyDown = (ev) => {
 			const {spotlightRestrict} = this.props;
 			const current = Spotlight.getCurrent();
@@ -487,9 +488,9 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
+		// handle key event from contextual popup and closes the popup
 		handleContainerKeyDown = (ev) => {
 			// Note: Container will be only rendered if `open`ed, therefore no need to check for `open`
-
 			const direction = getDirection(ev.keyCode);
 
 			if (direction) {

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -485,7 +485,7 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		handleContainreKeyDown = (ev) => {
+		handleContainerKeyDown = (ev) => {
 			// Note: Container will be only rendered if `open`ed, therefore no need to check for `open`
 
 			const direction = getDirection(ev.keyCode);
@@ -552,7 +552,7 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 							className={popupClassName}
 							showCloseButton={showCloseButton}
 							onCloseButtonClick={onClose}
-							onKeyDown={this.handleContainreKeyDown}
+							onKeyDown={this.handleContainerKeyDown}
 							direction={this.state.direction}
 							arrowPosition={this.state.arrowPosition}
 							containerPosition={this.state.containerPosition}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In react 16, [event  bubbling in `Portal`](https://reactjs.org/docs/portals.html#event-bubbling-through-portals) acts the same way as a normal React child, meaning that it will fire up the chain to the parent instead of the root node. This change has affected the event propagation path for `ContextualPopupDecorator` as it tries intercept keydown event to handle popup showing/closing. Since `keydown` event listener was attached to `document`, it no longer correctly stops event propagation. 

### Resolution
Proposed solution suggests to 
1. attach the `onKeyDown` handler directly to the popup container for handling the closing
2. only handle spotlight focus from the activator to the popup container at `document`

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
