### PR TITLE
ENYO-5299: Forward onDismiss and stop propagation only if defined

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -230,7 +230,7 @@ class FloatingLayerBase extends React.Component {
 
 const handleCancel = handle(
 	// can't use forProp safely since either could be undefined ~= false
-	(ev, {open, noAutoDismiss}) => open && !noAutoDismiss,
+	(ev, {open, noAutoDismiss, onDismiss}) => open && !noAutoDismiss && onDismiss,
 	forwardDismiss,
 	stop
 );


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`FloatingLayer` stops every cancel event even if not handled (see #1666). Changed to forward onDismiss and stop propagation only if it is handled. 

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
