### PR TITLE
ENYO-5338: Add repositionProps to trigger reposition

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/util.didPropChange` to support prop change check
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 No significant changes.

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -177,6 +177,17 @@ const mergeClassNameMaps = (baseMap, additiveMap, allowedClassNames) => {
 };
 
 /**
+ * Checks whether any props has changed or not for a given list of properties
+ *
+ * @param {Array} propsList An array of props to check
+ * @param {Object} prev Previous props
+ * @param {Object} next Next props
+ * @returns {Boolean} `true` if any of the props changed
+ * @private
+ */
+const didPropChange = (propsList, prev, next) => Array.isArray(propsList) && propsList.some((prop) => prev[prop] !== next[prop]);
+
+/**
  * Creates a function that memoizes the result of `fn`. Note that this function is a naive
  * implementation and only checks the first argument for memoization.
  *
@@ -203,6 +214,7 @@ export {
 	cap,
 	coerceArray,
 	coerceFunction,
+	didPropChange,
 	extractAriaProps,
 	isRenderable,
 	Job,

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer.MediaControls` to handle left and right key to jump when `moonstone/VideoPlayer` is focused
 - `moonstone/Popup` to spot its content correctly when `open` by default
 
+### Added
+
+- `moonstone/ContextualPopupDecorator` config option `repositionProps` to trigger reposition upon prop change
+
 ### Changed
 
 - `moonstone/VideoPlayer` to roam spotlight focus freely to left and right from `MediaControls`

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -1,4 +1,5 @@
 import direction from 'direction';
+import {didPropChange} from '@enact/core/util';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {contextTypes as stateContextTypes} from '@enact/core/internal/PubSub';
@@ -94,20 +95,6 @@ const defaultConfig = {
 	 * @memberof ui/Marquee.MarqueeDecorator.defaultConfig
 	 */
 	marqueeDirection: (str) => direction(str) === 'rtl' ? 'rtl' : 'ltr'
-};
-
-/**
- * Checks whether any of the invalidateProps has changed or not
- *
- * @param {Array} propList An array of invalidateProps
- * @param {Object} prev Previous props
- * @param {Object} next Next props
- * @returns {Boolean} `true` if any of the props changed
- * @private
- */
-const didPropChange = (propList, prev, next) => {
-	const hasPropsChanged = propList.map(i => prev[i] !== next[i]);
-	return hasPropsChanged.indexOf(true) !== -1;
 };
 
 /*
@@ -301,7 +288,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		componentWillReceiveProps (next) {
 			const {forceDirection, marqueeOn, marqueeDisabled, marqueeSpeed} = this.props;
 			this.validateTextDirection(next);
-			if (!shallowEqual(this.props.children, next.children) || (invalidateProps && didPropChange(invalidateProps, this.props, next))) {
+			if (!shallowEqual(this.props.children, next.children) || didPropChange(invalidateProps, this.props, next)) {
 				// restart marqueeOn="render" marquees or synced marquees that were animating
 				this.forceRestartMarquee = next.marqueeOn === 'render' || (
 					this.sync && (this.state.animating || this.timerState > TimerState.CLEAR)


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If the wrapper node or the container node changes the position, `ContextualPopup` needs to update its position, if necessary. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Suggest adding a config option of a list of props that will trigger reposition, as
1. repositioning of the container is one of the rare use cases which we don't need to validate for every prop update
2. exposing as a prop to the application will require for developers to know some knowledge of how the component works

### Additional Considerations
- Since reposition isn't triggered by existing props (in normal use cases), `repositionProps` are expected to be custom props, which means they need to be cleaned up and make sure it does not get passed down. So the usage would look something like:
```
const ContextualPopup = ContextualPopupDecorator({repositionProps: ['customProp']}, (props) => {
	const prop = Object.assign({}, props);
	delete prop.customProp;
	return <IconButton {...prop} />
});
```
which is quite verbose :(

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>