### PR TITLE
ENYO-5255: Handle back key in MediaControls

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Button` and `moonstone/IconButton` class name `small` to the list of allowed `css` overrides
+- `moonstone/VideoPlayer.MediaControls` property `onClose` to handle back key
 
 ### Fixed
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -37,14 +37,15 @@ const forwardToggleMore = forward('onToggleMore');
  * A set of components to control media playback and render additional components in designated
  * areas.
  *
- * @class MediaControls
+ * @class MediaControlsBase
  * @memberof moonstone/VideoPlayer
  * @ui
- * @public
+ * @private
  */
 const MediaControlsBase = kind({
 	name: 'MediaControls',
 
+	// intentionally assigning these props to MediaControls instead of Base (which is private)
 	propTypes: /** @lends moonstone/VideoPlayer.MediaControls.prototype */ {
 		/**
 		 * A string which is sent to the `backward` icon of the player controls. This can be
@@ -286,7 +287,7 @@ const MediaControlsBase = kind({
 		 * When `true`, more components are visible.
 		 *
 		 * @type {Boolean}
-		 * @public
+		 * @private
 		 */
 		showMoreComponents: PropTypes.bool,
 
@@ -424,7 +425,7 @@ const MediaControlsBase = kind({
  * @memberof moonstone/VideoPlayer
  * @mixes ui/Slottable.Slottable
  * @hoc
- * @public
+ * @private
  */
 const MediaControlsDecorator = hoc((config, Wrapped) => {
 	class MediaControlsDecoratorHOC extends React.Component {
@@ -860,15 +861,16 @@ const handleCancel = (ev, {onClose}) => {
 
 /**
  * A set of components to control media playback and render additional components in designated
- * areas. It accetps custom tags `<leftComponents>`, and `<rightComponents>`. Any additional
- * children will be rendered into the "more" controls area. "More" button would appear if any
- * children exist and transitioning will be handle by `MediaControls`.
+ * areas.
  *
+ * `MediaControls` uses [Slottable]{@link ui/Slottable} to accept the custom tags `<leftComponents>`
+ * and `<rightComponents>` to add components to the left and right, respectively, of the media
+ * controls. Any additional children will be rendered into the "more" controls area causing the
+ * "More" button to appear. Showing the additional components is handled by `MediaControls` when the
+ * user taps the "More" button.
  *
  * @class MediaControls
  * @memberof moonstone/VideoPlayer
- * @extends moonstone/VideoPlayer.MediaControlsBase
- * @mixes moonstone/VideoPlayer.MediaControlsDecorator
  * @mixes ui/Cancelable.Cancelable
  * @ui
  * @public

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -1,4 +1,5 @@
 import ApiDecorator from '@enact/core/internal/ApiDecorator';
+import Cancelable from '@enact/ui/Cancelable';
 import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
@@ -356,6 +357,8 @@ const MediaControlsBase = kind({
 	}) => {
 		delete rest.moreButtonCloseLabel;
 		delete rest.moreButtonLabel;
+		delete rest.onClose;
+		delete rest.onCloseMore;
 		delete rest.visible;
 
 		return (
@@ -783,7 +786,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.setState({showMoreComponents: false});
 		}
 
-		toggleMoreComponents () {
+		toggleMoreComponents = () => {
 			this.setState((prevState) => {
 				return {
 					showMoreComponents: !prevState.showMoreComponents
@@ -808,6 +811,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				<Wrapped
 					ref={this.getMediaControls}
 					{...props}
+					onCloseMore={this.toggleMoreComponents}
 					onMoreClick={this.handleMoreClick}
 					onPlayButtonClick={this.handlePlayButtonClick}
 					showMoreComponents={this.state.showMoreComponents}
@@ -819,12 +823,26 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 	return Slottable({slots: ['leftComponents', 'rightComponents']}, MediaControlsDecoratorHOC);
 });
 
+const handleCancel = (ev, {onClose, onCloseMore, visible, showMoreComponents}) => {
+	if (visible) {
+		if (showMoreComponents) {
+			onCloseMore();
+		} else {
+			onClose();
+		}
+	}
+};
+
 const MediaControls = ApiDecorator(
 	{api: [
 		'areMoreComponentsAvailable',
 		'showMoreComponents',
 		'hideMoreComponents'
-	]}, MediaControlsDecorator(MediaControlsBase));
+	]},
+	MediaControlsDecorator(
+		Cancelable({modal: true, onCancel: handleCancel}, MediaControlsBase)
+	)
+);
 
 MediaControls.defaultSlot = 'mediaControlsComponent';
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -411,10 +411,14 @@ const MediaControlsBase = kind({
 });
 
 /**
- * Media Control behaviors
+ * Media control behaviors to apply to [MediaControlsBase]{@link moonstone/VideoPlayer.MediaControlsBase}.
+ * Provides built-in support for showing more components and key handling for basic playback
+ * controls.
  *
  * @class MediaControlsDecorator
  * @memberof moonstone/VideoPlayer
+ * @mixes ui/Slottable.Slottable
+ * @hoc
  * @public
  */
 const MediaControlsDecorator = hoc((config, Wrapped) => {
@@ -852,13 +856,10 @@ const handleCancel = (ev, {onClose}) => {
  * children will be rendered into the "more" controls area. "More" button would appear if any
  * children exist and transitioning will be handle by `MediaControls`.
  *
- * Plus, it handles key events for handling basic playback controls. (e.g. ff/rew/jump forward/jump
- * backward)
  *
  * @class MediaControls
  * @memberof moonstone/VideoPlayer
  * @extends moonstone/VideoPlayer.MediaControlsBase
- * @mixes ui/Slottable.Slottable
  * @mixes moonstone/VideoPlayer.MediaControlsDecorator
  * @mixes ui/Cancelable.Cancelable
  * @ui

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -664,9 +664,11 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 
 				// Readout 'more' or 'back' button explicitly.
 				let selectedButton = Spotlight.getCurrent();
-				if (selectedButton) {
+				if (selectedButton === this.mediaControlsNode.querySelector(`.${css.moreButton}`)) {
 					selectedButton.blur();
 					selectedButton.focus();
+				} else if (!this.state.showMoreComponents) {
+					// if spotlight was not in "back" button, then focus "more" button
 					Spotlight.focus(this.props.moreButtonSpotlightId);
 				}
 			}

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -667,6 +667,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				if (selectedButton) {
 					selectedButton.blur();
 					selectedButton.focus();
+					Spotlight.focus(this.props.moreButtonSpotlightId);
 				}
 			}
 		}

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -798,7 +798,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.setState({showMoreComponents: false});
 		}
 
-		toggleMoreComponents = () => {
+		toggleMoreComponents () {
 			this.setState((prevState) => {
 				return {
 					showMoreComponents: !prevState.showMoreComponents

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1820,19 +1820,22 @@ const VideoPlayerBase = class extends React.Component {
 /**
  * {@link moonstone/VideoPlayer.VideoPlayer} is a standard HTML5 video player for Moonstone. It
  * behaves, responds to, and operates like a standard `<video>` tag in its support for `<source>`s
- * and accepts several additional custom tags like `<infoComponents>`, `<leftComponents>`, and
- * `<rightComponents>`. Any additional children will be rendered into the "more" controls area.
+ * It also accepts custom tags such as `<infoComponents>` for displaying additional information
+ * in the title area and `<MediaControls>` for handling media playback controls and adding more
+ * controls.
  *
  * Example usage:
  * ```
  *	<VideoPlayer title="Hilarious Cat Video" poster="http://my.cat.videos/boots-poster.jpg">
  *		<source src="http://my.cat.videos/boots.mp4" type="video/mp4" />
  *		<infoComponents>A video about my cat Boots, wearing boots.</infoComponents>
- *		<leftComponents><IconButton backgroundOpacity="translucent">star</IconButton></leftComponents>
- *		<rightComponents><IconButton backgroundOpacity="translucent">flag</IconButton></rightComponents>
+ *		<MediaControls>
+ *			<leftComponents><IconButton backgroundOpacity="translucent">star</IconButton></leftComponents>
+ *			<rightComponents><IconButton backgroundOpacity="translucent">flag</IconButton></rightComponents>
  *
- *		<Button backgroundOpacity="translucent">Add To Favorites</Button>
- *		<IconButton backgroundOpacity="translucent">search</IconButton>
+ *			<Button backgroundOpacity="translucent">Add To Favorites</Button>
+ *			<IconButton backgroundOpacity="translucent">search</IconButton>
+ *		</MediaControls>
  *	</VideoPlayer>
  * ```
  *

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1589,6 +1589,11 @@ const VideoPlayerBase = class extends React.Component {
 		});
 	}
 
+	handleMediaControlsClose = (ev) => {
+		this.hideControls();
+		ev.stopPropagation();
+	}
+
 	setPlayerRef = (node) => {
 		// TODO: We've moved SpotlightContainerDecorator up to allow VP to be spottable but also
 		// need a ref to the root node to query for children and set CSS variables.
@@ -1784,7 +1789,7 @@ const VideoPlayerBase = class extends React.Component {
 								component={mediaControlsComponent}
 								mediaDisabled={disabled || this.state.mediaControlsDisabled}
 								onBackwardButtonClick={this.handleRewind}
-								onClose={this.hideControls}
+								onClose={this.handleMediaControlsClose}
 								onFastForward={this.handleFastForward}
 								onForwardButtonClick={this.handleFastForward}
 								onJump={this.handleJump}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1784,6 +1784,7 @@ const VideoPlayerBase = class extends React.Component {
 								component={mediaControlsComponent}
 								mediaDisabled={disabled || this.state.mediaControlsDisabled}
 								onBackwardButtonClick={this.handleRewind}
+								onClose={this.hideControls}
 								onFastForward={this.handleFastForward}
 								onForwardButtonClick={this.handleFastForward}
 								onJump={this.handleJump}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -212,6 +212,7 @@ const VideoPlayerBase = class extends React.Component {
 		 *
 		 * * `mediaDisabled` -
 		 * * `onBackwardButtonClick` - Called when the rewind button is pressed
+		 * * `onClose` - Called when cancel key is pressed when the media controls are visible
 		 * * `onFastForward` - Called when the media is fast forwarded via a key event
 		 * * `onForwardButtonClick` - Called when the fast forward button is pressed
 		 * * `onJump` - Called when the media jumps either forward or backward


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added `onClose` prop to `moonstone/VideoPlayer.MediaControls` and updated `MediaControlsDecorator` to handle back key. 

When the back key is pressed, 
- It should close the media controls, if more components are NOT showing
- It should transition back to playback controls from more components, if more components are showing

Also updated the documentation to reflect recent changes in `VideoPlayer` and `MediaControls`

### Additional Consideration
In cases back keys are handled either by the `MediaControls` or `VideoPlayer`, the event will stop propagating. This was intentional for two reasons:
1. Since the states being managed for two cases are separated in MediaControls and VideoPlayer (i.e. visibility of MediaControls is managed by VideoPlayer and visibility of "more" components are managed by MediaControls), one cancel action can be handled by both components. We can create two separate callback props for each (e.g. `onCloseMore`, `onClose`), but  I wanted to only add one callback function prop for cancel.
2. Apps may add another `Cancelable` wrapped around the video player to hide the video player, and their condition might rely on `MediaControls`'s visibility . By the time `onCancel` event is handled in the wrapper, media controls would be hidden and apps would have no way to know if the back key was fired for hiding media controls or hiding video player. Another way is to add callback prop to `VideoPlayer` which only fires when back key is pressed and media controls aren't visible. This seems a bit out of reach for the general purpose of the video player, but I'm open for discussion.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
