### PR TITLE
ENYO-5315: Fix to show thumbnail only when focused on slider

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
+- `moonstone/VideoPlayer` to show thumbnail only when focused on slider
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -826,8 +826,8 @@ const VideoPlayerBase = class extends React.Component {
 			return {
 				announce,
 				bottomControlsRendered: true,
-				feedbackVisible: true,
 				feedbackIconVisible: true,
+				feedbackVisible: true,
 				mediaControlsVisible: true,
 				mediaSliderVisible: true,
 				miniFeedbackVisible: false,
@@ -849,8 +849,8 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopDelayedTitleHide();
 		this.stopAutoCloseTimeout();
 		this.setState({
-			feedbackVisible: false,
 			feedbackIconVisible: false,
+			feedbackVisible: false,
 			mediaControlsVisible: false,
 			mediaSliderVisible: false,
 			miniFeedbackVisible: false,

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -827,6 +827,7 @@ const VideoPlayerBase = class extends React.Component {
 				announce,
 				bottomControlsRendered: true,
 				feedbackVisible: true,
+				feedbackIconVisible: true,
 				mediaControlsVisible: true,
 				mediaSliderVisible: true,
 				miniFeedbackVisible: false,
@@ -849,6 +850,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopAutoCloseTimeout();
 		this.setState({
 			feedbackVisible: false,
+			feedbackIconVisible: false,
 			mediaControlsVisible: false,
 			mediaSliderVisible: false,
 			miniFeedbackVisible: false,
@@ -1568,6 +1570,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.setState({
 			// If paused is false that means it is playing. We only want to hide on playing.
 			feedbackIconVisible: this.state.paused,
+			feedbackVisible: false,
 			sliderTooltipTime: this.state.currentTime
 		});
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Thumbnail in `MediaSlider` should only appear when it's focused. However, the thumbnail appears even if it's not focused while playing. 

### Resolution
`feedbackVisible` and `feebackIconVisible` states were not properly reset when the slider loses focus. Plus, these states need to be reset when controls appear and disappear.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>