### PR TITLE
ENYO-5399: Workaround sampler browser detection for webOS

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- Inline Storybook CSS now correctly detecting feature support on WebOS against its internal Chromium version.
+
 ## [2.0.0-beta.9] - 2018-07-02
 
 No significant changes.

--- a/packages/sampler/src/addons.js
+++ b/packages/sampler/src/addons.js
@@ -1,3 +1,4 @@
+import './webos-fix';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-options/register';
 import '@storybook/addon-knobs/register';

--- a/packages/sampler/src/webos-fix.js
+++ b/packages/sampler/src/webos-fix.js
@@ -1,0 +1,21 @@
+/*
+ *  webos-fix.js
+ *
+ *  Patches the `bowser` package detection function to re-align platform
+ *  detection on LG webOS to idfentify Chromium version instead.
+ *
+ *  This is a temporary workaround for:
+ *  https://github.com/rofrischmann/inline-style-prefixer/issues/160
+ */
+
+import bowser from 'bowser';
+
+const fn = bowser.detect;
+bowser.detect = function (userAgent) {
+	let obj = fn.call(bowser, userAgent);
+	if (obj.webos && obj.blink) {
+		obj = fn.call(bowser, userAgent.replace('Web0S', ''));
+	}
+	return obj;
+};
+bowser._detect = bowser.detect;


### PR DESCRIPTION
### Issue Resolved / Feature Added
* A recent change to the browser userAgent parsing/identification package `bowser`, updated to support LG webOS userAgent. https://github.com/lancedikson/bowser/commit/49746c5547d8a0999d8daf5833937ab7413ef576
* In doing so, webOS TVs, signage, and raspberry pi devices are no longer being identified by Chrome version in `inline-style-prefixer` and feature detection has changed. Normally not a big issue, but when coupled with https://github.com/tomkp/react-split-pane/issues/289, it results in the Storybook panel not rendering correctly.

### Resolution
* Patches the `detect` function in `bowser` to re-detect without `Web0S` useragent token on blink-based webOS. This results in getting detected as Chrome 53 correctly on webOS, and allowing expected feature mapping.

### Additional Considerations
* Can be removed once https://github.com/rofrischmann/inline-style-prefixer/pull/161 is merged and an updated `inline-style-prefixer` is published to NPM.

### Links
* https://github.com/rofrischmann/inline-style-prefixer/issues/160
* https://github.com/tomkp/react-split-pane/issues/289
