### PR TITLE
ENYO-5110: Fix layout of Input and ContextualPopup QA samples

### DIFF
--- a/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
@@ -9,10 +9,12 @@ import {select} from '@storybook/addon-knobs';
 const ContextualButton = ContextualPopupDecorator(Button);
 ContextualButton.displayName = 'ContextualButton';
 
+const buttonMargin = {margin: '12px'};
+
 const renderPopup = () => (
 	<div style={{width: ri.unit(600, 'rem')}}>
-		<Button>First Button</Button>
-		<Button>Hello Spottable Button</Button>
+		<Button style={buttonMargin}>First Button</Button>
+		<Button style={buttonMargin}>Hello Spottable Button</Button>
 	</div>
 );
 

--- a/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
@@ -9,12 +9,12 @@ import {select} from '@storybook/addon-knobs';
 const ContextualButton = ContextualPopupDecorator(Button);
 ContextualButton.displayName = 'ContextualButton';
 
-const buttonMargin = {margin: '12px'};
+const buttonMargin = () => ({margin: ri.unit(12, 'rem')});
 
 const renderPopup = () => (
 	<div style={{width: ri.unit(600, 'rem')}}>
-		<Button style={buttonMargin}>First Button</Button>
-		<Button style={buttonMargin}>Hello Spottable Button</Button>
+		<Button style={buttonMargin()}>First Button</Button>
+		<Button style={buttonMargin()}>Hello Spottable Button</Button>
 	</div>
 );
 

--- a/packages/sampler/stories/qa-stories/Input.js
+++ b/packages/sampler/stories/qa-stories/Input.js
@@ -1,5 +1,6 @@
 import {icons} from '@enact/moonstone/Icon';
 import {Input, InputBase} from '@enact/moonstone/Input';
+import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -7,7 +8,7 @@ import {boolean, select, text} from '@storybook/addon-knobs';
 
 const iconNames = ['', ...Object.keys(icons)];
 
-const divMargin = () => ({margin: '12px'});
+const divMargin = () => ({margin: ri.unit(12, 'rem')});
 
 const inputData = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',

--- a/packages/sampler/stories/qa-stories/Input.js
+++ b/packages/sampler/stories/qa-stories/Input.js
@@ -7,7 +7,7 @@ import {boolean, select, text} from '@storybook/addon-knobs';
 
 const iconNames = ['', ...Object.keys(icons)];
 
-const divMargin = {margin: '12px'};
+const divMargin = () => ({margin: '12px'});
 
 const inputData = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',
@@ -132,7 +132,7 @@ storiesOf('Input', module)
 		'5 way test',
 		() => (
 			<div>
-				<div style={divMargin}>
+				<div style={divMargin()}>
 					<Input
 						autoFocus={boolean('autoFocus')}
 						onChange={action('onChange')}
@@ -156,7 +156,7 @@ storiesOf('Input', module)
 						defaultValue={inputData.initialValue + ' two'}
 					/>
 				</div>
-				<div style={divMargin}>
+				<div style={divMargin()}>
 					<Input
 						autoFocus={boolean('autoFocus')}
 						onChange={action('onChange')}

--- a/packages/sampler/stories/qa-stories/Input.js
+++ b/packages/sampler/stories/qa-stories/Input.js
@@ -7,6 +7,8 @@ import {boolean, select, text} from '@storybook/addon-knobs';
 
 const iconNames = ['', ...Object.keys(icons)];
 
+const divMargin = {margin: '12px'};
+
 const inputData = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',
 	longPlaceHolder : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Placeholder',
@@ -130,7 +132,7 @@ storiesOf('Input', module)
 		'5 way test',
 		() => (
 			<div>
-				<div>
+				<div style={divMargin}>
 					<Input
 						autoFocus={boolean('autoFocus')}
 						onChange={action('onChange')}
@@ -154,7 +156,7 @@ storiesOf('Input', module)
 						defaultValue={inputData.initialValue + ' two'}
 					/>
 				</div>
-				<div>
+				<div style={divMargin}>
 					<Input
 						autoFocus={boolean('autoFocus')}
 						onChange={action('onChange')}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A little bit of margin for some breathing room for QA samplers


### Links
[//]: # (Related issues, references)
ENYO-5110

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
