### PR TITLE
PLAT-61242: VirtualList/Scroller: Handle a page up or down key in pointer mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
+
 ## [2.0.0-beta.9] - 2018-07-02
 
 ### Added

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -425,7 +425,16 @@ class ScrollableBase extends Component {
 			// If there is a next spottable DOM element vertically or horizontally, focus it without animation
 			} else if (next !== spotItem && this.childRef.scrollToNextPage) {
 				this.animateOnFocus = false;
-				Spotlight.focus(next);
+				if (Spotlight.getPointerMode()) {
+					// When changing from "pointer" mode to "5way key" mode,
+					// a pointer is hidden and a last focused item get focused after 30ms.
+					// To make sure the item to be focused after that, we used 50ms.
+					setTimeout(() => {
+						Spotlight.focus(next);
+					}, 50);
+				} else {
+					Spotlight.focus(next);
+				}
 			// If a next spottable DOM element is equals to the current spottable item, we need to find a next item
 			} else {
 				const nextPage = scrollFn({direction, reverseDirection: rDirection, focusedItem: spotItem, spotlightId});

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -453,7 +453,7 @@ class ScrollableBase extends Component {
 	hasFocus () {
 		let current = Spotlight.getCurrent();
 
-		if (!current || Spotlight.getPointerMode()) {
+		if (!current) {
 			const spotlightId = Spotlight.getActiveContainer();
 			current = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 		}
@@ -464,7 +464,7 @@ class ScrollableBase extends Component {
 	onKeyDown = (ev) => {
 		this.animateOnFocus = true;
 
-		if (!Spotlight.getPointerMode() && !ev.repeat && this.hasFocus()) {
+		if (!ev.repeat && this.hasFocus()) {
 			if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
 				this.scrollByPage(ev.keyCode);
 			} else {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -485,7 +485,16 @@ class ScrollableBaseNative extends Component {
 			// If there is a next spottable DOM element vertically or horizontally, focus it without animation
 			} else if (next !== spotItem && this.childRef.scrollToNextPage) {
 				this.animateOnFocus = false;
-				Spotlight.focus(next);
+				if (Spotlight.getPointerMode()) {
+					// When changing from "pointer" mode to "5way key" mode,
+					// a pointer is hidden and a last focused item get focused after 30ms.
+					// To make sure the item to be focused after that, we used 50ms.
+					setTimeout(() => {
+						Spotlight.focus(next);
+					}, 50);
+				} else {
+					Spotlight.focus(next);
+				}
 			// If a next spottable DOM element is equals to the current spottable item, we need to find a next item
 			} else {
 				const nextPage = scrollFn({direction, reverseDirection: rDirection, focusedItem: spotItem, spotlightId});
@@ -513,7 +522,7 @@ class ScrollableBaseNative extends Component {
 	hasFocus () {
 		let current = Spotlight.getCurrent();
 
-		if (!current || Spotlight.getPointerMode()) {
+		if (!current) {
 			const spotlightId = Spotlight.getActiveContainer();
 			current = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 		}
@@ -525,9 +534,7 @@ class ScrollableBaseNative extends Component {
 		this.animateOnFocus = true;
 		if (isPageUp(ev.keyCode) || isPageDown(ev.keyCode)) {
 			ev.preventDefault();
-			if (Spotlight.getPointerMode()) {
-				ev.stopPropagation();
-			} else if (!ev.repeat && this.hasFocus()) {
+			if (!ev.repeat && this.hasFocus()) {
 				this.scrollByPage(ev.keyCode);
 			}
 		} else if (!Spotlight.getPointerMode() && !ev.repeat && this.hasFocus()) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -469,7 +469,12 @@ const VirtualListBaseFactory = (type) => {
 					const node = this.uiRef.containerRef.querySelector(`[data-index='${indexToScroll}'].spottable`);
 
 					if (node) {
-						Spotlight.focus(node);
+						// When changing from "pointer" mode to "5way key" mode,
+						// a pointer is hidden and a last focused item get focused after 30ms.
+						// To make sure the item to be focused after that, we used 50ms.
+						setTimeout(() => {
+							Spotlight.focus(node);
+						}, 50);
 					}
 				} else {
 					// Scroll to the next spottable item without animation


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing a page up or down key in pointer mode in VirtualList or Scroller, the key is ignored

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We misunderstood the Spotlight requirement, then we ignored key events in pointer mode. So we removed the guard ignoring it and focus an item after changing from pointer mode to 5 way key mode.

### Additional Consideration

There is the known issue that Scroller shuttles when pressing page up/down key. We'll fix it in PLAT-62228

### Links
[//]: # (Related issues, references)

PLAT-61242

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)