### PR TITLE
ENYO-5362: Fix sampler knobs for VideoPlayer and MediaOverlay

### DIFF
--- a/packages/sampler/stories/moonstone-stories/MediaOverlay.js
+++ b/packages/sampler/stories/moonstone-stories/MediaOverlay.js
@@ -13,18 +13,32 @@ const defaultPlaceholder =
 	'4NCg==';
 
 const prop = {
+	videoTitles: [
+		'Sintel',
+		'Big Buck Bunny',
+		'VideoTest',
+		'Bad Video Source'
+	],
 	videos: {
-		'http://media.w3.org/2010/05/sintel/trailer.mp4': 'Sintel',
-		'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov': 'Big Buck Bunny',
-		'http://media.w3.org/2010/05/video/movie_300.mp4': 'VideoTest',
-		'https://github.com/mderrick/react-html5video': 'Bad Video Source'
+		'Sintel': 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+		'Big Buck Bunny': 'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov',
+		'VideoTest': 'http://media.w3.org/2010/05/video/movie_300.mp4',
+		// Purposefully not a video to demonstrate source error state
+		'Bad Video Source': 'https://github.com/mderrick/react-html5video'
 	},
+	imageNames: [
+		'None',
+		'Strawberries',
+		'Tunnel',
+		'Mountains',
+		'Bad Image Source'
+	],
 	images: {
-		'': 'None',
-		'https://picsum.photos/1280/720?image=1080': 'Strawberries',
-		'https://picsum.photos/1280/720?image=1063': 'Tunnel',
-		'https://picsum.photos/1280/720?image=930': 'Mountains',
-		'imagenotfound.png': 'Bad Image Source'
+		'None': '',
+		'Strawberries': 'https://picsum.photos/1280/720?image=1080',
+		'Tunnel': 'https://picsum.photos/1280/720?image=1063',
+		'Mountains': 'https://picsum.photos/1280/720?image=930',
+		'Bad Image Source': 'imagenotfound.png'
 	},
 	text: [
 		'',
@@ -44,7 +58,6 @@ const prop = {
 	}
 };
 
-
 const Config = mergeComponentMetadata('MediaOverlay', MediaOverlay, MediaOverlayBase, MediaOverlayDecorator);
 MediaOverlay.displayName = 'MediaOverlay';
 
@@ -54,14 +67,20 @@ storiesOf('Moonstone', module)
 		withInfo({
 			propTablesExclude: [MediaOverlay],
 			text: 'The basic MediaOverlay'
-		})(() => (
-			<MediaOverlay
-				imageOverlay={select('imageOverlay', prop.images, Config)}
-				placeholder={select('placeholder', prop.placeholder, Config, 'None')}
-				text={select('text', prop.text, Config, prop.text[0])}
-				textAlign={select('textAlign', ['start', 'center', 'end'], Config, 'center')}
-			>
-				<source src={select('source', prop.videos, Config, Object.keys(prop.videos)[0])} />
-			</MediaOverlay>
-		))
+		})(() => {
+			const videoTitle = select('source', prop.videoTitles, Config, 'Sintel');
+			const videoSource = prop.videos[videoTitle];
+			const imageName = select('imageOverlay', prop.imageNames, Config, 'None');
+			const imageSource = prop.images[imageName];
+			return (
+				<MediaOverlay
+					imageOverlay={imageSource}
+					placeholder={select('placeholder', prop.placeholder, Config, '')}
+					text={select('text', prop.text, Config, prop.text[0])}
+					textAlign={select('textAlign', ['start', 'center', 'end'], Config, 'center')}
+				>
+					<source src={videoSource} />
+				</MediaOverlay>
+			);
+		})
 	);

--- a/packages/sampler/stories/moonstone-stories/MediaOverlay.js
+++ b/packages/sampler/stories/moonstone-stories/MediaOverlay.js
@@ -59,6 +59,7 @@ const prop = {
 };
 
 const Config = mergeComponentMetadata('MediaOverlay', MediaOverlay, MediaOverlayBase, MediaOverlayDecorator);
+Config.groupId = 'MediaOverlay';
 MediaOverlay.displayName = 'MediaOverlay';
 
 storiesOf('Moonstone', module)

--- a/packages/sampler/stories/moonstone-stories/MediaOverlay.js
+++ b/packages/sampler/stories/moonstone-stories/MediaOverlay.js
@@ -6,12 +6,6 @@ import {withInfo} from '@storybook/addon-info';
 import {select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
-const defaultPlaceholder =
-	'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
-	'9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
-	'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
-	'4NCg==';
-
 const prop = {
 	videoTitles: [
 		'Sintel',
@@ -52,9 +46,16 @@ const prop = {
 		'قفز الثعلب البني السريع فوق الكلب الكسول. الطيور تطير في الفول عند غروب الشمس.',
 		'فوری بھوری لومڑی سست کتے پر چھلانگ لگا. بین پرندوں سوریاست میں پرواز.'
 	],
+	placeholderNames: [
+		'None',
+		'SVG'
+	],
 	placeholder: {
-		'': 'None',
-		[defaultPlaceholder]: 'SVG'
+		'None': '',
+		'SVG': 'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC' +
+		'9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
+		'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
+		'4NCg=='
 	}
 };
 
@@ -71,12 +72,14 @@ storiesOf('Moonstone', module)
 		})(() => {
 			const videoTitle = select('source', prop.videoTitles, Config, 'Sintel');
 			const videoSource = prop.videos[videoTitle];
-			const imageName = select('imageOverlay', prop.imageNames, Config, 'None');
+			const imageName = select('imageOverlay', prop.imageNames, Config);
 			const imageSource = prop.images[imageName];
+			const placeholderName = select('placeholder', prop.placeholderNames, Config, 'None');
+			const placeholder = prop.placeholder[placeholderName];
 			return (
 				<MediaOverlay
 					imageOverlay={imageSource}
-					placeholder={select('placeholder', prop.placeholder, Config, '')}
+					placeholder={placeholder}
 					text={select('text', prop.text, Config, prop.text[0])}
 					textAlign={select('textAlign', ['start', 'center', 'end'], Config, 'center')}
 				>

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -18,25 +18,19 @@ const prop = {
 		'VideoTest',
 		'Bad Video Source'
 	],
-	videos: [
-		{
-			poster: 'http://media.w3.org/2010/05/sintel/poster.png',
-			source: 'http://media.w3.org/2010/05/sintel/trailer.mp4'
-		},
-		{
-			poster: 'http://media.w3.org/2010/05/bunny/poster.png',
-			source: 'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov'
-		},
-		{
-			poster: 'http://media.w3.org/2010/05/video/poster.png',
-			source: 'http://media.w3.org/2010/05/video/movie_300.mp4'
-		},
-		{
-			poster: 'http://media.w3.org/2010/05/video/poster.png',
-			// Purposefully not a video to demonstrate source error state
-			source: 'https://github.com/mderrick/react-html5video'
-		}
-	],
+	videos: {
+		'Sintel': 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+		'Big Buck Bunny': 'http://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_480p_h264.mov',
+		'VideoTest': 'http://media.w3.org/2010/05/video/movie_300.mp4',
+		// Purposefully not a video to demonstrate source error state
+		'Bad Video Source': 'https://github.com/mderrick/react-html5video'
+	},
+	posters: {
+		'Sintel': 'http://media.w3.org/2010/05/sintel/poster.png',
+		'Big Buck Bunny': 'http://media.w3.org/2010/05/bunny/poster.png',
+		'VideoTest': 'http://media.w3.org/2010/05/video/poster.png',
+		'Bad Video Source': 'http://media.w3.org/2010/05/video/poster.png'
+	},
 	events: [
 		'onAbort',
 		'onCanPlay',
@@ -70,22 +64,6 @@ const prop = {
 	]
 };
 
-const videoSources = {};
-for (let index = 0; index < prop.videos.length; index++) {
-	if (index != null && prop.videos[index]) {
-		videoSources[prop.videos[index].source] = prop.videoTitles[index];
-	}
-}
-
-const matchPoster = (src) => {
-	for (let index = 0; index < prop.videos.length; index += 1) {
-		if (prop.videos[index].source === src) {
-			return prop.videos[index].poster;
-		}
-	}
-	return '';
-};
-
 prop.eventActions = {};
 prop.events.forEach( (ev) => {
 	prop.eventActions[ev] = action(ev);
@@ -103,8 +81,9 @@ storiesOf('Moonstone', module)
 			propTablesExclude: [Button, IconButton, MediaControls, VideoPlayer],
 			text: 'The basic VideoPlayer'
 		})(() => {
-			const videoSource = select('source', videoSources, Config, prop.videos[0].source);
-			const poster = matchPoster(videoSource);
+			const videoTitle = select('source', prop.videoTitles, Config, 'Sintel');
+			const videoSource = prop.videos[videoTitle];
+			const poster = prop.posters[videoTitle];
 			return (
 				<div
 					style={{


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The knobs for video sources in `VideoPlayer` and `MediaOverlay` wasn't updated to the format needed to work with `enact-knobs`. Updated the knobs to properly show video titles and properly plug in the correct sources.


### Links
[//]: # (Related issues, references)
ENYO-5362

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com