### PR TITLE
ENYO-5029: Fix readAlert to subscribe to audio guidance changes

### DIFF
--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact webos module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `webos/speech` method `readAlert` to subscribe to changes in audio guidance to improve speech response time
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 No significant changes.

--- a/packages/webos/speech/readAlert.js
+++ b/packages/webos/speech/readAlert.js
@@ -4,6 +4,51 @@
 import LS2Request from '../LS2Request';
 import {platform} from '../platform';
 
+let audioGuidanceEnabled = null;
+
+const checkAudioGuidance = () => new Promise((resolve, reject) => {
+	if (audioGuidanceEnabled === null) {
+		new LS2Request().send({
+			service: 'luna://com.webos.settingsservice',
+			method: 'getSystemSettings',
+			subscribe: true,
+			parameters: {
+				'keys': ['audioGuidance'],
+				'category': 'option'
+			},
+			onSuccess: function (res) {
+				if (res && res.settings.audioGuidance === 'on') {
+					audioGuidanceEnabled = true;
+					resolve();
+					return;
+				}
+
+				audioGuidanceEnabled = false;
+				reject();
+			},
+			onFailure: function (err) {
+				reject('Failed to get system AudioGuidance settings: ' + JSON.stringify(err));
+			}
+		});
+	} else if (audioGuidanceEnabled) {
+		resolve();
+	} else {
+		reject();
+	}
+});
+
+const readAlertMessage = (string, clear) => () => new Promise((resolve, reject) => {
+	new LS2Request().send({
+		service: 'luna://com.webos.service.tts',
+		method: 'speak',
+		parameters: {'text': string, 'clear': clear},
+		onSuccess: resolve,
+		onFailure: (err) => {
+			reject('Failed to readAlertMessage: ' + JSON.stringify(err));
+		}
+	});
+});
+
 /**
  * Read alert text when accessibility VoiceReadout enabled.
  *
@@ -15,30 +60,13 @@ import {platform} from '../platform';
  */
 const readAlert = (string, clear = true) => {
 	if (platform.tv) {
-		const checkAudioGuidance = (callback) => new LS2Request().send({
-			service: 'luna://com.webos.settingsservice',
-			method: 'getSystemSettings',
-			parameters: {'keys': ['audioGuidance'], 'category': 'option'},
-			onSuccess: function (res) {
-				if (res && res.settings.audioGuidance === 'on') {
-					callback();
+		checkAudioGuidance()
+			.then(readAlertMessage(string, clear))
+			.catch(message => {
+				if (message) {
+					console.error(`Failed to readAlert: ${message}`);
 				}
-			},
-			onFailure: function (err) {
-				console.error('Failed to get system AudioGuidance settings: ' + JSON.stringify(err));
-			}
-		});
-
-		const readAlertMessage = () => new LS2Request().send({
-			service: 'luna://com.webos.service.tts',
-			method: 'speak',
-			parameters: {'text': string, 'clear': clear},
-			onFailure: (err) => {
-				console.error('Failed to readAlertMessage: ' + JSON.stringify(err));
-			}
-		});
-
-		checkAudioGuidance(readAlertMessage);
+			});
 	} else {
 		console.warn('Platform doesn\'t support TTS api.');
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`readAlert` response time suffered because it was checking on the audio guidance state every time.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Subscribe to changes in audio guidance so we can use a module-scoped variable to check state rather than checking settings every time.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)