### PR TITLE
ENYO-5405: Fix Picker 5-way focus behavior

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Picker` to properly set focus when navigating between buttons
+
 ## [2.0.0-rc.1] - 2018-07-09
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,8 +6,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Picker` to properly set focus when navigating between buttons
 - `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
+- `moonstone/Picker` to properly set focus when navigating between buttons
 
 ## [2.0.0-rc.1] - 2018-07-09
 

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -1,8 +1,8 @@
-import {forward} from '@enact/core/handle';
+import {forward, stopImmediate} from '@enact/core/handle';
 import clamp from 'ramda/src/clamp';
 import equals from 'ramda/src/equals';
 import {is} from '@enact/core/keymap';
-import {Job} from '@enact/core/util';
+import {cap, Job} from '@enact/core/util';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
@@ -627,45 +627,55 @@ const PickerBase = class extends React.Component {
 
 	handleDecKeyDown = (ev) => {
 		const {keyCode} = ev;
-		const {
-			onPickerSpotlightDown,
-			onPickerSpotlightLeft,
-			onPickerSpotlightRight,
-			onPickerSpotlightUp,
-			orientation,
-			step
-		} = this.props;
+		const direction = getDirection(keyCode);
 
-		if (isDown(keyCode) && onPickerSpotlightDown) {
-			onPickerSpotlightDown(ev);
-		} else if (isLeft(keyCode) && onPickerSpotlightLeft) {
-			onPickerSpotlightLeft(ev);
-		} else if (isRight(keyCode) && onPickerSpotlightRight && (orientation === 'vertical' || this.hasReachedBound(step))) {
-			onPickerSpotlightRight(ev);
-		} else if (isUp(keyCode) && onPickerSpotlightUp && (orientation === 'horizontal' || this.hasReachedBound(step))) {
-			onPickerSpotlightUp(ev);
+		if (direction) {
+			const {orientation, step, ...rest} = this.props;
+			const spotlightLeaveEvent = rest[`onPickerSpotlight${cap(direction)}`];
+
+			if (
+				!this.hasReachedBound(step) &&
+				(
+					isRight(keyCode) && orientation === 'horizontal' ||
+					isUp(keyCode) && orientation === 'vertical'
+				)
+			) {
+				ev.preventDefault();
+				// prevent default spotlight behavior
+				stopImmediate(ev);
+				// set the pointer mode to false on keydown
+				Spotlight.setPointerMode(false);
+				Spotlight.focus(this.containerRef.querySelector(`.${css.incrementer}`));
+			} else if (spotlightLeaveEvent) {
+				spotlightLeaveEvent(ev);
+			}
 		}
 	}
 
 	handleIncKeyDown = (ev) => {
 		const {keyCode} = ev;
-		const {
-			onPickerSpotlightDown,
-			onPickerSpotlightLeft,
-			onPickerSpotlightRight,
-			onPickerSpotlightUp,
-			orientation,
-			step
-		} = this.props;
+		const direction = getDirection(keyCode);
 
-		if (isDown(keyCode) && onPickerSpotlightDown && (orientation === 'horizontal' || this.hasReachedBound(step * -1))) {
-			onPickerSpotlightDown(ev);
-		} else if (isLeft(keyCode) && onPickerSpotlightLeft && (orientation === 'vertical' || this.hasReachedBound(step * -1))) {
-			onPickerSpotlightLeft(ev);
-		} else if (isRight(keyCode) && onPickerSpotlightRight) {
-			onPickerSpotlightRight(ev);
-		} else if (isUp(keyCode) && onPickerSpotlightUp) {
-			onPickerSpotlightUp(ev);
+		if (direction) {
+			const {orientation, step, ...rest} = this.props;
+			const spotlightLeaveEvent = rest[`onPickerSpotlight${cap(direction)}`];
+
+			if (
+				!this.hasReachedBound(step * -1) &&
+				(
+					isLeft(keyCode) && orientation === 'horizontal' ||
+					isDown(keyCode) && orientation === 'vertical'
+				)
+			) {
+				ev.preventDefault();
+				// prevent default spotlight behavior
+				stopImmediate(ev);
+				// set the pointer mode to false on keydown
+				Spotlight.setPointerMode(false);
+				Spotlight.focus(this.containerRef.querySelector(`.${css.decrementer}`));
+			} else if (spotlightLeaveEvent) {
+				spotlightLeaveEvent(ev);
+			}
 		}
 	}
 

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -630,8 +630,7 @@ const PickerBase = class extends React.Component {
 		const direction = getDirection(keyCode);
 
 		if (direction) {
-			const {orientation, step, ...rest} = this.props;
-			const spotlightLeaveEvent = rest[`onPickerSpotlight${cap(direction)}`];
+			const {orientation, step} = this.props;
 
 			if (
 				!this.hasReachedBound(step) &&
@@ -646,8 +645,8 @@ const PickerBase = class extends React.Component {
 				// set the pointer mode to false on keydown
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(this.containerRef.querySelector(`.${css.incrementer}`));
-			} else if (spotlightLeaveEvent) {
-				spotlightLeaveEvent(ev);
+			} else {
+				forward(`onPickerSpotlight${cap(direction)}`, ev, this.props);
 			}
 		}
 	}
@@ -657,8 +656,7 @@ const PickerBase = class extends React.Component {
 		const direction = getDirection(keyCode);
 
 		if (direction) {
-			const {orientation, step, ...rest} = this.props;
-			const spotlightLeaveEvent = rest[`onPickerSpotlight${cap(direction)}`];
+			const {orientation, step} = this.props;
 
 			if (
 				!this.hasReachedBound(step * -1) &&
@@ -673,8 +671,8 @@ const PickerBase = class extends React.Component {
 				// set the pointer mode to false on keydown
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(this.containerRef.querySelector(`.${css.decrementer}`));
-			} else if (spotlightLeaveEvent) {
-				spotlightLeaveEvent(ev);
+			} else {
+				forward(`onPickerSpotlight${cap(direction)}`, ev, this.props);
 			}
 		}
 	}


### PR DESCRIPTION
### Issue Resolved / Feature Added
When using 5-way to navigate between buttons in a non-joined `Picker` component, certain layouts can cause focus to change to other outside elements, rather than the intended alternate `Picker` button. 

Spotlight attempts to set focus to the natural "next" target based on the direction pressed. The targets gaining focus here are generally expected, however when pressing a 5-way directional key towards an opposing `Picker` button, it is always assumed that the other button should gain focus.


### Resolution
Since we handle the `Picker`'s internal button `keydown` events and have access to the spottables, we can decide during `keydown` when to prevent default spotlight behavior and set focus elsewhere, if needed.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>
