### PR TITLE
PLAT-54548: Disable VideoPlayer playback controls until it's playable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/VideoPlayer` to disable bottom controls when loading until it's playable
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Removed

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1140,6 +1140,10 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	play = () => {
+		if (this.state.sourceUnavailable) {
+			return;
+		}
+
 		this.speedIndex = 0;
 		this.setPlaybackRate(1);
 		this.send('play');
@@ -1156,6 +1160,10 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	pause = () => {
+		if (this.state.sourceUnavailable) {
+			return;
+		}
+
 		this.speedIndex = 0;
 		this.setPlaybackRate(1);
 		this.send('pause');
@@ -1173,7 +1181,7 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	seek = (timeIndex) => {
-		if (!this.props.seekDisabled && !isNaN(this.video.duration)) {
+		if (!this.props.seekDisabled && !isNaN(this.video.duration) && !this.state.sourceUnavailable) {
 			this.video.currentTime = timeIndex;
 		} else {
 			forward('onSeekFailed', {}, this.props);
@@ -1190,6 +1198,10 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	jump = (distance) => {
+		if (this.state.sourceUnavailable) {
+			return;
+		}
+
 		this.pulsedPlaybackRate = toUpperCase(new DurationFmt({length: 'long'}).format({second: this.props.jumpBy}));
 		this.pulsedPlaybackState = distance > 0 ? 'jumpForward' : 'jumpBackward';
 		this.showFeedback();
@@ -1206,6 +1218,10 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	fastForward = () => {
+		if (this.state.sourceUnavailable) {
+			return;
+		}
+
 		let shouldResumePlayback = false;
 
 		switch (this.prevCommand) {
@@ -1259,6 +1275,10 @@ const VideoPlayerBase = class extends React.Component {
 	 * @public
 	 */
 	rewind = () => {
+		if (this.state.sourceUnavailable) {
+			return;
+		}
+
 		const rateForSlowRewind = this.props.playbackRateHash['slowRewind'];
 		let shouldResumePlayback = false,
 			command = 'rewind';

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -611,7 +611,7 @@ const VideoPlayerBase = class extends React.Component {
 			miniFeedbackVisible: false,
 			proportionLoaded: 0,
 			proportionPlayed: 0,
-			sourceUnavailable: false,
+			sourceUnavailable: true,
 			titleVisible: true
 		};
 
@@ -990,6 +990,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.setState({
 			announce: AnnounceState.READY,
 			currentTime: 0,
+			sourceUnavailable: true,
 			proportionPlayed: 0,
 			proportionLoaded: 0
 		});
@@ -1067,7 +1068,8 @@ const VideoPlayerBase = class extends React.Component {
 			proportionLoaded: el.proportionLoaded,
 			proportionPlayed: el.proportionPlayed || 0,
 			sliderTooltipTime: this.sliderScrubbing ? (this.sliderKnobProportion * el.duration) : el.currentTime,
-			sourceUnavailable: !el.duration || el.error
+			// note: `el.loading && this.state.sourceUnavailable == false` is equivalent to `oncanplaythrough`
+			sourceUnavailable: el.loading && this.state.sourceUnavailable || el.error
 		};
 
 		// If there's an error, we're obviously not loading, no matter what the readyState is.


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Apps want to disable playback controls until it's playable. Changed `this.state.sourceUnavailable`'s default value to `true` which will be updated to `false` only when there's enough data to play. Note that this is equivalent to `oncanplaythrough` event condition which means we can handle the event instead of managing the condition at the component level, but given that we allow custom media components, I chose not to expand the required events for `mediaComponents.

Some clarifications:
- `loading` state in `VideoPlayer` not only represents the initial loading of the video, but also anytime the video doesn't have enough content to play. IOW, buffering.
- The app only wants to disable playback controls during the initial loading, and not during buffering.
- Showing `MediaControls` should still work while loading because the app has a "go back to playlist" button in it. So `disabled` props will not satisfy the requirement.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>