### PR TITLE
ENYO-5406: Fix spotlight navigation within Popup without onClose handler

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
 
+- `moonstone/Popup` to disable spotlight for empty `Popup` with no `onClose` event
+
 ## [2.0.0-beta.9] - 2018-07-02
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction, page up, and page down keys properly on page controls them when `focusableScrollbar` is false
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
-
 - `moonstone/Popup` to disable spotlight for empty `Popup` with no `onClose` event
 
 ## [2.0.0-beta.9] - 2018-07-02

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -336,9 +336,8 @@ class Popup extends React.Component {
 		/**
 		 * Restricts or prioritizes navigation when focus attempts to leave the popup.
 		 *
-		 * It can be either `'self-first'`, or `'self-only'`. Note: If `onClose` is not set, then
-		 * this has no effect on 5-way navigation. If the popup has no spottable children, 5-way
-		 * navigation will cause the popup to fire `onClose`.
+		 * It can be either `'self-first'`, or `'self-only'`. If the popup has no spottable children
+		 * , 5-way navigation will cause the popup to fire `onClose`.
 		 *
 		 * @type {String}
 		 * @default 'self-only'

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -424,9 +424,8 @@ class Popup extends React.Component {
 		const direction = getDirection(keyCode);
 		const spottables = Spotlight.getSpottableDescendants(this.state.containerId).length;
 
-		if (direction && onClose) {
+		if (direction) {
 			let focusChanged;
-
 			if (spottables && Spotlight.getCurrent() && spotlightRestrict !== 'self-only') {
 				focusChanged = Spotlight.move(direction);
 			}
@@ -438,7 +437,9 @@ class Popup extends React.Component {
 				ev.stopPropagation();
 				// set the pointer mode to false on keydown
 				Spotlight.setPointerMode(false);
-				onClose(ev);
+				if (onClose) {
+					onClose(ev);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
When popup is set with no children and with no `onClose` prop spotlight will still move throughout the background Panel.


### Resolution
Moved the code to check for `onClose` after the `stopPropagation`. This allows for the same behavior for Spotlight whether you have `onClose` or not.


### Additional Considerations
The `onClose` check did check a bigger block of code than my change. I think it's unneeded, but there could be something I'm missing.


### Links
ENYO-5406

