### PR TITLE
ENYO-5293: Fix FloatingLayer to render if already opened at mounting time

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/FloatingLayer` to render correctly if already opened at mounting time
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 ### Added
 
-- `ui/FloatingLayerDecorator` imperative API to close all floating layers registered in the same id 
+- `ui/FloatingLayerDecorator` imperative API to close all floating layers registered in the same id
 - `ui/ProgressBar` and `ui/Slider` prop `progressAnchor` to configure from where in the progress bar or slider progress should begin
 - `ui/Slider` prop `progressBarComponent` to support customization of progress bar within a slider
 - `ui/ForwardRef` HOC to adapt `React.forwardRef` to HOC chains


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `FloatingLayer` is `open`ed at mounting time, it does not render correctly. More specifically, the `this.context.getFloatingLayer()` would not be available until it has been mounted, which in turn will fail to create a node to attach to the `floatingLayer` DOM tree.

I believe we haven't run into the issue as rerendering of the parent component usually resolves the problem. (e.g. `View`, animated `Popup`, etc.)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Created a state `nodeRendered` so that `FloatingLayer` only renders the children when it is inserted into DOM tree.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
