### PR TITLE
PLAT-53458: ScrollButton to move a previous or next page when pressing a page up or down key

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` scrollbar button to move a previous or next page when pressing a page up or down key instead of releasing it
+
 ## [2.0.0-beta.7] - 2018-06-11
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualList` and `moonstone/VirtualList.VirtualGridList` scrollbar button to move a previous or next page when pressing a page up or down key instead of releasing it
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualList`, and `moonstone/VirtualList.VirtualGridList` scrollbar button to move a previous or next page when pressing a page up or down key instead of releasing it
 
 ## [2.0.0-beta.7] - 2018-06-11
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
+### Changed
 
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualList`, and `moonstone/VirtualList.VirtualGridList` scrollbar button to move a previous or next page when pressing a page up or down key instead of releasing it
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -151,12 +151,12 @@ class ScrollButtons extends Component {
 		if (shouldIgnore !== this.ignoreMode) {
 			if (shouldIgnore) {
 				this.ignoreMode = true;
-				on('mousemove', this.handleUp);
-				on('mouseup', this.handleUp);
+				on('mousemove', this.onUp);
+				on('mouseup', this.onUp);
 			} else {
 				this.ignoreMode = false;
-				off('mousemove', this.handleUp);
-				off('mouseup', this.handleUp);
+				off('mousemove', this.onUp);
+				off('mouseup', this.onUp);
 			}
 		}
 	}
@@ -200,7 +200,7 @@ class ScrollButtons extends Component {
 		return current === this.prevButtonNodeRef || current === this.nextButtonNodeRef;
 	}
 
-	handlePrevDown = () => {
+	onDownPrev = () => {
 		this.setPressStatus(true);
 
 		if (this.announce) {
@@ -209,7 +209,7 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handleNextDown = () => {
+	onDownNext = () => {
 		this.setPressStatus(true);
 
 		if (this.announce) {
@@ -218,19 +218,19 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handlePrevClick = (ev) => {
+	onClickPrev = (ev) => {
 		const {onPrevScroll, vertical} = this.props;
 
 		onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
 	}
 
-	handleNextClick = (ev) => {
+	onClickNext = (ev) => {
 		const {onNextScroll, vertical} = this.props;
 
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 	}
 
-	handlePrevHoldPulse = (ev) => {
+	onHoldPulsePrev = (ev) => {
 		const {onPrevScroll, vertical} = this.props;
 
 		if (!this.ignoreMode) {
@@ -238,7 +238,7 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handleNextHoldPulse = (ev) => {
+	onHoldPulseNext = (ev) => {
 		const {onNextScroll, vertical} = this.props;
 
 		if (!this.ignoreMode) {
@@ -246,7 +246,7 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handleSpotlight = (ev) => {
+	onSpotlight = (ev) => {
 		const
 			{rtl, vertical} = this.props,
 			{keyCode, target} = ev,
@@ -269,28 +269,32 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handleUp = () => {
+	onUp = () => {
 		this.setPressStatus(false);
 		this.setIgnoreMode(false);
 	}
 
-	handleKeyDown = (ev) => {
+	onKeyDownPrev = (ev) => {
 		const
-			{prevButtonDisabled, nextButtonDisabled} = this.state,
+			{nextButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (isPageUp(keyCode)) {
-			if (ev.target === this.nextButtonNodeRef && !prevButtonDisabled) {
-				Spotlight.focus(this.prevButtonNodeRef);
-			} else {
-				this.handlePrevClick(ev);
-			}
+		if (isPageDown(keyCode) && !nextButtonDisabled) {
+			Spotlight.focus(this.nextButtonNodeRef);
+		} else if (isPageUp(keyCode)) {
+			this.onClickPrev(ev);
+		}
+	}
+
+	onKeyDownNext = (ev) => {
+		const
+			{prevButtonDisabled} = this.state,
+			{keyCode} = ev;
+
+		if (isPageUp(keyCode) && !prevButtonDisabled) {
+			Spotlight.focus(this.prevButtonNodeRef);
 		} else if (isPageDown(keyCode)) {
-			if (ev.target === this.prevButtonNodeRef && !nextButtonDisabled) {
-				Spotlight.focus(this.nextButtonNodeRef);
-			} else {
-				this.handleNextClick(ev);
-			}
+			this.onClickNext(ev);
 		}
 	}
 
@@ -322,18 +326,18 @@ class ScrollButtons extends Component {
 		return [
 			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
-				key="prevButton"
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'up' : 'left'}
 				disabled={disabled || prevButtonDisabled}
-				onClick={this.handlePrevClick}
-				onDown={this.handlePrevDown}
-				onHoldPulse={this.handlePrevHoldPulse}
-				onKeyDown={this.handleKeyDown}
-				onSpotlightDown={this.handleSpotlight}
-				onSpotlightLeft={this.handleSpotlight}
-				onSpotlightRight={this.handleSpotlight}
-				onUp={this.handleUp}
+				key="prevButton"
+				onClick={this.onClickPrev}
+				onDown={this.onDownPrev}
+				onHoldPulse={this.onHoldPulsePrev}
+				onKeyDown={this.onKeyDownPrev}
+				onSpotlightDown={this.onSpotlight}
+				onSpotlightLeft={this.onSpotlight}
+				onSpotlightRight={this.onSpotlight}
+				onUp={this.onUp}
 				ref={this.initPrevButtonRef}
 			>
 				{prevIcon}
@@ -341,18 +345,18 @@ class ScrollButtons extends Component {
 			thumbRenderer(),
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
-				key="nextButton"
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'down' : 'right'}
 				disabled={disabled || nextButtonDisabled}
-				onClick={this.handleNextClick}
-				onDown={this.handleNextDown}
-				onHoldPulse={this.handleNextHoldPulse}
-				onKeyDown={this.handleKeyDown}
-				onSpotlightLeft={this.handleSpotlight}
-				onSpotlightRight={this.handleSpotlight}
-				onSpotlightUp={this.handleSpotlight}
-				onUp={this.handleUp}
+				key="nextButton"
+				onClick={this.onClickNext}
+				onDown={this.onDownNext}
+				onHoldPulse={this.onHoldPulseNext}
+				onKeyDown={this.onKeyDownNext}
+				onSpotlightLeft={this.onSpotlight}
+				onSpotlightRight={this.onSpotlight}
+				onSpotlightUp={this.onSpotlight}
+				onUp={this.onUp}
 				ref={this.initNextButtonRef}
 			>
 				{nextIcon}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -200,44 +200,50 @@ class ScrollButtons extends Component {
 		return current === this.prevButtonNodeRef || current === this.nextButtonNodeRef;
 	}
 
-	// Handle page up / page down keydown events
-	handleKeyDown = (ev) => {
-		const
-			{prevButtonDisabled, nextButtonDisabled} = this.state,
-			{keyCode} = ev,
-			isPreviousScrollButton = (ev.target === this.prevButtonNodeRef);
+	handlePrevDown = () => {
+		this.setPressStatus(true);
 
-		if (isPageUp(keyCode)) {
-			if (!isPreviousScrollButton && !prevButtonDisabled) {
-				Spotlight.focus(this.prevButtonNodeRef);
-			} else {
-				this.handleClick(ev);
-			}
-		} else if (isPageDown(keyCode)) {
-			if (isPreviousScrollButton && !nextButtonDisabled) {
-				Spotlight.focus(this.nextButtonNodeRef);
-			} else {
-				this.handleClick(ev);
-			}
+		if (this.announce) {
+			const {rtl, vertical} = this.props;
+			this.announce(vertical && $L('UP') || rtl && $L('RIGHT') || $L('LEFT'));
 		}
 	}
 
-	// Handle up / down / left / right keydown events
-	handleDown = (ev) => {
-		const
-			direction = getDirection(ev.keyCode),
-			isPreviousScrollButton = (ev.target === this.prevButtonNodeRef);
-
+	handleNextDown = () => {
 		this.setPressStatus(true);
 
-		if (direction && this.announce) {
+		if (this.announce) {
 			const {rtl, vertical} = this.props;
+			this.announce(vertical && $L('DOWN') || rtl && $L('LEFT') || $L('RIGHT'));
+		}
+	}
 
-			if (isPreviousScrollButton === true) {
-				this.announce(vertical && $L('UP') || rtl && $L('RIGHT') || $L('LEFT'));
-			} else if (isPreviousScrollButton === false) {
-				this.announce(vertical && $L('DOWN') || rtl && $L('LEFT') || $L('RIGHT'));
-			}
+	handlePrevClick = (ev) => {
+		const {onPrevScroll, vertical} = this.props;
+
+		onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
+	}
+
+	handleNextClick = (ev) => {
+		const {onNextScroll, vertical} = this.props;
+
+		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
+	}
+
+
+	handlePrevHoldPulse = (ev) => {
+		const {onPrevScroll, vertical} = this.props;
+
+		if (!this.ignoreMode) {
+			onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
+		}
+	}
+
+	handleNextHoldPulse = (ev) => {
+		const {onNextScroll, vertical} = this.props;
+
+		if (!this.ignoreMode) {
+			onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 		}
 	}
 
@@ -265,25 +271,30 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	handleHoldPulse = (isPreviousScrollButton) => (ev) => {
-		const {onNextScroll, onPrevScroll, vertical} = this.props;
-
-		if (!this.ignoreMode) {
-			(isPreviousScrollButton ? onPrevScroll : onNextScroll)({...ev, isPreviousScrollButton, isVerticalScrollBar: vertical});
-		}
-	}
-
-	handleUp = (ev) => {
+	handleUp = () => {
 		this.setPressStatus(false);
 		this.setIgnoreMode(false);
 	}
 
-	handleClick = (ev) => {
+	handleKeyDown = (ev) => {
 		const
-			{onNextScroll, onPrevScroll, vertical} = this.props,
+			{prevButtonDisabled, nextButtonDisabled} = this.state,
+			{keyCode} = ev,
 			isPreviousScrollButton = (ev.target === this.prevButtonNodeRef);
 
-		(isPreviousScrollButton? onPrevScroll : onNextScroll)({...ev, isPreviousScrollButton, isVerticalScrollBar: vertical});
+		if (isPageUp(keyCode)) {
+			if (!isPreviousScrollButton && !prevButtonDisabled) {
+				Spotlight.focus(this.prevButtonNodeRef);
+			} else {
+				this.handlePrevClick(ev);
+			}
+		} else if (isPageDown(keyCode)) {
+			if (isPreviousScrollButton && !nextButtonDisabled) {
+				Spotlight.focus(this.nextButtonNodeRef);
+			} else {
+				this.handleNextClick(ev);
+			}
+		}
 	}
 
 	initAnnounceRef = (ref) => {
@@ -318,9 +329,9 @@ class ScrollButtons extends Component {
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'up' : 'left'}
 				disabled={disabled || prevButtonDisabled}
-				onClick={this.handleClick}
-				onDown={this.handleDown}
-				onHoldPulse={this.handleHoldPulse(true)}
+				onClick={this.handlePrevClick}
+				onDown={this.handlePrevDown}
+				onHoldPulse={this.handlePrevHoldPulse}
 				onKeyDown={this.handleKeyDown}
 				onSpotlightDown={this.handleSpotlight}
 				onSpotlightLeft={this.handleSpotlight}
@@ -337,9 +348,9 @@ class ScrollButtons extends Component {
 				data-spotlight-overflow="ignore"
 				direction={vertical ? 'down' : 'right'}
 				disabled={disabled || nextButtonDisabled}
-				onClick={this.handleClick}
-				onDown={this.handleDown}
-				onHoldPulse={this.handleHoldPulse(false)}
+				onClick={this.handleNextClick}
+				onDown={this.handleNextDown}
+				onHoldPulse={this.handleNextHoldPulse}
 				onKeyDown={this.handleKeyDown}
 				onSpotlightLeft={this.handleSpotlight}
 				onSpotlightRight={this.handleSpotlight}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -230,7 +230,6 @@ class ScrollButtons extends Component {
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 	}
 
-
 	handlePrevHoldPulse = (ev) => {
 		const {onPrevScroll, vertical} = this.props;
 
@@ -247,7 +246,6 @@ class ScrollButtons extends Component {
 		}
 	}
 
-	// Handle up / down / left / right keydown events after Spotlight handled them
 	handleSpotlight = (ev) => {
 		const
 			{rtl, vertical} = this.props,
@@ -279,17 +277,16 @@ class ScrollButtons extends Component {
 	handleKeyDown = (ev) => {
 		const
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
-			{keyCode} = ev,
-			isPreviousScrollButton = (ev.target === this.prevButtonNodeRef);
+			{keyCode} = ev;
 
 		if (isPageUp(keyCode)) {
-			if (!isPreviousScrollButton && !prevButtonDisabled) {
+			if (ev.target === this.nextButtonNodeRef && !prevButtonDisabled) {
 				Spotlight.focus(this.prevButtonNodeRef);
 			} else {
 				this.handlePrevClick(ev);
 			}
 		} else if (isPageDown(keyCode)) {
-			if (isPreviousScrollButton && !nextButtonDisabled) {
+			if (ev.target === this.prevButtonNodeRef && !nextButtonDisabled) {
 				Spotlight.focus(this.nextButtonNodeRef);
 			} else {
 				this.handleNextClick(ev);

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -246,6 +246,17 @@ class ScrollButtons extends Component {
 		}
 	}
 
+	focusOnOppositeScrollButton = (ev, direction) => {
+		const buttonNode = (ev.target === this.nextButtonNodeRef) ? this.prevButtonNodeRef : this.nextButtonNodeRef;
+
+		ev.preventDefault();
+		ev.nativeEvent.stopPropagation();
+
+		if (!Spotlight.focus(buttonNode)) {
+			Spotlight.move(direction);
+		}
+	}
+
 	onSpotlight = (ev) => {
 		const
 			{rtl, vertical} = this.props,
@@ -257,15 +268,7 @@ class ScrollButtons extends Component {
 		// manually focus the opposite scroll button when 5way pressed
 		if ((fromNextToPrev && target === this.nextButtonNodeRef) ||
 			(fromPrevToNext && target === this.prevButtonNodeRef)) {
-			// Focus on opposite ScrollButton
-			const buttonNode = (ev.target === this.nextButtonNodeRef) ? this.prevButtonNodeRef : this.nextButtonNodeRef;
-
-			ev.preventDefault();
-			ev.nativeEvent.stopPropagation();
-
-			if (!Spotlight.focus(buttonNode)) {
-				Spotlight.move(direction);
-			}
+			this.focusOnOppositeScrollButton(ev, direction);
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The scrollbar button in VirtualList moves a previous or next page when releasing a page up or down key. It should move when pressing the key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I handles page up and down keys when receiving `onKeyDown` instead of `onKeyUp`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- `onKeyDown`, `onMouseDown`, and `onDown` 
The events are used in the ScrollButton. There is no reason to use more than one event. So all code excepting navigating via page up/down keys moves to the `onDown` event handlers.

- Renamed event handlers
handlePrevDown  -> onDownPrev
handlePrevScroll  -> onClickPrev
handlePrevHoldPulse  -> onHoldPulsePrev
releaseButton for onKeyUp -> onUp for onUp
depressButton for onKeyDown was unified into onDownPre and onDownNext
onKeyDownPrev, onKeyDownNext for onKeyDown were created

### Links
[//]: # (Related issues, references)

PLAT-53458

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)