### PR TITLE
PLAT-58301: Fix Touchable runtime error from simulated onMouseUp from Spottable

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+- `ui/Touchable` to guard against null events
+
 ## [2.0.0-beta.3] - 2018-05-14
 
 ### Changed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
 
 ### Fixed
+
 - `ui/Touchable` to guard against null events
 
 ## [2.0.0-beta.3] - 2018-05-14

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -4,7 +4,7 @@ class ClickAllow {
 	}
 
 	setLastMouseUp (ev) {
-		if (ev.type === 'mouseup') {
+		if (ev && ev.type === 'mouseup') {
 			this.lastMouseUpTime = ev.timeStamp;
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
ClickAllow can't handle null events

### Resolution
Add a guard to ClickAllow to handle check if event exists.

### Links
PLAT-58301

Enact-DCO-1.0-Signed-off-by: Derek Tor (derek.tor@lge.com)