### PR TITLE
ENYO-5329: Fix TooltipDecorator to hide tooltip on onDismiss

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/TooltipDecorator` to hide when `onDismiss` has been invoked
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/TooltipDecorator` to hide when `onDismiss` has been invoked
+
 ### Changed
 
 - `moonstone/VideoPlayer` container changes to provide a more natural 5-way focus behavior

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -406,7 +406,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (tooltipText) {
 				const renderedTooltip = (
-					<FloatingLayer open={this.state.showing} scrimType="none" key="tooltipFloatingLayer">
+					<FloatingLayer open={this.state.showing} onDismiss={this.hideTooltip} scrimType="none" key="tooltipFloatingLayer">
 						<Tooltip
 							aria-live="off"
 							role="alert"

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -8,7 +8,7 @@
 
 import {contextTypes} from '@enact/core/internal/PubSub';
 import hoc from '@enact/core/hoc';
-import FloatingLayer from '@enact/ui/FloatingLayer';
+import {FloatingLayerBase} from '@enact/ui/FloatingLayer';
 import {forward, handle, forProp} from '@enact/core/handle';
 import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';
@@ -406,7 +406,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (tooltipText) {
 				const renderedTooltip = (
-					<FloatingLayer open={this.state.showing} onDismiss={this.hideTooltip} scrimType="none" key="tooltipFloatingLayer">
+					<FloatingLayerBase open={this.state.showing} onDismiss={this.hideTooltip} scrimType="none" key="tooltipFloatingLayer">
 						<Tooltip
 							aria-live="off"
 							role="alert"
@@ -421,7 +421,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 						>
 							{tooltipText}
 						</Tooltip>
-					</FloatingLayer>
+					</FloatingLayerBase>
 				);
 
 				if (tooltipDestinationProp === 'children') {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/FloatingLayer.FloatingLayerBase` export 
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Fixed

--- a/packages/ui/FloatingLayer/index.js
+++ b/packages/ui/FloatingLayer/index.js
@@ -6,12 +6,13 @@
  * @module ui/FloatingLayer
  */
 
-import FloatingLayer from './FloatingLayer';
+import {FloatingLayer, FloatingLayerBase} from './FloatingLayer';
 import {FloatingLayerDecorator, contextTypes} from './FloatingLayerDecorator';
 
 export default FloatingLayer;
 export {
 	contextTypes,
 	FloatingLayer,
+	FloatingLayerBase,
 	FloatingLayerDecorator
 };


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`TooltipDecorator` assumes that it only appears on focus and disappears on blur. However, `ui/FloatingLayer `'s `context.closeAllFloatingLayers()` function expects all the layers to be closed by calling `onDismiss`. Fixed to handle `onDismiss` event in `TooltipDecorator` to hide tooltip when the event has been received.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
