### PR TITLE
ENYO-5378: Fix TooltipDecorator to prevent unnecessary renders

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus
+
 ## [2.0.0-beta.8] - 2018-06-25
 
 ### Added

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -331,7 +331,9 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.clientRef = null;
 				currentTooltip = null;
 				this.showTooltipJob.stop();
-				this.setState({showing: false});
+				if (this.state.showing) {
+					this.setState({showing: false});
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
`TooltipDecorator` always re-renders (to hide the tooltip) when losing focus, even when a tooltip is not yet visible.

### Resolution
We should check that the `showing` state of `TooltipDecorator` is `true` before setting it to `false`. 

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>