### PR TITLE
ENYO-5322: Fix floatingLayer unmount condition

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -158,8 +158,11 @@ class FloatingLayerBase extends React.Component {
 	}
 
 	componentWillUnmount () {
-		const floatingLayer = this.context.getFloatingLayer();
-		floatingLayer.removeChild(this.node);
+		if (this.node) {
+			const floatingLayer = this.context.getFloatingLayer();
+			floatingLayer.removeChild(this.node);
+			this.node = null;
+		}
 
 		off('click', this.handleClick);
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A recent change (#1688) in `FloatingLayer` has adopted the recommendation of react portals, and added `removeChild` in `componentWillUnmount`. However, `removeChild` should be guarded against `null`. 

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
