### PR TITLE
Updated Travis with cached NPM cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enyojs/enact-cli#develop
+    - npm install -g enactjs/cli#develop
     - npm install
     - npm run bootstrap
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 node_js:
     - "node"
 sudo: false
+cache:
+  directories:
+    - $(npm config get cache)
 install:
+    - npm config set prefer-offline true
     - npm install -g enyojs/enact-cli#develop
     - npm install
     - npm run bootstrap


### PR DESCRIPTION
### Issue Resolved / Feature Added
* Currently not using Travis cache support and pulling fresh modules from NPM everytime.

### Resolution
* Cache NPM's cache directory to improve speed and performance of `npm install`, as well as reduce out number of downloads from NPM servers.
* On a test run, It reduced Enact CLI install time from 78s down to 25s.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>