### PR TITLE
ENYO-5397: Sampler - Null select knob fix

### DIFF
--- a/packages/sampler/src/enact-knobs/select.js
+++ b/packages/sampler/src/enact-knobs/select.js
@@ -39,7 +39,7 @@ const select = (name, items, Config, selecetdValue) => {
 	if (items instanceof Array) {
 		// An array of items
 		items.forEach((item) => {
-			labels[defaultAppender(item)] = item;
+			labels[defaultAppender(item || '')] = item;
 		});
 	} else {
 		// Items is an object


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Storybook knob is returning a string `'null'` when given `null`. Change `null` values to empty strings for select knobs that takes null values.


### Links
[//]: # (Related issues, references)
ENYO-5397

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com