### PR TITLE
PLAT-61006: QA-Sampler - Update Knobs

### DIFF
--- a/packages/sampler/stories/moonstone-stories/Button.js
+++ b/packages/sampler/stories/moonstone-stories/Button.js
@@ -4,11 +4,13 @@ import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
+import {boolean as storybookBoolean} from '@storybook/addon-knobs';
 import {withInfo} from '@storybook/addon-info';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
+// Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean knob and return `void 0` when `true`.
 Button.displayName = 'Button';
 const Config = mergeComponentMetadata('Button', UIButtonBase, UIButton, ButtonBase, Button);
 
@@ -32,7 +34,7 @@ storiesOf('Moonstone', module)
 				casing={select('casing', prop.casing, Config, 'upper')}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
-				minWidth={boolean('minWidth', Config)}
+				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 				selected={boolean('selected', Config)}
 				small={boolean('small', Config)}
 			>

--- a/packages/sampler/stories/qa-stories/Button.js
+++ b/packages/sampler/stories/qa-stories/Button.js
@@ -1,16 +1,26 @@
-import Button from '@enact/moonstone/Button';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
+import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select, text} from '@storybook/addon-knobs';
+import {boolean as storybookBoolean} from '@storybook/addon-knobs';
 import css from './Button.less';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+// Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean knob and return `void 0` when `true`.
+Button.displayName = 'Button';
+const Config = mergeComponentMetadata('Button', UIButtonBase, UIButton, ButtonBase, Button);
 
 // Set up some defaults for info and knobs
 const prop = {
 	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent'],
 	casing: ['preserve', 'sentence', 'word', 'upper'],
 	longText:{'Loooooooooooooooooog Button': 'Loooooooooooooooooog Button', 'BUTTON   WITH   EXTRA   SPACES': 'BUTTON   WITH   EXTRA   SPACES'},
-	tallText:{'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  து', 'ÁÉÍÓÚÑÜ': 'ÁÉÍÓÚÑÜ', 'Bản văn': 'Bản văn'}
+	tallText:{'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  து', 'ÁÉÍÓÚÑÜ': 'ÁÉÍÓÚÑÜ', 'Bản văn': 'Bản văn'},
+	icons: ['', ...Object.keys(icons)]
 };
 
 storiesOf('Button', module)
@@ -18,15 +28,16 @@ storiesOf('Button', module)
 		'with long text',
 		() => (
 			<Button
-				casing={select('casing', prop.casing)}
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				disabled={boolean('disabled')}
-				minWidth={boolean('minWidth')}
-				selected={boolean('selected')}
-				small={boolean('small')}
+				backgroundOpacity={select('backgroundOpacity', Config.propTypes)}
+				casing={select('casing', prop.casing, Config, 'upper')}
+				disabled={boolean('disabled', Config)}
+				icon={select('icon', prop.icons, Config)}
+				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+				selected={boolean('selected', Config)}
+				small={boolean('small', Config)}
 			>
-				{select('value', prop.longText, 'Loooooooooooooooooog Button')}
+				{select('value', prop.longText, Config, 'Loooooooooooooooooog Button')}
 			</Button>
 		)
 	)
@@ -34,15 +45,16 @@ storiesOf('Button', module)
 		'with tall characters',
 		() => (
 			<Button
-				casing={select('casing', prop.casing, 'upper')}
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				disabled={boolean('disabled')}
-				minWidth={boolean('minWidth')}
-				selected={boolean('selected')}
-				small={boolean('small')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+				casing={select('casing', prop.casing, Config, 'upper')}
+				disabled={boolean('disabled', Config)}
+				icon={select('icon', prop.icons, Config)}
+				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+				selected={boolean('selected', Config)}
+				small={boolean('small', Config)}
 			>
-				{select('value', prop.tallText, 'ิ้  ไั  ஒ  து')}
+				{select('value', prop.tallText, Config, 'ิ้  ไั  ஒ  து')}
 			</Button>
 		)
 	)
@@ -50,15 +62,16 @@ storiesOf('Button', module)
 		'to validate minWidth with a single character',
 		() => (
 			<Button
-				casing={select('casing', prop.casing, 'upper')}
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				disabled={boolean('disabled')}
-				minWidth={boolean('minWidth', false)}
-				selected={boolean('selected')}
-				small={boolean('small')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+				casing={select('casing', prop.casing, Config, 'upper')}
+				disabled={boolean('disabled', Config)}
+				icon={select('icon', prop.icons, Config)}
+				minWidth={storybookBoolean('minWidth', false) ? void 0 : false}
+				selected={boolean('selected', Config)}
+				small={boolean('small', Config)}
 			>
-				{text('value', 'A')}
+				{text('value', Config, 'A')}
 			</Button>
 		)
 	)
@@ -68,7 +81,13 @@ storiesOf('Button', module)
 			<div className={css.bgColor}>
 				<Button
 					onClick={action('onClick')}
-					disabled={boolean('disabled')}
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+					casing={select('casing', prop.casing, Config, 'upper')}
+					disabled={boolean('disabled', Config)}
+					icon={select('icon', prop.icons, Config)}
+					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+					selected={boolean('selected', Config)}
+					small={boolean('small', Config)}
 				>
 					Normal Button
 				</Button>
@@ -80,24 +99,25 @@ storiesOf('Button', module)
 		() => (
 			<div>
 				<Button
-					casing={select('casing', prop.casing, 'upper')}
-					className={css.tapArea}
 					onClick={action('onClick')}
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-					disabled={boolean('disabled')}
-					minWidth={boolean('minWidth')}
-					selected={boolean('selected')}
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+					casing={select('casing', prop.casing, Config, 'upper')}
+					disabled={boolean('disabled', Config)}
+					icon={select('icon', prop.icons, Config)}
+					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+					selected={boolean('selected', Config)}
+					small={boolean('small', Config)}
 				>
 					Normal Button
 				</Button>
 				<Button
-					casing={select('casing', prop.casing, 'upper')}
-					className={css.tapArea}
 					onClick={action('onClick')}
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-					disabled={boolean('disabled')}
-					minWidth={boolean('minWidth')}
-					selected={boolean('selected')}
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+					casing={select('casing', prop.casing, Config, 'upper')}
+					disabled={boolean('disabled', Config)}
+					icon={select('icon', prop.icons, Config)}
+					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+					selected={boolean('selected', Config)}
 					small
 				>
 					Small Button

--- a/packages/sampler/stories/qa-stories/Button.js
+++ b/packages/sampler/stories/qa-stories/Button.js
@@ -29,7 +29,7 @@ storiesOf('Button', module)
 		() => (
 			<Button
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', Config.propTypes)}
+				backgroundOpacity={select('backgroundOpacity', Config.propTypes, Config)}
 				casing={select('casing', prop.casing, Config, 'upper')}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}

--- a/packages/sampler/stories/qa-stories/Button.js
+++ b/packages/sampler/stories/qa-stories/Button.js
@@ -29,7 +29,7 @@ storiesOf('Button', module)
 		() => (
 			<Button
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', Config.propTypes, Config)}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				casing={select('casing', prop.casing, Config, 'upper')}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}

--- a/packages/sampler/stories/qa-stories/CheckboxItem.js
+++ b/packages/sampler/stories/qa-stories/CheckboxItem.js
@@ -1,9 +1,16 @@
 import CheckboxItem from '@enact/moonstone/CheckboxItem';
+import ToggleItem from '@enact/moonstone/ToggleItem';
+import UiToggleItem, {ToggleItemBase as UiToggleItemBase} from '@enact/ui/ToggleItem';
+import Item, {ItemBase} from '@enact/moonstone/Item';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, text, select} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+const Config = mergeComponentMetadata('CheckboxItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, CheckboxItem);
 
 const prop = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',
@@ -17,11 +24,12 @@ storiesOf('CheckboxItem', module)
 		'with long text',
 		() => (
 			<CheckboxItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', Config, false)}
+				iconPosition={select('iconPosition', ['before', 'after'], Config)}
+				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
-				{text('children', prop.longText)}
+				{text('children', Config, prop.longText)}
 			</CheckboxItem>
 		)
 	)
@@ -29,11 +37,12 @@ storiesOf('CheckboxItem', module)
 		'with tall characters',
 		() => (
 			<CheckboxItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', Config, false)}
+				iconPosition={select('iconPosition', ['before', 'after'], Config)}
+				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
-				{select('children', prop.tallText, prop.tallText[0])}
+				{select('children', prop.tallText, Config, prop.tallText[0])}
 			</CheckboxItem>
 		)
 	)
@@ -41,11 +50,12 @@ storiesOf('CheckboxItem', module)
 		'with extra spacing',
 		() => (
 			<CheckboxItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', Config, false)}
+				iconPosition={select('iconPosition', ['before', 'after'], Config)}
+				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
-				{text('children', prop.extraSpaceText)}
+				{text('children', Config, prop.extraSpaceText)}
 			</CheckboxItem>
 		)
 	)
@@ -53,11 +63,12 @@ storiesOf('CheckboxItem', module)
 		'with right to left text',
 		() => (
 			<CheckboxItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', Config, false)}
+				iconPosition={select('iconPosition', ['before', 'after'], Config)}
+				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
-				{text('children', prop.rtlText)}
+				{text('children', Config, prop.rtlText)}
 			</CheckboxItem>
 		)
 	)
@@ -70,7 +81,7 @@ storiesOf('CheckboxItem', module)
 				itemProps={{
 					inline: boolean('ItemProps-Inline', false)
 				}}
-				select={select('select', ['single', 'radio', 'multiple'], 'multiple')}
+				select={select('select', ['single', 'radio', 'multiple'], Group, 'multiple')}
 				selectedProp="selected"
 				defaultSelected={0}
 				onSelect={action('onSelect')}

--- a/packages/sampler/stories/qa-stories/CheckboxItem.js
+++ b/packages/sampler/stories/qa-stories/CheckboxItem.js
@@ -79,7 +79,7 @@ storiesOf('CheckboxItem', module)
 				childComponent={CheckboxItem}
 				childSelect="onToggle"
 				itemProps={{
-					inline: boolean('ItemProps-Inline', false)
+					inline: boolean('ItemProps-Inline', Group, false)
 				}}
 				select={select('select', ['single', 'radio', 'multiple'], Group, 'multiple')}
 				selectedProp="selected"

--- a/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
@@ -4,7 +4,8 @@ import Divider from '@enact/moonstone/Divider';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {select} from '@storybook/addon-knobs';
+
+import {select} from '../../src/enact-knobs';
 
 const ContextualButton = ContextualPopupDecorator(Button);
 ContextualButton.displayName = 'ContextualButton';
@@ -67,9 +68,9 @@ storiesOf('ContextualPopupDecorator', module)
 		() => (
 			<div style={{textAlign: 'center', marginTop: ri.unit(99, 'rem')}}>
 				<ContextualPopupWithActivator
-					direction={select('direction', ['up', 'down', 'left', 'right'], 'down')}
+					direction={select('direction', ['up', 'down', 'left', 'right'], ContextualButton, 'down')}
 					popupComponent={renderPopup}
-					spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], 'self-only')}
+					spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], ContextualButton, 'self-only')}
 				>
 					Hello Contextual Button
 				</ContextualPopupWithActivator>

--- a/packages/sampler/stories/qa-stories/Divider.js
+++ b/packages/sampler/stories/qa-stories/Divider.js
@@ -4,7 +4,10 @@ import ri from '@enact/ui/resolution';
 import Scroller from '@enact/moonstone/Scroller';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {text, select} from '@storybook/addon-knobs';
+
+import {select, text} from '../../src/enact-knobs';
+
+Divider.displayName = 'Divider';
 
 const
 	prop = {
@@ -17,9 +20,9 @@ storiesOf('Divider', module)
 		'with long text',
 		() => (
 			<Divider
-				marqueeOn={select('marqueeOn', prop.marqueeOn)}
+				marqueeOn={select('marqueeOn', prop.marqueeOn, Divider)}
 			>
-				{text('children', 'This long text is for the marquee test in divider component. This long text is for the marquee test in divider component. This long text is for the marquee test in divider component.')}
+				{text('children', Divider, 'This long text is for the marquee test in divider component. This long text is for the marquee test in divider component. This long text is for the marquee test in divider component.')}
 			</Divider>
 		)
 	)
@@ -28,7 +31,7 @@ storiesOf('Divider', module)
 		'with tall characters',
 		() => (
 			<Divider>
-				{select('children', prop.tallText, 'नरेंद्र मोदी')}
+				{select('children', prop.tallText, Divider, 'नरेंद्र मोदी')}
 			</Divider>
 		)
 	)
@@ -41,9 +44,9 @@ storiesOf('Divider', module)
 					Adjust the spacing prop to see how the Divider is positioned with respect to the element below.
 				</div>
 				<Divider
-					spacing={select('spacing', ['normal', 'small', 'medium', 'large', 'none'])}
+					spacing={select('spacing', ['normal', 'small', 'medium', 'large', 'none'], Divider)}
 				>
-					{text('children', 'Hello World')}
+					{text('children', Divider, 'Hello World')}
 				</Divider>
 				<Item>
 					Some content below

--- a/packages/sampler/stories/qa-stories/Divider.js
+++ b/packages/sampler/stories/qa-stories/Divider.js
@@ -1,3 +1,4 @@
+import BodyText from '@enact/moonstone/BodyText';
 import Divider from '@enact/moonstone/Divider';
 import Item from '@enact/moonstone/Item';
 import ri from '@enact/ui/resolution';
@@ -40,9 +41,9 @@ storiesOf('Divider', module)
 		'with an element below',
 		() => (
 			<div>
-				<div>
+				<BodyText>
 					Adjust the spacing prop to see how the Divider is positioned with respect to the element below.
-				</div>
+				</BodyText>
 				<Divider
 					spacing={select('spacing', ['normal', 'small', 'medium', 'large', 'none'], Divider)}
 				>
@@ -59,51 +60,21 @@ storiesOf('Divider', module)
 		'Multiple',
 		() => (
 			<div>
-				<Divider>
-					First Divider
-				</Divider>
-				<Item>
-					Item 11
-				</Item>
-				<Item>
-					Item 12
-				</Item>
-				<Item>
-					Item 13
-				</Item>
-				<Divider>
-					Second Divider
-				</Divider>
-				<Item>
-					Item 21
-				</Item>
-				<Item>
-					Item 22
-				</Item>
-				<Item>
-					Item 23
-				</Item>
-				<Divider>
-					Third Divider
-				</Divider>
-				<Item>
-					Item 31
-				</Item>
-				<Item>
-					Item 32
-				</Item>
-				<Item>
-					Item 33
-				</Item>
-				<Divider>
-					Fourth Divider
-				</Divider>
-				<Item>
-					Item 41
-				</Item>
-				<Item>
-					Item 42
-				</Item>
+				<Divider>First Divider</Divider>
+				<Item>Item 11</Item>
+				<Item>Item 12</Item>
+				<Item>Item 13</Item>
+				<Divider>Second Divider</Divider>
+				<Item>Item 21</Item>
+				<Item>Item 22</Item>
+				<Item>Item 23</Item>
+				<Divider>Third Divider</Divider>
+				<Item>Item 31</Item>
+				<Item>Item 32</Item>
+				<Item>Item 33</Item>
+				<Divider>Fourth Divider</Divider>
+				<Item>Item 41</Item>
+				<Item>Item 42</Item>
 			</div>
 		)
 	)
@@ -125,51 +96,21 @@ storiesOf('Divider', module)
 						width: ri.unit(2001, 'rem')
 					}}
 				>
-					<Divider>
-						First Divider
-					</Divider>
-					<Item>
-						Item 11
-					</Item>
-					<Item>
-						Item 12
-					</Item>
-					<Item>
-						Item 13
-					</Item>
-					<Divider>
-						Second Divider
-					</Divider>
-					<Item>
-						Item 21
-					</Item>
-					<Item>
-						Item 22
-					</Item>
-					<Item>
-						Item 23
-					</Item>
-					<Divider>
-						Third Divider
-					</Divider>
-					<Item>
-						Item 31
-					</Item>
-					<Item>
-						Item 32
-					</Item>
-					<Item>
-						Item 33
-					</Item>
-					<Divider>
-						Fourth Divider
-					</Divider>
-					<Item>
-						Item 41
-					</Item>
-					<Item>
-						Item 42
-					</Item>
+					<Divider>First Divider</Divider>
+					<Item>Item 11</Item>
+					<Item>Item 12</Item>
+					<Item>Item 13</Item>
+					<Divider>Second Divider</Divider>
+					<Item>Item 21</Item>
+					<Item>Item 22</Item>
+					<Item>Item 23</Item>
+					<Divider>Third Divider</Divider>
+					<Item>Item 31</Item>
+					<Item>Item 32</Item>
+					<Item>Item 33</Item>
+					<Divider>Fourth Divider</Divider>
+					<Item>Item 41</Item>
+					<Item>Item 42</Item>
 				</div>
 			</Scroller>
 		)

--- a/packages/sampler/stories/qa-stories/ExpandableInput.js
+++ b/packages/sampler/stories/qa-stories/ExpandableInput.js
@@ -3,7 +3,8 @@ import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select, text} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
 
 const iconNames = ['', ...Object.keys(icons)];
 
@@ -12,17 +13,17 @@ storiesOf('ExpandableInput', module)
 		'Long Placeholder',
 		() => (
 			<ExpandableInput
-				disabled={boolean('disabled', false)}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
-				noneText={text('noneText', 'nothing inputted')}
+				disabled={boolean('disabled', ExpandableInput)}
+				iconAfter={select('iconAfter', iconNames, ExpandableInput)}
+				iconBefore={select('iconBefore', iconNames, ExpandableInput)}
+				noneText={text('noneText', ExpandableInput, 'noneText')}
 				onChange={action('onChange')}
 				onClose={action('onClose')}
 				onOpen={action('onOpen')}
-				open={boolean('open', true)}
-				title={text('title', 'title')}
-				placeholder={text('placeholder', 'Looooooooooooooooooooooong')}
-				type={text('type')}
+				open={boolean('open', ExpandableInput, true)}
+				title={text('title', ExpandableInput, 'title')}
+				placeholder={text('placeholder', ExpandableInput, 'Looooooooooooooooooooooong')}
+				type={text('type', ExpandableInput, 'text')}
 			/>
 		)
 	)

--- a/packages/sampler/stories/qa-stories/ExpandableList.js
+++ b/packages/sampler/stories/qa-stories/ExpandableList.js
@@ -1,11 +1,16 @@
 import Button from '@enact/moonstone/Button';
-import ExpandableList from '@enact/moonstone/ExpandableList';
+import Divider from '@enact/moonstone/Divider';
+import ExpandableList, {ExpandableListBase} from '@enact/moonstone/ExpandableList';
 import Scroller from '@enact/moonstone/Scroller';
 import {RadioControllerDecorator} from '@enact/ui/RadioDecorator';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
+
 import {boolean, text, select} from '@storybook/addon-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+const Config = mergeComponentMetadata('ExpandableList', ExpandableList, ExpandableListBase);
 
 const ExpandableGroup = RadioControllerDecorator('div');
 
@@ -37,6 +42,7 @@ class ExpandableListChildrenLengthUpdate extends React.Component {
 		return (
 			<div>
 				<Button onClick={this.updateValue}>update value</Button>
+				<Divider />
 				<ExpandableList {...this.props}>
 					{prop.listArray[this.state.index]}
 				</ExpandableList>
@@ -50,16 +56,16 @@ storiesOf('ExpandableList', module)
 		'with children length update',
 		() => (
 			<ExpandableListChildrenLengthUpdate
-				closeOnSelect={boolean('closeOnSelect', false)}
-				disabled={boolean('disabled', false)}
-				noAutoClose={boolean('noAutoClose', false)}
-				noLockBottom={boolean('noLockBottom', false)}
-				noneText={text('noneText', 'nothing selected')}
+				closeOnSelect={boolean('closeOnSelect', Config)}
+				disabled={boolean('disabled', Config)}
+				noAutoClose={boolean('noAutoClose', Config)}
+				noLockBottom={boolean('noLockBottom', Config)}
+				noneText={text('noneText', Config, 'nothing selected')}
 				onSelect={action('onSelect')}
 				onClose={action('onClose')}
 				onOpen={action('onOpen')}
-				select={select('select', ['radio', 'multiple', 'single'], 'radio')}
-				title={text('title', 'title')}
+				select={select('select', ['radio', 'multiple', 'single'], Config, 'radio')}
+				title="with children length update"
 			/>
 		)
 	)

--- a/packages/sampler/stories/qa-stories/Header.js
+++ b/packages/sampler/stories/qa-stories/Header.js
@@ -3,14 +3,17 @@ import Button from '@enact/moonstone/Button';
 import Input from '@enact/moonstone/Input';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {boolean, text} from '@storybook/addon-knobs';
+
+import {boolean, text} from '../../src/enact-knobs';
+
+Header.displayName = 'Header';
 
 storiesOf('Header', module)
 	.add(
 		'with headerComponent',
 		() => (
 			<Header
-				title={text('title', 'Title')}
+				title={text('title', Header, 'Title')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -21,7 +24,7 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', 'Title')}
+				title={text('title', Header, 'Title')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -31,9 +34,9 @@ storiesOf('Header', module)
 		'with titles below',
 		() => (
 			<Header
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			/>
 		)
 	)
@@ -42,9 +45,9 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			/>
 		)
 	)
@@ -52,9 +55,9 @@ storiesOf('Header', module)
 		'with titles below and headerComponent',
 		() => (
 			<Header
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -65,9 +68,9 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -77,9 +80,9 @@ storiesOf('Header', module)
 		'with RTL text',
 		() => (
 			<Header
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'כתוביות למט')}
-				subTitleBelow={text('subTitleBelow', 'כתוביות למט')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'כתוביות למט')}
+				subTitleBelow={text('subTitleBelow', Header, 'כתוביות למט')}
 			/>
 		)
 	)
@@ -88,8 +91,8 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'כתוביות למט')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'כתוביות למט')}
 			/>
 		)
 	)
@@ -97,9 +100,9 @@ storiesOf('Header', module)
 		'with long text and headerComponent',
 		() => (
 			<Header
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -110,9 +113,9 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', 'Title')}
-				titleBelow={text('titleBelow', 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
-				subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				title={text('title', Header, 'Title')}
+				titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
+				subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -122,13 +125,13 @@ storiesOf('Header', module)
 	.add(
 		'with Input, long text and headerComponent',
 		() => {
-			const input = boolean('Input Mode', true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', true)} /> : null;
+			const input = boolean('Input Mode', Header, true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', Header, true)} /> : null;
 			return (
 				<Header
-					title={text('title', 'Title')}
+					title={text('title', Header, 'Title')}
 					headerInput={input}
-					titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-					subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+					titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+					subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 				>
 					<Button small>On / Off</Button>
 				</Header>
@@ -138,13 +141,13 @@ storiesOf('Header', module)
 	.add(
 		'with Input, tall-glyphs, and titles below',
 		() => {
-			const input = boolean('Input Mode', true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', true)} /> : null;
+			const input = boolean('Input Mode', Header, true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', Header, true)} /> : null;
 			return (
 				<Header
-					title={text('title', 'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  த')}
+					title={text('title', Header, 'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  த')}
 					headerInput={input}
-					titleBelow={text('titleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-					subTitleBelow={text('subTitleBelow', 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+					titleBelow={text('titleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+					subTitleBelow={text('subTitleBelow', Header, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 				/>
 			);
 		}

--- a/packages/sampler/stories/qa-stories/Input.js
+++ b/packages/sampler/stories/qa-stories/Input.js
@@ -4,7 +4,10 @@ import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select, text} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+
+Input.displayName = 'Input';
 
 const iconNames = ['', ...Object.keys(icons)];
 
@@ -26,15 +29,15 @@ storiesOf('Input', module)
 		'with long text',
 		() => (
 			<Input
-				autoFocus={boolean('autoFocus')}
+				autoFocus={boolean('autoFocus', Input)}
 				onChange={action('onChange')}
-				disabled={boolean('disabled')}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
-				invalid={boolean('invalid', false)}
-				invalidMessage={text('invalidMessage', InputBase.defaultProps.invalidMessage)}
-				placeholder={text('placeholder')}
-				type={select('type', inputData.type, inputData.type[0])}
+				disabled={boolean('disabled', Input)}
+				iconAfter={select('iconAfter', iconNames, Input)}
+				iconBefore={select('iconBefore', iconNames, Input)}
+				invalid={boolean('invalid', Input, false)}
+				invalidMessage={text('invalidMessage', Input, InputBase.defaultProps.invalidMessage)}
+				placeholder={text('placeholder', Input)}
+				type={select('type', inputData.type, Input, inputData.type[0])}
 				defaultValue={inputData.longText}
 			/>
 		)
@@ -43,15 +46,15 @@ storiesOf('Input', module)
 		'with long placeholder',
 		() => (
 			<Input
-				autoFocus={boolean('autoFocus')}
+				autoFocus={boolean('autoFocus', Input)}
 				onChange={action('onChange')}
-				disabled={boolean('disabled')}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
-				invalid={boolean('invalid', false)}
-				invalidMessage={text('invalidMessage', InputBase.defaultProps.invalidMessage)}
-				placeholder={text('placeholder', inputData.longPlaceHolder)}
-				type={select('type', inputData.type, inputData.type[0])}
+				disabled={boolean('disabled', Input)}
+				iconAfter={select('iconAfter', iconNames, Input)}
+				iconBefore={select('iconBefore', iconNames, Input)}
+				invalid={boolean('invalid', Input, false)}
+				invalidMessage={text('invalidMessage', Input, InputBase.defaultProps.invalidMessage)}
+				placeholder={text('placeholder', Input, inputData.longPlaceHolder)}
+				type={select('type', inputData.type, Input, inputData.type[0])}
 			/>
 		)
 	)
@@ -60,33 +63,33 @@ storiesOf('Input', module)
 		() => (
 			<div>
 				<Input
-					autoFocus={boolean('autoFocus')}
+					autoFocus={boolean('autoFocus', Input)}
 					onChange={action('onChange')}
-					disabled={boolean('disabled')}
-					iconAfter={select('iconAfter', iconNames)}
-					iconBefore={select('iconBefore', iconNames)}
-					placeholder={text('placeholder', 'Input some tall characters')}
-					type={select('type', inputData.type, inputData.type[0])}
+					disabled={boolean('disabled', Input)}
+					iconAfter={select('iconAfter', iconNames, Input)}
+					iconBefore={select('iconBefore', iconNames, Input)}
+					placeholder={text('placeholder', Input, 'Input some tall characters')}
+					type={select('type', inputData.type, Input, inputData.type[0])}
 					defaultValue={inputData.tallText[0]}
 				/>
 				<Input
-					autoFocus={boolean('autoFocus')}
+					autoFocus={boolean('autoFocus', Input)}
 					onChange={action('onChange')}
-					disabled={boolean('disabled')}
-					iconAfter={select('iconAfter', iconNames)}
-					iconBefore={select('iconBefore', iconNames)}
-					placeholder={text('placeholder', 'Input some tall characters')}
-					type={select('type', inputData.type, inputData.type[0])}
+					disabled={boolean('disabled', Input)}
+					iconAfter={select('iconAfter', iconNames, Input)}
+					iconBefore={select('iconBefore', iconNames, Input)}
+					placeholder={text('placeholder', Input, 'Input some tall characters')}
+					type={select('type', inputData.type, Input, inputData.type[0])}
 					defaultValue={inputData.tallText[1]}
 				/>
 				<Input
-					autoFocus={boolean('autoFocus')}
+					autoFocus={boolean('autoFocus', Input)}
 					onChange={action('onChange')}
-					disabled={boolean('disabled')}
-					iconAfter={select('iconAfter', iconNames)}
-					iconBefore={select('iconBefore', iconNames)}
-					placeholder={text('placeholder', 'Input some tall characters')}
-					type={select('type', inputData.type, inputData.type[0])}
+					disabled={boolean('disabled', Input)}
+					iconAfter={select('iconAfter', iconNames, Input)}
+					iconBefore={select('iconBefore', iconNames, Input)}
+					placeholder={text('placeholder', Input, 'Input some tall characters')}
+					type={select('type', inputData.type, Input, inputData.type[0])}
 					defaultValue={inputData.tallText[2]}
 				/>
 			</div>
@@ -96,13 +99,13 @@ storiesOf('Input', module)
 		'with extra spacing',
 		() => (
 			<Input
-				autoFocus={boolean('autoFocus')}
+				autoFocus={boolean('autoFocus', Input)}
 				onChange={action('onChange')}
-				disabled={boolean('disabled')}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
-				placeholder={text('placeholder')}
-				type={select('type', inputData.type, inputData.type[0])}
+				disabled={boolean('disabled', Input)}
+				iconAfter={select('iconAfter', iconNames, Input)}
+				iconBefore={select('iconBefore', iconNames, Input)}
+				placeholder={text('placeholder', Input)}
+				type={select('type', inputData.type, Input, inputData.type[0])}
 				defaultValue={inputData.extraSpaceText}
 			/>
 		)
@@ -111,13 +114,13 @@ storiesOf('Input', module)
 		'with RTL and LTR text together',
 		() => (
 			<Input
-				autoFocus={boolean('autoFocus')}
+				autoFocus={boolean('autoFocus', Input)}
 				onChange={action('onChange')}
-				disabled={boolean('disabled')}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
-				placeholder={text('placeholder', 'Input RTL and LTR text together')}
-				type={select('type', inputData.type, inputData.type[0])}
+				disabled={boolean('disabled', Input)}
+				iconAfter={select('iconAfter', iconNames, Input)}
+				iconBefore={select('iconBefore', iconNames, Input)}
+				placeholder={text('placeholder', Input, 'Input RTL and LTR text together')}
+				type={select('type', inputData.type, Input, inputData.type[0])}
 				defaultValue={inputData.rtlAndLtr}
 			/>
 		)
@@ -128,45 +131,45 @@ storiesOf('Input', module)
 			<div>
 				<div style={divMargin()}>
 					<Input
-						autoFocus={boolean('autoFocus')}
+						autoFocus={boolean('autoFocus', Input)}
 						onChange={action('onChange')}
-						disabled={boolean('disabled')}
-						iconAfter={select('iconAfter', iconNames)}
-						iconBefore={select('iconBefore', iconNames)}
-						placeholder={text('placeholder')}
-						type={select('type', inputData.type, inputData.type[0])}
+						disabled={boolean('disabled', Input)}
+						iconAfter={select('iconAfter', iconNames, Input)}
+						iconBefore={select('iconBefore', iconNames, Input)}
+						placeholder={text('placeholder', Input)}
+						type={select('type', inputData.type, Input, inputData.type[0])}
 						defaultValue={inputData.initialValue + ' one'}
 					/>
 					<Input
-						autoFocus={boolean('autoFocus')}
+						autoFocus={boolean('autoFocus', Input)}
 						onChange={action('onChange')}
-						disabled={boolean('disabled')}
-						iconAfter={select('iconAfter', iconNames)}
-						iconBefore={select('iconBefore', iconNames)}
-						placeholder={text('placeholder')}
-						type={select('type', inputData.type, inputData.type[0])}
+						disabled={boolean('disabled', Input)}
+						iconAfter={select('iconAfter', iconNames, Input)}
+						iconBefore={select('iconBefore', iconNames, Input)}
+						placeholder={text('placeholder', Input)}
+						type={select('type', inputData.type, Input, inputData.type[0])}
 						defaultValue={inputData.initialValue + ' two'}
 					/>
 				</div>
 				<div style={divMargin()}>
 					<Input
-						autoFocus={boolean('autoFocus')}
+						autoFocus={boolean('autoFocus', Input)}
 						onChange={action('onChange')}
-						disabled={boolean('disabled')}
-						iconAfter={select('iconAfter', iconNames)}
-						iconBefore={select('iconBefore', iconNames)}
-						placeholder={text('placeholder')}
-						type={select('type', inputData.type, inputData.type[0])}
+						disabled={boolean('disabled', Input)}
+						iconAfter={select('iconAfter', iconNames, Input)}
+						iconBefore={select('iconBefore', iconNames, Input)}
+						placeholder={text('placeholder', Input)}
+						type={select('type', inputData.type, Input, inputData.type[0])}
 						defaultValue={inputData.initialValue + ' three'}
 					/>
 					<Input
-						autoFocus={boolean('autoFocus')}
+						autoFocus={boolean('autoFocus', Input)}
 						onChange={action('onChange')}
-						disabled={boolean('disabled')}
-						iconAfter={select('iconAfter', iconNames)}
-						iconBefore={select('iconBefore', iconNames)}
-						placeholder={text('placeholder')}
-						type={select('type', inputData.type, inputData.type[0])}
+						disabled={boolean('disabled', Input)}
+						iconAfter={select('iconAfter', iconNames, Input)}
+						iconBefore={select('iconBefore', iconNames, Input)}
+						placeholder={text('placeholder', Input)}
+						type={select('type', inputData.type, Input, inputData.type[0])}
 						defaultValue={inputData.initialValue + ' four'}
 					/>
 				</div>
@@ -177,11 +180,11 @@ storiesOf('Input', module)
 		'with a range',
 		() => (
 			<Input
-				autoFocus={boolean('autoFocus')}
+				autoFocus={boolean('autoFocus', Input)}
 				onChange={action('onChange')}
-				disabled={boolean('disabled')}
-				iconAfter={select('iconAfter', iconNames)}
-				iconBefore={select('iconBefore', iconNames)}
+				disabled={boolean('disabled', Input)}
+				iconAfter={select('iconAfter', iconNames, Input)}
+				iconBefore={select('iconBefore', iconNames, Input)}
 				type={inputData.type[1]}
 				defaultValue={inputData.initialNumericValue}
 			/>

--- a/packages/sampler/stories/qa-stories/Item.js
+++ b/packages/sampler/stories/qa-stories/Item.js
@@ -4,7 +4,8 @@ import React from 'react';
 import Button from '@enact/moonstone/Button';
 import Image from '@enact/moonstone/Image';
 import {storiesOf} from '@storybook/react';
-import {boolean, select, text} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
 
 const iconNames = ['', ...Object.keys(icons)];
 
@@ -21,9 +22,9 @@ storiesOf('Item', module)
 		'with long text',
 		() => (
 			<Item
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Item)}
 			>
-				{text('Children', inputData.longText)}
+				{text('Children', Item, inputData.longText)}
 			</Item>
 		)
 	)
@@ -31,9 +32,9 @@ storiesOf('Item', module)
 		'with tall characters',
 		() => (
 			<Item
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Item)}
 			>
-				{select('value', inputData.tallText, inputData.tallText[2])}
+				{select('value', inputData.tallText, Item, inputData.tallText[2])}
 			</Item>
 		)
 	)
@@ -41,9 +42,9 @@ storiesOf('Item', module)
 		'with extra spaces',
 		() => (
 			<Item
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Item)}
 			>
-				{text('Children', inputData.extraSpaceText)}
+				{text('Children', Item, inputData.extraSpaceText)}
 			</Item>
 		)
 	)
@@ -51,10 +52,10 @@ storiesOf('Item', module)
 		'integrated with other components',
 		() => (
 			<Item
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Item)}
 			>
 				<Button>Click here</Button>
-				{text('Children', 'Hello Item')}
+				{text('Children', Item, 'Hello Item')}
 				<Button>Click here</Button>
 				<Image src="http://lorempixel.com/512/512/city/1/" sizing="fill" alt="lorempixel" />
 				<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.</p>
@@ -68,48 +69,48 @@ storiesOf('Item', module)
 		() => (
 			<div>
 				<Item>
-					{text('Spottable Text', inputData.normalText)}
+					{text('Spottable Text', Item, inputData.normalText)}
 				</Item>
 				<Item
 					disabled
 				>
-					{text('Disabled Text', inputData.disabledText)}
+					{text('Disabled Text', Item, inputData.disabledText)}
 				</Item>
 				<Item>
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
-						{select('iconBefore', iconNames, 'plus')}
+						{select('iconBefore', iconNames, Icon, 'plus')}
 					</Icon>
 
-					{text('Text with icon at start', 'Item with text that is spottable with an icon (at the start of the string)')}
+					{text('Text with icon at start', Item, 'Item with text that is spottable with an icon (at the start of the string)')}
 				</Item>
 				<Item>
-					{text('Text with icon at end', 'Item with text that is spottable with an icon(at the end of the string)')}
+					{text('Text with icon at end', Item, 'Item with text that is spottable with an icon(at the end of the string)')}
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
-						{select('iconAfter', iconNames, 'pauseforward')}
+						{select('iconAfter', iconNames, Icon, 'pauseforward')}
 					</Icon>
 				</Item>
 				<Item>
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
 						gear
 					</Icon>
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
 						minus
 					</Icon>
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
 						trash
 					</Icon>
 					<Icon
-						small={boolean('small')}
+						small={boolean('small', Icon)}
 					>
 						flag
 					</Icon>

--- a/packages/sampler/stories/qa-stories/Item.js
+++ b/packages/sampler/stories/qa-stories/Item.js
@@ -1,5 +1,5 @@
 import Item from '@enact/moonstone/Item';
-import {Icon, icons} from '@enact/moonstone/Icon';
+import Icon, {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import Button from '@enact/moonstone/Button';
 import Image from '@enact/moonstone/Image';
@@ -17,13 +17,14 @@ const inputData = {
 	normalText : 'Item with text that is spottable'
 };
 
+Item.displayName = 'Item';
+Icon.displayName = 'Icon';
+
 storiesOf('Item', module)
 	.add(
 		'with long text',
 		() => (
-			<Item
-				disabled={boolean('disabled', Item)}
-			>
+			<Item disabled={boolean('disabled', Item)}>
 				{text('Children', Item, inputData.longText)}
 			</Item>
 		)
@@ -31,9 +32,7 @@ storiesOf('Item', module)
 	.add(
 		'with tall characters',
 		() => (
-			<Item
-				disabled={boolean('disabled', Item)}
-			>
+			<Item disabled={boolean('disabled', Item)}>
 				{select('value', inputData.tallText, Item, inputData.tallText[2])}
 			</Item>
 		)
@@ -41,9 +40,7 @@ storiesOf('Item', module)
 	.add(
 		'with extra spaces',
 		() => (
-			<Item
-				disabled={boolean('disabled', Item)}
-			>
+			<Item disabled={boolean('disabled', Item)}>
 				{text('Children', Item, inputData.extraSpaceText)}
 			</Item>
 		)
@@ -51,9 +48,7 @@ storiesOf('Item', module)
 	.add(
 		'integrated with other components',
 		() => (
-			<Item
-				disabled={boolean('disabled', Item)}
-			>
+			<Item disabled={boolean('disabled', Item)}>
 				<Button>Click here</Button>
 				{text('Children', Item, 'Hello Item')}
 				<Button>Click here</Button>
@@ -71,49 +66,26 @@ storiesOf('Item', module)
 				<Item>
 					{text('Spottable Text', Item, inputData.normalText)}
 				</Item>
-				<Item
-					disabled
-				>
+				<Item disabled>
 					{text('Disabled Text', Item, inputData.disabledText)}
 				</Item>
 				<Item>
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						{select('iconBefore', iconNames, Icon, 'plus')}
+					<Icon small={boolean('small', Icon)}>
+						{select('iconBefore', iconNames, Item, 'plus')}
 					</Icon>
-
-					{text('Text with icon at start', Item, 'Item with text that is spottable with an icon (at the start of the string)')}
+					{text('Text with iconBefore', Item, 'Item with text that is spottable with an icon (at the start of the string)')}
 				</Item>
 				<Item>
-					{text('Text with icon at end', Item, 'Item with text that is spottable with an icon(at the end of the string)')}
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						{select('iconAfter', iconNames, Icon, 'pauseforward')}
+					{text('Text with iconAfter', Item, 'Item with text that is spottable with an icon(at the end of the string)')}
+					<Icon small={boolean('small', Icon)}>
+						{select('iconAfter', iconNames, Item, 'pauseforward')}
 					</Icon>
 				</Item>
 				<Item>
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						gear
-					</Icon>
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						minus
-					</Icon>
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						trash
-					</Icon>
-					<Icon
-						small={boolean('small', Icon)}
-					>
-						flag
-					</Icon>
+					<Icon small={boolean('small', Icon)}>gear</Icon>
+					<Icon small={boolean('small', Icon)}>minus</Icon>
+					<Icon small={boolean('small', Icon)}>trash</Icon>
+					<Icon small={boolean('small', Icon)}>flag</Icon>
 				</Item>
 			</div>
 		)

--- a/packages/sampler/stories/qa-stories/Marquee.js
+++ b/packages/sampler/stories/qa-stories/Marquee.js
@@ -4,8 +4,10 @@ import ri from '@enact/ui/resolution';
 import Spottable from '@enact/spotlight/Spottable';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {boolean, number, select} from '@storybook/addon-knobs';
-import nullify from '../../src/utils/nullify.js';
+
+import {boolean, number, select} from '../../src/enact-knobs';
+
+Marquee.displayName = 'Marquee';
 
 const SpottableMarquee = Spottable(Marquee);
 const Controller = MarqueeController('div');
@@ -31,20 +33,20 @@ storiesOf('Marquee', module)
 	.add(
 		'LTR',
 		() => {
-			const disabled = nullify(boolean('disabled', false));
+			const disabled = boolean('disabled', Marquee, false);
 			return (
 				<section>
 					<Marquee
 						style={{width: ri.unit(399, 'rem')}}
 						disabled={disabled}
-						marqueeDelay={number('marqueeDelay', 1000)}
-						marqueeDisabled={boolean('marqueeDisabled', false)}
-						marqueeOn={select('marqueeOn', ['hover', 'render'], 'render')}
+						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
+						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
+						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
 						marqueeOnRenderDelay={1000}
-						marqueeResetDelay={number('marqueeResetDelay', 1000)}
-						marqueeSpeed={number('marqueeSpeed', 60)}
+						marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
+						marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 					>
-						{select('children', LTR, LTR[0])}
+						{select('children', LTR, Marquee, LTR[0])}
 					</Marquee>
 					{disabledDisclaimer(disabled)}
 				</section>
@@ -55,20 +57,20 @@ storiesOf('Marquee', module)
 	.add(
 		'RTL',
 		() => {
-			const disabled = nullify(boolean('disabled', false));
+			const disabled = boolean('disabled', Marquee, false);
 			return (
 				<section>
 					<Marquee
 						style={{width: ri.unit(399, 'rem')}}
 						disabled={disabled}
-						marqueeDelay={number('marqueeDelay', 1000)}
-						marqueeDisabled={boolean('marqueeDisabled', false)}
-						marqueeOn={select('marqueeOn', ['hover', 'render'], 'render')}
+						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
+						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
+						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
 						marqueeOnRenderDelay={1000}
-						marqueeResetDelay={number('marqueeResetDelay', 1000)}
-						marqueeSpeed={number('marqueeSpeed', 60)}
+						marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
+						marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 					>
-						{select('children', RTL, RTL[0])}
+						{select('children', RTL, Marquee, RTL[0])}
 					</Marquee>
 					{disabledDisclaimer(disabled)}
 				</section>
@@ -79,19 +81,19 @@ storiesOf('Marquee', module)
 	.add(
 		'Synchronized',
 		() => {
-			const disabled = nullify(boolean('disabled', false));
+			const disabled = boolean('disabled', Marquee, false);
 			return (
 				<Controller style={{width: ri.unit(399, 'rem')}}>
 					{LTR.map((children, index) => (
 						<Marquee
 							disabled={disabled}
 							key={index}
-							marqueeDelay={number('marqueeDelay', 1000)}
-							marqueeDisabled={boolean('marqueeDisabled', false)}
-							marqueeOn={select('marqueeOn', ['hover', 'render'], 'render')}
+							marqueeDelay={number('marqueeDelay', Marquee, 1000)}
+							marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
+							marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
 							marqueeOnRenderDelay={5000}
-							marqueeResetDelay={number('marqueeResetDelay', 1000)}
-							marqueeSpeed={number('marqueeSpeed', 60)}
+							marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
+							marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 						>
 							{children}
 						</Marquee>

--- a/packages/sampler/stories/qa-stories/Picker.js
+++ b/packages/sampler/stories/qa-stories/Picker.js
@@ -76,7 +76,7 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={select('width', prop.width, Picker, Picker, 'large')}
+				width={select('width', prop.width, Picker, 'large')}
 				orientation={select('orientation', prop.orientation, Picker, 'horizontal')}
 				wrap={boolean('wrap', Picker)}
 				joined={boolean('joined', Picker)}
@@ -114,8 +114,8 @@ storiesOf('Picker', module)
 			<Picker
 				onChange={action('onChange')}
 				width={select('width', prop.width, Picker, 'large')}
-				orientation={select('orientation', prop.orientation)}
-				wrap={boolean('wrap', true, Picker)}
+				orientation={select('orientation', prop.orientation, Picker)}
+				wrap={boolean('wrap', Picker, true)}
 				joined={boolean('joined', Picker)}
 				noAnimation={boolean('noAnimation', Picker)}
 				disabled={boolean('disabled', Picker)}
@@ -132,8 +132,8 @@ storiesOf('Picker', module)
 			<Picker
 				onChange={action('onChange')}
 				width={select('width', prop.width, Picker, 'large')}
-				orientation={select('orientation', prop.orientation)}
-				wrap={boolean('wrap', true, Picker)}
+				orientation={select('orientation', prop.orientation, Picker)}
+				wrap={boolean('wrap', Picker, true)}
 				joined={boolean('joined', Picker)}
 				noAnimation={boolean('noAnimation', Picker)}
 				disabled={boolean('disabled', Picker)}

--- a/packages/sampler/stories/qa-stories/Picker.js
+++ b/packages/sampler/stories/qa-stories/Picker.js
@@ -5,8 +5,10 @@ import PickerRTL from './components/PickerRTL';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select} from '@storybook/addon-knobs';
-import nullify from '../../src/utils/nullify.js';
+
+import {boolean, select} from '../../src/enact-knobs';
+
+Picker.displayName = 'Picker';
 
 const prop = {
 	orientation: ['horizontal', 'vertical'],
@@ -56,14 +58,14 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={nullify(select('width', prop.width, 'large'))}
-				orientation={select('orientation', prop.orientation, 'horizontal')}
-				wrap={boolean('wrap')}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
-				incrementIcon={select('incrementIcon', iconNames)}
-				decrementIcon={select('decrementIcon', iconNames)}
+				width={select('width', prop.width, Picker, 'large')}
+				orientation={select('orientation', prop.orientation, Picker, 'horizontal')}
+				wrap={boolean('wrap', Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
+				incrementIcon={select('incrementIcon', iconNames, Picker)}
+				decrementIcon={select('decrementIcon', iconNames, Picker)}
 			>
 				{pickerList.long}
 			</Picker>
@@ -74,14 +76,14 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={nullify(select('width', prop.width, 'large'))}
-				orientation={select('orientation', prop.orientation, 'horizontal')}
-				wrap={boolean('wrap')}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
-				incrementIcon={select('incrementIcon', iconNames)}
-				decrementIcon={select('decrementIcon', iconNames)}
+				width={select('width', prop.width, Picker, Picker, 'large')}
+				orientation={select('orientation', prop.orientation, Picker, 'horizontal')}
+				wrap={boolean('wrap', Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
+				incrementIcon={select('incrementIcon', iconNames, Picker)}
+				decrementIcon={select('decrementIcon', iconNames, Picker)}
 			>
 				{pickerList.tall}
 			</Picker>
@@ -92,14 +94,14 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={nullify(select('width', prop.width, 'medium'))}
-				orientation={select('orientation', prop.orientation, 'horizontal')}
-				wrap={boolean('wrap')}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
-				incrementIcon={select('incrementIcon', iconNames)}
-				decrementIcon={select('decrementIcon', iconNames)}
+				width={select('width', prop.width, Picker, 'medium')}
+				orientation={select('orientation', prop.orientation, Picker, 'horizontal')}
+				wrap={boolean('wrap', Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
+				incrementIcon={select('incrementIcon', iconNames, Picker)}
+				decrementIcon={select('decrementIcon', iconNames, Picker)}
 				defaultValue={2}
 			>
 				{pickerList.vegetables}
@@ -111,14 +113,14 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={select('width', prop.width, 'large')}
+				width={select('width', prop.width, Picker, 'large')}
 				orientation={select('orientation', prop.orientation)}
-				wrap={boolean('wrap', true)}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
-				incrementIcon={select('incrementIcon', iconNames)}
-				decrementIcon={select('decrementIcon', iconNames)}
+				wrap={boolean('wrap', true, Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
+				incrementIcon={select('incrementIcon', iconNames, Picker)}
+				decrementIcon={select('decrementIcon', iconNames, Picker)}
 			>
 				{[]}
 			</Picker>
@@ -129,14 +131,14 @@ storiesOf('Picker', module)
 		() => (
 			<Picker
 				onChange={action('onChange')}
-				width={nullify(select('width', prop.width, 'large'))}
+				width={select('width', prop.width, Picker, 'large')}
 				orientation={select('orientation', prop.orientation)}
-				wrap={boolean('wrap', true)}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
-				incrementIcon={select('incrementIcon', iconNames)}
-				decrementIcon={select('decrementIcon', iconNames)}
+				wrap={boolean('wrap', true, Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
+				incrementIcon={select('incrementIcon', iconNames, Picker)}
+				decrementIcon={select('decrementIcon', iconNames, Picker)}
 			>
 				{pickerList.oneAirport}
 			</Picker>
@@ -146,12 +148,12 @@ storiesOf('Picker', module)
 		'with item add/remove (ENYO-2448)',
 		() => (
 			<PickerAddRemove
-				width={select('width', prop.width, 'medium')}
-				orientation={select('orientation', prop.orientation, 'horizontal')}
-				wrap={boolean('wrap')}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
+				width={select('width', prop.width, Picker, 'medium')}
+				orientation={select('orientation', prop.orientation, Picker, 'horizontal')}
+				wrap={boolean('wrap', Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
 			>
 				{pickerList.emptyList}
 			</PickerAddRemove>
@@ -161,11 +163,11 @@ storiesOf('Picker', module)
 		'RTL Layout (PLAT-28123)',
 		() => (
 			<PickerRTL
-				width={select('width', prop.width, 'medium')}
-				wrap={boolean('wrap')}
-				joined={boolean('joined')}
-				noAnimation={boolean('noAnimation')}
-				disabled={boolean('disabled')}
+				width={select('width', prop.width, Picker, 'medium')}
+				wrap={boolean('wrap', Picker)}
+				joined={boolean('joined', Picker)}
+				noAnimation={boolean('noAnimation', Picker)}
+				disabled={boolean('disabled', Picker)}
 			>
 				{pickerList.orderedList}
 			</PickerRTL>

--- a/packages/sampler/stories/qa-stories/Popup.js
+++ b/packages/sampler/stories/qa-stories/Popup.js
@@ -4,7 +4,10 @@ import React from 'react';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, text, select} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+
+Popup.displayName = 'Popup';
 
 const Container = SpotlightContainerDecorator('div');
 
@@ -21,14 +24,14 @@ storiesOf('Popup', module)
 				</p>
 				<Button>Button</Button>
 				<Popup
-					open={boolean('open', true)}
-					noAnimation={boolean('noAnimation', false)}
-					noAutoDismiss={boolean('noAutoDismiss', false)}
+					open={boolean('open', Popup, true)}
+					noAnimation={boolean('noAnimation', Popup, false)}
+					noAutoDismiss={boolean('noAutoDismiss', Popup, false)}
 					onClose={action('onClose')}
-					showCloseButton={boolean('showCloseButton', true)}
-					spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], 'self-only')}
+					showCloseButton={boolean('showCloseButton', Popup, true)}
+					spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Popup, 'self-only')}
 				>
-					<div>{text('children', 'Hello Popup')}</div>
+					<div>{text('children', Popup, 'Hello Popup')}</div>
 					<br />
 					<Container>
 						<Button>Button</Button>

--- a/packages/sampler/stories/qa-stories/ProgressBar.js
+++ b/packages/sampler/stories/qa-stories/ProgressBar.js
@@ -1,9 +1,9 @@
 import ProgressBar, {ProgressBarBase} from '@enact/moonstone/ProgressBar';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {boolean, number, select} from '@storybook/addon-knobs';
 
-import nullify from '../../src/utils/nullify.js';
+import {boolean, number, select} from '../../src/enact-knobs';
+
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('ProgressBar', ProgressBarBase, ProgressBar);
@@ -13,12 +13,12 @@ storiesOf('ProgressBar', module)
 		'The basic ProgressBar',
 		() => (
 			<ProgressBar
-				backgroundProgress={number('backgroundProgress', 0.5, {range: true, min: 0, max: 1, step: 0.01})}
-				tooltip={boolean('tooltip', false)}
-				highlighted={nullify(boolean('highlighted', false))}
-				progress={number('progress', 0.4, {range: true, min: 0, max: 1, step: 0.01})}
-				orientation={select('orientation', ['horizontal', 'vertical'], 'horizontal')}
-				disabled={nullify(boolean('disabled', false))}
+				backgroundProgress={number('backgroundProgress', Config, 0.5, {range: true, min: 0, max: 1, step: 0.01})}
+				tooltip={boolean('tooltip', Config, false)}
+				highlighted={boolean('highlighted', Config, false)}
+				progress={number('progress', Config, 0.4, {range: true, min: 0, max: 1, step: 0.01})}
+				orientation={select('orientation', ['horizontal', 'vertical'], Config, 'horizontal')}
+				disabled={boolean('disabled', Config, false)}
 			/>
 		),
 		{propTables: [Config]}

--- a/packages/sampler/stories/qa-stories/RadioItem.js
+++ b/packages/sampler/stories/qa-stories/RadioItem.js
@@ -2,7 +2,10 @@ import RadioItem from '@enact/moonstone/RadioItem';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean} from '@storybook/addon-knobs';
+
+import {boolean} from '../../src/enact-knobs';
+
+RadioItem.displayName = 'RaditoItem';
 
 const radioData = {
 	longTextWithSpace : ['FirstLongTextWithSpace FirstLongTextWithSpace FirstLongTextWithSpace FirstLongTextWithSpace', 'SecondLongTextWithSpace SecondLongTextWithSpace SecondLongTextWithSpace SecondLongTextWithSpace'],
@@ -17,15 +20,15 @@ storiesOf('RadioItem', module)
 		() => (
 			<div>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.longTextWithSpace[0]}
 				</RadioItem>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.longTextWithSpace[1]}
@@ -38,15 +41,15 @@ storiesOf('RadioItem', module)
 		() => (
 			<div>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.longTextWithoutSpace[0]}
 				</RadioItem>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.longTextWithoutSpace[1]}
@@ -59,15 +62,15 @@ storiesOf('RadioItem', module)
 		() => (
 			<div>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.tallText[0]}
 				</RadioItem>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.tallText[1]}
@@ -80,15 +83,15 @@ storiesOf('RadioItem', module)
 		() => (
 			<div>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.rightToLeft[0]}
 				</RadioItem>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 				>
 					{radioData.rightToLeft[1]}
@@ -101,16 +104,16 @@ storiesOf('RadioItem', module)
 		() => (
 			<div>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 					defaultSelected
 				>
 					RadioItem1
 				</RadioItem>
 				<RadioItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', RadioItem, false)}
+					inline={boolean('inline', RadioItem, false)}
 					onToggle={action('onToggle')}
 					defaultSelected
 				>

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -7,9 +7,10 @@ import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select} from '@storybook/addon-knobs';
 
-import nullify from '../../src/utils/nullify.js';
+import {boolean, select} from '../../src/enact-knobs';
+
+Scroller.displayName = 'Scroller';
 
 const itemData = [];
 for (let i = 0; i < 100; i++) {
@@ -27,7 +28,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 				style={{height: ri.unit(600, 'rem')}}
 			>
 				<Group childComponent={Item}>
@@ -40,7 +41,7 @@ storiesOf('Scroller', module)
 		'With ExpandableList',
 		() => (
 			<Scroller
-				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 				style={{height: ri.unit(600, 'rem')}}
 			>
 				<ExpandableList
@@ -56,9 +57,9 @@ storiesOf('Scroller', module)
 		'Horizontal scroll',
 		() => (
 			<Scroller
-				direction={select('direction', prop.direction, 'horizontal')}
-				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
-				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, 'auto')}
+				direction={select('direction', prop.direction, Scroller, 'horizontal')}
+				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Scroller, 'auto')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				style={{

--- a/packages/sampler/stories/qa-stories/SelectableItem.js
+++ b/packages/sampler/stories/qa-stories/SelectableItem.js
@@ -103,7 +103,11 @@ storiesOf('SelectableItem', module)
 				onSelect={action('onSelect')}
 			>
 
-				{[text('Normal Text 1', SelectableItem, inputData.normalText + 1), text('Normal Text 2', SelectableItem, inputData.normalText + 2), text('Normal Text 3', SelectableItem, inputData.normalText + 3)]}
+				{[
+					text('Normal Text 1', SelectableItem, inputData.normalText + 1),
+					text('Normal Text 2', SelectableItem, inputData.normalText + 2),
+					text('Normal Text 3', SelectableItem, inputData.normalText + 3)
+				]}
 			</Group>
 		)
 	)
@@ -117,11 +121,10 @@ storiesOf('SelectableItem', module)
 				onSelect={action('onSelect')}
 			>
 				{[
-					{children: '1', disabled: true},
-					{children: '2', disabled: false},
-					{children: '3', disabled: true},
-					{children: '4', disabled: false}
-
+					{key: 'item1', children: '1', disabled: true},
+					{key: 'item2', children: '2', disabled: false},
+					{key: 'item3', children: '3', disabled: true},
+					{key: 'item4', children: '4', disabled: false}
 				]}
 			</Group>
 		)

--- a/packages/sampler/stories/qa-stories/SelectableItem.js
+++ b/packages/sampler/stories/qa-stories/SelectableItem.js
@@ -3,7 +3,10 @@ import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, text, select} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+
+SelectableItem.displayName = 'SelectableItem';
 
 const inputData = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',
@@ -20,18 +23,18 @@ storiesOf('SelectableItem', module)
 		() => (
 			<div>
 				<SelectableItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', SelectableItem, false)}
+					inline={boolean('inline', SelectableItem, false)}
 					onToggle={action('onToggle')}
 				>
-					{text('Long Text', inputData.longText)}
+					{text('Long Text', SelectableItem, inputData.longText)}
 				</SelectableItem>
 				<SelectableItem
 					disabled
-					inline={boolean('inline', false)}
+					inline={boolean('inline', SelectableItem, false)}
 					onToggle={action('onToggle')}
 				>
-					{text('Disable Long Text', inputData.disabledLong)}
+					{text('Disable Long Text', SelectableItem, inputData.disabledLong)}
 				</SelectableItem>
 			</div>
 		)
@@ -40,11 +43,11 @@ storiesOf('SelectableItem', module)
 		'with tall characters',
 		() => (
 			<SelectableItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', SelectableItem, false)}
+				inline={boolean('inline', SelectableItem, false)}
 				onToggle={action('onToggle')}
 			>
-				{select('children', inputData.tallText, inputData.tallText[0])}
+				{select('children', inputData.tallText, SelectableItem, inputData.tallText[0])}
 			</SelectableItem>
 		)
 	)
@@ -52,11 +55,11 @@ storiesOf('SelectableItem', module)
 		'with right to left text',
 		() => (
 			<SelectableItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', SelectableItem, false)}
+				inline={boolean('inline', SelectableItem, false)}
 				onToggle={action('onToggle')}
 			>
-				{text('Right to Left Text', inputData.rtlText)}
+				{text('Right to Left Text', SelectableItem, inputData.rtlText)}
 			</SelectableItem>
 		)
 	)
@@ -64,11 +67,11 @@ storiesOf('SelectableItem', module)
 		'with extra spacing',
 		() => (
 			<SelectableItem
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', SelectableItem, false)}
+				inline={boolean('inline', SelectableItem, false)}
 				onToggle={action('onToggle')}
 			>
-				{text('extra space text', inputData.extraSpaceText)}
+				{text('extra space text', SelectableItem, inputData.extraSpaceText)}
 			</SelectableItem>
 		)
 	)
@@ -77,11 +80,11 @@ storiesOf('SelectableItem', module)
 		() => (
 			<SelectableItem
 				defaultSelected
-				disabled={boolean('disabled', false)}
-				inline={boolean('inline', false)}
+				disabled={boolean('disabled', SelectableItem, false)}
+				inline={boolean('inline', SelectableItem, false)}
 				onToggle={action('onToggle')}
 			>
-				{text('children', inputData.normalText)}
+				{text('children', SelectableItem, inputData.normalText)}
 			</SelectableItem>
 		)
 	)
@@ -91,16 +94,16 @@ storiesOf('SelectableItem', module)
 			<Group
 				childComponent={SelectableItem}
 				itemProps={{
-					inline: boolean('inline', false),
-					disabled: boolean('disabled', false)
+					inline: boolean('inline', SelectableItem, false),
+					disabled: boolean('disabled', SelectableItem, false)
 				}}
 				childSelect="onToggle"
 				selectedProp="selected"
-				disabled={boolean('disabled', false)}
+				disabled={boolean('disabled', SelectableItem, false)}
 				onSelect={action('onSelect')}
 			>
 
-				{[text('Normal Text 1', inputData.normalText + 1), text('Normal Text 2', inputData.normalText + 2), text('Normal Text 3', inputData.normalText + 3)]}
+				{[text('Normal Text 1', SelectableItem, inputData.normalText + 1), text('Normal Text 2', SelectableItem, inputData.normalText + 2), text('Normal Text 3', SelectableItem, inputData.normalText + 3)]}
 			</Group>
 		)
 	)

--- a/packages/sampler/stories/qa-stories/Slider.js
+++ b/packages/sampler/stories/qa-stories/Slider.js
@@ -100,7 +100,7 @@ storiesOf('Slider', module)
 	.add(
 		'Add and Remove ',
 		() => {
-			const itemSize = ri.scale(number('itemSize', 72));
+			const itemSize = ri.scale(number('itemSize', Slider, 72));
 			return (
 				<SliderList itemSize={itemSize} />
 			);

--- a/packages/sampler/stories/qa-stories/Spinner.js
+++ b/packages/sampler/stories/qa-stories/Spinner.js
@@ -4,8 +4,10 @@ import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {text, boolean, select} from '@storybook/addon-knobs';
-import nullify from '../../src/utils/nullify.js';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+
+Spinner.displayName = 'Spinner';
 
 // Set up some defaults for info and knobs
 const
@@ -27,12 +29,12 @@ storiesOf('Spinner', module)
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 					<Button onClick={action('Inside Button events')}>Button</Button>
 					<Spinner
-						transparent={boolean('transparent', false)}
-						centered={boolean('centered', false)}
-						blockClickOn={nullify(select('blockClickOn', [null, 'container', 'screen']))}
-						scrim={boolean('scrim', true)}
+						transparent={boolean('transparent', Spinner, false)}
+						centered={boolean('centered', Spinner, false)}
+						blockClickOn={select('blockClickOn', [null, 'container', 'screen'], Spinner)}
+						scrim={boolean('scrim', Spinner, true)}
 					>
-						{text('content', prop.longText)}
+						{text('content', Spinner, prop.longText)}
 					</Spinner>
 				</div>
 				<Button onClick={action('Outside Button events')}>Button</Button>
@@ -53,12 +55,12 @@ storiesOf('Spinner', module)
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 					<Button onClick={action('Inside Button events')}>Button</Button>
 					<Spinner
-						transparent={boolean('transparent', false)}
-						centered={boolean('centered', false)}
-						blockClickOn={nullify(select('blockClickOn', [null, 'container', 'screen']))}
-						scrim={boolean('scrim', true)}
+						transparent={boolean('transparent', Spinner, false)}
+						centered={boolean('centered', Spinner, false)}
+						blockClickOn={select('blockClickOn', [null, 'container', 'screen'], Spinner)}
+						scrim={boolean('scrim', Spinner, true)}
 					>
-						{text('content')}
+						{text('content', Spinner)}
 					</Spinner>
 				</div>
 				<Button onClick={action('Outside Button events')}>Button</Button>

--- a/packages/sampler/stories/qa-stories/Spotlight.js
+++ b/packages/sampler/stories/qa-stories/Spotlight.js
@@ -30,7 +30,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, select} from '@storybook/addon-knobs';
+
+import {boolean, select} from '../../src/enact-knobs';
 
 const Container = SpotlightContainerDecorator(
 	{enterTo: 'last-focused'},
@@ -283,11 +284,11 @@ storiesOf('Spotlight', module)
 		'Popup Navigation',
 		() => (
 			<PopupFocusTest
-				noAnimation={boolean('noAnimation', false)}
-				noAutoDismiss={boolean('noAutoDismiss', false)}
-				scrimType={select('scrimType', ['none', 'transparent', 'translucent'], 'translucent')}
-				showCloseButton={boolean('showCloseButton', true)}
-				spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], 'self-only')}
+				noAnimation={boolean('noAnimation', PopupFocusTest, false)}
+				noAutoDismiss={boolean('noAutoDismiss', PopupFocusTest, false)}
+				scrimType={select('scrimType', ['none', 'transparent', 'translucent'], PopupFocusTest, 'translucent')}
+				showCloseButton={boolean('showCloseButton', PopupFocusTest, true)}
+				spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], PopupFocusTest, 'self-only')}
 			/>
 		)
 	)
@@ -299,7 +300,7 @@ storiesOf('Spotlight', module)
 					Use the knobs to test the available behaviors for the spottable components
 					below.
 				</p>
-				<Container style={style.flexBox} spotlightMuted={boolean('spotlightMuted', false)}>
+				<Container style={style.flexBox} spotlightMuted={boolean('spotlightMuted', Container, false)}>
 					<div style={style.flexItem}>
 						<Divider>
 							Misc Components
@@ -310,7 +311,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								Button
 							</Button>
@@ -320,7 +321,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								Translucent
 							</Button>
@@ -332,7 +333,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								Transparent
 							</Button>
@@ -341,7 +342,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								ToggleButton
 							</ToggleButton>
@@ -352,7 +353,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								plus
 							</IconButton>
@@ -361,7 +362,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							/>
 						</div>
 						<div style={style.flexBox}>
@@ -370,7 +371,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								{Items}
 							</Picker>
@@ -380,7 +381,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 							>
 								{Items}
 							</Picker>
@@ -390,21 +391,21 @@ storiesOf('Spotlight', module)
 							onSpotlightLeft={action('onSpotlightLeft')}
 							onSpotlightRight={action('onSpotlightRight')}
 							onSpotlightUp={action('onSpotlightUp')}
-							spotlightDisabled={boolean('spotlightDisabled', false)}
+							spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 						/>
 						<Slider
 							onSpotlightDown={action('onSpotlightDown')}
 							onSpotlightLeft={action('onSpotlightLeft')}
 							onSpotlightRight={action('onSpotlightRight')}
 							onSpotlightUp={action('onSpotlightUp')}
-							spotlightDisabled={boolean('spotlightDisabled', false)}
+							spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 						/>
 						<Item
 							onSpotlightDown={action('onSpotlightDown')}
 							onSpotlightLeft={action('onSpotlightLeft')}
 							onSpotlightRight={action('onSpotlightRight')}
 							onSpotlightUp={action('onSpotlightUp')}
-							spotlightDisabled={boolean('spotlightDisabled', false)}
+							spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 						>
 							Item
 						</Item>
@@ -414,7 +415,7 @@ storiesOf('Spotlight', module)
 							onSpotlightLeft={action('onSpotlightLeft')}
 							onSpotlightRight={action('onSpotlightRight')}
 							onSpotlightUp={action('onSpotlightUp')}
-							spotlightDisabled={boolean('spotlightDisabled', false)}
+							spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 						>
 							LabeledItem
 						</LabeledItem>
@@ -429,7 +430,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="Various Items in an ExpandableItem"
 							>
 								<CheckboxItem
@@ -437,7 +438,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									CheckboxItem
 								</CheckboxItem>
@@ -446,7 +447,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									FormCheckboxItem
 								</FormCheckboxItem>
@@ -455,7 +456,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									RadioItem
 								</RadioItem>
@@ -464,7 +465,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									SelectableItem
 								</SelectableItem>
@@ -473,7 +474,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									SwitchItem
 								</SwitchItem>
@@ -483,7 +484,7 @@ storiesOf('Spotlight', module)
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}
 									onSpotlightUp={action('onSpotlightUp')}
-									spotlightDisabled={boolean('spotlightDisabled', false)}
+									spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								>
 									ToggleItem
 								</ToggleItem>
@@ -494,7 +495,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="ExpandableList"
 							>
 								{Items}
@@ -504,7 +505,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="ExpandableInput"
 							/>
 							<ExpandablePicker
@@ -512,7 +513,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="ExpandablePicker"
 							>
 								{Items}
@@ -522,7 +523,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="DatePicker"
 							/>
 							<DayPicker
@@ -530,7 +531,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="DayPicker"
 							/>
 							<TimePicker
@@ -538,7 +539,7 @@ storiesOf('Spotlight', module)
 								onSpotlightLeft={action('onSpotlightLeft')}
 								onSpotlightRight={action('onSpotlightRight')}
 								onSpotlightUp={action('onSpotlightUp')}
-								spotlightDisabled={boolean('spotlightDisabled', false)}
+								spotlightDisabled={boolean('spotlightDisabled', Container, false)}
 								title="TimePicker"
 							/>
 						</Scroller>

--- a/packages/sampler/stories/qa-stories/Spotlight.js
+++ b/packages/sampler/stories/qa-stories/Spotlight.js
@@ -8,6 +8,7 @@ import ExpandableItem from '@enact/moonstone/ExpandableItem';
 import ExpandableList from '@enact/moonstone/ExpandableList';
 import ExpandablePicker from '@enact/moonstone/ExpandablePicker';
 import FormCheckboxItem from '@enact/moonstone/FormCheckboxItem';
+import Icon from '@enact/moonstone/Icon';
 import IconButton from '@enact/moonstone/IconButton';
 import IncrementSlider from '@enact/moonstone/IncrementSlider';
 import Input from '@enact/moonstone/Input';
@@ -480,6 +481,7 @@ storiesOf('Spotlight', module)
 								</SwitchItem>
 								<ToggleItem
 									icon="plus"
+									iconComponent={Icon}
 									onSpotlightDown={action('onSpotlightDown')}
 									onSpotlightLeft={action('onSpotlightLeft')}
 									onSpotlightRight={action('onSpotlightRight')}

--- a/packages/sampler/stories/qa-stories/SwitchItem.js
+++ b/packages/sampler/stories/qa-stories/SwitchItem.js
@@ -4,7 +4,10 @@ import Divider from '@enact/moonstone/Divider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {text, boolean} from '@storybook/addon-knobs';
+
+import {boolean, text} from '../../src/enact-knobs';
+
+SwitchItem.displayName = 'SwitchItem';
 
 const inputData = {
 	longText : 'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Text',
@@ -18,18 +21,18 @@ storiesOf('SwitchItem', module)
 		() => (
 			<div>
 				<SwitchItem
-					disabled={boolean('disabled', false)}
-					inline={boolean('inline', false)}
+					disabled={boolean('disabled', SwitchItem, false)}
+					inline={boolean('inline', SwitchItem, false)}
 					onToggle={action('onToggle')}
 				>
-					{text('Long Text', inputData.longText)}
+					{text('Long Text', SwitchItem, inputData.longText)}
 				</SwitchItem>
 				<SwitchItem
 					disabled
-					inline={boolean('inline', false)}
+					inline={boolean('inline', SwitchItem, false)}
 					onToggle={action('onToggle')}
 				>
-					{text('Disable Long Text', inputData.disabledLong)}
+					{text('Disable Long Text', SwitchItem, inputData.disabledLong)}
 				</SwitchItem>
 			</div>
 		)
@@ -44,14 +47,14 @@ storiesOf('SwitchItem', module)
 				<Group
 					childComponent={SwitchItem}
 					itemProps={{
-						inline: boolean('ItemProps-Inline', false),
-						disabled: boolean('disabled', false)
+						inline: boolean('ItemProps-Inline', SwitchItem, false),
+						disabled: boolean('disabled', SwitchItem, false)
 					}}
 					selectedProp="selected"
 					defaultSelected={1}
 					onSelect={action('onSelect')}
 				>
-					{[text('Normal Text 1', inputData.normalText + 1), text('Normal Text 2', inputData.normalText + 2), text('Normal Text 3', inputData.normalText + 3)]}
+					{[text('Normal Text 1', SwitchItem, inputData.normalText + 1), text('Normal Text 2', SwitchItem, inputData.normalText + 2), text('Normal Text 3', SwitchItem, inputData.normalText + 3)]}
 				</Group>
 				<Divider>
 					{'Switch items with long text in a group'}
@@ -59,16 +62,16 @@ storiesOf('SwitchItem', module)
 				<Group
 					childComponent={SwitchItem}
 					itemProps={{
-						inline: boolean('ItemProps-Inline', false),
-						disabled: boolean('disabled', false)
+						inline: boolean('ItemProps-Inline', SwitchItem, false),
+						disabled: boolean('disabled', SwitchItem, false)
 					}}
 					childSelect="onToggle"
 					selectedProp="selected"
-					disabled={boolean('disabled', false)}
+					disabled={boolean('disabled', SwitchItem, false)}
 					defaultSelected={1}
 					onSelect={action('onSelect')}
 				>
-					{[text('Long Text 1', 'First ' + inputData.longText), text('Long Text 2', 'Second ' + inputData.longText), text('Long Text 3', 'Third ' + inputData.longText)]}
+					{[text('Long Text 1', SwitchItem, 'First ' + inputData.longText), text('Long Text 2', SwitchItem, 'Second ' + inputData.longText), text('Long Text 3', SwitchItem, 'Third ' + inputData.longText)]}
 				</Group>
 			</div>
 		)

--- a/packages/sampler/stories/qa-stories/ToggleButton.js
+++ b/packages/sampler/stories/qa-stories/ToggleButton.js
@@ -2,7 +2,10 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {text, boolean, select} from '@storybook/addon-knobs';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+
+ToggleButton.displayName = 'ToggleButton';
 
 // Set up some defaults for info and knobs
 const prop = {
@@ -17,12 +20,12 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				casing={select('casing', prop.casing, 'upper')}
-				disabled={boolean('disabled')}
-				small={boolean('small')}
-				toggleOnLabel={text('toggleOnLabel', 'Loooooooooooooooooog On')}
-				toggleOffLabel={text('toggleOffLabel', 'Loooooooooooooooooog Off')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, ToggleButton)}
+				casing={select('casing', prop.casing, ToggleButton, 'upper')}
+				disabled={boolean('disabled', ToggleButton)}
+				small={boolean('small', ToggleButton)}
+				toggleOnLabel={text('toggleOnLabel', ToggleButton, 'Loooooooooooooooooog On')}
+				toggleOffLabel={text('toggleOffLabel', ToggleButton, 'Loooooooooooooooooog Off')}
 			/>
 		)
 	)
@@ -31,12 +34,12 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity)}
-				casing={select('casing', prop.casing, 'upper')}
-				disabled={boolean('disabled')}
-				small={boolean('small')}
-				toggleOnLabel={select('toggleOnLabel', prop.tallText, 'ิ้  ไั  ஒ  து')}
-				toggleOffLabel={select('toggleOffLabel', prop.tallText, 'ิ้  ไั  ஒ  து')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, ToggleButton)}
+				casing={select('casing', prop.casing, ToggleButton, 'upper')}
+				disabled={boolean('disabled', ToggleButton)}
+				small={boolean('small', ToggleButton)}
+				toggleOnLabel={select('toggleOnLabel', prop.tallText, ToggleButton, 'ิ้  ไั  ஒ  து')}
+				toggleOffLabel={select('toggleOffLabel', prop.tallText, ToggleButton, 'ิ้  ไั  ஒ  து')}
 			/>
 		)
 	);

--- a/packages/sampler/stories/qa-stories/Touchable.js
+++ b/packages/sampler/stories/qa-stories/Touchable.js
@@ -3,7 +3,8 @@ import React from 'react';
 import Touchable from '@enact/ui/Touchable';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, number} from '@storybook/addon-knobs';
+
+import {boolean, number} from '../../src/enact-knobs';
 
 const TouchableDiv = Touchable('div');
 
@@ -14,7 +15,7 @@ storiesOf('Touchable', module)
 			<Button
 				onHold={action('onHold')}
 				onHoldPulse={action('onHoldPulse')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Button)}
 			>
 				Touchable
 			</Button>
@@ -33,7 +34,7 @@ storiesOf('Touchable', module)
 				}}
 				onHold={action('onHold')}
 				onHoldPulse={action('onHoldPulse')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Button)}
 			>
 				LongPress
 			</Button>
@@ -44,13 +45,13 @@ storiesOf('Touchable', module)
 		() => (
 			<Button
 				holdConfig={{
-					moveTolerance: number('holdConfig.moveTolerance', 16),
-					cancelOnMove: boolean('holdConfig.cancelOnMove', true)
+					moveTolerance: number('holdConfig.moveTolerance', Button, 16),
+					cancelOnMove: boolean('holdConfig.cancelOnMove', Button, true)
 				}}
-				noResume={boolean('noResume', false)}
+				noResume={boolean('noResume', Button, false)}
 				onHold={action('onHold')}
 				onHoldPulse={action('onHoldPulse')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Button)}
 			>
 				Resumable
 			</Button>
@@ -60,10 +61,10 @@ storiesOf('Touchable', module)
 		'that does not resume when re-entering component',
 		() => (
 			<Button
-				noResume={boolean('noResume', true)}
+				noResume={boolean('noResume', Button, true)}
 				onHold={action('onHold')}
 				onHoldPulse={action('onHoldPulse')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', Button)}
 			>
 				Not Resumable
 			</Button>
@@ -74,7 +75,7 @@ storiesOf('Touchable', module)
 		() => (
 			<TouchableDiv
 				onFlick={action('onFlick')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', TouchableDiv)}
 				style={{border: '2px dashed #888', width: 500, height: 500}}
 			>
 				Flick within this component
@@ -86,14 +87,14 @@ storiesOf('Touchable', module)
 		() => (
 			<TouchableDiv
 				dragConfig={{
-					global: boolean('dragConfig.global', false),
-					moveTolerance: number('dragConfig.moveTolerance', 16)
+					global: boolean('dragConfig.global', TouchableDiv, false),
+					moveTolerance: number('dragConfig.moveTolerance', TouchableDiv, 16)
 				}}
-				noResume={boolean('noResume', false)}
+				noResume={boolean('noResume', TouchableDiv, false)}
 				onDragStart={action('onDragStart')}
 				onDrag={action('onDrag')}
 				onDragEnd={action('onDragEnd')}
-				disabled={boolean('disabled')}
+				disabled={boolean('disabled', TouchableDiv)}
 				style={{border: '2px dashed #888', width: 500, height: 500}}
 			>
 				Drag within this component. Setting <code>noResume</code> to <code>false</code> should
@@ -105,8 +106,8 @@ storiesOf('Touchable', module)
 		'onTap when clicked',
 		() => (
 			<TouchableDiv
-				disabled={boolean('disabled')}
-				noResume={boolean('noResume', false)}
+				disabled={boolean('disabled', TouchableDiv)}
+				noResume={boolean('noResume', TouchableDiv, false)}
 				onClick={action('onClick')}
 				onDown={action('onDown')}
 				onMouseDown={action('onMouseDown')}

--- a/packages/sampler/stories/qa-stories/VideoPlayer.js
+++ b/packages/sampler/stories/qa-stories/VideoPlayer.js
@@ -3,6 +3,8 @@ import {button} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 
+const videoTabLabel = 'VideoPlayer';
+
 class VideoSourceSwap extends React.Component {
 	constructor (props) {
 		super(props);
@@ -59,11 +61,11 @@ class VideoSourceSwap extends React.Component {
 	render () {
 		return (
 			<div>
-				{button('Next Preload Video', this.nextVideo)}
-				{button('Non Preload Video', this.differentVideo)}
-				{button('Next Preload Video without changing preload', this.nextVideoKeepPreload)}
-				{button('Change Preload without changing video', this.nextPreloadVideoKeepVideo)}
-				{button('Reset Sources', this.resetSources)}
+				{button('Next Preload Video', this.nextVideo, videoTabLabel)}
+				{button('Non Preload Video', this.differentVideo, videoTabLabel)}
+				{button('Next Preload Video without changing preload', this.nextVideoKeepPreload, videoTabLabel)}
+				{button('Change Preload without changing video', this.nextPreloadVideoKeepVideo, videoTabLabel)}
+				{button('Reset Sources', this.resetSources, videoTabLabel)}
 				<VideoPlayer
 					muted
 					onJumpBackward={this.differentVideo}

--- a/packages/sampler/stories/qa-stories/VirtualGridList.js
+++ b/packages/sampler/stories/qa-stories/VirtualGridList.js
@@ -5,9 +5,8 @@ import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, number} from '@storybook/addon-knobs';
 
-import nullify from '../../src/utils/nullify.js';
+import {boolean, number} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
@@ -44,17 +43,17 @@ storiesOf('VirtualList.VirtualGridList', module)
 		'Horizontal VirtualGridList',
 		() => (
 			<VirtualGridList
-				dataSize={number('dataSize', items.length)}
+				dataSize={number('dataSize', Config, items.length)}
 				direction="horizontal"
-				focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 				itemRenderer={renderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', 180)),
-					minHeight: ri.scale(number('minHeight', 270))
+					minWidth: ri.scale(number('minWidth', Config, 180)),
+					minHeight: ri.scale(number('minHeight', Config, 270))
 				}}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				spacing={ri.scale(number('spacing', 18))}
+				spacing={ri.scale(number('spacing', Config, 18))}
 				style={{
 					height: ri.unit(552, 'rem')
 				}}

--- a/packages/sampler/stories/qa-stories/VirtualList.js
+++ b/packages/sampler/stories/qa-stories/VirtualList.js
@@ -6,9 +6,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean, number} from '@storybook/addon-knobs';
 
-import nullify from '../../src/utils/nullify.js';
+import {boolean, number} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBase, UiVirtualListBase);
@@ -79,16 +78,16 @@ storiesOf('VirtualList', module)
 	.add(
 		'with more items',
 		() => {
-			const itemSize = ri.scale(number('itemSize', 72));
+			const itemSize = ri.scale(number('itemSize', Config, 72));
 			return (
 				<VirtualList
-					dataSize={number('dataSize', items.length)}
-					focusableScrollbar={nullify(boolean('focusableScrollbar', false))}
+					dataSize={number('dataSize', Config, items.length)}
+					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', 0))}
+					spacing={ri.scale(number('spacing', Config, 0))}
 					style={style.list}
 				/>
 			);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update QA Sampler knobs and fix `Button`'s `minWidth` knob to work as expected.

`Button`'s `minWidth` is the only prop that is `true` by default so we want to hide `minWidth` in the Storybook JSX by default, but show `minWidth={false}`. As a result, we have this for `minWidth` knob: `storybookBoolean('minWidth', true) ? void 0 : false`, where `void 0` hides the prop when `true`.

### Links
[//]: # (Related issues, references)
PLAT-61006

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com
