### PR TITLE
ENYO-5320: Add bad image source for testing placeholder

### DIFF
--- a/packages/sampler/stories/moonstone-stories/MediaOverlay.js
+++ b/packages/sampler/stories/moonstone-stories/MediaOverlay.js
@@ -25,7 +25,8 @@ const prop = {
 		'': 'None',
 		'https://picsum.photos/1280/720?image=1080': 'Strawberries',
 		'https://picsum.photos/1280/720?image=1063': 'Tunnel',
-		'https://picsum.photos/1280/720?image=930': 'Mountains'
+		'https://picsum.photos/1280/720?image=930': 'Mountains',
+		'imagenotfound.png': 'Bad Image Source'
 	},
 	text: [
 		'',


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's no proper way to see placeholder in `MediaOverlay` sampler. Resolved by adding bad image source in one of the options in `imageOverlay` knob

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>