### PR TITLE
Update resolution workspaceBounds to window dimensions during Resolut…

### DIFF
--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -76,7 +76,7 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		constructor (props) {
 			super(props);
-			init();
+			init({measurementNode: (typeof window !== 'undefined' && window)});
 			this.state = {
 				resolutionClasses: ''
 			};


### PR DESCRIPTION
…ionDecorator's constructor to fix snapshot sizing.

### Issue Resolved / Feature Added
* In v8 snapshot, the modular level initial workspaceBounds fallback to 1080p. So when the snapshot app loads into the window, it loads as 1080p even on larger/smaller screens.

### Resolution
* Use the `window` node during the `ResolutionDecorator` constructor to update the workspace bounds.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
