### PR TITLE
PLAT-52482: Added a `highlighted` prop to ProgressBar

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Button` and `moonstone/IconButton` class name `small` to the list of allowed `css` overrides
+- `moonstone/ProgressBar` prop, `highlighted`, for when the UX needs to call special attention to a progress bar
 
 ### Fixed
 

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -51,6 +51,14 @@ const ProgressBarBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Enable to draw special visual attention to this component.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		highlighted: PropTypes.bool,
+
+		/**
 		 * Sets the orientation of the slider, whether the progress-bar depicts its progress value
 		 * in a left and right orientation or up and down onientation.
 		 * Must be either `'horizontal'` or `'vertical'`.
@@ -112,6 +120,7 @@ const ProgressBarBase = kind({
 	},
 
 	computed: {
+		className: ({highlighted, styler}) => styler.append({highlighted}),
 		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
 	},
 

--- a/packages/moonstone/ProgressBar/ProgressBar.less
+++ b/packages/moonstone/ProgressBar/ProgressBar.less
@@ -23,5 +23,11 @@
 		.load {
 			background-color: @moon-progress-bar-loaded-bg-color;
 		}
+
+		&.highlighted {
+			.fill {
+				background-color: @moon-progress-bar-highlighted-fill-bg-color;
+			}
+		}
 	});
 }

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -171,6 +171,7 @@
 @moon-progress-bar-loaded-bg-color: fade(@moon-text-color, 40%);
 @moon-progress-bar-fill-bg-color: @moon-text-color;
 @moon-progress-bar-tooltip-text-color: @moon-white;
+@moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
 // RadioItem
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -175,6 +175,7 @@
 @moon-progress-bar-loaded-bg-color: rgba(200, 200, 200, 0.5);
 @moon-progress-bar-fill-bg-color: #f5f5f5;
 @moon-progress-bar-tooltip-text-color: @moon-white;
+@moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
 // RadioItem
 // ---------------------------------------

--- a/packages/sampler/stories/moonstone-stories/ProgressBar.js
+++ b/packages/sampler/stories/moonstone-stories/ProgressBar.js
@@ -23,6 +23,7 @@ storiesOf('Moonstone', module)
 				<ProgressBar
 					backgroundProgress={number('backgroundProgress', 0.5, {range: true, min: 0, max: 1, step: 0.01})}
 					disabled={nullify(boolean('disabled', false))}
+					highlighted={nullify(boolean('highlighted', false))}
 					orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 					progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
 					side={nullify(select('side', ['after', 'before', 'left', 'right'], 'before'))}

--- a/packages/sampler/stories/qa-stories/ProgressBar.js
+++ b/packages/sampler/stories/qa-stories/ProgressBar.js
@@ -15,6 +15,7 @@ storiesOf('ProgressBar', module)
 			<ProgressBar
 				backgroundProgress={number('backgroundProgress', 0.5, {range: true, min: 0, max: 1, step: 0.01})}
 				tooltip={boolean('tooltip', false)}
+				highlighted={nullify(boolean('highlighted', false))}
 				progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
 				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
 				disabled={nullify(boolean('disabled', false))}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Apps have no way to customize the color of a ProgressBar. If a ProgressBar is surrounded by other text-based elements, it would either completely blend in, or be mistaken for a simple horizontal line.


### Resolution
Added a new prop to `moonstone/ProgressBar` to allow an app to easily call attention to a ProgressBar, which sets the foreground ("fill" color) to the common spotlight color.