### PR TITLE
PLAT-61706: Add moreButtonColor knob to VideoPlayer sample

### DIFF
--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -24,8 +24,9 @@ import css from './VideoPlayer.less';
 
 const Container = SpotlightContainerDecorator({enterTo: ''}, 'div');
 const MediaButton = onlyUpdateForKeys([
-	'className',
 	'children',
+	'className',
+	'color',
 	'disabled',
 	'onClick',
 	'spotlightDisabled'

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -12,6 +12,12 @@ import {mergeComponentMetadata} from '../../src/utils';
 
 // Set up some defaults for info and knobs
 const prop = {
+	moreButtonColor: [
+		'red',
+		'green',
+		'yellow',
+		'blue'
+	],
 	videoTitles: [
 		'Sintel',
 		'Big Buck Bunny',
@@ -71,6 +77,7 @@ prop.events.forEach( (ev) => {
 
 const Config = mergeComponentMetadata('VideoPlayer', VideoPlayer);
 const MediaControlsConfig = mergeComponentMetadata('MediaControls', MediaControls);
+
 VideoPlayer.displayName = 'VideoPlayer';
 MediaControls.displayName = 'MediaControls';
 
@@ -138,6 +145,7 @@ storiesOf('Moonstone', module)
 							jumpDelay={number('jumpDelay', MediaControlsConfig, 200)}
 							jumpForwardIcon={select('jumpForwardIcon', icons, MediaControlsConfig, 'skipforward')}
 							moreButtonCloseLabel={text('moreButtonCloseLabel', MediaControlsConfig)}
+							moreButtonColor={select('moreButtonColor', prop.moreButtonColor, MediaControlsConfig, 'blue')}
 							moreButtonDisabled={boolean('moreButtonDisabled', MediaControlsConfig)}
 							moreButtonLabel={text('moreButtonLabel', MediaControlsConfig)}
 							no5WayJump={boolean('no5WayJump', MediaControlsConfig)}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add `moreButtonColor` knob to `VideoPlayer` sample

### Additional Consideration
Not excited about adding `color` prop in `onlyUpdateForKeys()` for `MediaButton`. In a normal use case, no developer would ever change that unless they want to confuse the hell out of the user. I wonder if there's a way we can configure that only for the sampler context?

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>