### PR TITLE
ENYO- 5398: Fix more button color default value

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scrollable` to update scroll properly on pointer click
 - `moonstone/TooltipDecorator` to prevent unnecessary re-renders when losing focus
+- `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
 
 ## [2.0.0-beta.8] - 2018-06-25
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -480,6 +480,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			 *
 			 * @type {String}
 			 * @see {@link moonstone/IconButton.IconButtonBase.color}
+			 * @default 'blue'
 			 * @public
 			 */
 			moreButtonColor: PropTypes.oneOf(['red', 'green', 'yellow', 'blue']),
@@ -611,6 +612,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		static defaultProps = {
 			initialJumpDelay: 400,
 			jumpDelay: 200,
+			moreButtonColor: 'blue',
 			moreButtonSpotlightId: 'moreButton'
 		}
 

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -13,6 +13,7 @@ import {mergeComponentMetadata} from '../../src/utils';
 // Set up some defaults for info and knobs
 const prop = {
 	moreButtonColor: [
+		'',
 		'red',
 		'green',
 		'yellow',
@@ -145,7 +146,7 @@ storiesOf('Moonstone', module)
 							jumpDelay={number('jumpDelay', MediaControlsConfig, 200)}
 							jumpForwardIcon={select('jumpForwardIcon', icons, MediaControlsConfig, 'skipforward')}
 							moreButtonCloseLabel={text('moreButtonCloseLabel', MediaControlsConfig)}
-							moreButtonColor={select('moreButtonColor', prop.moreButtonColor, MediaControlsConfig, 'blue')}
+							moreButtonColor={select('moreButtonColor', prop.moreButtonColor, MediaControlsConfig, '')}
 							moreButtonDisabled={boolean('moreButtonDisabled', MediaControlsConfig)}
 							moreButtonLabel={text('moreButtonLabel', MediaControlsConfig)}
 							no5WayJump={boolean('no5WayJump', MediaControlsConfig)}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The key press of the default "blue" color keys do not work correctly if `moreButtonColor` prop is not specified. Added default value in `MediaControlsDecorator` to fix the sue.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
