### PR TITLE
ENYO-5387: Add disableFullscreen config to MoonstoneDecorator

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/MoonstoneDecorator` config property `disableFullscreen` to exclude `enact-fit` className
+
 ### Fixed
 
 - `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -28,17 +28,17 @@ import {configure} from '@enact/ui/Touchable';
  * @hocconfig
  */
 const defaultConfig = {
-	i18n: true,
+	disableFullscreen: false,
 	float: true,
+	i18n: true,
 	noAutoFocus: false,
 	overlay: false,
 	ri: {
 		screenTypes
 	},
-	spotlight: true,
-	textSize: true,
 	skin: true,
-	disableFullscreen: false
+	spotlight: true,
+	textSize: true
 };
 
 /**

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -65,7 +65,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	// Apply classes depending on screen type (overlay / fullscreen)
 	const bgClassName = classNames({
 		'enact-fit': !disableFullscreen,
-		[`${css.bg}`]: !overlay
+		[css.bg]: !overlay
 	});
 
 	let App = Wrapped;
@@ -123,13 +123,10 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		static displayName = 'MoonstoneDecorator';
 
 		render () {
-			let className = css.root + ' enact-unselectable enact-fit';
-			if (!float) {
-				className += ' ' + bgClassName;
-			}
-			if (this.props.className) {
-				className += ` ${this.props.className}`;
-			}
+			const className = classNames(css.root, this.props.className, 'enact-unselectable', {
+				[bgClassName]: !float,
+				'enact-fit': !disableFullscreen
+			});
 
 			return (
 				<App {...this.props} className={className} />

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -8,6 +8,7 @@ import {addAll} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
 import I18nDecorator from '@enact/i18n/I18nDecorator';
 import React from 'react';
+import classNames from 'classnames';
 import {ResolutionDecorator} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
 import SpotlightRootDecorator from '@enact/spotlight/SpotlightRootDecorator';
@@ -58,10 +59,14 @@ const defaultConfig = {
  * @public
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {ri, i18n, spotlight, float, noAutoFocus, overlay, textSize, skin, highContrast} = config;
+	const {ri, i18n, spotlight, float, noAutoFocus, overlay,
+		textSize, skin, highContrast, disableFullscreen} = config;
 
 	// Apply classes depending on screen type (overlay / fullscreen)
-	const bgClassName = 'enact-fit' + (overlay ? '' : ` ${css.bg}`);
+	const bgClassName = classNames({
+		'enact-fit': !disableFullscreen,
+		[`${css.bg}`]: !overlay
+	});
 
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -37,7 +37,8 @@ const defaultConfig = {
 	},
 	spotlight: true,
 	textSize: true,
-	skin: true
+	skin: true,
+	disableFullscreen: false
 };
 
 /**


### PR DESCRIPTION
### Issue Resolved / Feature Added
The `.enact-fit` class is currently a required addition to `MoonstoneDecorator`. It means that if Moonstone is used in a normal DOM node, it takes up no space, so layout does not flow around it as one would expect.


### Resolution
This change will give consumers an option to exclude the `.enact-fit` class which, by default expects that MoonstoneDecorator will be used in a "full screen" context.


### Additional Considerations
This absolute position breaks some other places. e.g. MoonstonePreview in the docs.
