### PR TITLE
ENYO-5414: ProgressBarTooltip: warning is displayed in console for `rtl` prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
+
 ## [2.0.0-rc.1] - 2018-07-09
 
 ### Added

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -180,6 +180,7 @@ const ProgressBarTooltipBase = kind({
 		delete rest.orientation;
 		delete rest.percent;
 		delete rest.proportion;
+		delete rest.rtl;
 		delete rest.side;
 
 		return (


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Warning logs are displayed in console when using `rtl` prop in `ProgressBarTooltip`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I deleted `rtl` prop in render function to not pass that to `Tooltip` node.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5414

Enact-DCO-1.0-Signed-off-by: Sangwook Lee (sangwook1203.lee@lge.com)