### PR TITLE
ENYO-5359: ProgressBar: warning is displayed in console for `highlighted` prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,7 +15,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to prevent updating state when the source is changed to the preload source, but the current preload source is the same
-- `moonstone/ProgressBar` to prevent displaying warning log by deleting `highlighted` prop in render function
 
 ## [2.0.0-beta.7] - 2018-06-11
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to prevent updating state when the source is changed to the preload source, but the current preload source is the same
+- `moonstone/ProgressBar` to prevent displaying warning log by deleting `highlighted` prop in render function
 
 ## [2.0.0-beta.7] - 2018-06-11
 

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -126,6 +126,7 @@ const ProgressBarBase = kind({
 
 	render: ({css, orientation, progress, tooltip, ...rest}) => {
 		delete rest.tooltip;
+		delete rest.highlighted;
 
 		return (
 			<UiProgressBar


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Warning logs are displayed in console when using `highlighted` prop in `ProgressBar`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I deleted `highlighted` prop in render function to not pass that to div node.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5359

Enact-DCO-1.0-Signed-off-by: Sangwook Lee (sangwook1203.lee@lge.com)
