### PR TITLE
ENYO-5377: Dialog: 'open' prop is applied as opposed to the actual popup state

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle direction, page up, and page down keys properly on page controls them when `focusableScrollbar` is false
 - `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to handle a page up or down key in pointer mode
 - `moonstone/VideoPlayer.MediaControls` to correctly handle more button color when the prop is not specified
+- `moonstone/Popup` to make the floatLayerOpen state reflect the open prop
 
 ## [2.0.0-beta.9] - 2018-07-02
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -369,21 +369,16 @@ class Popup extends React.Component {
 	}
 
 	componentWillReceiveProps (nextProps) {
+		const newState = {
+			popupOpen: nextProps.noAnimation,
+			floatLayerOpen: nextProps.open
+		};
 		if (!this.props.open && nextProps.open) {
-			this.setState({
-				popupOpen: nextProps.noAnimation,
-				floatLayerOpen: true,
-				activator: Spotlight.getCurrent()
-			});
+			newState.activator = Spotlight.getCurrent();
 		} else if (this.props.open && !nextProps.open) {
-			const activator = this.state.activator;
-
-			this.setState({
-				popupOpen: nextProps.noAnimation,
-				floatLayerOpen: !nextProps.noAnimation,
-				activator: nextProps.noAnimation ? null : activator
-			});
+			newState.activator = nextProps.noAnimation ? null : this.state.activator;
 		}
+		this.setState(newState);
 		checkScrimNone(nextProps);
 	}
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -441,11 +441,6 @@ class Popup extends React.Component {
 	handlePopupHide = (ev) => {
 		forwardHide(ev, this.props);
 
-		this.setState({
-			floatLayerOpen: false,
-			activator: null
-		});
-
 		if (ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 			this.paused.resume();
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
- ENYO-5377
- The `floatLayerOpen` state now reflects the `open` prop of popup. 

### Resolution
This change will open for close the floating layer that contains the popup according to the popup's `open` prop.


### Additional Considerations
- When a popup should open, there should be a floating layer open. So having  handleFloatingLayerOpen(), handlePopupHide() and handlePopupShow() to handle open/close state changes in addition to state updates in componentWillReceiveProps() seems overcomplicate things and duplicates jobs. We should consider refactoring this.
- Also, why the `popupOpen` state is set to `noAnimation` prop?


Enact-DCO-1.0-Signed-off-by: HanGyeol Ryu hangyeol.ryu@lge.com

