### PR TITLE
ENYO-5282: Disable MediaSlider if the source is unavailable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ProgressBar` prop, `highlighted`, for when the UX needs to call special attention to a progress bar
 
 ### Changed
+
 - `moonstone/VideoPlayer` to disable media slider when source is unavailable
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Button` and `moonstone/IconButton` class name `small` to the list of allowed `css` overrides
 - `moonstone/ProgressBar` prop, `highlighted`, for when the UX needs to call special attention to a progress bar
 
+### Changed
+- `moonstone/VideoPlayer` to disable media slider when source is unavailable
+
 ### Fixed
 
 - `moonstone/IconButton` to allow external customization of the `Icon` vertical alignment (by setting `line-height`)


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When video loads, `duration`'s default value is `NaN` until it receives the `durationchange` event. It's possible for the user to click on slider while source hasn't been loaded properly (i.e. duration is `NaN`), and video player will throw an error trying to `seek()` to the poistion. 
Proposing to disable MediaSlider when the video source is unavailable.

### Additional Consideration
While adding a check in `seek` function for `isNaN(duration)` is sufficient for the fix, it seemed awkward how the slider can be selected while the source is unavailable. Since this change introduces a UX change, I am open for discussion and won't push too hard on the change if others have concerns with it.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
