### PR TITLE
ENYO-5268: Fix MediaControls to only handle directional events when player has focus

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,9 +4,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Added
-
-- `moonstone/VideoPlayer.MediaControls` property `playerNode`
 ### Removed
 
 - `moonstone/IncrementSlider` prop `children` which was no longer supported for setting the tooltip (since 2.0.0-beta.1)
@@ -19,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to not hide title and info section when showing more components
 - `moonstone/VideoPlayer` to select a position in slider to seek in 5-way mode
 - `moonstone/ToggleButton` to have correct padding and orientation for RTL
+- `moonstone/VideoPlayer.MediaControls` to handle left and right key to jump when `moonstone/VideoPlayer` is focused
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VideoPlayer.MediaControls` property `playerNode`
-## [Unreleased]
 
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/VideoPlayer.MediaControls` property `playerNode`
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -27,7 +27,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
 - `moonstone/ToggleButton` padding and orientation for RTL
 - `moonstone/VideoPlayer` to not hide title and info section when showing more components
-- `moonstone/VideoPlayer` to select a position in slider to seek in 5-way 
+- `moonstone/VideoPlayer` to select a position in slider to seek in 5-way mode
 - `moonstone/VideoPlayer` to show thumbnail only when focused on slider
 
 ## [2.0.0-beta.5] - 2018-05-29

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -572,6 +572,14 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			paused: PropTypes.bool,
 
 			/**
+			 * A DOM Node of the player.
+			 *
+			 * @type {Node}
+			 * @public
+			 */
+			playerNode: PropTypes.node,
+
+			/**
 			 * Sets the `disabled` state on the media playback-rate control buttons; the inner pair.
 			 *
 			 * @type {Boolean}
@@ -637,8 +645,8 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				countReactChildren(this.props.rightComponents),
 				countReactChildren(this.props.children)
 			);
-			on('keydown', this.handleKeyDown);
-			on('keyup', this.handleKeyUp);
+			on('keydown', this.handleKeyDown, this.props.playerNode);
+			on('keyup', this.handleKeyUp, this.props.playerNode);
 		}
 
 		componentWillReceiveProps (nextProps) {
@@ -835,6 +843,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			delete props.onPlay;
 			delete props.onRewind;
 			delete props.onToggleMore;
+			delete props.playerNode;
 			delete props.setApiProvider;
 
 			return (

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -572,14 +572,6 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			paused: PropTypes.bool,
 
 			/**
-			 * A DOM Node of the player.
-			 *
-			 * @type {Node}
-			 * @public
-			 */
-			playerNode: PropTypes.node,
-
-			/**
 			 * Sets the `disabled` state on the media playback-rate control buttons; the inner pair.
 			 *
 			 * @type {Boolean}
@@ -645,8 +637,8 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				countReactChildren(this.props.rightComponents),
 				countReactChildren(this.props.children)
 			);
-			on('keydown', this.handleKeyDown, this.props.playerNode);
-			on('keyup', this.handleKeyUp, this.props.playerNode);
+			on('keydown', this.handleKeyDown);
+			on('keyup', this.handleKeyUp);
 		}
 
 		componentWillReceiveProps (nextProps) {
@@ -705,9 +697,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				visible
 			} = this.props;
 
+			const current = Spotlight.getCurrent();
+
 			if (!no5WayJump &&
 					!visible &&
 					!mediaDisabled &&
+					(!current || current.classList.contains(css.controlsHandleAbove)) &&
 					(is('left', ev.keyCode) || is('right', ev.keyCode))) {
 				this.paused.pause();
 				this.startListeningForPulses(ev.keyCode);
@@ -843,7 +838,6 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			delete props.onPlay;
 			delete props.onRewind;
 			delete props.onToggleMore;
-			delete props.playerNode;
 			delete props.setApiProvider;
 
 			return (

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1829,7 +1829,6 @@ const VideoPlayerBase = class extends React.Component {
 								onRewind={this.handleRewind}
 								onToggleMore={this.handleToggleMore}
 								paused={this.state.paused}
-								playerNode={this.player}
 								spotlightDisabled={!this.state.mediaControlsVisible || spotlightDisabled}
 								visible={this.state.mediaControlsVisible}
 							/>

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1829,6 +1829,7 @@ const VideoPlayerBase = class extends React.Component {
 								onRewind={this.handleRewind}
 								onToggleMore={this.handleToggleMore}
 								paused={this.state.paused}
+								playerNode={this.player}
 								spotlightDisabled={!this.state.mediaControlsVisible || spotlightDisabled}
 								visible={this.state.mediaControlsVisible}
 							/>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Attaching key event handlers to `document` for media control is not desirable and we need to confine the scope of handling to the player. 
~Suggest passing down the player node to `MediaControls` and attach key event handlers to it.~
Suggest handling key down event when current focus is in `VideoPlayer` 

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>