### PR TITLE
Fix Spinner to check existence of focused element before blurring

### DIFF
--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -174,10 +174,13 @@ const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {
 
 		componentWillMount () {
 			const {blockClickOn} = this.props;
+			const current = Spotlight.getCurrent();
 
 			if (blockClickOn === 'screen') {
 				this.paused.pause();
-				Spotlight.getCurrent().blur();
+				if (current) {
+					current.blur();
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If spotlight isn't set when a Spinner is unmounted, the application will generate a runtime error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check for existence of a focused element before blurring

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)