### PR TITLE
ENYO-5415: Fix to call stopPropagation() properly

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` page controls to stop propagating an event if the event is handled
+
 ## [2.0.0-rc.1] - 2018-07-09
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` page controls to stop propagating an event if the event is handle
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` page controls to stop propagating an event if the event is handled
 - `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warn
 
 ## [2.0.0-rc.1] - 2018-07-09

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` page controls to stop propagating an event if the event is handled
-- `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warn
+- `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
 
 ## [2.0.0-rc.1] - 2018-07-09
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -260,8 +260,7 @@ class ScrollButtons extends Component {
 	focusOnOppositeScrollButton = (ev, direction) => {
 		const buttonNode = (ev.target === this.nextButtonNodeRef) ? this.prevButtonNodeRef : this.nextButtonNodeRef;
 
-		ev.preventDefault();
-		ev.nativeEvent.stopPropagation();
+		ev.stopPropagation();
 
 		if (!Spotlight.focus(buttonNode)) {
 			Spotlight.move(direction);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

We called native event's stopPropagation function incorrectly. So we could not stop to propagate a react synthetic event.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

To stop to propagate a react synthetic event, we call react event's stopPropagation function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

`ev.preventDefault();` was useless. So I removed it.

### Links
[//]: # (Related issues, references)

ENYO-5415

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)
