### PR TITLE
ENYO-5231: Fix scrolling by page down at Scroller bounds

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,15 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
 ## [Unreleased]
 
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
+- `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 ### Removed

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -284,10 +284,10 @@ class ScrollerBase extends Component {
 		return oPoint;
 	}
 
-	scrollToNextPage = ({direction, reverseDirection, focusedItem, containerId}) => {
+	scrollToNextPage = ({direction, reverseDirection, focusedItem, spotlightId}) => {
 		const
 			endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect()),
-			next = getTargetByDirectionFromPosition(reverseDirection, endPoint, containerId);
+			next = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
 
 		if (next === focusedItem) {
 			return false; // Scroll one page with animation


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/Scroller` was not passing a container id to spotlight when attempting to determine the next spottable by position. As a result, spotlight was ignoring the spottables that were out of bounds and selecting a different, in bounds, target.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update `moonstone/Scroller.scrollToNextPage` to access `spotlightId` instead of `containerId` which is the correct object member passed to the function.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)