### PR TITLE
ENYO-5151: Adjust Spotlight Partitions/Priorities

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -13,6 +13,10 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 No significant changes.
 
+### Fixed
+
+- `spotlight` to partition and prioritize next spottable elements for more natural 5-way behavior
+
 ## [2.0.0-beta.4] - 2018-05-21
 
 ### Fixed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,16 +6,13 @@ The following is a curated list of changes in the Enact spotlight module, newest
  
 ### Fixed
 
+- `spotlight` to partition and prioritize next spottable elements for more natural 5-way behavior
 - `spotlight` to handle pointer events only when pointer has moved
 - `spotlight` to correctly set the active container id when unable to set focus to a container
 
 ## [2.0.0-beta.5] - 2018-05-29
 
 No significant changes.
-
-### Fixed
-
-- `spotlight` to partition and prioritize next spottable elements for more natural 5-way behavior
 
 ## [2.0.0-beta.4] - 2018-05-21
 

--- a/packages/spotlight/src/navigate.js
+++ b/packages/spotlight/src/navigate.js
@@ -1,9 +1,55 @@
 
-const calcGroupId = (x, y) => y * 3 + x;
 const obliqueMinDistance = 1;
 const obliqueMultiplier = 5;
 const straightMinDistance = 0;
 const straightMultiplier = 1;
+
+const calcGroupId = ({x, y}) => y * 3 + x;
+
+const calcNextGridPosition = (current, next) => {
+	const center = current.center;
+	let x, y;
+
+	if (center.x < next.left) {
+		x = 0;
+	} else if (center.x <= next.right) {
+		x = 1;
+	} else {
+		x = 2;
+	}
+
+	if (center.y < next.top) {
+		y = 0;
+	} else if (center.y <= next.bottom) {
+		y = 1;
+	} else {
+		y = 2;
+	}
+
+	return {x, y};
+};
+
+const calcNextExtendedGridPosition = (current, next) => {
+	let x, y;
+
+	if (current.right <= next.left) {
+		x = 0;
+	} else if (current.left < next.right) {
+		x = 1;
+	} else {
+		x = 2;
+	}
+
+	if (current.bottom <= next.top) {
+		y = 0;
+	} else if (current.top < next.bottom) {
+		y = 1;
+	} else {
+		y = 2;
+	}
+
+	return {x, y};
+};
 
 function prioritize (priorities, targetEdge) {
 	const destGroup = [];
@@ -184,53 +230,18 @@ function navigate (targetRect, direction, rects, config) {
 		rects,
 		targetRect,
 		config.straightOverlapThreshold,
-		(rect, destRect) => {
-			let x, y;
-
-			if (rect.right <= destRect.left) {
-				x = 0;
-			} else if (rect.left < destRect.right) {
-				x = 1;
-			} else {
-				x = 2;
-			}
-
-			if (rect.bottom <= destRect.top) {
-				y = 0;
-			} else if (rect.top < destRect.bottom) {
-				y = 1;
-			} else {
-				y = 2;
-			}
-			return calcGroupId(x, y);
-		}
+		(rect, destRect) => (
+			calcGroupId(
+				direction === 'up' || direction === 'down' ? calcNextExtendedGridPosition(rect, destRect) : calcNextGridPosition(rect, destRect)
+			)
+		)
 	);
 
 	const internalGroups = partition(
 		groups[4],
 		targetRect.center,
 		config.straightOverlapThreshold,
-		(rect, destRect) => {
-			const center = rect.center;
-			let x, y;
-
-			if (center.x < destRect.left) {
-				x = 0;
-			} else if (center.x <= destRect.right) {
-				x = 1;
-			} else {
-				x = 2;
-			}
-
-			if (center.y < destRect.top) {
-				y = 0;
-			} else if (center.y <= destRect.bottom) {
-				y = 1;
-			} else {
-				y = 2;
-			}
-			return calcGroupId(x, y);
-		}
+		(rect, destRect) => calcGroupId(calcNextGridPosition(rect, destRect))
 	);
 
 	let priorities, targetEdge;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Spotlight sometimes fails to select the expected "most natural" spottable element when using 5-way. We adjusted the spotlight partitions and priorities in #1495. That fix appears to be ever-so-slightly heavy-handed in its execution - as there are rare cases where 5-way does not perform as expected after that change.

### Resolution
When pressing a 5-way directional key, spotlight calculates where the "next" element is located on a 9-tile grid location, relative to the currently focused element (top-left, top-center, top-right, middle-left, etc). The correct grid location of "next" (when not an internal group) should be based on an additional factors we aren't taking into consideration at the time - 5-way direction pressed. The "next" element could actually live in multiple grid locations. We are able to isolate and identify which grid location to target based on 5-way direction pressed.

The solution is to revert the original calculation, unless navigating vertically. Spotlight internal group calculations are not relevant or affected by this change.

### Links
Issue caused by #1495 

