### PR TITLE
PLAT-61063: Delegate voice group label to IconButton

### DIFF
--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -45,7 +45,7 @@ const ExpandablePickerBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
-		 * The `data-webos-voice-group-label` for LabeledItem and Picker.
+		 * The `data-webos-voice-group-label` for ExpandableItem and Picker.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -45,6 +45,14 @@ const ExpandablePickerBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
+		 * The `data-webos-voice-group-label` for the IconButton of IncrementSlider.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		'data-webos-voice-group-label': PropTypes.string,
+
+		/**
 		 * The "aria-label" for the the check button.
 		 *
 		 * @type {String}
@@ -280,6 +288,7 @@ const ExpandablePickerBase = kind({
 
 	render: (props) => {
 		const {
+			'data-webos-voice-group-label': voiceGroupLabel,
 			checkButtonAriaLabel,
 			children,
 			decrementAriaLabel,
@@ -309,6 +318,7 @@ const ExpandablePickerBase = kind({
 		return (
 			<ExpandableItemBase
 				{...rest}
+				data-webos-voice-group-label={voiceGroupLabel}
 				disabled={disabled}
 				onSpotlightDisappear={onSpotlightDisappear}
 				onSpotlightDown={!open ? onSpotlightDown : null}
@@ -320,6 +330,7 @@ const ExpandablePickerBase = kind({
 				<Picker
 					aria-label={pickerAriaLabel}
 					className={css.picker}
+					data-webos-voice-group-label={voiceGroupLabel}
 					decrementAriaLabel={decrementAriaLabel}
 					decrementIcon={decrementIcon}
 					disabled={disabled}

--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -45,7 +45,7 @@ const ExpandablePickerBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
-		 * The `data-webos-voice-group-label` for the Picker.
+		 * The `data-webos-voice-group-label` for LabeledItem and Picker.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -48,6 +48,7 @@ const ExpandablePickerBase = kind({
 		 * The `data-webos-voice-group-label` for ExpandableItem and Picker.
 		 *
 		 * @type {String}
+		 * @memberof moonstone/ExpandablePicker.ExpandablePickerBase.prototype
 		 * @public
 		 */
 		'data-webos-voice-group-label': PropTypes.string,

--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -45,7 +45,7 @@ const ExpandablePickerBase = kind({
 		children: PropTypes.node.isRequired,
 
 		/**
-		 * The `data-webos-voice-group-label` for the IconButton of IncrementSlider.
+		 * The `data-webos-voice-group-label` for the Picker.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -87,6 +87,14 @@ const IncrementSliderBase = kind({
 		'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
 		/**
+		 * The `data-webos-voice-group-label` for the IconButton of Picker.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		'data-webos-voice-group-label': PropTypes.string,
+
+		/**
 		 * When `true`, the knob displays selected and can be moved using 5-way controls.
 		 *
 		 * @type {Boolean}
@@ -453,6 +461,7 @@ const IncrementSliderBase = kind({
 
 	render: ({active,
 		'aria-hidden': ariaHidden,
+		'data-webos-voice-group-label': voiceGroupLabel,
 		backgroundProgress,
 		css,
 		decrementAriaLabel,
@@ -498,6 +507,7 @@ const IncrementSliderBase = kind({
 					aria-hidden={ariaHidden}
 					aria-label={decrementAriaLabel}
 					className={css.decrementButton}
+					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={decrementDisabled}
 					onTap={onDecrement}
 					onSpotlightDisappear={onDecrementSpotlightDisappear}
@@ -534,6 +544,7 @@ const IncrementSliderBase = kind({
 					aria-hidden={ariaHidden}
 					aria-label={incrementAriaLabel}
 					className={css.incrementButton}
+					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={incrementDisabled}
 					onTap={onIncrement}
 					onSpotlightDisappear={onIncrementSpotlightDisappear}

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -90,6 +90,7 @@ const IncrementSliderBase = kind({
 		 * The `data-webos-voice-group-label` for the IconButton of IncrementSlider.
 		 *
 		 * @type {String}
+		 * @memberof moonstone/IncrementSlider.IncrementSliderBase.prototype
 		 * @public
 		 */
 		'data-webos-voice-group-label': PropTypes.string,

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -87,7 +87,7 @@ const IncrementSliderBase = kind({
 		'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
 		/**
-		 * The `data-webos-voice-group-label` for the IconButton of Picker.
+		 * The `data-webos-voice-group-label` for the IconButton of IncrementSlider.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -123,7 +123,7 @@ const PickerBase = class extends React.Component {
 		'aria-valuetext': PropTypes.string,
 
 		/**
-		 * The `data-webos-voice-group-label` for the IconButton of picker.
+		 * The `data-webos-voice-group-label` for the IconButton of Picker.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -126,6 +126,7 @@ const PickerBase = class extends React.Component {
 		 * The `data-webos-voice-group-label` for the IconButton of Picker.
 		 *
 		 * @type {String}
+		 * @memberof moonstone/internal/Picker.PickerBase.prototype
 		 * @public
 		 */
 		'data-webos-voice-group-label': PropTypes.string,

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -123,6 +123,14 @@ const PickerBase = class extends React.Component {
 		'aria-valuetext': PropTypes.string,
 
 		/**
+		 * The `data-webos-voice-group-label` for the IconButton of picker.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		'data-webos-voice-group-label': PropTypes.string,
+
+		/**
 		 * Accessibility hint
 		 *
 		 * For example, `hour`, `year`, and `meridiem`
@@ -740,6 +748,7 @@ const PickerBase = class extends React.Component {
 		const {active} = this.state;
 		const {
 			'aria-valuetext': ariaValueText,
+			'data-webos-voice-group-label': voiceGroupLabel,
 			noAnimation,
 			children,
 			disabled,
@@ -814,6 +823,7 @@ const PickerBase = class extends React.Component {
 					aria-controls={!joined ? incrementerAriaControls : null}
 					aria-label={this.calcIncrementLabel(valueText)}
 					className={css.incrementer}
+					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={incrementerDisabled}
 					hidden={reachedEnd}
 					icon={incrementIcon}
@@ -849,6 +859,7 @@ const PickerBase = class extends React.Component {
 					aria-controls={!joined ? decrementerAriaControls : null}
 					aria-label={this.calcDecrementLabel(valueText)}
 					className={css.decrementer}
+					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={decrementerDisabled}
 					hidden={reachedStart}
 					icon={decrementIcon}


### PR DESCRIPTION
When same component is used on one screen,

data-webos-voice-group-label has to declared to each IconButton.

Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
