### PR TITLE
PLAT-61241: Handle direction keys properly over ScrollButtons when `focusableScrollbar` is false

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,6 +5,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [Unreleased]
 
 ### Fixed
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction keys properly over page controls in them when `focusableScrollbar` is false
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
 
 ## [2.0.0-beta.9] - 2018-07-02

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,7 +5,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [Unreleased]
 
 ### Fixed
-- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction keys properly over page controls in them when `focusableScrollbar` is false
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction, page up, and page down keys properly on page controls them when `focusableScrollbar` is false
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -275,8 +275,7 @@ class ScrollButtons extends Component {
 		// We don't need to navigate manually if `focusableScrollbar` is `false`
 		if (focusableScrollbar) {
 			const
-				{keyCode} = ev,
-				direction = getDirection(keyCode),
+				direction = getDirection(ev.keyCode),
 				fromNextToPrev = (vertical && direction === 'up') || (!vertical && direction === (rtl ? 'right' : 'left')),
 				fromPrevToNext = (vertical && direction === 'down') || (!vertical && direction === (rtl ? 'left' : 'right'));
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -127,6 +127,7 @@ class ScrollButtons extends Component {
 	}
 
 	static defaultProps = {
+		focusableScrollButtons: false,
 		onNextScroll: nop,
 		onPrevScroll: nop
 	}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -286,6 +286,8 @@ class ScrollButtons extends Component {
 				this.focusOnOppositeScrollButton(ev, direction);
 			}
 		} else {
+			// If it is vertical `Scrollable`, move focus to the left for ltr or to the right for rtl
+			// If is is horizontal `Scrollable`, move focus to the up
 			const direction = !vertical && 'up' || rtl && 'right' || 'left';
 
 			if (Spotlight.getPointerMode()) {

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -291,6 +291,9 @@ class ScrollButtons extends Component {
 			const direction = !vertical && 'up' || rtl && 'right' || 'left';
 
 			if (Spotlight.getPointerMode()) {
+				// When changing from "pointer" mode to "5way key" mode,
+				// a pointer is hidden and a last focused item get focused after 30ms.
+				// To make sure the content in `VirtualList` or `Scroller` to be focused after that, we used 50ms.
 				setTimeout(() => {
 					if (Spotlight.getCurrent() === target) {
 						Spotlight.move(direction);

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -285,12 +285,14 @@ class ScrollButtons extends Component {
 				(fromPrevToNext && target === this.prevButtonNodeRef)) {
 				this.focusOnOppositeScrollButton(ev, direction);
 			}
-		} else if (target === this.nextButtonNodeRef || target === this.prevButtonNodeRef) {
+		} else {
 			const direction = !vertical && 'up' || rtl && 'right' || 'left';
 
 			if (Spotlight.getPointerMode()) {
 				setTimeout(() => {
-					Spotlight.move(direction);
+					if (Spotlight.getCurrent() === target) {
+						Spotlight.move(direction);
+					}
 				}, 50);
 			} else {
 				Spotlight.move(direction);

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -74,7 +74,7 @@ class ScrollButtons extends Component {
 		 * @default false
 		 * @public
 		 */
-		focusableScrollbar: PropTypes.bool,
+		focusableScrollButtons: PropTypes.bool,
 
 		/**
 		* Sets the hint string read when focusing the next button in the scroll bar.
@@ -269,11 +269,11 @@ class ScrollButtons extends Component {
 
 	onSpotlight = (ev) => {
 		const
-			{focusableScrollbar, rtl, vertical} = this.props,
+			{focusableScrollButtons, rtl, vertical} = this.props,
 			{target} = ev;
 
-		// We don't need to navigate manually if `focusableScrollbar` is `false`
-		if (focusableScrollbar) {
+		// We don't need to navigate manually if `focusableScrollButtons` is `false`
+		if (focusableScrollButtons) {
 			const
 				direction = getDirection(ev.keyCode),
 				fromNextToPrev = (vertical && direction === 'up') || (!vertical && direction === (rtl ? 'right' : 'left')),
@@ -298,7 +298,7 @@ class ScrollButtons extends Component {
 						Spotlight.move(direction);
 					}
 				}, 50);
-			} else {
+			} else if (Spotlight.getCurrent() === target) {
 				Spotlight.move(direction);
 			}
 		}
@@ -311,14 +311,14 @@ class ScrollButtons extends Component {
 
 	onKeyDownPrev = (ev) => {
 		const
-			{focusableScrollbar} = this.props,
+			{focusableScrollButtons} = this.props,
 			{nextButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (isPageDown(keyCode)) {
-			if (focusableScrollbar && !nextButtonDisabled) {
+		if (isPageDown(keyCode) && !nextButtonDisabled) {
+			if (focusableScrollButtons) {
 				Spotlight.focus(this.nextButtonNodeRef);
-			} else if (!focusableScrollbar) {
+			} else {
 				this.onClickNext(ev);
 			}
 		} else if (isPageUp(keyCode)) {
@@ -328,14 +328,14 @@ class ScrollButtons extends Component {
 
 	onKeyDownNext = (ev) => {
 		const
-			{focusableScrollbar} = this.props,
+			{focusableScrollButtons} = this.props,
 			{prevButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (isPageUp(keyCode)) {
-			if (focusableScrollbar && !prevButtonDisabled) {
+		if (isPageUp(keyCode) && !prevButtonDisabled) {
+			if (focusableScrollButtons) {
 				Spotlight.focus(this.prevButtonNodeRef);
-			} else if (!focusableScrollbar) {
+			} else {
 				this.onClickPrev(ev);
 			}
 		} else if (isPageDown(keyCode)) {

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -67,12 +67,12 @@ class ScrollButtons extends Component {
 		disabled: PropTypes.bool,
 
 		/**
-		 * When `true`, allows 5-way navigation to the scrollbar controls. By default, 5-way will
-		 * not move focus to the scrollbar controls.
+		 * When it is `true`, it allows 5 way navigation to the ScrollButtons.
+		 * This value is set by `Scrollable`.
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @public
+		 * @private
 		 */
 		focusableScrollButtons: PropTypes.bool,
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -723,6 +723,7 @@ class ScrollableBase extends Component {
 				'data-spotlight-container': spotlightContainer,
 				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
+				focusableScrollbar,
 				scrollRightAriaLabel,
 				scrollLeftAriaLabel,
 				scrollDownAriaLabel,
@@ -793,6 +794,7 @@ class ScrollableBase extends Component {
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
+									focusableScrollbar={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
@@ -806,6 +808,7 @@ class ScrollableBase extends Component {
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
+								focusableScrollbar={focusableScrollbar}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -803,7 +803,7 @@ class ScrollableBase extends Component {
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
-									focusableScrollbar={focusableScrollbar}
+									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
@@ -817,7 +817,7 @@ class ScrollableBase extends Component {
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
-								focusableScrollbar={focusableScrollbar}
+								focusableScrollButtons={focusableScrollbar}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -867,7 +867,7 @@ class ScrollableBaseNative extends Component {
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
-									focusableScrollbar={focusableScrollbar}
+									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
@@ -881,7 +881,7 @@ class ScrollableBaseNative extends Component {
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
-								focusableScrollbar={focusableScrollbar}
+								focusableScrollButtons={focusableScrollbar}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -789,6 +789,7 @@ class ScrollableBaseNative extends Component {
 				'data-spotlight-container': spotlightContainer,
 				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
+				focusableScrollbar,
 				scrollRightAriaLabel,
 				scrollLeftAriaLabel,
 				scrollDownAriaLabel,
@@ -859,6 +860,7 @@ class ScrollableBaseNative extends Component {
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
+									focusableScrollbar={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
@@ -872,6 +874,7 @@ class ScrollableBaseNative extends Component {
 								{...this.scrollbarProps}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
+								focusableScrollbar={focusableScrollbar}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though pressing up/down/left/right keys in the ScrollButton when `focusableScrollbar` is false, the ScrollButton keep get focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If there is any spottable component to the direction of the key, give it focus. If not, give a content focus.

The expected result with my PR is...

Step
1. Launch http://nebula.lgsvl.com/enyojs/enact-sampler/develop/
2. Select VirtualList
3. Wheel a little bit

- Hover the previous ScrollButton, then press a 'right' key.
Expected result is that the VirtualList item gets focus.
- Hover the previous ScrollButton, then press a 'left' key.
Expected result is that the VirtualList item gets focus.
- Hover the previous ScrollButton, then press a 'down' key.
Expected result is that the VirtualList item gets focus.
- Hover the previous ScrollButton, then press a 'up' key.
Expected result is that the 'close' button gets focus.
- Hover the previous ScrollButton, then press a 'page down' key.
Expected result is that the VirtualList scrolls.

### Links
[//]: # (Related issues, references)

PLAT-61241

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)
