### PR TITLE
PLAT-62147: Limit voice control area of ContexturePopup

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -72,6 +72,15 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			popupComponent: PropTypes.func.isRequired,
 
 			/**
+			 * When `true`, the range of voice control is limited to popup.
+			 *
+			 * @type {String}
+			 * @default true
+			 * @public
+			 */
+			'data-webos-voice-exclusive': PropTypes.bool,
+
+			/**
 			 * Direction of ContextualPopup
 			 *
 			 * @type {String}
@@ -194,6 +203,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static defaultProps = {
 			direction: 'down',
+			'data-webos-voice-exclusive': true,
 			open: false,
 			showCloseButton: false,
 			spotlightRestrict: 'self-first'
@@ -529,7 +539,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		render () {
-			const {showCloseButton, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, onClose, onOpen, popupProps, skin, spotlightRestrict, ...rest} = this.props;
+			const {'data-webos-voice-exclusive': voiceExclusive, showCloseButton, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, onClose, onOpen, popupProps, skin, spotlightRestrict, ...rest} = this.props;
 			const scrimType = spotlightRestrict === 'self-only' ? 'transparent' : 'none';
 			const popupPropsRef = Object.assign({}, popupProps);
 			const ariaProps = extractAriaProps(popupPropsRef);
@@ -557,6 +567,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							arrowPosition={this.state.arrowPosition}
 							containerPosition={this.state.containerPosition}
 							containerRef={this.getContainerNode}
+							data-webos-voice-exclusive={voiceExclusive}
 							skin={skin}
 							spotlightId={this.state.containerId}
 							spotlightRestrict={spotlightRestrict}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -74,7 +74,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * When `true`, the range of voice control is limited to popup.
 			 *
-			 * @type {String}
+			 * @type {Boolean}
 			 * @default true
 			 * @public
 			 */
@@ -202,8 +202,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static defaultProps = {
-			direction: 'down',
 			'data-webos-voice-exclusive': true,
+			direction: 'down',
 			open: false,
 			showCloseButton: false,
 			spotlightRestrict: 'self-first'

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -74,6 +74,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * When `true`, the range of voice control is limited to popup.
 			 *
+			 * @memberof moonstone/ContextualPopupDecorator.ContextualPopupDecorator.prototype
 			 * @type {Boolean}
 			 * @default true
 			 * @public

--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -39,7 +39,7 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {
 			/**
 			 * The "aria-label" for the selector.
 			 *
-			 * @memberof moonstone/DaySelector.DaySelectorDecorator
+			 * @memberof moonstone/DaySelector.DaySelectorDecorator.prototype
 			 * @type {String}
 			 * @private
 			 */


### PR DESCRIPTION
Limit voice control area using by data-webos-voice-exclusive attribute

Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
