### PR TITLE
PLAT-61040: (release/1.x branch) Add disableBackHistoryAPI with `true` option to the appinfo.json of sampler

### DIFF
--- a/packages/sampler/.storybook/webos-meta/appinfo.json
+++ b/packages/sampler/.storybook/webos-meta/appinfo.json
@@ -13,6 +13,7 @@
 	"visible": true,
 	"uiRevision": 2,
 	"useNativeScroll": true,
+	"disableBackHistoryAPI": true,
 	"class": {
 		"hidden": false
 	},


### PR DESCRIPTION
### Issue Resolved / Feature Added
Add the disableBackHistoryAPI flag to the appinfo.json of Enact sampler
We expect popup close when pressing back key but App goes history back without this flag
### Links
PLAT-61040

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)