### PR TITLE
PLAT-48029: Scroller makes apps to know it's scrolled to the edge.

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -428,22 +428,19 @@ class ScrollableBase extends Component {
 			const name = {horizontal: 'Left', vertical: 'Top'};
 
 			['horizontal', 'vertical'].forEach((orientation) => {
-				const
-					info = this.reachEdgeInfo[orientation],
-					currentPosition = this['scroll' + name[orientation]];
-				let condition = {begin: false, end: false};
+				const currentPosition = this['scroll' + name[orientation]];
 
 				if (this.getScrollabilities(orientation)) {
-					condition.begin = currentPosition <= 0;
-					condition.end = currentPosition >= this.getScrollBounds()['max' + name[orientation]];
+					this.checkAndForwardReachEdge(
+						orientation,
+						{
+							begin: currentPosition <= 0,
+							end: currentPosition >= this.getScrollBounds()['max' + name[orientation]]
+						}
+					);
+				} else {
+					this.checkAndForwardReachEdge(orientation, {begin: false, end: false});
 				}
-
-				['begin', 'end'].forEach((position) => {
-					if (info[position] !== condition[position]) {
-						info[position] = condition[position];
-						forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
-					}
-				});
 			});
 		}
 
@@ -841,6 +838,18 @@ class ScrollableBase extends Component {
 		this.setOverscrollStatus('vertical', overscrollTypes.none);
 	}
 
+	// check and call reachEdge callback
+	checkAndForwardReachEdge (orientation, updatedStatus) {
+		const info = this.reachEdgeInfo[orientation];
+
+		['begin', 'end'].forEach((position) => {
+			if (info[position] !== updatedStatus[position]) {
+				info[position] = updatedStatus[position];
+				forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			}
+		});
+	}
+
 	// call scroll callbacks
 
 	forwardScrollEvent (type) {
@@ -860,16 +869,13 @@ class ScrollableBase extends Component {
 		this.scrollLeft = clamp(0, maxValue, value);
 
 		if (onReachEdge && this.getScrollabilities(orientation)) {
-			const
-				info = this.reachEdgeInfo[orientation],
-				condition = {begin: this.scrollLeft <= 0, end: this.scrollLeft >= maxValue};
-
-			['begin', 'end'].forEach((position) => {
-				if (info[position] !== condition[position]) {
-					info[position] = condition[position];
-					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			this.checkAndForwardReachEdge(
+				orientation,
+				{
+					begin: this.scrollLeft <= 0,
+					end: this.scrollLeft >= maxValue
 				}
-			});
+			);
 		}
 
 		if (type === overscrollTypes.scrolling) {
@@ -892,16 +898,13 @@ class ScrollableBase extends Component {
 		this.scrollTop = clamp(0, maxValue, value);
 
 		if (onReachEdge && this.getScrollabilities(orientation)) {
-			const
-				info = this.reachEdgeInfo[orientation],
-				condition = {begin: this.scrollTop <= 0, end: this.scrollTop >= maxValue};
-
-			['begin', 'end'].forEach((position) => {
-				if (info[position] !== condition[position]) {
-					info[position] = condition[position];
-					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			this.checkAndForwardReachEdge(
+				orientation,
+				{
+					begin: this.scrollTop <= 0,
+					end: this.scrollTop >= maxValue
 				}
-			});
+			);
 		}
 
 		if (type === overscrollTypes.scrolling) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -176,6 +176,34 @@ class ScrollableBaseNative extends Component {
 		onMouseDown: PropTypes.func,
 
 		/**
+		 * Called when the edges are reached.
+		 * Passes `orientation`, `position`, and `reached`.
+		 *
+		 * Example:
+		 * ```
+		 * onReachEdge = ({orientation, position, reached}) => {
+		 *     // do something along with reached
+		 * }
+		 *
+		 * render = () => (
+		 *     <VirtualList
+		 *         ...
+		 *         onReachEdge={this.onReachEdge}
+		 *         ...
+		 *     />
+		 * )
+		 * ```
+		 *
+		 * @type {Function}
+		 * @param {Object} event
+		 * @param {String} event.orientation The orientation of scrolling. `'horizontal'` or `'vertical'`
+		 * @param {String} event.position The position of the edge. `'begin'` or `'end'`
+		 * @param {Boolean} event.reached `true` when the edge is reached.
+		 * @private
+		 */
+		onReachEdge: PropTypes.func,
+
+		/**
 		 * Called when scrolling.
 		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
 		 * It is not recommended to set this prop since it can cause performance degradation.
@@ -394,6 +422,9 @@ class ScrollableBaseNative extends Component {
 			}
 		}
 
+		this.forwardReachEdgeEvent('horizontal');
+		this.forwardReachEdgeEvent('vertical');
+
 		this.addEventListeners();
 		if (
 			hasDataSizeChanged === false &&
@@ -491,6 +522,16 @@ class ScrollableBaseNative extends Component {
 	scrollLeft = 0
 	scrollTop = 0
 	scrollToInfo = null
+	touchingEdgeInfo = {
+		horizontal: {
+			begin: false,
+			end: false
+		},
+		vertical: {
+			begin: false,
+			end: false
+		}
+	}
 
 	// component info
 	childRef = null
@@ -851,6 +892,43 @@ class ScrollableBaseNative extends Component {
 		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo()}, this.props);
 	}
 
+	compareAndSet (obj, name, value) {
+		const changed = (obj[name] !== value);
+		obj[name] = value;
+		return changed;
+	}
+
+	forwardReachEdgeEvent (orientation) {
+		const {onReachEdge} = this.props;
+		if (onReachEdge) {
+			const {direction} = this.props;
+
+			if (direction === orientation || direction === 'both') {
+				const
+					{compareAndSet} = this,
+					info = this.touchingEdgeInfo[orientation];
+				let
+					conditionBegin = false,
+					conditionEnd = false;
+
+				if (this.getScrollabilities(orientation)) {
+					const
+						name = (orientation === 'vertical') ? 'Top' : 'Left',
+						curPos = this['scroll' + name];
+					conditionBegin = (curPos <= 0);
+					conditionEnd = (curPos >= this.getScrollBounds()['max' + name]);
+				}
+
+				if (compareAndSet(info, 'begin', conditionBegin)) {
+					onReachEdge({orientation, position: 'begin', reached: info.begin});
+				}
+				if (compareAndSet(info, 'end', conditionEnd)) {
+					onReachEdge({orientation, position: 'end', reached: info.end});
+				}
+			}
+		}
+	}
+
 	// call scroll callbacks and update scrollbars for native scroll
 
 	scrollStartOnScroll = () => {
@@ -899,12 +977,14 @@ class ScrollableBaseNative extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			maxValue = bounds.maxLeft,
-			{type, ratio} = this.getOverscrollStatus('horizontal');
+			orientation = 'horizontal',
+			{type, ratio} = this.getOverscrollStatus(orientation);
 
 		this.scrollLeft = clamp(0, maxValue, value);
+		this.forwardReachEdgeEvent(orientation);
 
 		if (type === overscrollTypes.scrolling) {
-			this.updateOverscrollEffect('horizontal', this.scrollLeft, type, ratio);
+			this.updateOverscrollEffect(orientation, this.scrollLeft, type, ratio);
 		}
 
 		if (this.state.isHorizontalScrollbarVisible) {
@@ -916,12 +996,14 @@ class ScrollableBaseNative extends Component {
 		const
 			bounds = this.getScrollBounds(),
 			maxValue = bounds.maxTop,
-			{type, ratio} = this.getOverscrollStatus('vertical');
+			orientation = 'vertical',
+			{type, ratio} = this.getOverscrollStatus(orientation);
 
 		this.scrollTop = clamp(0, maxValue, value);
+		this.forwardReachEdgeEvent(orientation);
 
 		if (type === overscrollTypes.scrolling) {
-			this.updateOverscrollEffect('vertical', this.scrollTop, type, ratio);
+			this.updateOverscrollEffect(orientation, this.scrollTop, type, ratio);
 		}
 
 		if (this.state.isVerticalScrollbarVisible) {
@@ -1241,6 +1323,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.onScroll;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
+		delete rest.onReachEdge;
 		delete rest.onWheel;
 		delete rest.removeEventListeners;
 		delete rest.scrollStopOnScroll;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -427,22 +427,19 @@ class ScrollableBaseNative extends Component {
 			const name = {horizontal: 'Left', vertical: 'Top'};
 
 			['horizontal', 'vertical'].forEach((orientation) => {
-				const
-					info = this.reachEdgeInfo[orientation],
-					currentPosition = this['scroll' + name[orientation]];
-				let condition = {begin: false, end: false};
+				const currentPosition = this['scroll' + name[orientation]];
 
 				if (this.getScrollabilities(orientation)) {
-					condition.begin = currentPosition <= 0;
-					condition.end = currentPosition >= this.getScrollBounds()['max' + name[orientation]];
+					this.checkAndForwardReachEdge(
+						orientation,
+						{
+							begin: currentPosition <= 0,
+							end: currentPosition >= this.getScrollBounds()['max' + name[orientation]]
+						}
+					);
+				} else {
+					this.checkAndForwardReachEdge(orientation, {begin: false, end: false});
 				}
-
-				['begin', 'end'].forEach((position) => {
-					if (info[position] !== condition[position]) {
-						info[position] = condition[position];
-						forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
-					}
-				});
 			});
 		}
 
@@ -907,6 +904,18 @@ class ScrollableBaseNative extends Component {
 		this.setOverscrollStatus('vertical', overscrollTypes.none);
 	}
 
+	// check and call reachEdge callback
+	checkAndForwardReachEdge (orientation, updatedStatus) {
+		const info = this.reachEdgeInfo[orientation];
+
+		['begin', 'end'].forEach((position) => {
+			if (info[position] !== updatedStatus[position]) {
+				info[position] = updatedStatus[position];
+				forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			}
+		});
+	}
+
 	// call scroll callbacks
 
 	forwardScrollEvent (type) {
@@ -968,16 +977,13 @@ class ScrollableBaseNative extends Component {
 		this.scrollLeft = clamp(0, maxValue, value);
 
 		if (onReachEdge && this.getScrollabilities(orientation)) {
-			const
-				info = this.reachEdgeInfo[orientation],
-				condition = {begin: this.scrollLeft <= 0, end: this.scrollLeft >= maxValue};
-
-			['begin', 'end'].forEach((position) => {
-				if (info[position] !== condition[position]) {
-					info[position] = condition[position];
-					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			this.checkAndForwardReachEdge(
+				orientation,
+				{
+					begin: this.scrollLeft <= 0,
+					end: this.scrollLeft >= maxValue
 				}
-			});
+			);
 		}
 
 		if (type === overscrollTypes.scrolling) {
@@ -1000,16 +1006,13 @@ class ScrollableBaseNative extends Component {
 		this.scrollTop = clamp(0, maxValue, value);
 
 		if (onReachEdge && this.getScrollabilities(orientation)) {
-			const
-				info = this.reachEdgeInfo[orientation],
-				condition = {begin: this.scrollTop <= 0, end: this.scrollTop >= maxValue};
-
-			['begin', 'end'].forEach((position) => {
-				if (info[position] !== condition[position]) {
-					info[position] = condition[position];
-					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+			this.checkAndForwardReachEdge(
+				orientation,
+				{
+					begin: this.scrollTop <= 0,
+					end: this.scrollTop >= maxValue
 				}
-			});
+			);
 		}
 
 		if (type === overscrollTypes.scrolling) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -176,7 +176,7 @@ class ScrollableBaseNative extends Component {
 		onMouseDown: PropTypes.func,
 
 		/**
-		 * Called when the edges are reached.
+		 * Called when reached to an edge.
 		 * Passes `orientation`, `position`, and `reached`.
 		 *
 		 * Example:
@@ -410,6 +410,7 @@ class ScrollableBaseNative extends Component {
 
 	componentDidUpdate (prevProps, prevState) {
 		const
+			{onReachEdge} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			{hasDataSizeChanged} = this.childRef;
 
@@ -422,8 +423,28 @@ class ScrollableBaseNative extends Component {
 			}
 		}
 
-		this.forwardReachEdgeEvent('horizontal');
-		this.forwardReachEdgeEvent('vertical');
+		if (onReachEdge) {
+			const name = {horizontal: 'Left', vertical: 'Top'};
+
+			['horizontal', 'vertical'].forEach((orientation) => {
+				const
+					info = this.reachEdgeInfo[orientation],
+					currentPosition = this['scroll' + name[orientation]];
+				let condition = {begin: false, end: false};
+
+				if (this.getScrollabilities(orientation)) {
+					condition.begin = currentPosition <= 0;
+					condition.end = currentPosition >= this.getScrollBounds()['max' + name[orientation]];
+				}
+
+				['begin', 'end'].forEach((position) => {
+					if (info[position] !== condition[position]) {
+						info[position] = condition[position];
+						forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+					}
+				});
+			});
+		}
 
 		this.addEventListeners();
 		if (
@@ -522,7 +543,7 @@ class ScrollableBaseNative extends Component {
 	scrollLeft = 0
 	scrollTop = 0
 	scrollToInfo = null
-	touchingEdgeInfo = {
+	reachEdgeInfo = {
 		horizontal: {
 			begin: false,
 			end: false
@@ -892,43 +913,6 @@ class ScrollableBaseNative extends Component {
 		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo()}, this.props);
 	}
 
-	compareAndSet (obj, name, value) {
-		const changed = (obj[name] !== value);
-		obj[name] = value;
-		return changed;
-	}
-
-	forwardReachEdgeEvent (orientation) {
-		const {onReachEdge} = this.props;
-		if (onReachEdge) {
-			const {direction} = this.props;
-
-			if (direction === orientation || direction === 'both') {
-				const
-					{compareAndSet} = this,
-					info = this.touchingEdgeInfo[orientation];
-				let
-					conditionBegin = false,
-					conditionEnd = false;
-
-				if (this.getScrollabilities(orientation)) {
-					const
-						name = (orientation === 'vertical') ? 'Top' : 'Left',
-						curPos = this['scroll' + name];
-					conditionBegin = (curPos <= 0);
-					conditionEnd = (curPos >= this.getScrollBounds()['max' + name]);
-				}
-
-				if (compareAndSet(info, 'begin', conditionBegin)) {
-					onReachEdge({orientation, position: 'begin', reached: info.begin});
-				}
-				if (compareAndSet(info, 'end', conditionEnd)) {
-					onReachEdge({orientation, position: 'end', reached: info.end});
-				}
-			}
-		}
-	}
-
 	// call scroll callbacks and update scrollbars for native scroll
 
 	scrollStartOnScroll = () => {
@@ -975,13 +959,26 @@ class ScrollableBaseNative extends Component {
 
 	setScrollLeft (value) {
 		const
+			{onReachEdge} = this.props,
 			bounds = this.getScrollBounds(),
 			maxValue = bounds.maxLeft,
 			orientation = 'horizontal',
-			{type, ratio} = this.getOverscrollStatus(orientation);
+			{ratio, type} = this.getOverscrollStatus(orientation);
 
 		this.scrollLeft = clamp(0, maxValue, value);
-		this.forwardReachEdgeEvent(orientation);
+
+		if (onReachEdge && this.getScrollabilities(orientation)) {
+			const
+				info = this.reachEdgeInfo[orientation],
+				condition = {begin: this.scrollLeft <= 0, end: this.scrollLeft >= maxValue};
+
+			['begin', 'end'].forEach((position) => {
+				if (info[position] !== condition[position]) {
+					info[position] = condition[position];
+					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+				}
+			});
+		}
 
 		if (type === overscrollTypes.scrolling) {
 			this.updateOverscrollEffect(orientation, this.scrollLeft, type, ratio);
@@ -994,13 +991,26 @@ class ScrollableBaseNative extends Component {
 
 	setScrollTop (value) {
 		const
+			{onReachEdge} = this.props,
 			bounds = this.getScrollBounds(),
 			maxValue = bounds.maxTop,
 			orientation = 'vertical',
-			{type, ratio} = this.getOverscrollStatus(orientation);
+			{ratio, type} = this.getOverscrollStatus(orientation);
 
 		this.scrollTop = clamp(0, maxValue, value);
-		this.forwardReachEdgeEvent(orientation);
+
+		if (onReachEdge && this.getScrollabilities(orientation)) {
+			const
+				info = this.reachEdgeInfo[orientation],
+				condition = {begin: this.scrollTop <= 0, end: this.scrollTop >= maxValue};
+
+			['begin', 'end'].forEach((position) => {
+				if (info[position] !== condition[position]) {
+					info[position] = condition[position];
+					forward('onReachEdge', {orientation, position, reached: info[position]}, this.props);
+				}
+			});
+		}
 
 		if (type === overscrollTypes.scrolling) {
 			this.updateOverscrollEffect(orientation, this.scrollTop, type, ratio);
@@ -1320,10 +1330,10 @@ class ScrollableBaseNative extends Component {
 		delete rest.onFlick;
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;
+		delete rest.onReachEdge;
 		delete rest.onScroll;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
-		delete rest.onReachEdge;
 		delete rest.onWheel;
 		delete rest.removeEventListeners;
 		delete rest.scrollStopOnScroll;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We need to tell app developers when a scroller is scrolled to the top or the bottom so that app can add specified visual effect. We already provide `onScroll` event-type callback but this callback is called whenever a scroller is scrolled, so quite costly.
We have this requirement only for limited internal scenes for now.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The new prop `onReachEdge` is added as **private** which is called back when and only when a scroller reached to the edge or left from the edge.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Note: If a scroller is shortened and not scrollable anymore, a scroller will notify that it is NOT reached to any edge since apps don't need to show a visual effect for short contents.

### Links
[//]: # (Related issues, references)
PLAT-48029

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)