### PR TITLE
ENYO-5304: Fix ContextualPopup to refocus activator on close for a11y

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/ContextualPopup` to refocus its activator on close when the popup lacks spottable children
 - `moonstone/Scrollable` to update scroll properly on pointer click
 - `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -269,18 +269,18 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (this.props.open && !nextProps.open) {
 
 				this.updateLeaveFor(null);
-				this.setState({
+				this.setState(state => ({
 					activator: null,
 					// only spot the activator on close if spotlight ...
 					shouldSpotActivator: (
 						// isn't set
 						!current ||
 						// is on the activator and we want to re-spot it so a11y read out can occur
-						current === this.state.activator ||
+						current === state.activator ||
 						// is within the popup
 						this.containerNode.contains(current)
 					)
-				});
+				}));
 			}
 		}
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -271,9 +271,15 @@ const ContextualPopupDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.updateLeaveFor(null);
 				this.setState({
 					activator: null,
-					// only spot the activator on close if spotlight isn't set or if the current
-					// focus is within the popup
-					shouldSpotActivator: !current || this.containerNode.contains(current)
+					// only spot the activator on close if spotlight ...
+					shouldSpotActivator: (
+						// isn't set
+						!current ||
+						// is on the activator and we want to re-spot it so a11y read out can occur
+						current === this.state.activator ||
+						// is within the popup
+						this.containerNode.contains(current)
+					)
 				});
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a contextual popup doesn't contain spottable children, closing it should refocus the activator so a11y read out can occur.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add another condition to `shouldSpotActivator` to refocus the activator if it had focus on close

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)