### PR TITLE
ENYO-5276: ToggleButton padding fix

### DIFF
--- a/packages/moonstone/ToggleButton/ToggleButton.less
+++ b/packages/moonstone/ToggleButton/ToggleButton.less
@@ -8,7 +8,7 @@
 .toggleButton {
 	text-align: center;
 	position: relative;
-	.padding-start-end(@moon-toggle-button-text-switch-gutter, @moon-toggle-button-text-switch-gutter + @moon-button-h-padding + @moon-toggle-button-switch-width + 2*@moon-toggle-button-switch-border-width);
+	.padding-start-end(auto, @moon-toggle-button-text-switch-gutter + @moon-button-h-padding + @moon-toggle-button-switch-width + 2*@moon-toggle-button-switch-border-width);
 
 	&::after {
 		position: absolute;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Set `ToggleButton` padding start to auto so it'll use the padding from Button.

### Links
[//]: # (Related issues, references)
ENYO-5276

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com