### PR TITLE
ENYO-5313: Fix seeking in 5-way mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
+- `moonstone/VideoPlayer` to select a position in slider to seek in 5-way mode
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
+++ b/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
@@ -192,6 +192,7 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {
 					onBlur={this.handleBlur}
 					onFocus={this.handleFocus}
 					onKeyDown={this.handleKeyDown}
+					onKeyUp={this.handleKeyUp}
 					onMouseOver={this.handleMouseOver}
 					onMouseOut={this.handleMouseOut}
 					onMouseMove={this.handleMouseMove}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Seeking in 5-way select does not work. Fixed by adding back `keyup` handler in `MediaSliderDecorator`.

ref: #1662

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>