### PR TITLE
ENYO-5346: Fix VirtualList to allow scrollingon focus on webOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `ui/VirtualList` to remove adding `data-preventscrollonfocus` since `Spottable` handles it by default.
 ## [2.0.0-beta.7] - 2018-06-11
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` to remove adding `data-preventscrollonfocus` since `Spottable` handles it by default.
+
 ## [2.0.0-beta.6] - 2018-06-04
 
 ### Removed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/VirtualList` to remove preventing scroll on focus on webOS
+
 ## [2.0.0-beta.7] - 2018-06-11
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,9 +4,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
-### Changed
+### Fixed
 
-- `ui/VirtualList` to remove preventing scroll on focus on webOS
+- `ui/VirtualList` to allow scrolling on focus by default on webOS
 
 ## [2.0.0-beta.7] - 2018-06-11
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -631,7 +631,6 @@ const VirtualListBaseFactory = (type) => {
 			this.cc[key] = React.cloneElement(itemElement, {
 				...componentProps,
 				className: classNames(css.listItem, itemElement.props.className),
-				['data-preventscrollonfocus']: true, // Added this attribute to prevent scroll on focus by browser
 				style: {...itemElement.props.style, ...(this.composeStyle(...rest))}
 			});
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Due to `data-preventscrollonfocus` is handled by `Spottable`, we can remove adding logic from `VirtualList`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove it!

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5346
ENYO-5217

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi (yeram.choi@lge.com)