### PR TITLE
PLAT-49380: Add `initialScrollPosition` prop to scroll when initialized

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
+- `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` property `initialScrollPosition` to scroll when initialized
 - `moonstone/VirtualList.VirtualList`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/Scroller.Scroller` overscroll effect when the edges are reached
 
 ### Changed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -544,16 +544,18 @@ class ScrollableBase extends Component {
 	}
 
 	clearOverscrollEffect = (orientation, position) => {
-		const {type} = this.uiRef.getOverscrollStatus(orientation);
+		if (this.uiRef) {
+			const {type} = this.uiRef.getOverscrollStatus(orientation);
 
-		if (type !== overscrollTypes.none) {
-			this.overscrollJobs[orientation][position].startAfter(
-				(type === overscrollTypes.scrolling) ? overscrollTimeout : 0,
-				orientation,
-				position,
-				overscrollTypes.none,
-				0
-			);
+			if (type !== overscrollTypes.none) {
+				this.overscrollJobs[orientation][position].startAfter(
+					(type === overscrollTypes.scrolling) ? overscrollTimeout : 0,
+					orientation,
+					position,
+					overscrollTypes.none,
+					0
+				);
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -602,16 +602,18 @@ class ScrollableBaseNative extends Component {
 	}
 
 	clearOverscrollEffect = (orientation, position) => {
-		const {type} = this.uiRef.getOverscrollStatus(orientation);
+		if (this.uiRef) {
+			const {type} = this.uiRef.getOverscrollStatus(orientation);
 
-		if (type !== overscrollTypes.none) {
-			this.overscrollJobs[orientation][position].startAfter(
-				(type === overscrollTypes.scrolling) ? overscrollTimeout : 0,
-				orientation,
-				position,
-				overscrollTypes.none,
-				0
-			);
+			if (type !== overscrollTypes.none) {
+				this.overscrollJobs[orientation][position].startAfter(
+					(type === overscrollTypes.scrolling) ? overscrollTimeout : 0,
+					orientation,
+					position,
+					overscrollTypes.none,
+					0
+				);
+			}
 		}
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -399,18 +399,17 @@ class ScrollableBase extends Component {
 			{hasDataSizeChanged} = this.childRef;
 
 		// Need to sync calculated client size if it is different from the real size
-		if (this.childRef.syncClientSize) {
-			// If we actually synced, we need to reset scroll position.
-			const isSync = this.childRef.syncClientSize();
+		const isSync = this.childRef.syncClientSize ? this.childRef.syncClientSize() : null;
 
-			if (this.props.initialScrollPosition) {
-				const {left, top} = this.props.initialScrollPosition;
-				this.scroll(left, top);
-			} else if (isSync) {
-				this.setScrollLeft(0);
-				this.setScrollTop(0);
-			}
+		if (!this.initialScrollTo && this.props.initialScrollPosition) {
+			const {left, top} = this.props.initialScrollPosition;
+			this.scroll(left, top);
+		} else if (isSync) {
+			// If we actually synced, we need to reset scroll position.
+			this.setScrollLeft(0);
+			this.setScrollTop(0);
 		}
+		this.initialScrollTo = true;
 
 		this.clampScrollPosition();
 
@@ -494,6 +493,7 @@ class ScrollableBase extends Component {
 
 	// status
 	deferScrollTo = true
+	initialScrollTo = false
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -403,7 +403,7 @@ class ScrollableBase extends Component {
 
 		if (!this.initialScrollTo && this.props.initialScrollPosition) {
 			const {left, top} = this.props.initialScrollPosition;
-			this.scroll(left, top);
+			this.start({targetX: left, targetY: top, animate: false});
 		} else if (isSync) {
 			// If we actually synced, we need to reset scroll position.
 			this.setScrollLeft(0);

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -159,6 +159,20 @@ class ScrollableBase extends Component {
 		horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
 
 		/**
+		 * Specifies initial scroll position including the following properties
+		 *
+		 * `x` is the number of scroll x position.
+		 * `y` is the number of scroll y position.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		initialScrollPosition: PropTypes.shape({
+			x: PropTypes.number.isRequired,
+			y: PropTypes.number.isRequired
+		}),
+
+		/**
 		 * Called when flicking with a mouse or a touch screen.
 		 *
 		 * @type {Function}
@@ -387,7 +401,12 @@ class ScrollableBase extends Component {
 		// Need to sync calculated client size if it is different from the real size
 		if (this.childRef.syncClientSize) {
 			// If we actually synced, we need to reset scroll position.
-			if (this.childRef.syncClientSize()) {
+			const isSync = this.childRef.syncClientSize();
+
+			if (this.props.initialScrollPosition) {
+				const {x, y} = this.props.initialScrollPosition;
+				this.scroll(x, y);
+			} else if (isSync) {
 				this.setScrollLeft(0);
 				this.setScrollTop(0);
 			}
@@ -1204,6 +1223,7 @@ class ScrollableBase extends Component {
 		delete rest.cbScrollTo;
 		delete rest.clearAllOverscrollEffects;
 		delete rest.horizontalScrollbar;
+		delete rest.initialScrollPosition;
 		delete rest.onFlick;
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -161,15 +161,15 @@ class ScrollableBase extends Component {
 		/**
 		 * Specifies initial scroll position including the following properties
 		 *
-		 * `x` is the number of scroll x position.
-		 * `y` is the number of scroll y position.
+		 * `left` is the number of scroll left position.
+		 * `top` is the number of scroll top position.
 		 *
 		 * @type {Object}
 		 * @public
 		 */
 		initialScrollPosition: PropTypes.shape({
-			x: PropTypes.number.isRequired,
-			y: PropTypes.number.isRequired
+			left: PropTypes.number.isRequired,
+			top: PropTypes.number.isRequired
 		}),
 
 		/**
@@ -404,8 +404,8 @@ class ScrollableBase extends Component {
 			const isSync = this.childRef.syncClientSize();
 
 			if (this.props.initialScrollPosition) {
-				const {x, y} = this.props.initialScrollPosition;
-				this.scroll(x, y);
+				const {left, top} = this.props.initialScrollPosition;
+				this.scroll(left, top);
 			} else if (isSync) {
 				this.setScrollLeft(0);
 				this.setScrollTop(0);

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -363,6 +363,10 @@ class ScrollableBase extends Component {
 		};
 
 		props.cbScrollTo(this.scrollTo);
+
+		if (!props.initialScrollPosition) {
+			this.scrollInitially = nop;
+		}
 	}
 
 	getChildContext = () => ({
@@ -487,17 +491,12 @@ class ScrollableBase extends Component {
 	}
 
 	scrollInitially () {
-		const initialScrollTo = this.initialScrollTo;
+		const {left, top} = this.props.initialScrollPosition;
 
-		this.initialScrollTo = true;
+		this.scrollInitially = nop;
+		this.start({targetX: left, targetY: top, animate: false});
 
-		if (!initialScrollTo && this.props.initialScrollPosition) {
-			const {left, top} = this.props.initialScrollPosition;
-			this.start({targetX: left, targetY: top, animate: false});
-			return true;
-		} else {
-			return false;
-		}
+		return true;
 	}
 
 	// constants
@@ -506,7 +505,6 @@ class ScrollableBase extends Component {
 
 	// status
 	deferScrollTo = true
-	initialScrollTo = false
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -364,6 +364,10 @@ class ScrollableBaseNative extends Component {
 		};
 
 		props.cbScrollTo(this.scrollTo);
+
+		if (!props.initialScrollPosition) {
+			this.scrollInitially = nop;
+		}
 	}
 
 	getChildContext = () => ({
@@ -474,17 +478,12 @@ class ScrollableBaseNative extends Component {
 	}
 
 	scrollInitially () {
-		const initialScrollTo = this.initialScrollTo;
+		const {left, top} = this.props.initialScrollPosition;
 
-		this.initialScrollTo = true;
+		this.scrollInitially = nop;
+		this.start(left, top, false);
 
-		if (!initialScrollTo && this.props.initialScrollPosition) {
-			const {left, top} = this.props.initialScrollPosition;
-			this.start(left, top, false);
-			return true;
-		} else {
-			return false;
-		}
+		return true;
 	}
 
 	// constants
@@ -493,7 +492,6 @@ class ScrollableBaseNative extends Component {
 
 	// status
 	deferScrollTo = true
-	initialScrollTo = false
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -404,9 +404,7 @@ class ScrollableBaseNative extends Component {
 
 		if (!this.initialScrollTo && this.props.initialScrollPosition) {
 			const {left, top} = this.props.initialScrollPosition;
-			this.childRef.containerRef.style.scrollBehavior = null;
-			this.childRef.scrollToPosition(left, top);
-			this.childRef.containerRef.style.scrollBehavior = 'smooth';
+			this.start(left, top, false);
 		} else if (isSync) {
 			// If we actually synced, we need to reset scroll position.
 			this.setScrollLeft(0);

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -152,6 +152,20 @@ class ScrollableBaseNative extends Component {
 		horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
 
 		/**
+		 * Specifies initial scroll position including the following properties
+		 *
+		 * `x` is the number of scroll x position.
+		 * `y` is the number of scroll y position.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		initialScrollPosition: PropTypes.shape({
+			x: PropTypes.number.isRequired,
+			y: PropTypes.number.isRequired
+		}),
+
+		/**
 		 * Called when flicking with a mouse or a touch screen.
 		 *
 		 * @type {Function}
@@ -388,7 +402,12 @@ class ScrollableBaseNative extends Component {
 		// Need to sync calculated client size if it is different from the real size
 		if (this.childRef.syncClientSize) {
 			// If we actually synced, we need to reset scroll position.
-			if (this.childRef.syncClientSize()) {
+			const isSync = this.childRef.syncClientSize();
+
+			if (this.props.initialScrollPosition) {
+				const {x, y} = this.props.initialScrollPosition;
+				this.childRef.scrollToPosition(x, y);
+			} else if (isSync) {
 				this.setScrollLeft(0);
 				this.setScrollTop(0);
 			}
@@ -1235,6 +1254,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.cbScrollTo;
 		delete rest.clearAllOverscrollEffects;
 		delete rest.horizontalScrollbar;
+		delete rest.initialScrollPosition;
 		delete rest.onFlick;
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -154,15 +154,15 @@ class ScrollableBaseNative extends Component {
 		/**
 		 * Specifies initial scroll position including the following properties
 		 *
-		 * `x` is the number of scroll x position.
-		 * `y` is the number of scroll y position.
+		 * `left` is the number of scroll left position.
+		 * `top` is the number of scroll top position.
 		 *
 		 * @type {Object}
 		 * @public
 		 */
 		initialScrollPosition: PropTypes.shape({
-			x: PropTypes.number.isRequired,
-			y: PropTypes.number.isRequired
+			left: PropTypes.number.isRequired,
+			top: PropTypes.number.isRequired
 		}),
 
 		/**
@@ -405,8 +405,8 @@ class ScrollableBaseNative extends Component {
 			const isSync = this.childRef.syncClientSize();
 
 			if (this.props.initialScrollPosition) {
-				const {x, y} = this.props.initialScrollPosition;
-				this.childRef.scrollToPosition(x, y);
+				const {left, top} = this.props.initialScrollPosition;
+				this.childRef.scrollToPosition(left, top);
 			} else if (isSync) {
 				this.setScrollLeft(0);
 				this.setScrollTop(0);

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -400,18 +400,19 @@ class ScrollableBaseNative extends Component {
 			{hasDataSizeChanged} = this.childRef;
 
 		// Need to sync calculated client size if it is different from the real size
-		if (this.childRef.syncClientSize) {
-			// If we actually synced, we need to reset scroll position.
-			const isSync = this.childRef.syncClientSize();
+		const isSync = this.childRef.syncClientSize ? this.childRef.syncClientSize() : null;
 
-			if (this.props.initialScrollPosition) {
-				const {left, top} = this.props.initialScrollPosition;
-				this.childRef.scrollToPosition(left, top);
-			} else if (isSync) {
-				this.setScrollLeft(0);
-				this.setScrollTop(0);
-			}
+		if (!this.initialScrollTo && this.props.initialScrollPosition) {
+			const {left, top} = this.props.initialScrollPosition;
+			this.childRef.containerRef.style.scrollBehavior = null;
+			this.childRef.scrollToPosition(left, top);
+			this.childRef.containerRef.style.scrollBehavior = 'smooth';
+		} else if (isSync) {
+			// If we actually synced, we need to reset scroll position.
+			this.setScrollLeft(0);
+			this.setScrollTop(0);
 		}
+		this.initialScrollTo = true;
 
 		this.addEventListeners();
 		if (
@@ -481,6 +482,7 @@ class ScrollableBaseNative extends Component {
 
 	// status
 	deferScrollTo = true
+	initialScrollTo = false
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Add `initialScrollPosition` prop in Scrollable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I would like to scroll a list or a scroller first, then to render the items or the content in it when creating it. But at that time `bounds` information is incorrect. So I render the items or the content first, then scroll them.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-49380

### Comments
