### PR TITLE
ENYO-5309 - Scroller added spotlightPaging prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [Unreleased]
 
+### Added
+- `moonstone/Scrollable` props `spotlightPaging` to determine how spotlight moves when page up/down are pressed
+
 ### Fixed
 - `moonstone/Scroller` ordering of logic for Scroller focus to check focus possibilities first then go to fallback at the top of the container
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -175,14 +175,14 @@ class ScrollableBase extends Component {
 
 		/**
 		* Sets Spotlight to behave differently on page up/down controls. When set to `scroller`
-		* spotlight will move within the `Scroller`'s larger container. When set to `child` to
-		* spotlight will move within the smaller container the current spotlight is in.
+		* spotlight will move within the `Scroller`'s larger container. When set to `container` to
+		* spotlight will move within the immediate container the current spotlight is in.
 		*
 		* @type {String}
 		* @default 'scroller'
 		* @public
 		*/
-		spotlightPaging: PropTypes.oneOf(['child', 'scroller'])
+		spotlightPaging: PropTypes.oneOf(['container', 'scroller'])
 	}
 
 	static defaultProps = {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -174,11 +174,12 @@ class ScrollableBase extends Component {
 		scrollUpAriaLabel: PropTypes.string,
 
 		/**
-		* Sets Spotlight to lock with either to the scroller container or the current child
-		* spotlight container
+		* Sets Spotlight to behave differently on page up/down controls. When set to `scroller`
+		* spotlight will move within the `Scroller`'s larger container. When set to `child` to
+		* spotlight will move within the smaller container the current spotlight is in.
 		*
 		* @type {String}
-		* @default 'child'
+		* @default 'scroller'
 		* @public
 		*/
 		spotlightPaging: PropTypes.oneOf(['child', 'scroller'])

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -171,12 +171,23 @@ class ScrollableBase extends Component {
 		* @default $L('scroll up')
 		* @public
 		*/
-		scrollUpAriaLabel: PropTypes.string
+		scrollUpAriaLabel: PropTypes.string,
+
+		/**
+		* Sets Spotlight to lock with either to the scroller container or the current child
+		* spotlight container
+		*
+		* @type {String}
+		* @default 'child'
+		* @public
+		*/
+		spotlightPaging: PropTypes.oneOf(['child', 'scroller'])
 	}
 
 	static defaultProps = {
 		'data-spotlight-container-disabled': false,
-		focusableScrollbar: false
+		focusableScrollbar: false,
+		spotlightPaging: 'scroller'
 	}
 
 	constructor (props) {
@@ -351,8 +362,8 @@ class ScrollableBase extends Component {
 			}
 
 			const
+				spotlightId = this.props.spotlightPaging === 'scroller' ? containerRef.dataset.spotlightId : Spotlight.getActiveContainer(),
 				// VirtualList and Scroller have a spotlightId on containerRef
-				spotlightId = containerRef.dataset.spotlightId,
 				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
@@ -530,6 +541,7 @@ class ScrollableBase extends Component {
 			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
 		delete rest.focusableScrollbar;
+		delete rest.spotlightPaging;
 
 		return (
 			<UiScrollableBase

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -151,12 +151,23 @@ class ScrollableBaseNative extends Component {
 		* @default $L('scroll up')
 		* @public
 		*/
-		scrollUpAriaLabel: PropTypes.string
+		scrollUpAriaLabel: PropTypes.string,
+		/**
+		* Sets Spotlight to behave differently on page up/down controls. When set to `scroller`
+		* spotlight will move within the `Scroller`'s larger container. When set to `child` to
+		* spotlight will move within the smaller container the current spotlight is in.
+		*
+		* @type {String}
+		* @default 'scroller'
+		* @public
+		*/
+		spotlightPaging: PropTypes.oneOf(['child', 'scroller'])
 	}
 
 	static defaultProps = {
 		'data-spotlight-container-disabled': false,
-		focusableScrollbar: false
+		focusableScrollbar: false,
+		spotlightPaging: 'scroller'
 	}
 
 	constructor (props) {
@@ -396,7 +407,7 @@ class ScrollableBaseNative extends Component {
 				return;
 			}
 			const
-				spotlightId = containerRef.dataset.spotlightId,
+				spotlightId = this.props.spotlightPaging === 'scroller' ? containerRef.dataset.spotlightId : Spotlight.getActiveContainer(),
 				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = this.uiRef.containerRef.getBoundingClientRect(),
@@ -579,6 +590,7 @@ class ScrollableBaseNative extends Component {
 			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
 		delete rest.focusableScrollbar;
+		delete rest.spotlightPaging;
 
 		return (
 			<UiScrollableBaseNative

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -152,16 +152,17 @@ class ScrollableBaseNative extends Component {
 		* @public
 		*/
 		scrollUpAriaLabel: PropTypes.string,
+
 		/**
 		* Sets Spotlight to behave differently on page up/down controls. When set to `scroller`
 		* spotlight will move within the `Scroller`'s larger container. When set to `child` to
-		* spotlight will move within the smaller container the current spotlight is in.
+		* spotlight will move within the immediate container the current spotlight is in.
 		*
 		* @type {String}
 		* @default 'scroller'
 		* @public
 		*/
-		spotlightPaging: PropTypes.oneOf(['child', 'scroller'])
+		spotlightPaging: PropTypes.oneOf(['container', 'scroller'])
 	}
 
 	static defaultProps = {

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -20,7 +20,7 @@ const
 	prop = {
 		direction: ['both', 'horizontal', 'vertical'],
 		horizontalScrollbar: ['auto', 'hidden', 'visible'],
-		spotlightPaging: ['child', 'scroller']
+		spotlightPaging: ['container', 'scroller']
 	};
 
 storiesOf('Scroller', module)
@@ -42,7 +42,7 @@ storiesOf('Scroller', module)
 		() => (
 			<Scroller
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
-				spotlightPaging={select('spotlightPaging', prop.spotlightPaging, 'child')}
+				spotlightPaging={select('spotlightPaging', prop.spotlightPaging, 'container')}
 				style={{height: ri.unit(600, 'rem')}}
 			>
 				<ExpandableList

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -19,7 +19,8 @@ for (let i = 0; i < 100; i++) {
 const
 	prop = {
 		direction: ['both', 'horizontal', 'vertical'],
-		horizontalScrollbar: ['auto', 'hidden', 'visible']
+		horizontalScrollbar: ['auto', 'hidden', 'visible'],
+		spotlightPaging: ['child', 'scroller']
 	};
 
 storiesOf('Scroller', module)
@@ -41,6 +42,7 @@ storiesOf('Scroller', module)
 		() => (
 			<Scroller
 				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				spotlightPaging={select('spotlightPaging', prop.spotlightPaging, 'child')}
 				style={{height: ri.unit(600, 'rem')}}
 			>
 				<ExpandableList


### PR DESCRIPTION
### Issue Resolved / Feature Added
ExpandableList inside of a scroller has incorrect spotlight focus when paging up/down.


### Resolution
Added `spotlightPaging` prop to allow the app developer to choose how they want to handle paging. When set to the default of `scroller` it will work the way it currently works, but if set to `container` it will only spot within the container that the spotlight is currently in.

### Links
ENYO-5309

Enact-DCO-1.0-Signed-off-by: Derek Tor (derek.tor@lge.com)
