### PR TITLE
ENYO-5351: Fix Video infinite state loop when only updating the primary source

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+- `moonstone/VideoPlayer` to prevent updating state when the source is changed to the preload source, but the current preload source is the same
+
 ## [2.0.0-beta.7] - 2018-06-11
 
 ### Removed

--- a/packages/moonstone/VideoPlayer/Video.js
+++ b/packages/moonstone/VideoPlayer/Video.js
@@ -109,7 +109,7 @@ const VideoBase = class extends React.Component {
 		}
 
 		if (source) {
-			if (key === prevPreloadKey) {
+			if (key === prevPreloadKey && preloadKey !== prevPreloadKey) {
 				// if there's source and it was the preload source
 
 				// if the preloaded video didn't error, notify VideoPlayer it is ready to reset


### PR DESCRIPTION
### Issue Resolved / Feature Added
Video player was going into an infinite loop when changing the source, but the preload source stayed the same.


### Resolution
Added a guard to stop `componentDidUpdate` from setting state indefinitely 


### Links
ENYO-5351

Enact-DCO-1.0-Signed-off-by: Derek Tor (derek.tor@lge.com)
