### PR TITLE
PLAT-60211: Fixed qa-sampler slider runtime error

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -8,6 +8,11 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 - `smartSelect` knob in `src/utils` to incorporate several useful features into a simple knob-creation interface. It can automatically gather the default value and label it in the selection knob.
 
+
+### Fixed
+
+- `Slider` sample in `src/qa-stories` to deprecate `data` prop in VirtualList.
+
 ## [2.0.0-beta.5] - 2018-05-29
 
 No significant changes.

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 - `smartSelect` knob in `src/utils` to incorporate several useful features into a simple knob-creation interface. It can automatically gather the default value and label it in the selection knob.
 
-
 ### Fixed
 
 - `Slider` sample in `src/qa-stories` to deprecate `data` prop in VirtualList.

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 ### Fixed
 
-- `Slider` sample in `src/qa-stories` to deprecate `data` prop in VirtualList.
+- `Slider` in QA sampler to deprecate `data` prop in `moonstone/VirtualList`
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/sampler/stories/qa-stories/Slider.js
+++ b/packages/sampler/stories/qa-stories/Slider.js
@@ -56,7 +56,7 @@ class SliderList extends React.Component {
 		this.fillItems(e.value);
 	}
 
-	renderItem = (size) => ({data, index, ...rest}) => {
+	renderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {
 			height: size + 'px',
 			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
@@ -65,7 +65,7 @@ class SliderList extends React.Component {
 
 		return (
 			<Item {...rest} style={itemStyle}>
-				{data[index].item + ': ' + data[index].count}
+				{this.items[index].item + ': ' + this.items[index].count}
 			</Item>
 		);
 	}
@@ -85,7 +85,6 @@ class SliderList extends React.Component {
 				/>
 				<VirtualList
 					itemRenderer={this.renderItem(this.props.itemSize)}
-					data={this.state.selectedItems}
 					dataSize={this.state.selectedItems.length}
 					itemSize={this.props.itemSize}
 					spacing={ri.scale(0)}

--- a/packages/sampler/stories/qa-stories/Slider.js
+++ b/packages/sampler/stories/qa-stories/Slider.js
@@ -10,7 +10,6 @@ import {storiesOf} from '@storybook/react';
 import {withKnobs, number} from '@storybook/addon-knobs';
 
 class SliderList extends React.Component {
-
 	static propTypes = {
 		itemSize: PropTypes.number
 	}
@@ -84,10 +83,9 @@ class SliderList extends React.Component {
 					value={this.state.value}
 				/>
 				<VirtualList
-					itemRenderer={this.renderItem(this.props.itemSize)}
 					dataSize={this.state.selectedItems.length}
+					itemRenderer={this.renderItem(this.props.itemSize)}
 					itemSize={this.props.itemSize}
-					spacing={ri.scale(0)}
 					style={{
 						height: ri.unit(552, 'rem')
 					}}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed run-time error in 'qa-sampler/Slider'.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`data` prop of `moonstone/VirtualList` is deprecated, and item render function which is passed to a list as `itemRenderer` should fetch data not from arguments but from in-app code.

Fixed `itemRenderer` to refer to own `items` variable instead of deprecated `data` prop.

### Links
[//]: # (Related issues, references)
PLAT-60211

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
