### PR TITLE
ENYO-5237: Add slider role and fix incorrect proptypes in SliderBehaviorDecorator

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` to not cut off expandables when scrollbar appears
+- `moonstone/Slider` to read when focus to knob or change value
 
 ## [2.0.0-beta.4] - 2018-05-21
 
@@ -14,7 +15,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button` and `moonstone/IconButton` class name `small` to the list of allowed `css` overrides
 - `moonstone/ProgressBar` prop `highlighted` for when the UX needs to call special attention to a progress bar
-- `moonstone/Slider` ARIA property `role="slider"`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button` and `moonstone/IconButton` class name `small` to the list of allowed `css` overrides
 - `moonstone/ProgressBar` prop `highlighted` for when the UX needs to call special attention to a progress bar
+- `moonstone/Slider` ARIA property `role="slider"`
 
 ### Fixed
 

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -48,7 +48,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		static displayName = 'SliderBehaviorDecorator'
 
 		static propTypes = {
-			'aria-valuetext': PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+			'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 			max: PropTypes.number,
 			min: PropTypes.number,
 			orientation: PropTypes.string,
@@ -159,6 +159,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			return (
 				<Wrapped
+					role="slider"
 					{...props}
 					active={this.state.active}
 					aria-valuetext={this.getValueText()}


### PR DESCRIPTION
### Issue Resolved / Feature Added
An error message is being output due to incorrect proptypes.
TV don't read a11y because the slider role is missing.

### Resolution
Fixed incorrect proptypes (oneOf compares the values. oneOfType is correct.)
Added role="slider" in Slider component

### Links
ENYO-5237

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)