### PR TITLE
PLAT-58640: Fix VirtualList focus behavior when entering 5way mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction, page up, and page down keys properly on page controls them when `focusableScrollbar` is false
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
+- `VirtualList.VirtualList` to handle focus properly when switching to 5-way mode
 
 ## [2.0.0-beta.9] - 2018-07-02
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -662,6 +662,7 @@ const VirtualListBaseFactory = (type) => {
 			if (getDirection(keyCode)) {
 				ev.preventDefault();
 				this.setSpotlightContainerRestrict(keyCode, target);
+				Spotlight.setPointerMode(false);
 				if (this.jumpToSpottableItem(keyCode, repeat, target)) {
 					ev.stopPropagation();
 				}


### PR DESCRIPTION
### Issue Resolved / Feature Added
When in pointer mode, pressing a 5-way directional key (switching from pointer-mode to 5-way mode) while a `VirtualList` a) is using an `isItemDisabled` function prop and b) contains a currently focused item, focus will:
- not change on Chrome and is unable to switch into 5-way mode, even with repeated 5-way directional presses
- not change initially on TV, but will only change with successive 5-way directional presses

### Resolution
There is some logic in the `VirtualList` internal method `jumpToSpottableItem` that is not called or used unless the instance is using a `isItemDisabled` prop. That logic will request focus to be changed to the "next" list item. However, since this method is being called via an internal `keydown` event (and propagation will be stopped anyway), spotlight will be unable to turn off pointer mode, so a focus change cannot occur.

This is remedied by turning off pointer mode in response to the keydown event that initiates the focus change call. We don't usually want to explicitly change the pointer mode status, however this scenario fits the use-case (see `moonstone/Popup.Popup`) where it should be safe to do so as:
- it's called in response to a `keydown` event
- is guarded by `getDirection(keyCode)`
- a focus change is required that would otherwise be prevented by being in pointer mode


### Comments
I didn't notice any unexpected side-effects to focus behavior when applying this fix and testing the various focus behaviors contained in `VirtualList` (switching between pointer & 5-way modes, page up/down behavior from items and/or scroll buttons, scroll wheel focus behavior, etc.).

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>