### PR TITLE
ENYO-5217: Fix Spottable to prevent scroll on focus on webOS

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -3,12 +3,13 @@
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
 ## [unreleased]
- 
+
 ### Fixed
 
 - `spotlight` to partition and prioritize next spottable elements for more natural 5-way behavior
 - `spotlight` to handle pointer events only when pointer has moved
 - `spotlight` to correctly set the active container id when unable to set focus to a container
+- `spotlight/Spottable` to not trigger a scroll on focus on webOS
 
 ## [2.0.0-beta.5] - 2018-05-29
 

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -377,6 +377,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			return (
 				<Wrapped
+					data-preventscrollonfocus=""
 					{...rest}
 					onBlur={this.handleBlur}
 					onFocus={this.handleFocus}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spottable components introduced odd scrolling behaviors in ScrollableNative due to built-in scroll on focus behaviors for the browser. On webOS, this can be prevented with the custom {{data-preventscrollonfocus}} attribute until the browser is updated to support the FocusOptions arg to `element.focus()`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added the `data-preventscrollonfocus` to spottable but included it before the spread so that it can be overridden by applications. Given the scope of the change and that there is no clear way to describe this API in a cross-platform manner, I've left it off the prop types and public documentation. I'm not entirely opposed to including it but wanted to avoid confusion since it is unlikely to be used (e.g. using the `overflow: scroll` on webOS).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
https://github.com/whatwg/html/pull/2787

### Comments

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)