### PR TITLE
ENYO-5393 - Added spotlight blur when spinner is launched

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Changed
+
+- `moonstone/spinner` to blur Spotlight when the spinner is active
+
 ## [2.0.0-beta.9] - 2018-07-02
 
 ### Added

--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -18,6 +18,7 @@ import compose from 'ramda/src/compose';
 import React from 'react';
 import Pause from '@enact/spotlight/Pause';
 import UiSpinnerBase from '@enact/ui/Spinner';
+import Spotlight from '@enact/spotlight';
 
 import $L from '../internal/$L';
 import Marquee from '../Marquee';
@@ -176,6 +177,7 @@ const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {
 
 			if (blockClickOn === 'screen') {
 				this.paused.pause();
+				Spotlight.getCurrent().blur();
 			}
 		}
 
@@ -183,6 +185,7 @@ const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {
 			const {blockClickOn} = this.props;
 
 			if (blockClickOn === 'screen') {
+				Spotlight.focus();
 				this.paused.resume();
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
Spotlight still shows when spinner is showing and it is movable.

### Resolution
Blur spotlight to when spinner is up. 

### Links
ENYO-5393

Enact-DCO-1.0-Signed-off-by: Derek Tor <derek.tor@lge.com>