### PR TITLE
ENYO-5234: Fix Scroller's logic for calculating focus scrollTop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+- `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 ### Removed

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -158,15 +158,15 @@ class ScrollerBase extends Component {
 				nestedItemTop = this.uiRef.containerRef.scrollTop + (top - containerTop),
 				nestedItemBottom = nestedItemTop + nestedItemHeight;
 
-			if (newItemTop - nestedItemHeight - currentScrollTop > epsilon) {
-				// set scroll position so that the top of the container is at least on the top
-				newScrollTop = newItemTop - nestedItemHeight;
-			} else if (nestedItemBottom - scrollBottom > epsilon) {
+			if (nestedItemBottom - scrollBottom > epsilon) {
 				// Caculate when 5-way focus down past the bottom.
 				newScrollTop += nestedItemBottom - scrollBottom;
 			} else if (nestedItemTop - currentScrollTop < epsilon) {
 				// Caculate when 5-way focus up past the top.
 				newScrollTop += nestedItemTop - currentScrollTop;
+			} else if (newItemTop - nestedItemHeight - currentScrollTop > epsilon) {
+				// set scroll position so that the top of the container is at least on the top
+				newScrollTop = newItemTop - nestedItemHeight;
 			}
 		} else if (itemBottom - scrollBottom > epsilon) {
 			// Caculate when 5-way focus down past the bottom.

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -151,8 +151,8 @@ class ScrollerBase extends Component {
 			}
 		}
 
-		// Calculations for `containerHeight` that are bigger than `clientHeight`
 		if (itemHeight > clientHeight) {
+			// Calculations for `containerHeight` that are bigger than `clientHeight`
 			const
 				{top, height: nestedItemHeight} = focusedItem.getBoundingClientRect(),
 				nestedItemTop = this.uiRef.containerRef.scrollTop + (top - containerTop),
@@ -165,7 +165,7 @@ class ScrollerBase extends Component {
 				// Caculate when 5-way focus up past the top.
 				newScrollTop += nestedItemTop - currentScrollTop;
 			} else if (newItemTop - nestedItemHeight - currentScrollTop > epsilon) {
-				// set scroll position so that the top of the container is at least on the top
+				// set scroll position so that the top of the container is at least on the top as a fallback.
 				newScrollTop = newItemTop - nestedItemHeight;
 			}
 		} else if (itemBottom - scrollBottom > epsilon) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
Scroller would not properly scroll to last focused item while the scroller was still animating.


### Resolution
The logic to calculate scroll top was getting stuck on the first condition, which should be a fall back condition. So we moved it to the bottom so focus will try to focus above or below first then fallback to the top scroll position.



### Links
ENYO-5234


Enact-DCO-1.0-Signed-off-by: Derek Tor (derek.tor@lge.com)
