### PR TITLE
ENYO-5153: Fix Button's sampler to toggle minWidth correctly

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -49,7 +49,7 @@ const ButtonBase = kind({
 		 * @type {String}
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf(['translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The color of the underline beneath button's content. Used for `IconButton`.
@@ -60,7 +60,7 @@ const ButtonBase = kind({
 		 * @type {String}
 		 * @public
 		 */
-		color: PropTypes.oneOf([null, 'red', 'green', 'yellow', 'blue']),
+		color: PropTypes.oneOf(['red', 'green', 'yellow', 'blue']),
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -86,6 +86,10 @@ const ButtonBase = kind({
 		css: PropTypes.object
 	},
 
+	defaultProps: {
+		backgroundOpacity: 'opaque'
+	},
+
 	styles: {
 		css: componentCss,
 		publicClassNames: ['button', 'bg', 'selected', 'small']

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -42,21 +42,14 @@ const ButtonBase = kind({
 		 * The background-color opacity of this button.
 		 *
 		 * Valid values are:
-		 * * `'opaque'`,
 		 * * `'translucent'`,
 		 * * `'lightTranslucent'`, and
 		 * * `'transparent'`.
 		 *
 		 * @type {String}
-		 * @default 'opaque'
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf([
-			'opaque',
-			'translucent',
-			'lightTranslucent',
-			'transparent'
-		]),
+		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The color of the underline beneath button's content. Used for `IconButton`.
@@ -84,10 +77,6 @@ const ButtonBase = kind({
 		 * @public
 		 */
 		css: PropTypes.object
-	},
-
-	defaultProps: {
-		backgroundOpacity: 'opaque'
 	},
 
 	styles: {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Removed
+
+- `moonstone/Button` and `moonstone/IconButton` allowed value `'opaque'` from prop `backgroundOpacity` which was the default and therefore has the same effect as omitting the prop
+
 ### Fixed
 
 - `moonstone/Scroller` to not cut off expandables when scrollbar appears

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -43,16 +43,14 @@ const IconButtonBase = kind({
 		 * The background-color opacity of this icon button
 		 *
 		 * Valid values are:
-		 * * `'opaque'`,
 		 * * `'translucent'`,
 		 * * `'lightTranslucent'`, and
 		 * * `'transparent'`.
 		 *
 		 * @type {String}
-		 * @default 'opaque'
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The color of the underline beneath the icon.

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -50,7 +50,7 @@ const IconButtonBase = kind({
 		 * @type {String}
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf(['translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The color of the underline beneath the icon.
@@ -61,7 +61,7 @@ const IconButtonBase = kind({
 		 * @type {String}
 		 * @public
 		 */
-		color: PropTypes.oneOf([null, 'red', 'green', 'yellow', 'blue']),
+		color: PropTypes.oneOf(['red', 'green', 'yellow', 'blue']),
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -40,7 +40,7 @@ const ApplicationCloseButton = kind({
 		 * @default 'transparent'
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf(['translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * A function to run when app close button is clicked

--- a/packages/moonstone/Panels/ApplicationCloseButton.js
+++ b/packages/moonstone/Panels/ApplicationCloseButton.js
@@ -33,14 +33,14 @@ const ApplicationCloseButton = kind({
 		'aria-label': PropTypes.string,
 
 		/**
-		 * The background-color opacity of this button; valid values are `'opaque'`, `'translucent'`,
+		 * The background-color opacity of this button; valid values are 'translucent'`,
 		 * `'lightTranslucent'` and `'transparent'`.
 		 *
 		 * @type {String}
 		 * @default 'transparent'
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * A function to run when app close button is clicked

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -69,14 +69,14 @@ const PanelsBase = kind({
 		closeButtonAriaLabel: PropTypes.string,
 
 		/**
-		 * The background-color opacity of the application close button; valid values are `'opaque'`,
+		 * The background-color opacity of the application close button; valid values are
 		 * `'translucent'`, `'lightTranslucent'`, and `'transparent'`.
 		 *
 		 * @type {String}
 		 * @default 'transparent'
 		 * @public
 		 */
-		closeButtonBackgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'lightTranslucent', 'transparent']),
+		closeButtonBackgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * Unique identifier for the Panels instance

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -76,7 +76,7 @@ const PanelsBase = kind({
 		 * @default 'transparent'
 		 * @public
 		 */
-		closeButtonBackgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
+		closeButtonBackgroundOpacity: PropTypes.oneOf(['translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * Unique identifier for the Panels instance

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -30,14 +30,13 @@ const ToggleButtonBase = kind({
 
 	propTypes: /** @lends moonstone/ToggleButton.ToggleButtonBase.prototype */ {
 		/**
-		 * The background-color opacity of this button; valid values are `'opaque'`, `'translucent'`,
-		 * and `'transparent'`.
+		 * The background-color opacity of this button; valid values are `'translucent'`,
+		 * `'lightTranslucent'` and `'transparent'`.
 		 *
 		 * @type {String}
-		 * @default 'opaque'
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf(['opaque', 'translucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The string to be displayed as the main content of the toggle button.
@@ -121,7 +120,6 @@ const ToggleButtonBase = kind({
 	},
 
 	defaultProps: {
-		backgroundOpacity: 'opaque',
 		disabled: false,
 		minWidth: true,
 		selected: false,

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -36,7 +36,7 @@ const ToggleButtonBase = kind({
 		 * @type {String}
 		 * @public
 		 */
-		backgroundOpacity: PropTypes.oneOf([null, 'translucent', 'lightTranslucent', 'transparent']),
+		backgroundOpacity: PropTypes.oneOf(['translucent', 'lightTranslucent', 'transparent']),
 
 		/**
 		 * The string to be displayed as the main content of the toggle button.

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -132,7 +132,7 @@ const MediaControlsBase = kind({
 		 * @default 'blue'
 		 * @public
 		 */
-		moreButtonColor: PropTypes.oneOf([null, 'red', 'green', 'yellow', 'blue']),
+		moreButtonColor: PropTypes.oneOf(['red', 'green', 'yellow', 'blue']),
 
 		/**
 		 * Sets the `disabled` state on the media "more" button.
@@ -463,7 +463,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			 * @see {@link moonstone/IconButton.IconButtonBase.color}
 			 * @public
 			 */
-			moreButtonColor: PropTypes.oneOf([null, 'red', 'green', 'yellow', 'blue']),
+			moreButtonColor: PropTypes.oneOf(['red', 'green', 'yellow', 'blue']),
 
 			/**
 			 * Sets the `disabled` state on the media "more" button.

--- a/packages/sampler/stories/moonstone-stories/Button.js
+++ b/packages/sampler/stories/moonstone-stories/Button.js
@@ -14,7 +14,8 @@ const Config = mergeComponentMetadata('Button', ButtonBase, Button, UIButton, UI
 
 // Set up some defaults for info and knobs
 const prop = {
-	backgroundOpacity: ['opaque', 'translucent', 'lightTranslucent', 'transparent'],
+	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
+	casing: ['preserve', 'sentence', 'word', 'upper'],
 	icons: ['', ...Object.keys(icons)]
 };
 
@@ -28,7 +29,7 @@ storiesOf('Moonstone', module)
 			<Button
 				onClick={action('onClick')}
 				backgroundOpacity={nullify(select('backgroundOpacity', prop.backgroundOpacity))}
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				disabled={boolean('disabled', Config.defaultProps.disabled)}
 				icon={nullify(select('icon', prop.icons, Config.defaultProps.icon))}
 				minWidth={boolean('minWidth', Config.defaultProps.minWidth)}

--- a/packages/sampler/stories/moonstone-stories/Button.js
+++ b/packages/sampler/stories/moonstone-stories/Button.js
@@ -1,4 +1,5 @@
 import Button, {ButtonBase} from '@enact/moonstone/Button';
+import {Button as UIButton, ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -9,11 +10,11 @@ import {withInfo} from '@storybook/addon-info';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 import nullify from '../../src/utils/nullify.js';
 
-const Config = mergeComponentMetadata('Button', ButtonBase, Button);
+const Config = mergeComponentMetadata('Button', ButtonBase, Button, UIButton, UIButtonBase);
 
 // Set up some defaults for info and knobs
 const prop = {
-	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
+	backgroundOpacity: ['opaque', 'translucent', 'lightTranslucent', 'transparent'],
 	icons: ['', ...Object.keys(icons)]
 };
 
@@ -30,7 +31,7 @@ storiesOf('Moonstone', module)
 				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
 				disabled={boolean('disabled', Config.defaultProps.disabled)}
 				icon={nullify(select('icon', prop.icons, Config.defaultProps.icon))}
-				minWidth={nullify(boolean('minWidth', Config.defaultProps.minWidth))}
+				minWidth={boolean('minWidth', Config.defaultProps.minWidth)}
 				selected={nullify(boolean('selected', false))}
 				small={nullify(boolean('small', Config.defaultProps.small))}
 			>

--- a/packages/sampler/stories/moonstone-stories/ToggleButton.js
+++ b/packages/sampler/stories/moonstone-stories/ToggleButton.js
@@ -12,7 +12,8 @@ const Config = mergeComponentMetadata('ToggleButton', ToggleButtonBase, ToggleBu
 
 // Set up some defaults for info and knobs
 const prop = {
-	backgroundOpacity: ['', 'translucent', 'transparent']
+	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
+	casing: ['preserve', 'sentence', 'word', 'upper']
 };
 
 storiesOf('Moonstone', module)
@@ -25,7 +26,7 @@ storiesOf('Moonstone', module)
 			<ToggleButton
 				aria-label="toggle button"
 				backgroundOpacity={nullify(select('backgroundOpacity', prop.backgroundOpacity))}
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				disabled={boolean('disabled', false)}
 				onToggle={action('onToggle')}
 				small={nullify(boolean('small', false))}

--- a/packages/sampler/stories/qa-stories/Button.js
+++ b/packages/sampler/stories/qa-stories/Button.js
@@ -7,7 +7,8 @@ import css from './Button.less';
 
 // Set up some defaults for info and knobs
 const prop = {
-	backgroundOpacity: {'opaque': 'opaque', 'translucent': 'translucent', 'lightTranslucent': 'lightTranslucent', 'transparent': 'transparent'},
+	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
+	casing: ['preserve', 'sentence', 'word', 'upper'],
 	longText:{'Loooooooooooooooooog Button': 'Loooooooooooooooooog Button', 'BUTTON   WITH   EXTRA   SPACES': 'BUTTON   WITH   EXTRA   SPACES'},
 	tallText:{'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  து', 'ÁÉÍÓÚÑÜ': 'ÁÉÍÓÚÑÜ', 'Bản văn': 'Bản văn'}
 };
@@ -17,7 +18,7 @@ storiesOf('Button', module)
 		'with long text',
 		() => (
 			<Button
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing)}
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
@@ -33,7 +34,7 @@ storiesOf('Button', module)
 		'with tall characters',
 		() => (
 			<Button
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
@@ -49,7 +50,7 @@ storiesOf('Button', module)
 		'to validate minWidth with a single character',
 		() => (
 			<Button
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
 				disabled={boolean('disabled')}
@@ -79,7 +80,7 @@ storiesOf('Button', module)
 		() => (
 			<div>
 				<Button
-					casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+					casing={select('casing', prop.casing, 'upper')}
 					className={css.tapArea}
 					onClick={action('onClick')}
 					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
@@ -90,7 +91,7 @@ storiesOf('Button', module)
 					Normal Button
 				</Button>
 				<Button
-					casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+					casing={select('casing', prop.casing, 'upper')}
 					className={css.tapArea}
 					onClick={action('onClick')}
 					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}

--- a/packages/sampler/stories/qa-stories/ToggleButton.js
+++ b/packages/sampler/stories/qa-stories/ToggleButton.js
@@ -6,7 +6,8 @@ import {text, boolean, select} from '@storybook/addon-knobs';
 
 // Set up some defaults for info and knobs
 const prop = {
-	backgroundOpacity: {'opaque': 'opaque', 'translucent': 'translucent', 'transparent': 'transparent'},
+	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
+	casing: ['preserve', 'sentence', 'word', 'upper'],
 	tallText:{'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  து', 'ÁÉÍÓÚÑÜ': 'ÁÉÍÓÚÑÜ', 'Bản văn': 'Bản văn'}
 };
 
@@ -17,7 +18,7 @@ storiesOf('ToggleButton', module)
 			<ToggleButton
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				disabled={boolean('disabled')}
 				small={boolean('small')}
 				toggleOnLabel={text('toggleOnLabel', 'Loooooooooooooooooog On')}
@@ -31,7 +32,7 @@ storiesOf('ToggleButton', module)
 			<ToggleButton
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				casing={select('casing', ['preserve', 'sentence', 'word', 'upper'], 'upper')}
+				casing={select('casing', prop.casing, 'upper')}
 				disabled={boolean('disabled')}
 				small={boolean('small')}
 				toggleOnLabel={select('toggleOnLabel', prop.tallText, 'ิ้  ไั  ஒ  து')}
@@ -39,5 +40,3 @@ storiesOf('ToggleButton', module)
 			/>
 		)
 	);
-
-


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`minWidth` prop's default value is set to `true`, and by `nullifying` the boolean value, it will always set to `true` even if the knob is set to `false`. Fixed by removing `nullifying` in the select knob.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Button's props weren't being properly merged in the info section and made an update to it. It seems like other components that uses `ui` as a base component show similar pattern and we need to update them all.
- Any props that were added by HOCs (e.g. `casing` prop from `i18n/Uppercase`) will not be fetched and need to be set with constants. Should we declare those `propTypes` in the base component or is there a way to fetch them and feed it to `propTables` in the story?

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
