### PR TITLE
PLAT-61277: Update i18n docs

### DIFF
--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -110,7 +110,7 @@ const extractAriaProps = function (props) {
  *	their PropTypes as keys
  * @param  {Component} Wrapped	A component to apply this to
  *
- * @return {Component}              The component, now with context on it
+ * @returns {Component}              The component, now with context on it
  * @private
  */
 const withContextFromProps = (propsList, Wrapped) => withContext(propsList, (props) => {

--- a/packages/i18n/$L/$L.js
+++ b/packages/i18n/$L/$L.js
@@ -1,7 +1,7 @@
 /**
- * Exports the {@link i18n/$L.$L} function and {@link i18n/$L.toIString} function to map to
- * translated strings.
+ * Provides methods to map to transtalted strings.
  *
+ * Usage:
  * ```
  * import $L, {toIString} from '@enact/i18n/$L';
  * $L('Close');        // => "Close" in the current locale
@@ -9,6 +9,8 @@
  * ```
  *
  * @module i18n/$L
+ * @exports $L
+ * @exports $toIString
  */
 
 import '../src/glue';
@@ -16,7 +18,7 @@ import {getResBundle} from '../src/resBundle';
 import IString from '../ilib/lib/IString';
 
 /**
- * Maps a string or key/value object to a translated string for the current locale
+ * Maps a string or key/value object to a translated string for the current locale.
  *
  * @memberof i18n/$L
  * @param  {String|Object} str Source string
@@ -34,12 +36,12 @@ function toIString (str) {
 }
 
 /**
- * Maps a string or key/value object to a translated string for the current locale
+ * Maps a string or key/value object to a translated string for the current locale.
  *
  * @memberof i18n/$L
  * @param  {String|Object} str Source string
  *
- * @returns {String} The translated string.
+ * @returns {String} The translated string
  */
 function $L (str) {
 	return String(toIString(str));

--- a/packages/i18n/$L/$L.js
+++ b/packages/i18n/$L/$L.js
@@ -1,5 +1,5 @@
 /**
- * Provides methods to map to transtalted strings.
+ * Provides methods to map to translated strings.
  *
  * Usage:
  * ```

--- a/packages/i18n/$L/$L.js
+++ b/packages/i18n/$L/$L.js
@@ -1,5 +1,5 @@
 /**
- * Provides methods to map to translated strings.
+ * Provides functions to map to translated strings.
  *
  * Usage:
  * ```
@@ -20,6 +20,7 @@ import IString from '../ilib/lib/IString';
 /**
  * Maps a string or key/value object to a translated string for the current locale.
  *
+ * @function
  * @memberof i18n/$L
  * @param  {String|Object} str Source string
  *
@@ -38,6 +39,7 @@ function toIString (str) {
 /**
  * Maps a string or key/value object to a translated string for the current locale.
  *
+ * @function
  * @memberof i18n/$L
  * @param  {String|Object} str Source string
  *

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -62,7 +62,7 @@ const IntlHoc = hoc((config, Wrapped) => {
 			className: PropTypes.string,
 
 			/**
-			 * Locale string in the format.
+			 * A string with a {@link https://tools.ietf.org/html/rfc5646|BCP 47 language tag}.
 			 *
 			 * The system locale will be used by default.
 			 *

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -1,8 +1,9 @@
 /**
- * Exports the {@link i18n/I18nDecorator.I18nDecorator} component and
- * {@link i18n/I18nDecorator.contextTypes} validation rules.
+ * Provides a HOC interface for internationalization.
  *
  * @module i18n/I18nDecorator
+ * @exports contextTypes
+ * @exports I18nDecorator
  */
 
 import hoc from '@enact/core/hoc';
@@ -17,8 +18,9 @@ import {isRtlLocale, updateLocale} from '../locale';
 import getI18nClasses from './getI18nClasses';
 
 /**
- * `contextTypes` is an object that exports the default context validation rules. These must be applied
- * to any child components that wish to receive the i18n context.
+ * An object that exports the default context validation rules.
+ *
+ * These must be applied to any child components that wish to receive the i18n context.
  *
  * ```
  * import {contextTypes} from '@enact/i18n/I18nDecorator';
@@ -35,10 +37,9 @@ const contextTypes = {
 };
 
 /**
- * {@link i18n/I18nDecorator.I18nDecorator} is a Higher Order Component that is used to wrap
- * the root element in an app. It provides an `rtl` member on the context of the wrapped component, allowing
- * the children to check the current text directionality as well as an `updateLocale` method that can be
- * used to update the current locale.
+ * A higher-order component that is used to wrap the root element in an app. It provides an `rtl` member on the
+ * context of the wrapped component, allowing the children to check the current text directionality as well as
+ * an `updateLocale` method that can be used to update the current locale.
  *
  * There are no configurable options on this HOC.
  *
@@ -52,7 +53,22 @@ const IntlHoc = hoc((config, Wrapped) => {
 		static contextTypes = stateContextTypes
 		static childContextTypes = {...contextTypes, ...stateContextTypes}
 		static propTypes = /** @lends i18n/I18nDecorator.I18nDecorator.prototype */ {
+			/**
+			 * Classname for a root app element.
+			 *
+			 * @type {String}
+			 * @public
+			 */
 			className: PropTypes.string,
+
+			/**
+			 * Locale string in the format.
+			 *
+			 * The system locale will be used by default.
+			 *
+			 * @type {String}
+			 * @public
+			 */
 			locale: PropTypes.string
 		}
 
@@ -139,4 +155,7 @@ const IntlHoc = hoc((config, Wrapped) => {
 });
 
 export default IntlHoc;
-export {IntlHoc as I18nDecorator, contextTypes};
+export {
+	IntlHoc as I18nDecorator,
+	contextTypes
+};

--- a/packages/i18n/I18nDecorator/getI18nClasses.js
+++ b/packages/i18n/I18nDecorator/getI18nClasses.js
@@ -1,6 +1,13 @@
 import {isNonLatinLocale, isRtlLocale} from '../locale';
 import LocaleInfo from '../ilib/lib/LocaleInfo';
 
+/**
+ * A function that returns locale in class name.
+ *
+ * @memberof i18n/I18nDecorator
+ * @returns {String} Class
+ * @private
+ */
 function getI18nClasses () {
 	const li = new LocaleInfo(); // for the current locale
 	const locale = li.getLocale();
@@ -8,7 +15,7 @@ function getI18nClasses () {
 	const classes = [];
 
 	if (isNonLatinLocale(locale)) {
-		// allow enyo to define other fonts for non-Latin languages, or for certain
+		// allow enact to define other fonts for non-Latin languages, or for certain
 		// Latin-based languages where the characters with some accents don't appear in the
 		// regular fonts, creating a strange 'ransom note' look with a mix of fonts in the
 		// same word. So, treat it like a non-Latin language in order to get all the characters
@@ -18,17 +25,17 @@ function getI18nClasses () {
 
 	const scriptName = li.getScript();
 	if (scriptName !== 'Latn' && scriptName !== 'Cyrl' && scriptName !== 'Grek') {
-		// GF-45884: allow enyo to avoid setting italic fonts for those scripts that do not
+		// GF-45884: allow enact to avoid setting italic fonts for those scripts that do not
 		// commonly use italics
 		classes.push(base + 'non-italic');
 	}
 
-	// allow enyo to apply right-to-left styles to the app and widgets if necessary
+	// allow enact to apply right-to-left styles to the app and widgets if necessary
 	if (isRtlLocale()) {
 		classes.push(base + 'right-to-left');
 	}
 
-	// allow enyo or the apps to give CSS classes that are specific to the language, country, or script
+	// allow enact or the apps to give CSS classes that are specific to the language, country, or script
 	if (locale.getLanguage()) {
 		classes.push(base + locale.getLanguage());
 		if (locale.getScript()) {

--- a/packages/i18n/I18nDecorator/getI18nClasses.js
+++ b/packages/i18n/I18nDecorator/getI18nClasses.js
@@ -1,7 +1,7 @@
 import {isNonLatinLocale, isRtlLocale} from '../locale';
 import LocaleInfo from '../ilib/lib/LocaleInfo';
 
-/**
+/*
  * A function that returns locale in class name.
  *
  * @memberof i18n/I18nDecorator

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -4,7 +4,7 @@
 
 `@enact/i18n` provides a decorator that can be used to wrap a root component in a React (or Enact) application.
 This decorator provides a context to child components that can be used to determine locale text directionality
-and to update the current locale. Additionally, it provides a locale-aware `Uppercase` Higher Order Component (HOC).
+and to update the current locale. Additionally, it provides a locale-aware `Uppercase` higher-order component (HOC).
 
 ## Usage
 

--- a/packages/i18n/Uppercase/Uppercase.js
+++ b/packages/i18n/Uppercase/Uppercase.js
@@ -1,7 +1,8 @@
 /**
- * Exports the {@link i18n/Uppercase.Uppercase} Higher-Order Component (HOC)
+ * Provide higher-order component interface for handling locale-aware uppercasing.
  *
  * @module i18n/Uppercase
+ * @exports Uppercase
  */
 
 import hoc from '@enact/core/hoc';
@@ -12,10 +13,9 @@ import PropTypes from 'prop-types';
 import {toCapitalized, toUpperCase, toWordCase} from '../util';
 
 /**
- * {@link i18n/Uppercase.Uppercase} is a Higher Order Component that is used to wrap
- * an element to provide locale-aware uppercasing of `children`, provided that `children` is a single
- * string. Other values for `children` are unchanged. It supports a `casing` property which can be
- * used to override the uppercase as-needed.
+ * A higher-order component that is used to wrap an element to provide locale-aware uppercasing of
+ * `children`, provided that `children` is a single string. Other values for `children` are
+ * unchanged. It supports a `casing` property which can be used to override the uppercase as-needed.
  *
  * There are no configurable options on this HOC.
  *
@@ -29,7 +29,9 @@ const Uppercase = hoc((config, Wrapped) => kind({
 
 	propTypes: /** @lends i18n/Uppercase.Uppercase.prototype */ {
 		/**
-		 * Configures the mode of uppercasing that should be performed. Options are:
+		 * Configures the mode of uppercasing that should be performed.
+		 *
+		 * Options are:
 		 *   `'upper'` to capitalize all characters.
 		 *   `'preserve'` to maintain the original casing.
 		 *   `'word'` to capitalize the first letter of each word.
@@ -74,4 +76,6 @@ const Uppercase = hoc((config, Wrapped) => kind({
 }));
 
 export default Uppercase;
-export {Uppercase};
+export {
+	Uppercase
+};

--- a/packages/i18n/Uppercase/Uppercase.js
+++ b/packages/i18n/Uppercase/Uppercase.js
@@ -1,5 +1,5 @@
 /**
- * Provide higher-order component interface for handling locale-aware uppercasing.
+ * Provides higher-order component interface for handling locale-aware uppercasing.
  *
  * @module i18n/Uppercase
  * @exports Uppercase

--- a/packages/i18n/docs/index.md
+++ b/packages/i18n/docs/index.md
@@ -18,7 +18,7 @@ This guide details how to use some of i18n library's features. For an overview o
 <a name="2"></a>
 ## Using I18nDecorator
 
-`I18nDecorator` is a Higher-order Component (HOC) that provides easy access to locale information. Applications wishing to receive locale information can wrap the root component with the HOC. It is not necessary to use `I18nDecorator` directly for applications using `MoonstoneDecorator`.
+`I18nDecorator` is a higher-order component (HOC) that provides easy access to locale information. Applications wishing to receive locale information can wrap the root component with the HOC. It is not necessary to use `I18nDecorator` directly for applications using `MoonstoneDecorator`.
 
 The HOC works by passing locale information to the app through `context` and CSS classes. It contains two properties inside its `context`:
 
@@ -137,7 +137,7 @@ The `strings.json` files should contain the translations in JSON format, i.e.:
 		"source string1": "translated string1",
 		"source string2": "translated string2",
 		...
-	} 
+	}
 ```
 
 Many localization companies are able to provide translations in this format.
@@ -160,4 +160,3 @@ iLib provides the locale-specific features of i18n. If you wish to learn about s
 ## Sample
 
 A sample i18n app is available [here](https://github.com/enactjs/samples/tree/master/pattern-locale-switching).
-

--- a/packages/i18n/docs/updating-locale.md
+++ b/packages/i18n/docs/updating-locale.md
@@ -18,7 +18,7 @@ class SomeComponent extends React.Component {
     changeLocale = (locale) => {
         this.context.updateLocale(locale);
     }
-	...
+    ...
 ```
 
 ## Updating locale via props
@@ -84,4 +84,3 @@ export default connect(mapStateToProps, mapDispatchToProps, null, {pure: false})
 ```
 
 This will allow the `context` to flow through to the component, but it will also cause performance issues because your component will be re-rendering on every change. If you must use `context` with `react-redux`, please make the component as small as possible to reduce re-renders or use `shouldComponentUpdate`.
-

--- a/packages/i18n/util/util.js
+++ b/packages/i18n/util/util.js
@@ -2,8 +2,8 @@
  * A collection of locale-aware text utility function.
  *
  * @module i18n/util
- * @exports toCapitalized
  * @exports isRtlText
+ * @exports toCapitalized
  * @exports toLowerCase
  * @exports toUpperCase
  * @exports toWordCase
@@ -65,8 +65,8 @@ const toWordCase = (str) => {
 };
 
 export {
-	toCapitalized,
 	isRtlText,
+	toCapitalized,
 	toLowerCase,
 	toUpperCase,
 	toWordCase

--- a/packages/i18n/util/util.js
+++ b/packages/i18n/util/util.js
@@ -1,5 +1,5 @@
 /**
- * A collection of locale-aware text utility methods.
+ * A collection of locale-aware text utility function.
  *
  * @module i18n/util
  * @exports toCapitalized
@@ -11,23 +11,24 @@
 import '../src/glue';
 import {toLowerCase, toUpperCase} from '../src/case';
 
-/**
-* This regex pattern is used by the [isRtlText()]{@link i18n/utils.isRtlText} function.
-*
-* Arabic: \u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFE
-* Hebrew: \u0590-\u05FF\uFB1D-\uFB4F
-*
-* @private
-*/
+/*
+ * This regex pattern is used by the [isRtlText()]{@link i18n/utils.isRtlText} function.
+ *
+ * Arabic: \u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFE
+ * Hebrew: \u0590-\u05FF\uFB1D-\uFB4F
+ *
+ * @private
+ */
 const rtlPattern = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFE\u0590-\u05FF\uFB1D-\uFB4F]/;
 
 /**
-* Takes content `str` and determines whether or not it is [RTL]{@glossary RTL}.
-*
-* @param {String} str - A [String]{@glossary String} to check the [RTL]{@glossary RTL}-ness of.
-* @returns {Boolean} `true` if `str` should be RTL; `false` if not.
-* @public
-*/
+ * Takes content `str` and determines whether or not it is [RTL]{@glossary RTL}.
+ *
+ * @function
+ * @param {String} str - A [String]{@glossary String} to check the [RTL]{@glossary RTL}-ness of.
+ * @returns {Boolean} `true` if `str` should be RTL; `false` if not.
+ * @public
+ */
 const isRtlText = function (str) {
 	if (typeof str === 'string') {
 		return rtlPattern.test(str);
@@ -39,7 +40,7 @@ const isRtlText = function (str) {
 /**
  * Capitalizes the first letter of a given string (locale aware).
  *
- * @method
+ * @function
  * @memberof i18n/util
  * @param {String} str - The string to capitalize.
  * @returns {String} The capitalized string.
@@ -53,7 +54,7 @@ const toCapitalized = function (str) {
  * Capitalizes every word in a string. Words are separated by spaces, not necessarily
  * word-breaks (locale aware).
  *
- * @method
+ * @function
  * @memberof i18n/util
  * @param {String} str - The string to capitalize.
  * @returns {String} The word-cased string.

--- a/packages/i18n/util/util.js
+++ b/packages/i18n/util/util.js
@@ -1,3 +1,13 @@
+/**
+ * A collection of locale-aware text utility methods.
+ *
+ * @module i18n/util
+ * @exports toCapitalized
+ * @exports isRtlText
+ * @exports toLowerCase
+ * @exports toUpperCase
+ * @exports toWordCase
+ */
 import '../src/glue';
 import {toLowerCase, toUpperCase} from '../src/case';
 

--- a/packages/moonstone/MoonstoneDecorator/I18nFontDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/I18nFontDecorator.js
@@ -48,4 +48,6 @@ const I18nFontDecorator = hoc((config, Wrapped) => {
 });
 
 export default I18nFontDecorator;
-export {I18nFontDecorator};
+export {
+	I18nFontDecorator
+};

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1506,7 +1506,7 @@ const VideoPlayerBase = class extends React.Component {
 	 * left components, right components, media controls or more controls (depending on which is
 	 * available)
 	 *
-	 * @return {Node|false} The focused control or `false` if nothing is found.
+	 * @returns {Node|false} The focused control or `false` if nothing is found.
 	 * @private
 	 */
 	focusDefaultMediaControl = () => {

--- a/packages/moonstone/VideoPlayer/util.js
+++ b/packages/moonstone/VideoPlayer/util.js
@@ -7,7 +7,7 @@ import React from 'react';
  *
  * @param  {Number|String} value A duration of time represented in seconds
  *
- * @return {Object}       An object with keys {hour, minute, second} representing the duration
+ * @returns {Object}       An object with keys {hour, minute, second} representing the duration
  *                        seconds provided as an argument.
  * @private
  */
@@ -28,7 +28,7 @@ const parseTime = (value) => {
  *
  * @param  {Number|String} seconds A duration of time represented in seconds
  *
- * @return {String}      String formatted for use in a `datetime` field of a `<time>` tag.
+ * @returns {String}      String formatted for use in a `datetime` field of a `<time>` tag.
  * @private
  */
 const secondsToPeriod = (seconds) => {
@@ -44,7 +44,7 @@ const secondsToPeriod = (seconds) => {
  *                             component.
  * @param  {Object} config Additional configuration object that includes `includeHour`.
  *
- * @return {String}      Formatted duration string
+ * @returns {String}      Formatted duration string
  * @private
  */
 const secondsToTime = (seconds, durfmt, config) => {
@@ -79,7 +79,7 @@ const calcNumberValueOfPlaybackRate = (rate) => {
  * real children
  *
  * @param {component} children React.Component or React.PureComponent
- * @return {Number} Number of children nodes
+ * @returns {Number} Number of children nodes
  * @private
  */
 const countReactChildren = (children) => React.Children.toArray(children).filter(n => n != null).length;

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -563,7 +563,7 @@ const isNavigable = (node, containerId, verify) => {
 /**
  * Returns the IDs of all containers
  *
- * @return {String[]}  Array of container IDs
+ * @returns {String[]}  Array of container IDs
  * @memberof spotlight/container
  * @private
  */

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -104,7 +104,8 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * Compare our current version of the resolved resolution class names with a fresh
 		 * initialization of RI.
 		 *
-		 * @return {String|undefined} A string of new class names or undefined when there is no change.
+		 * @returns {String|undefined} A string of new class names or undefined when there is no change.
+		 * @private
 		 */
 		didClassesChange () {
 			const prevClassNames = getResolutionClasses();

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -100,7 +100,7 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		/**
+		/*
 		 * Compare our current version of the resolved resolution class names with a fresh
 		 * initialization of RI.
 		 *


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `i18n` documentation.

A couple of things I noticed in our current doc (http://enactjs.com/docs/modules/i18n/$L/):
1. `util` module is not shown. I'm assuming this module is public, here. Though our recommendation is to use `i18nDecorator` and `Uppercase` HOC over using `isRTLText` or all the casing functions, it seems reasonable to make it public IMO. I'm open for debate on this.
2. `docs/iLib` and `docs/updateLocale` link is hard to find
3. There are mentions of `moonstone` in `docs/index.md` and `update-locale.md`. I wonder if these need to be modified so that it shows the example of using in non-moonstone context.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>