### PR TITLE
ENYO-5273: VideoPlayer show MediaControls on mount

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/IconButton` to allow external customization of the `Icon` vertical alignment (by setting `line-height`)
 - `moonstone/ContextualPopupDecorator` to not set focus to activator when closing if focus was set elsewhere
+- `moonstone/VideoPlayer` to show controls on mount and when playing next preload video
 
 ## [2.0.0-beta.3] - 2018-05-14
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -609,8 +609,7 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (!compareSources(source, nextSource)) {
 			this.firstPlayReadFlag = true;
-			this.setState({currentTime: 0, proportionPlayed: 0, proportionLoaded: 0});
-			this.showControls();
+			this.setState({announce: AnnounceState.READY, currentTime: 0, proportionPlayed: 0, proportionLoaded: 0});
 		}
 	}
 
@@ -664,6 +663,7 @@ const VideoPlayerBase = class extends React.Component {
 		if (!compareSources(source, prevSource)) {
 			const isPreloadedVideo = source && prevPreloadSource && compareSources(source, prevPreloadSource);
 			this.reloadVideo(isPreloadedVideo);
+			this.showControls();
 		}
 
 		this.setFloatingLayerShowing(this.state.mediaControlsVisible || this.state.mediaSliderVisible);

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -579,12 +579,12 @@ const VideoPlayerBase = class extends React.Component {
 			bottomOffsetHeight: 0,
 
 			// Non-standard state computed from properties
-			bottomControlsRendered: true,
-			feedbackIconVisible: true,
-			feedbackVisible: true,
-			mediaControlsVisible: true,
+			bottomControlsRendered: false,
+			feedbackIconVisible: false,
+			feedbackVisible: false,
+			mediaControlsVisible: false,
 			miniFeedbackVisible: false,
-			mediaSliderVisible: true,
+			mediaSliderVisible: false,
 			infoVisible: false,
 			proportionLoaded: 0,
 			proportionPlayed: 0,
@@ -601,8 +601,6 @@ const VideoPlayerBase = class extends React.Component {
 		on('keypress', this.activityDetected);
 		on('keydown', this.handleGlobalKeyDown);
 		this.startDelayedFeedbackHide();
-		this.startDelayedTitleHide();
-		this.startAutoCloseTimeout();
 	}
 
 	componentWillReceiveProps (nextProps) {
@@ -1054,6 +1052,7 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	renderBottomControl = new Job(() => {
+		this.showControls();
 		this.setState({bottomControlsRendered: true});
 	});
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -580,7 +580,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			// Non-standard state computed from properties
 			bottomControlsRendered: false,
-			feedbackIconVisible: false,
+			feedbackIconVisible: true,
 			feedbackVisible: false,
 			mediaControlsVisible: false,
 			miniFeedbackVisible: false,
@@ -609,7 +609,12 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (!compareSources(source, nextSource)) {
 			this.firstPlayReadFlag = true;
-			this.setState({announce: AnnounceState.READY, currentTime: 0, proportionPlayed: 0, proportionLoaded: 0});
+			this.setState({
+				announce: AnnounceState.READY,
+				currentTime: 0,
+				proportionPlayed: 0,
+				proportionLoaded: 0
+			});
 		}
 	}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -579,12 +579,12 @@ const VideoPlayerBase = class extends React.Component {
 			bottomOffsetHeight: 0,
 
 			// Non-standard state computed from properties
-			bottomControlsRendered: false,
+			bottomControlsRendered: true,
 			feedbackIconVisible: true,
-			feedbackVisible: false,
-			mediaControlsVisible: false,
+			feedbackVisible: true,
+			mediaControlsVisible: true,
 			miniFeedbackVisible: false,
-			mediaSliderVisible: false,
+			mediaSliderVisible: true,
 			infoVisible: false,
 			proportionLoaded: 0,
 			proportionPlayed: 0,
@@ -601,6 +601,8 @@ const VideoPlayerBase = class extends React.Component {
 		on('keypress', this.activityDetected);
 		on('keydown', this.handleGlobalKeyDown);
 		this.startDelayedFeedbackHide();
+		this.startDelayedTitleHide();
+		this.startAutoCloseTimeout();
 	}
 
 	componentWillReceiveProps (nextProps) {
@@ -610,6 +612,7 @@ const VideoPlayerBase = class extends React.Component {
 		if (!compareSources(source, nextSource)) {
 			this.firstPlayReadFlag = true;
 			this.setState({currentTime: 0, proportionPlayed: 0, proportionLoaded: 0});
+			this.showControls();
 		}
 	}
 

--- a/packages/sampler/stories/qa-stories/VideoPlayer.js
+++ b/packages/sampler/stories/qa-stories/VideoPlayer.js
@@ -67,9 +67,11 @@ class VideoSourceSwap extends React.Component {
 				{button('Change Preload without changing video', this.nextPreloadVideoKeepVideo)}
 				{button('Reset Sources', this.resetSources)}
 				<VideoPlayer
-					title={this.state.videoTitles[this.state.preloadCursor]}
 					muted
+					onJumpBackward={this.differentVideo}
+					onJumpForward={this.nextVideo}
 					preloadSource={<source src={this.state.playlist[this.state.preloadCursor]} type="video/mp4" />}
+					title={this.state.videoTitles[this.state.cursor]}
 				>
 					<source src={this.state.playlist[this.state.cursor]} type="video/mp4" />
 					<infoComponents>A video about some things happening to and around some characters. Very exciting stuff.</infoComponents>

--- a/packages/sampler/stories/qa-stories/VideoPlayer.js
+++ b/packages/sampler/stories/qa-stories/VideoPlayer.js
@@ -9,6 +9,11 @@ class VideoSourceSwap extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
+			videoTitles: [
+				'Big Buck Bunny',
+				'Sintel',
+				'VideoTest'
+			],
 			playlist: [
 				'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov',
 				'http://media.w3.org/2010/05/sintel/trailer.mp4',
@@ -62,6 +67,7 @@ class VideoSourceSwap extends React.Component {
 				{button('Change Preload without changing video', this.nextPreloadVideoKeepVideo)}
 				{button('Reset Sources', this.resetSources)}
 				<VideoPlayer
+					title={this.state.videoTitles[this.state.preloadCursor]}
 					muted
 					preloadSource={<source src={this.state.playlist[this.state.preloadCursor]} type="video/mp4" />}
 				>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VideoPlayer should show `MediaControls` on mount and also whenever it switches to another video.
Set the default state to show the title and `MediaControls` and show controls if the `source` is changed.


### Links
[//]: # (Related issues, references)
ENYO-5273

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com