### PR TITLE
PLAT-42418: Update docs for node-component proptypes

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
@@ -66,13 +66,13 @@ const ContextualPopupBase = kind({
 		/**
 		 * The element(s) to be displayed in the body of the popup.
 		 *
-		 * @type {Node}
+		 * @type {Element|Element[]}
 		 * @required
 		 * @public
 		 */
 		children: PropTypes.oneOfType([
-			PropTypes.arrayOf(PropTypes.element),
-			PropTypes.element
+			PropTypes.element,
+			PropTypes.arrayOf(PropTypes.element)
 		]).isRequired,
 
 		/**

--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -40,6 +40,7 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {
 			 * The "aria-label" for the selector.
 			 *
 			 * @memberof moonstone/DaySelector.DaySelectorDecorator
+			 * @type {String}
 			 * @private
 			 */
 			'aria-label': PropTypes.string,
@@ -112,7 +113,7 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {
 			 *
 			 * Type set to "any" to avoid warnings if passed in some other unknown scenario
 			 *
-			 * @type {String}
+			 * @type {Node}
 			 * @private
 			 */
 			title: PropTypes.any

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -34,12 +34,12 @@ const DialogBase = kind({
 		/**
 		 * Buttons, typically to close or take action in the dialog.
 		 *
-		 * @type {Node}
+		 * @type {Element|Element[]}
 		 * @public
 		 */
 		buttons: PropTypes.oneOfType([
-			PropTypes.arrayOf(PropTypes.element),
-			PropTypes.element
+			PropTypes.element,
+			PropTypes.arrayOf(PropTypes.element)
 		]),
 
 		/**

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -73,7 +73,7 @@ const EditableIntegerPickerBase = kind({
 		 * Assign a custom icon for the decrementer. All strings supported by [Icon]{moonstone/Icon.Icon} are
 		 * supported. Without a custom icon, the default is used.
 		 *
-		 * @type {string}
+		 * @type {String}
 		 * @public
 		 */
 		decrementIcon: PropTypes.string,
@@ -99,7 +99,7 @@ const EditableIntegerPickerBase = kind({
 		 * Assign a custom icon for the incrementer. All strings supported by [Icon]{moonstone/Icon.Icon} are
 		 * supported. Without a custom icon, the default is used.
 		 *
-		 * @type {string}
+		 * @type {String}
 		 * @public
 		 */
 		incrementIcon: PropTypes.string,

--- a/packages/moonstone/ExpandablePicker/ExpandablePicker.js
+++ b/packages/moonstone/ExpandablePicker/ExpandablePicker.js
@@ -102,7 +102,7 @@ const ExpandablePickerBase = kind({
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
 		 * the [orientation]{Icon#orientation} is changed.
 		 *
-		 * @type {string}
+		 * @type {String}
 		 * @public
 		 */
 		incrementIcon: PropTypes.string,

--- a/packages/moonstone/MediaOverlay/MediaOverlay.js
+++ b/packages/moonstone/MediaOverlay/MediaOverlay.js
@@ -63,7 +63,7 @@ const MediaOverlayBase = kind({
 		 *
 		 * NOTE: When image is displayed, media is not displayed even though it is playing.
 		 *
-		 * @type {String | Object}
+		 * @type {String|Object}
 		 * @public
 		 */
 		imageOverlay: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -31,12 +31,12 @@ const NotificationBase = kind({
 		 * Buttons, typically to close or take action in the Notification. Buttons must have their
 		 * `small` property set and will be coerced to `small` if not specified.
 		 *
-		 * @type {Node}
+		 * @type {Element|Element[]}
 		 * @public
 		 */
 		buttons: PropTypes.oneOfType([
-			PropTypes.arrayOf(PropTypes.element),
-			PropTypes.element
+			PropTypes.element,
+			PropTypes.arrayOf(PropTypes.element)
 		]),
 
 		/**

--- a/packages/moonstone/Panels/BreadcrumbDecorator.js
+++ b/packages/moonstone/Panels/BreadcrumbDecorator.js
@@ -27,7 +27,7 @@ const defaultConfig = {
 	/**
 	 * Classes to be added to the root node
 	 *
-	 * @type {string}
+	 * @type {String}
 	 * @default null
 	 * @memberof moonstone/Panels.BreadcrumbDecorator.defaultConfig
 	 */
@@ -37,7 +37,7 @@ const defaultConfig = {
 	 * Maximum number of breadcrumbs to display. If a function, it will be called on render to
 	 * calculate the number of breadcrumbs
 	 *
-	 * @type {number|function}
+	 * @type {Number|Function}
 	 * @default 0
 	 * @memberof moonstone/Panels.BreadcrumbDecorator.defaultConfig
 	 */
@@ -46,7 +46,7 @@ const defaultConfig = {
 	/**
 	 * Arranger for Panels
 	 *
-	 * @type {object}
+	 * @type {Object}
 	 * @default null
 	 * @memberof moonstone/Panels.BreadcrumbDecorator.defaultConfig
 	 */
@@ -74,7 +74,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Array of breadcrumbs or a function that generates an array of breadcrumbs
 			 *
-			 * @type {Function|node[]}
+			 * @type {Function|Node[]}
 			 * @default IndexedBreadcrumbs
 			 */
 			breadcrumbs: PropTypes.oneOfType([

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -59,11 +59,11 @@ const HeaderBase = kind({
 		 * Children provided are added to the header-components area. A space for controls which
 		 * live in the header, apart from the body of the panel view.
 		 *
-		 * @type {String}
+		 * @type {Element|Element[]}
 		 */
 		children: PropTypes.oneOfType([
-			PropTypes.arrayOf(PropTypes.element),
-			PropTypes.element
+			PropTypes.element,
+			PropTypes.arrayOf(PropTypes.element)
 		]),
 
 		/**
@@ -91,7 +91,7 @@ const HeaderBase = kind({
 		 *  </Header>
 		 * ```
 		 *
-		 * @type {[type]}
+		 * @type {Node}
 		 */
 		headerInput: PropTypes.node,
 

--- a/packages/moonstone/Panels/Router.js
+++ b/packages/moonstone/Panels/Router.js
@@ -56,7 +56,7 @@ const Router = class extends React.Component {
 		/**
 		 * The component wrapping the rendered path
 		 *
-		 * @type {String|Function}
+		 * @type {Component}
 		 * @default 'div'
 		 * @public
 		 */

--- a/packages/moonstone/RangePicker/RangePicker.js
+++ b/packages/moonstone/RangePicker/RangePicker.js
@@ -114,7 +114,7 @@ const RangePickerBase = kind({
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
 		 * the [orientation]{Icon#orientation} is changed.
 		 *
-		 * @type {string}
+		 * @type {String}
 		 * @public
 		 */
 		incrementIcon: PropTypes.string,

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -45,7 +45,7 @@ const SwitchItemBase = kind({
 		/**
 		 * Customize the component used as the switch.
 		 *
-		 * @type {Component}
+		 * @type {Element|Function}
 		 * @default {@link moonstone/Switch.Switch}
 		 * @private
 		 */

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -43,7 +43,7 @@ const ToggleButtonBase = kind({
 		 * If `toggleOffLabel` and/or `toggleOnLabel` are provided, they will
 		 * be used for the respective states.
 		 *
-		 * @type {node}
+		 * @type {Node}
 		 * @public
 		 */
 		children: PropTypes.node,

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -37,9 +37,9 @@ const ToggleItemBase = kind({
 
 	propTypes: /** @lends moonstone/ToggleItem.ToggleItemBase.prototype */ {
 		/**
-		 * The string to be displayed as the main content of the toggle item.
+		 * The content to be displayed as the main content of the toggle item.
 		 *
-		 * @type {String}
+		 * @type {Node}
 		 * @required
 		 * @public
 		 */
@@ -50,7 +50,7 @@ const ToggleItemBase = kind({
 		 * and must therefore respond to it in some way. It is recommended to use the
 		 * [ToggleIcon]{@link moonstone/ToggleIcon} for this.
 		 *
-		 * @type {Component}
+		 * @type {Component|Element}
 		 * @default null
 		 * @required
 		 * @public

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -122,7 +122,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * The text to be displayed as the main content of the tooltip.
 			 *
-			 * @type {String|Node}}
+			 * @type {Node}
 			 * @public
 			 */
 			tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.js
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.js
@@ -113,7 +113,7 @@ const FeedbackTooltipBase = kind({
 		 * This can be a tag name as a string, a rendered DOM node, a component, or a component
 		 * instance.
 		 *
-		 * @type {Component}
+		 * @type {Component|Element}
 		 * @public
 		 */
 		thumbnailComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),

--- a/packages/moonstone/VideoPlayer/MediaTitle.js
+++ b/packages/moonstone/VideoPlayer/MediaTitle.js
@@ -50,7 +50,7 @@ const MediaTitleBase = kind({
 		/**
 		 * A title string to identify the media's title.
 		 *
-		 * @type {String|Node}
+		 * @type {Node}
 		 * @public
 		 */
 		title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -60,7 +60,7 @@ const MediaTitleBase = kind({
 		 * the control has rendered causes a fade-out transition. Setting to `true` after or during
 		 * the transition makes the component immediately visible again, without delay or transition.
 		 *
-		 * @type {String}
+		 * @type {Boolean}
 		 * @default true
 		 * @public
 		 */

--- a/packages/moonstone/VideoPlayer/Video.js
+++ b/packages/moonstone/VideoPlayer/Video.js
@@ -54,7 +54,7 @@ const VideoBase = class extends React.Component {
 		 * The [`source`]{@link moonstone/VideoPlayer.VideoBase.source} property is passed to
 		 * the video component as a child node.
 		 *
-		 * @type {String | Element | Component}
+		 * @type {Component|Element}
 		 * @default 'video'
 		 * @public
 		 */
@@ -63,7 +63,7 @@ const VideoBase = class extends React.Component {
 		/**
 		 * The video source to be preloaded. Expects a `<source>` node.
 		 *
-		 * @type {String|Node}
+		 * @type {Node}
 		 * @public
 		 */
 		preloadSource:  PropTypes.node,
@@ -84,7 +84,7 @@ const VideoBase = class extends React.Component {
 		 *
 		 * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 		 *
-		 * @type {String | Node}
+		 * @type {Node}
 		 * @public
 		 */
 		source: PropTypes.oneOfType([PropTypes.string, PropTypes.node])

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -227,7 +227,7 @@ const VideoPlayerBase = class extends React.Component {
 		 * * `spotlightDisabled` - `true` when spotlight is disabled for the media controls
 		 * * `visible` - `true` when the media controls should be displayed
 		 *
-		 * @type {Component|Element}
+		 * @type {Function|Element}
 		 * @default `moonstone/VideoPlayer.MediaControls`
 		 * @public
 		 */
@@ -504,7 +504,7 @@ const VideoPlayerBase = class extends React.Component {
 		/**
 		 * Set a title for the video being played.
 		 *
-		 * @type {String|Node}
+		 * @type {Node}
 		 * @public
 		 */
 		title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -548,7 +548,7 @@ const VideoPlayerBase = class extends React.Component {
 		 * The [`source`]{@link moonstone/VideoPlayer.VideoPlayerBase.source} property is passed to the video
 		 * component as a child node.
 		 *
-		 * @type {Component}
+		 * @type {Component|Element}
 		 * @default {@link ui/Media.Media}
 		 * @public
 		 */

--- a/packages/ui/Cancelable/Cancelable.js
+++ b/packages/ui/Cancelable/Cancelable.js
@@ -53,7 +53,7 @@ const defaultConfig = {
 	 * When set, the Wrapped component will be contained within an instance of `component`. This may
 	 * be necessary if the props passed to Wrapped are not placed on the root element.
 	 *
-	 * @type {String|Function}
+	 * @type {Component}
 	 * @default null
 	 * @memberof ui/Cancelable.Cancelable.defaultConfig
 	 */

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -46,7 +46,7 @@ const GridListImageItem = kind({
 		/**
 		 * The component used to render the captions
 		 *
-		 * @type {Function|string}
+		 * @type {Component}
 		 * @public
 		 */
 		captionComponent: PropTypes.oneOfType([

--- a/packages/ui/Group/Group.js
+++ b/packages/ui/Group/Group.js
@@ -121,7 +121,7 @@ const GroupBase = kind({
 		/**
 		 * The index(es) of the currently activated item.
 		 *
-		 * @type {Number | Array}
+		 * @type {Number|Array}
 		 * @public
 		 */
 		selected: PropTypes.oneOfType([PropTypes.number, PropTypes.array]),

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -60,7 +60,7 @@ const IconButtonBase = kind({
 		 * If `icon` isn't specified but `children` is, `children` is used as the icon's value.
 		 *
 		 * @see {@link ui/Icon.Icon#children}
-		 * @type {String|Object}
+		 * @type {Node}
 		 * @public
 		 */
 		children: PropTypes.node,
@@ -98,7 +98,7 @@ const IconButtonBase = kind({
 		 *
 		 * If not specified, `children` is used as the icon value instead.
 		 *
-		 * @type {Node}
+		 * @type {String}
 		 * @public
 		 */
 		icon: PropTypes.string,

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -48,7 +48,7 @@ const ImageBase = kind({
 		 * String value or Object of values used to determine which image will appear on
 		 * a specific screenSize.
 		 *
-		 * @type {String | Object}
+		 * @type {String|Object}
 		 * @required
 		 * @public
 		 */

--- a/packages/ui/Item/Item.js
+++ b/packages/ui/Item/Item.js
@@ -41,7 +41,7 @@ const ItemBase = kind({
 		 * The type of component to use to render the item. May be a DOM node name (e.g 'div',
 		 * 'span', etc.) or a custom component.
 		 *
-		 * @type {String|Node}
+		 * @type {Component}
 		 * @default 'div'
 		 * @public
 		 */

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -49,7 +49,7 @@ const CellBase = kind({
 		 * The type of component to use to render as the Cell. May be a DOM node name (e.g 'div',
 		 * 'span', etc.) or a custom component.
 		 *
-		 * @type {String|Node}
+		 * @type {Component}
 		 * @default 'div'
 		 * @public
 		 */

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -89,7 +89,7 @@ const LayoutBase = kind({
 		 * The type of component to use to render as the Layout. May be a DOM node name (e.g 'div',
 		 * 'span', etc.) or a custom component.
 		 *
-		 * @type {String|Node}
+		 * @type {Component}
 		 * @default 'div'
 		 * @public
 		 */

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -52,7 +52,7 @@ const MarqueeBase = kind({
 		 *
 		 * This prop may be empty in some cases, which is OK.
 		 *
-		 * @type {Node|Node[]}
+		 * @type {Node}
 		 * @public
 		 */
 		children: PropTypes.node,

--- a/packages/ui/Media/Media.js
+++ b/packages/ui/Media/Media.js
@@ -162,7 +162,7 @@ class Media extends React.Component {
 		 *
 		 * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 		 *
-		 * @type {Node}
+		 * @type {*}
 		 * @public
 		 */
 		source: PropTypes.any

--- a/packages/ui/Slider/Knob.js
+++ b/packages/ui/Slider/Knob.js
@@ -19,7 +19,7 @@ const Knob = kind({
 		/**
 		 * The orientation of the slider, either `"horizontal"` or `"vertical"`.
 		 *
-		 * @type {Boolean}
+		 * @type {String}
 		 * @default "horizontal"
 		 * @public
 		 */
@@ -49,7 +49,7 @@ const Knob = kind({
 		 *
 		 * See {@link ui/ComponentOverride} for more information.
 		 *
-		 * @type {Component|Element}
+		 * @type {Function|Element}
 		 * @public
 		 */
 		tooltipComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/packages/ui/Slider/Slider.js
+++ b/packages/ui/Slider/Slider.js
@@ -50,7 +50,7 @@ const SliderBase = kind({
 		 * the above props or a component instance (e.g. `<MyProgress customProp="value" />`) which
 		 * will have its props merged with the above props.
 		 *
-		 * @type {Component|Element}
+		 * @type {Function|Element}
 		 * @required
 		 * @public
 		 */
@@ -111,7 +111,7 @@ const SliderBase = kind({
 		 *
 		 * See {@link ui/ComponentOverride} for more information.
 		 *
-		 * @type {Component|Element}
+		 * @type {Function|Element}
 		 * @default {@link ui/Slider.Knob}
 		 * @public
 		 */
@@ -147,7 +147,7 @@ const SliderBase = kind({
 		/**
 		 * The orientation of the slider, either `"horizontal"` or `"vertical"`.
 		 *
-		 * @type {Boolean}
+		 * @type {String}
 		 * @default "horizontal"
 		 * @public
 		 */
@@ -200,7 +200,7 @@ const SliderBase = kind({
 		 *
 		 * See {@link ui/ComponentOverride} for more information.
 		 *
-		 * @type {Component|Element}
+		 * @type {Function|Element}
 		 * @public
 		 */
 		tooltipComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),

--- a/packages/ui/SlotItem/SlotItem.js
+++ b/packages/ui/SlotItem/SlotItem.js
@@ -35,7 +35,7 @@ const SlotItemBase = kind({
 		 * This component will receive the `inline` prop and any additional unhandled props provided
 		 * to `SlotItem`. A derivative of [Item]{@link ui/Item.Item} is recommended.
 		 *
-		 * @type {Component}
+		 * @type {Function}
 		 * @required
 		 * @public
 		 */

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -50,7 +50,7 @@ const ToggleItemBase = kind({
 		/**
 		 * The string to be displayed as the main content of the toggle item.
 		 *
-		 * @type {String}
+		 * @type {Node}
 		 * @required
 		 * @public
 		 */
@@ -61,7 +61,7 @@ const ToggleItemBase = kind({
 		 * theme extension and therefore must be a custom component and not a simple HTML DOM node.
 		 * Recommended component or themed derivitive: [SlotItem]{@link ui/SlotItem.SlotItem}
 		 *
-		 * @type {Component}
+		 * @type {Function}
 		 * @required
 		 * @public
 		 */
@@ -72,7 +72,7 @@ const ToggleItemBase = kind({
 		 * and must therefore respond to it in some way. It is recommended to use
 		 * [ToggleIcon]{@link ui/ToggleIcon} for this.
 		 *
-		 * @type {Component}
+		 * @type {Component|Element}
 		 * @required
 		 * @public
 		 */

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -137,7 +137,7 @@ class TransitionGroup extends React.Component {
 		/**
 		 * Type of component wrapping the children. May be a DOM node or a custom React component.
 		 *
-		 * @type {String|Component}
+		 * @type {Component}
 		 * @default 'div'
 		 */
 		component: PropTypes.any,

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -49,7 +49,7 @@ class ViewManager extends React.Component {
 		/**
 		 * Type of component wrapping the children. May be a DOM node or a custom React component.
 		 *
-		 * @type {String|Component}
+		 * @type {Component}
 		 * @default 'div'
 		 */
 		component: PropTypes.oneOfType([


### PR DESCRIPTION
### Issue Resolved / Feature Added
Need to align the “type” for `component`-ish props, since they are very inconsistent.

### Resolution
I updated the component prop type documentation being used (string, function, object, component, node, etc) to be more consistent, based on our guidelines: https://github.com/enactjs/enact/blob/develop/docs/contributing/documentation.md

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
