### PR TITLE
ENYO-5222: Update doc for disabled prop in Marquee

### DIFF
--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -163,8 +163,10 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			children: PropTypes.node,
 
 			/**
-			 * When `true`, adds the `disabled` element attribute to the marquee. By default, no
-			 * styling is applied to the marquee by the framework.
+			 * Passed through to the wrapped component. Does not affect Marquee behavior except that
+			 * components that are `marqueeOn="focus"` will be treated as if they were
+			 * `marqueeOn="hover"`, to allow disabled (and thuse, unfocusable) components to
+			 * marquee.
 			 *
 			 * @type {Boolean}
 			 * @public

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -163,8 +163,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			children: PropTypes.node,
 
 			/**
-			 * Disables all marquee behavior except when `marqueeOn` is `'hover'` or `'focus'`. Will
-			 * be forwarded onto the wrapped component as well.
+			 * When `true`, adds the `disabled` element attribute to the marquee. By default, no
+			 * styling is applied to the marquee by the framework.
 			 *
 			 * @type {Boolean}
 			 * @public


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This patch corrects the docs for the `disabled` prop in `MarqueeDecorator`.


### Links
[//]: # (Related issues, references)
ENYO-5222

Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)