### PR TITLE
ENYO-5280: Fix MarqueeController incorrectly canceling valid animations

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/IconButton` to allow external customization of the `Icon` vertical alignment (by setting `line-height`)
 - `moonstone/ContextualPopupDecorator` to not set focus to activator when closing if focus was set elsewhere
+- `moonstone/Marquee.MarqueeController` to not cancel valid animations
 - `moonstone/VideoPlayer` feedback and feedback icon to hide properly on play/pause/fast forward/rewind
 - `moonstone/VideoPlayer` to correctly focus to default media controls component
 - `moonstone/VideoPlayer` to show controls on mount and when playing next preload video

--- a/packages/ui/Marquee/MarqueeController.js
+++ b/packages/ui/Marquee/MarqueeController.js
@@ -208,7 +208,9 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{undefined}
 		 */
 		handleCancel = () => {
-			this.cancelJob.start();
+			if (this.anyRunning()) {
+				this.cancelJob.start();
+			}
 		}
 
 		doCancel = () => {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -396,8 +396,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {Boolean} - `true` if a possible marquee condition exists
 		 */
 		shouldStartMarquee () {
-			const {disabled, marqueeOn} = this.props;
-			return (
+			const {disabled, marqueeDisabled, marqueeOn} = this.props;
+			return !marqueeDisabled && (
 				marqueeOn === 'render' ||
 				this.forceRestartMarquee ||
 				!this.sync && (


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

MarqueeController batches up cancel animation requests so that multiple synced marquees don't incur extra work when multiple cancel at the same time. However, if the cancellation was due to a change in prop and the synced marquees should start on render, they will likely be cancelled (when the job timer fires) before they can start (after the `marqueeOnRenderDelay`).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Prevent starting the cancel job if there aren't any marquees running.
* (Incidentally) Avoid trying to start a marquee if `marqueeDisabled`

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)