### PR TITLE
ENYO-5413: Fix errors in Storybook enact-knobs usage

### DIFF
--- a/packages/sampler/stories/moonstone-stories/IncrementSlider.js
+++ b/packages/sampler/stories/moonstone-stories/IncrementSlider.js
@@ -8,7 +8,9 @@ import {withInfo} from '@storybook/addon-info';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
-const Config = mergeComponentMetadata('IncrementSlider', IncrementSliderBase, IncrementSlider);
+const IncrementSliderConfig = mergeComponentMetadata('IncrementSlider', IncrementSliderBase, IncrementSlider);
+const IncrementSliderTooltipConfig = mergeComponentMetadata('IncrementSliderTooltip', IncrementSliderTooltip);
+
 IncrementSlider.displayName = 'IncrementSlider';
 
 storiesOf('Moonstone', module)
@@ -18,23 +20,23 @@ storiesOf('Moonstone', module)
 			propTablesExclude: [IncrementSlider],
 			text: 'Basic usage of IncrementSlider'
 		})(() => {
-			const side = select('side', ['after', 'before', 'left', 'right'], IncrementSliderTooltip, 'after');
-			const tooltip = boolean('tooltip', IncrementSliderTooltip);
-			const percent = boolean('percent', IncrementSliderTooltip);
+			const side = select('side', ['after', 'before', 'left', 'right'], IncrementSliderTooltipConfig, 'after');
+			const tooltip = boolean('tooltip', IncrementSliderTooltipConfig);
+			const percent = boolean('percent', IncrementSliderTooltipConfig);
 
 			return (
 				<IncrementSlider
-					backgroundProgress={number('backgroundProgress', Config, {range: true, min: 0, max: 1, step: 0.01})}
-					decrementIcon={select('decrementIcon', ['', ...decrementIcons], Config)}
-					disabled={boolean('disabled', Config)}
-					incrementIcon={select('incrementIcon', ['', ...incrementIcons], Config)}
-					knobStep={number('knobStep', Config)}
-					max={number('max', Config)}
-					min={number('min', Config)}
-					noFill={boolean('noFill', Config)}
+					backgroundProgress={number('backgroundProgress', IncrementSliderConfig, {range: true, min: 0, max: 1, step: 0.01})}
+					decrementIcon={select('decrementIcon', ['', ...decrementIcons], IncrementSliderConfig)}
+					disabled={boolean('disabled', IncrementSliderConfig)}
+					incrementIcon={select('incrementIcon', ['', ...incrementIcons], IncrementSliderConfig)}
+					knobStep={number('knobStep', IncrementSliderConfig)}
+					max={number('max', IncrementSliderConfig)}
+					min={number('min', IncrementSliderConfig)}
+					noFill={boolean('noFill', IncrementSliderConfig)}
 					onChange={action('onChange')}
-					orientation={select('orientation', ['horizontal', 'vertical'], Config)}
-					step={number('step', Config)} // def: 1
+					orientation={select('orientation', ['horizontal', 'vertical'], IncrementSliderConfig)}
+					step={number('step', IncrementSliderConfig)} // def: 1
 				>
 					{tooltip ? (
 						<IncrementSliderTooltip

--- a/packages/sampler/stories/moonstone-stories/ProgressBar.js
+++ b/packages/sampler/stories/moonstone-stories/ProgressBar.js
@@ -6,7 +6,8 @@ import {withInfo} from '@storybook/addon-info';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
-const Config = mergeComponentMetadata('ProgressBar', ProgressBar);
+const ProgressBarConfig = mergeComponentMetadata('ProgressBar', ProgressBar);
+const ProgressBarTooltipConfig = mergeComponentMetadata('ProgressBarTooltip', ProgressBarTooltip);
 
 ProgressBar.displayName = 'ProgressBar';
 ProgressBarTooltip.displayName = 'ProgressBarTooltip';
@@ -18,17 +19,17 @@ storiesOf('Moonstone', module)
 			propTablesExclude: [ProgressBar, ProgressBarTooltip],
 			text: 'The basic ProgressBar'
 		})(() => {
-			const side = select('side', ['after', 'before', 'left', 'right'], ProgressBarTooltip, 'before');
-			const tooltip = boolean('tooltip', ProgressBarTooltip);
+			const side = select('side', ['after', 'before', 'left', 'right'], ProgressBarTooltipConfig, 'before');
+			const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
 
 			return (
 				<ProgressBar
-					backgroundProgress={number('backgroundProgress', Config, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
-					disabled={boolean('disabled', Config)}
-					highlighted={boolean('highlighted', Config)}
-					orientation={select('orientation', ['horizontal', 'vertical'], Config, 'horizontal')}
-					progress={number('progress', Config, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
-					side={select('side', ['after', 'before', 'left', 'right'], Config, 'before')}
+					backgroundProgress={number('backgroundProgress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
+					disabled={boolean('disabled', ProgressBarConfig)}
+					highlighted={boolean('highlighted', ProgressBarConfig)}
+					orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig, 'horizontal')}
+					progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
+					side={select('side', ['after', 'before', 'left', 'right'], ProgressBarConfig, 'before')}
 				>
 					{tooltip ? (
 						<ProgressBarTooltip

--- a/packages/sampler/stories/moonstone-stories/Slider.js
+++ b/packages/sampler/stories/moonstone-stories/Slider.js
@@ -7,7 +7,8 @@ import {withInfo} from '@storybook/addon-info';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
-const Config = mergeComponentMetadata('Slider', Slider);
+const SliderConfig = mergeComponentMetadata('Slider', Slider);
+const SliderTooltipConfig = mergeComponentMetadata('SliderTooltip', SliderTooltip);
 
 Slider.displayName = 'Slider';
 SliderTooltip.displayName = 'SliderTooltip';
@@ -19,22 +20,22 @@ storiesOf('Moonstone', module)
 			propTablesExclude: [Slider, SliderTooltip],
 			text: 'Basic usage of Slider'
 		})(() => {
-			const side = select('side', ['after', 'before', 'left', 'right'], SliderTooltip, 'before');
-			const tooltip = boolean('tooltip', SliderTooltip);
-			const percent = boolean('percent', SliderTooltip);
+			const side = select('side', ['after', 'before', 'left', 'right'], SliderTooltipConfig, 'before');
+			const tooltip = boolean('tooltip', SliderTooltipConfig);
+			const percent = boolean('percent', SliderTooltipConfig);
 
 			return (
 				<Slider
-					activateOnFocus={boolean('activateOnFocus', Config)}
-					backgroundProgress={number('backgroundProgress', Config, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
-					disabled={boolean('disabled', Config)}
-					knobStep={number('knobStep', Config)}
-					max={number('max', Config, 10)}
-					min={number('min', Config, 0)}
-					noFill={boolean('noFill', Config)}
+					activateOnFocus={boolean('activateOnFocus', SliderConfig)}
+					backgroundProgress={number('backgroundProgress', SliderConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
+					disabled={boolean('disabled', SliderConfig)}
+					knobStep={number('knobStep', SliderConfig)}
+					max={number('max', SliderConfig, 10)}
+					min={number('min', SliderConfig, 0)}
+					noFill={boolean('noFill', SliderConfig)}
 					onChange={action('onChange')}
-					orientation={select('orientation', ['horizontal', 'vertical'], Config, 'horizontal')}
-					step={number('step', Config, 1)}
+					orientation={select('orientation', ['horizontal', 'vertical'], SliderConfig, 'horizontal')}
+					step={number('step', SliderConfig, 1)}
 				>
 					{tooltip ? (
 						<SliderTooltip

--- a/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/qa-stories/ContextualPopupDecorator.js
@@ -6,8 +6,10 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
 
 const ContextualButton = ContextualPopupDecorator(Button);
+const Config = mergeComponentMetadata('ContextualButton', ContextualButton);
 ContextualButton.displayName = 'ContextualButton';
 
 const buttonMargin = () => ({margin: ri.unit(12, 'rem')});
@@ -68,9 +70,9 @@ storiesOf('ContextualPopupDecorator', module)
 		() => (
 			<div style={{textAlign: 'center', marginTop: ri.unit(99, 'rem')}}>
 				<ContextualPopupWithActivator
-					direction={select('direction', ['up', 'down', 'left', 'right'], ContextualButton, 'down')}
+					direction={select('direction', ['up', 'down', 'left', 'right'], Config, 'down')}
 					popupComponent={renderPopup}
-					spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], ContextualButton, 'self-only')}
+					spotlightRestrict={select('spotlightRestrict', ['none', 'self-first', 'self-only'], Config, 'self-only')}
 				>
 					Hello Contextual Button
 				</ContextualPopupWithActivator>

--- a/packages/sampler/stories/qa-stories/ExpandableList.js
+++ b/packages/sampler/stories/qa-stories/ExpandableList.js
@@ -7,7 +7,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
-import {boolean, text, select} from '@storybook/addon-knobs';
+import {boolean, text, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ExpandableList', ExpandableList, ExpandableListBase);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Setup knobs correctly for the components that have two groups of knobs and fix other things that were missed by #1754 
Fixes: `ContextualPopup` QA, `ExpandableList` QA, `Slider`, `IncrementSlider`, and `ProgressBar` samples.


### Links
[//]: # (Related issues, references)
ENYO-5413

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com