### PR TITLE
PLAT-61174: Add default declaration of voice intent

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -245,6 +245,7 @@ const ExpandableItemBase = kind({
 	},
 
 	defaultProps: {
+		'data-webos-voice-intent': 'Select',
 		autoClose: false,
 		disabled: false,
 		lockBottom: false,


### PR DESCRIPTION
Default value of 'data-webos-voice-intent' has to declaration as 'Select'
(In current status, LabeledItem's intent is not setted)

Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
