### PR TITLE
ENYO-5314: Fix to not hide title and info when showing more components

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
+- `moonstone/VideoPlayer` to not hide title and info section when showing more components
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1605,7 +1605,7 @@ const VideoPlayerBase = class extends React.Component {
 	)
 
 	handleToggleMore = ({showMoreComponents}) => {
-		if (showMoreComponents) {
+		if (!showMoreComponents) {
 			this.startAutoCloseTimeout();	// Restore the timer since we are leaving "more.
 			// Restore the title-hide now that we're finished with "more".
 			this.startDelayedTitleHide();


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VideoPlayer's title and info section should not hide when more components are shown. Fixed the condition for resetting the timer when showing more state changes.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
