### PR TITLE
PLAT-62334:  Add data-spotlight-container-disabled knob in Scroller qa-sampler

### DIFF
--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -1,5 +1,6 @@
 import Button from '@enact/moonstone/Button';
 import ExpandableList from '@enact/moonstone/ExpandableList';
+import {ScrollableBase} from '@enact/moonstone/Scrollable';
 import Scroller from '@enact/moonstone/Scroller';
 import Item from '@enact/moonstone/Item';
 import ri from '@enact/ui/resolution';
@@ -28,6 +29,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
+				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', ScrollableBase, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 				style={{height: ri.unit(600, 'rem')}}
 			>

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -1,6 +1,5 @@
 import Button from '@enact/moonstone/Button';
 import ExpandableList from '@enact/moonstone/ExpandableList';
-import {ScrollableBase} from '@enact/moonstone/Scrollable';
 import Scroller from '@enact/moonstone/Scroller';
 import Item from '@enact/moonstone/Item';
 import ri from '@enact/ui/resolution';
@@ -29,7 +28,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', ScrollableBase, false)}
+				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', Scroller, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 				style={{height: ri.unit(600, 'rem')}}
 			>


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

We need the way to check if a `Scroller` supports `data-spotlight-container-disabled` prop well.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I added `data-spotlight-container-disabled` knob in Scroller qa-sampler

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-62334

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)