### PR TITLE
PLAT-62474: Fix spotlight in Scrollable after flick

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
+- `moonstone/Scrollable` to disable container during flick events only when contents can scroll
 
 ## [2.0.0-rc.1] - 2018-07-09
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -239,14 +239,20 @@ class ScrollableBase extends Component {
 		vertical: {before: null, after: null}
 	}
 
-	onFlick = () => {
+	onFlick = ({direction}) => {
+		const bounds = this.uiRef.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
 			focusedItem.blur();
 		}
 
-		this.childRef.setContainerDisabled(true);
+		if (
+			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
+			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
+		) {
+			this.childRef.setContainerDisabled(true);
+		}
 	}
 
 	onWheel = ({delta, horizontalScrollbarRef, verticalScrollbarRef}) => {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -227,14 +227,20 @@ class ScrollableBaseNative extends Component {
 		this.childRef.setContainerDisabled(false);
 	}
 
-	onFlick = () => {
+	onFlick = ({direction}) => {
+		const bounds = this.uiRef.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
 			focusedItem.blur();
 		}
 
-		this.childRef.setContainerDisabled(true);
+		if (
+			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
+			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
+		) {
+			this.childRef.setContainerDisabled(true);
+		}
 	}
 
 	onMouseOver = () => {


### PR DESCRIPTION
… event

### Issue Resolved / Feature Added
Flick events emitted in `Scrollable` can cause the spotlight container within to become stuck in a "disabled" state, making it impossible to set focus to components within the `Scroller`.


### Resolution
Flick events in `Scrollable` immediately disable the container, relying on its own scroller `stop` method to re-enable the container when the scrolling (or "flicked") animation comes to an end. When disabling the container, `Scrollable` was not taking into account whether or not its contents can actually scroll or not. If the contents cannot scroll, then the `stop` method is not called, thus can never re-enable the container.

Before disabling the container, we should check to see the `direction` of the flick event and whether or not we can scroll in that direction.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>