### PR TITLE
ENYO-5217: add "true" string to data-preventscrollonfocus property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to add `true` string value on `data-preventscrollonfocus` property to be handled by web engine correctly.
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `spotlight/Spottable` to add `true` string value on `data-preventscrollonfocus` property to be handled by web engine correctly.
-
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Removed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight/Spottable` to prevent scroll on focus on webOS
+
 ## [2.0.0-beta.7] - 2018-06-11
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to prevent scroll on focus on webOS
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Fixed

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -377,7 +377,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			return (
 				<Wrapped
-					data-preventscrollonfocus=""
+					data-preventscrollonfocus="true"
 					{...rest}
 					onBlur={this.handleBlur}
 					onFocus={this.handleFocus}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Stuttering still occurs with `data-preventscrollonfocus` property.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It's not enough to just exist `data-preventscrollonfocus` attribute on dom to fix issue.
So I added `true` value on it to be handled by web engine correctly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5217
PLAT-43386

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi (yeram.choi@lge.com)