### PR TITLE
ENYO-5333: Popup spot content correctly on mount

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/TooltipDecorator` to hide when `onDismiss` has been invoked
 - `moonstone/VideoPlayer.MediaControls` to handle left and right key to jump when `moonstone/VideoPlayer` is focused
+- `moonstone/Popup` to spot its content correctly when `open` by default
 
 ### Changed
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -365,13 +365,6 @@ class Popup extends React.Component {
 		checkScrimNone(this.props);
 	}
 
-	componentDidMount () {
-		if (this.props.open) {
-			on('keydown', this.handleKeyDown);
-			this.spotPopupContent();
-		}
-	}
-
 	componentWillReceiveProps (nextProps) {
 		if (!this.props.open && nextProps.open) {
 			this.setState({
@@ -395,11 +388,9 @@ class Popup extends React.Component {
 				this.paused.pause();
 			} else if (this.props.open) {
 				forwardShow({}, this.props);
-				on('keydown', this.handleKeyDown);
 				this.spotPopupContent();
 			} else if (prevProps.open) {
 				forwardHide({}, this.props);
-				off('keydown', this.handleKeyDown);
 				this.spotActivator(prevState.activator);
 			}
 		}
@@ -417,6 +408,8 @@ class Popup extends React.Component {
 			this.setState({
 				popupOpen: true
 			});
+		} else if (this.state.popupOpen && this.props.open) {
+			this.spotPopupContent();
 		}
 	}
 
@@ -457,7 +450,6 @@ class Popup extends React.Component {
 			this.paused.resume();
 
 			if (!this.props.open) {
-				off('keydown', this.handleKeyDown);
 				this.spotActivator(this.state.activator);
 			}
 		}
@@ -470,7 +462,6 @@ class Popup extends React.Component {
 			this.paused.resume();
 
 			if (this.props.open) {
-				on('keydown', this.handleKeyDown);
 				this.spotPopupContent();
 			}
 		}
@@ -479,6 +470,8 @@ class Popup extends React.Component {
 	spotActivator = (activator) => {
 		const current = Spotlight.getCurrent();
 		const containerNode = getContainerNode(this.state.containerId);
+
+		off('keydown', this.handleKeyDown);
 
 		// if there is no currently-spotted control or it is wrapped by the popup's container, we
 		// know it's safe to change focus
@@ -492,6 +485,9 @@ class Popup extends React.Component {
 
 	spotPopupContent = () => {
 		const {containerId} = this.state;
+
+		on('keydown', this.handleKeyDown);
+
 		if (!Spotlight.focus(containerId)) {
 			const current = Spotlight.getCurrent();
 
@@ -519,13 +515,13 @@ class Popup extends React.Component {
 			>
 				<SkinnedPopupBase
 					{...rest}
+					data-webos-voice-exclusive
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
-					spotlightId={this.state.containerId}
 					onShow={this.handlePopupShow}
 					open={this.state.popupOpen}
+					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
-					data-webos-voice-exclusive
 				/>
 			</FloatingLayer>
 		);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,11 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
-- `ui/FloatingLayer.FloatingLayerBase` export 
+- `ui/FloatingLayer.FloatingLayerBase` export
+
+### Changed
+
+- `ui/FloatingLayer` to call `onOpen` only after it is rendered
 
 ## [2.0.0-beta.6] - 2018-06-04
 

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -124,7 +124,6 @@ class FloatingLayerBase extends React.Component {
 
 	componentDidMount () {
 		if (this.props.open) {
-			forwardOpen(null, this.props);
 			this.renderNode();
 		}
 
@@ -139,12 +138,12 @@ class FloatingLayerBase extends React.Component {
 		}
 	}
 
-	componentDidUpdate (prevProps) {
+	componentDidUpdate (prevProps, prevState) {
 		const {open, scrimType} = this.props;
 
 		if (prevProps.open && !open) {
 			forwardClose(null, this.props);
-		} else if (!prevProps.open && open) {
+		} else if (!prevProps.open && open || (open && !prevState.nodeRendered && this.state.nodeRendered)) {
 			forwardOpen(null, this.props);
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When Popup is open by default, it unsuccessfully tries to spot its contents on mount before it was even rendered to FloatingLayer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Ryan:
* the change in FloatingLayer to not fire `onOpen` on mount and instead only from `componentDidUpdate` when the child node has rendered
* the addition of `spotPopupContent` to the `onOpen` callback in Popup



### Links
[//]: # (Related issues, references)
ENYO-5333

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com