### PR TITLE
ENYO-5162: Divider now always uses a fixed height

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to read when focus to knob or change value
 - `moonstone/Scroller` to not cut off expandables when scrollbar appears
 - `moonstone/VideoPlayer` to correctly read out when play button is pressed
+- `moonstone/Divider` to always use a fixed height, regardless of locale
 
 ## [2.0.0-beta.4] - 2018-05-21
 

--- a/packages/moonstone/Divider/Divider.less
+++ b/packages/moonstone/Divider/Divider.less
@@ -1,8 +1,8 @@
 // Divider.less
 //
-@import '../styles/variables.less';
-@import '../styles/text.less';
-@import '../styles/skin.less';
+@import "../styles/variables.less";
+@import "../styles/text.less";
+@import "../styles/skin.less";
 
 .divider {
 	.moon-divider-text();
@@ -10,7 +10,7 @@
 	border-bottom: @moon-divider-border-width solid transparent;
 	margin: 0 @moon-spotlight-outset (1.5 * @moon-spotlight-outset) @moon-spotlight-outset;
 	min-height: (1.5 * @moon-spotlight-outset);
-	line-height: 1.6em;
+	line-height: @moon-divider-height;
 
 	&.none {
 		margin-bottom: 0;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -160,7 +160,9 @@
 @moon-button-h-margin: @moon-spotlight-outset;
 
 // Divider
+// ---------------------------------------
 @moon-divider-border-width: 3px;
+@moon-divider-height: 39px;
 
 // Icon Sizes
 // ---------------------------------------


### PR DESCRIPTION
### Issue Resolved / Feature Added
Divider changes in height when switching locales

### Resolution
Set `Divider` to a fixed height that can accommodate even the tallest glyphs in any locale.
