### PR TITLE
ENYO-4947:  Ensure Picker disables when containing 1 or no items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
-- `moonston/EditableIntegerPicker` to disable itself when on a range producing a single static value.
-- `moonston/Picker` to disable itself when containing only one or zero items.
-- `moonston/RangePicker` to disable itself when on a range producing a single static value.
 - `moonstone/Scroller` to check focus possibilities first then go to fallback at the top of the container of focused item
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
 - `moonstone/ToggleButton` padding and orientation for RTL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
+- `moonston/EditableIntegerPicker` to disable itself when on a range producing a single static value.
+- `moonston/Picker` to disable itself when containing only one or zero items.
+- `moonston/RangePicker` to disable itself when on a range producing a single static value.
 - `moonstone/Scroller` to check focus possibilities first then go to fallback at the top of the container of focused item
 - `moonstone/Scroller` to scroll by page when focus was at the edge of the viewport
 - `moonstone/ToggleButton` padding and orientation for RTL

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonston/EditableIntegerPicker` to disable itself when on a range producing a single static value.
+- `moonston/Picker` to disable itself when containing only one or zero items.
+- `moonston/RangePicker` to disable itself when on a range producing a single static value.
 - `moonstone/TooltipDecorator` to hide when `onDismiss` has been invoked
 - `moonstone/VideoPlayer.MediaControls` to handle left and right key to jump when `moonstone/VideoPlayer` is focused
 

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -14,7 +14,6 @@ import React from 'react';
 
 import {MarqueeController} from '../Marquee';
 import {Picker, PickerItem} from '../internal/Picker';
-import SpottablePicker from '../Picker/SpottablePicker';
 import {validateRange} from '../internal/validators';
 
 import css from './EditableIntegerPicker.less';
@@ -249,22 +248,28 @@ const EditableIntegerPickerBase = kind({
 				label = value;
 			}
 
-			return (
-				editMode ?
+			if (editMode) {
+				return (
 					<input
 						className={css.input}
 						key={value}
 						onBlur={onInputBlur}
 						ref={inputRef}
-					/> : <PickerItem
-						key={value}
-						onClick={onPickerItemClick}
-					>
-						{`${label} ${unit}`}
-					</PickerItem>
+					/>
+				);
+			}
+
+			return (
+				<PickerItem
+					key={value}
+					onClick={onPickerItemClick}
+				>
+					{`${label} ${unit}`}
+				</PickerItem>
 			);
 		},
-		className: ({className, editMode, styler}) => editMode ? styler.append({editMode}) : className
+		className: ({className, editMode, styler}) => editMode ? styler.append({editMode}) : className,
+		disabled: ({disabled, max, min}) => min >= max ? true : disabled
 	},
 
 	render: ({pickerRef, ...rest}) => {
@@ -300,9 +305,7 @@ const EditableIntegerPicker = Pure(
 		EditableIntegerPickerDecorator(
 			MarqueeController(
 				{marqueeOnFocus: true},
-				SpottablePicker(
-					EditableIntegerPickerBase
-				)
+				EditableIntegerPickerBase
 			)
 		)
 	)

--- a/packages/moonstone/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
+++ b/packages/moonstone/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
-import EditableIntegerPicker from '../EditableIntegerPicker';
+import {mount, shallow} from 'enzyme';
+import {EditableIntegerPicker, EditableIntegerPickerBase} from '../EditableIntegerPicker';
 import Spotlight from '@enact/spotlight';
 
 const isPaused = () => Spotlight.isPaused() ? 'paused' : 'not paused';
@@ -152,6 +152,15 @@ describe('EditableIntegerPicker', () => {
 		node.parentNode.removeChild(node);
 
 		expect(actual).to.equal(expected);
+	});
+
+	it('should be disabled when limited to a single value', function () {
+		const picker = mount(
+			<EditableIntegerPickerBase min={0} max={0} value={0} />
+		);
+
+		const actual = picker.find('SpottablePicker').last().prop('disabled');
+		expect(actual).to.be.true();
 	});
 
 });

--- a/packages/moonstone/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
+++ b/packages/moonstone/EditableIntegerPicker/tests/EditableIntegerPicker-specs.js
@@ -155,7 +155,7 @@ describe('EditableIntegerPicker', () => {
 	});
 
 	it('should be disabled when limited to a single value', function () {
-		const picker = mount(
+		const picker = shallow(
 			<EditableIntegerPickerBase min={0} max={0} value={0} />
 		);
 

--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -16,7 +16,6 @@ import {MarqueeController} from '../Marquee';
 import {validateRange} from '../internal/validators';
 
 import PickerCore, {PickerItem} from '../internal/Picker';
-import SpottablePicker from './SpottablePicker';
 
 /**
  * The base component for {@link moonstone/Picker.Picker}. This version is not spottable.
@@ -181,6 +180,7 @@ const PickerBase = kind({
 				</PickerItem>
 			);
 		}),
+		disabled: ({children, disabled}) => React.Children.count(children) > 1 ? disabled : true,
 		value: ({value, children}) => {
 			const max = children && children.length ? children.length - 1 : 0;
 			if (__DEV__) {
@@ -219,9 +219,7 @@ const Picker = Pure(
 	Changeable(
 		MarqueeController(
 			{marqueeOnFocus: true},
-			SpottablePicker(
-				PickerBase
-			)
+			PickerBase
 		)
 	)
 );

--- a/packages/moonstone/Picker/tests/Picker-specs.js
+++ b/packages/moonstone/Picker/tests/Picker-specs.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
-import Picker from '../Picker';
+import {mount, shallow} from 'enzyme';
+import {Picker, PickerBase} from '../Picker';
 
 describe('Picker Specs', () => {
 	it('should render selected child wrapped with <PickerItem/>', function () {
@@ -29,4 +29,15 @@ describe('Picker Specs', () => {
 		expect(actual).to.equal(expected);
 	});
 
+
+	it('should be disabled when empty', function () {
+		const picker = shallow(
+			<PickerBase>
+				{[]}
+			</PickerBase>
+		);
+
+		const actual = picker.find('SpottablePicker').last().prop('disabled');
+		expect(actual).to.be.true();
+	});
 });

--- a/packages/moonstone/RangePicker/RangePicker.js
+++ b/packages/moonstone/RangePicker/RangePicker.js
@@ -13,7 +13,6 @@ import PropTypes from 'prop-types';
 import Pure from '@enact/ui/internal/Pure';
 
 import {Picker, PickerItem} from '../internal/Picker';
-import SpottablePicker from '../Picker/SpottablePicker';
 import {validateRange} from '../internal/validators';
 
 const digits = (num) => {
@@ -207,6 +206,7 @@ const RangePickerBase = kind({
 	},
 
 	computed: {
+		disabled: ({disabled, max, min}) => min >= max ? true : disabled,
 		label: ({max, min, padded, value}) => {
 			if (padded) {
 				const maxDigits = digits(Math.max(Math.abs(min), Math.abs(max)));
@@ -254,9 +254,7 @@ const RangePickerBase = kind({
  */
 const RangePicker = Pure(
 	Changeable(
-		SpottablePicker(
-			RangePickerBase
-		)
+		RangePickerBase
 	)
 );
 

--- a/packages/moonstone/RangePicker/tests/RangePicker-specs.js
+++ b/packages/moonstone/RangePicker/tests/RangePicker-specs.js
@@ -70,7 +70,7 @@ describe('RangePicker Specs', () => {
 	});
 
 	it('should be disabled when limited to a single value', function () {
-		const picker = mount(
+		const picker = shallow(
 			<RangePickerBase min={0} max={0} value={0} />
 		);
 

--- a/packages/moonstone/RangePicker/tests/RangePicker-specs.js
+++ b/packages/moonstone/RangePicker/tests/RangePicker-specs.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
-import RangePicker from '../RangePicker';
+import {mount, shallow} from 'enzyme';
+import {RangePicker, RangePickerBase} from '../RangePicker';
 
 const tap = (node) => {
 	node.simulate('mousedown');
@@ -67,5 +67,14 @@ describe('RangePicker Specs', () => {
 		const actual = picker.find('PickerItem').text();
 
 		expect(actual).to.equal(expected);
+	});
+
+	it('should be disabled when limited to a single value', function () {
+		const picker = mount(
+			<RangePickerBase min={0} max={0} value={0} />
+		);
+
+		const actual = picker.find('SpottablePicker').last().prop('disabled');
+		expect(actual).to.be.true();
 	});
 });

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -17,6 +17,7 @@ import {validateRange, validateStepped} from '../validators';
 import IdProvider from '../IdProvider';
 import $L from '../$L';
 import PickerButton from './PickerButton';
+import SpottablePicker from './SpottablePicker';
 
 import css from './Picker.less';
 
@@ -865,10 +866,12 @@ const PickerBase = class extends React.Component {
 	}
 };
 
-const Picker = IdProvider(
-	{generateProp: null, prefix: 'p_'},
-	Skinnable(
-		PickerBase
+const Picker = SpottablePicker(
+	IdProvider(
+		{generateProp: null, prefix: 'p_'},
+		Skinnable(
+			PickerBase
+		)
 	)
 );
 

--- a/packages/moonstone/internal/Picker/SpottablePicker.js
+++ b/packages/moonstone/internal/Picker/SpottablePicker.js
@@ -1,7 +1,7 @@
 import hoc from '@enact/core/hoc';
 import Spottable from '@enact/spotlight/Spottable';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 const SpottablePicker = hoc(null, (config, Wrapped) => {
 	const Joined = Spottable(Wrapped);
@@ -34,4 +34,6 @@ const SpottablePicker = hoc(null, (config, Wrapped) => {
 });
 
 export default SpottablePicker;
-export {SpottablePicker};
+export {
+	SpottablePicker
+};


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Picker, when joined, was spottable even with no children.

### Resolution
* Refactored `SpottablePicker` to be applied on `internal/Picker` directly.
* Updated `moonstone/Picker` to compute disabled property accounting to `>1` children.
* Updated `moonstone/EditibleIntegerPicker`, and `moonstone/RangePicker` to compute disabled property according to single item range.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>