### PR TITLE
ENYO-5312: Remove unsupported children prop from IncrementSlider

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- `moonstone/IncrementSlider` prop `children` which was no longer supported for setting the tooltip (since 2.0.0-beta.1)
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 ### Removed

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -104,15 +104,6 @@ const IncrementSliderBase = kind({
 		backgroundProgress: PropTypes.number,
 
 		/**
-		 * The custom value or component for the tooltip. If [tooltip]{@link moonstone/Slider.SliderBase#tooltip},
-		 * is `true`, then it will use built-in tooltip with given a string. If `false`, a custom tooltip
-		 * component, which follows the knob, may be used instead.
-		 *
-		 * @type {String|Node}
-		 */
-		children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-
-		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
 		 * corresponding internal Elements and states of this component.
 		 *
@@ -463,7 +454,6 @@ const IncrementSliderBase = kind({
 	render: ({active,
 		'aria-hidden': ariaHidden,
 		backgroundProgress,
-		children,
 		css,
 		decrementAriaLabel,
 		decrementDisabled,
@@ -538,9 +528,7 @@ const IncrementSliderBase = kind({
 					step={step}
 					tooltip={tooltip}
 					value={value}
-				>
-					{children}
-				</Slider>
+				/>
 				<IncrementSliderButton
 					aria-controls={!decrementDisabled ? id : null}
 					aria-hidden={ariaHidden}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We changed the tooltip approach for slider and progress bar but forgot to remove the `children` prop from `IncrementSlider`. It didn't function so it's only a documentation change.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `children` prop from docs and forwarded to `Slider`

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)