### PR TITLE
ENYO-5396: Fix TooltipDecorator to remain visible when window is clicked

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scrollable` to update scroll properly on pointer click
 - `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus
+- `moonstone/TooltipDecorator` to not incorrectly dismiss the tooltip in certain cases
 
 ## [2.0.0-beta.8] - 2018-06-25
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,7 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scrollable` to update scroll properly on pointer click
 - `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus
-- `moonstone/TooltipDecorator` to not incorrectly dismiss the tooltip in certain cases
+- `moonstone/TooltipDecorator` to not dismiss the tooltip on pointer click
 
 ## [2.0.0-beta.8] - 2018-06-25
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -394,7 +394,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (tooltipText) {
 				const renderedTooltip = (
-					<FloatingLayerBase open={this.state.showing} onDismiss={this.hideTooltip} scrimType="none" key="tooltipFloatingLayer">
+					<FloatingLayerBase open={this.state.showing} noAutoDismiss onDismiss={this.hideTooltip} scrimType="none" key="tooltipFloatingLayer">
 						<Tooltip
 							aria-live="off"
 							role="alert"


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`TooltipDecorator`'s `<FloatingLayerBase>` would incorrectly dismiss the tooltip in certain cases.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adding `noAutoDismiss` corrects the behavior.

### Links
[//]: # (Related issues, references)
ENYO-5396


Enact-DCO-1.0-Signed-off-by: Dave Freeman (dave.freeman@lge.com)