### PR TITLE
ENYO-5385: ProgressBar: allow to overriede css for 'load', 'fill'

### DIFF
--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -116,7 +116,7 @@ const ProgressBarBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['progressBar']
+		publicClassNames: ['progressBar', 'fill']
 	},
 
 	computed: {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It is allow to override css.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `load` and `fill` to `publicClassNames` in Progress.js.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N

### Links
[//]: # (Related issues, references)
ENYO-5385

### Comments
