### PR TITLE
ENYO-5356: Fix Feedback tooltip showing condition

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
+- `moonstone/VideoPlayer` to display feedback tooltip when hover out from slider while playing
 
 ## [2.0.0-rc.1] - 2018-07-09
 

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.js
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.js
@@ -107,7 +107,7 @@ const FeedbackTooltipBase = kind({
 		/**
 		 * This component will be used instead of the built-in version. The internal thumbnail style
 		 * will be applied to this component. This component follows the same rules as the built-in
-		 * version; hiding and showing according to the state of `thumbnailVisible`.
+		 * version; hiding and showing according to the state of `action`.
 		 *
 		 * This can be a tag name as a string, a rendered DOM node, a component, or a component
 		 * instance.
@@ -136,15 +136,6 @@ const FeedbackTooltipBase = kind({
 		thumbnailSrc: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
 		/**
-		 * When `true`, thumbnail would appear in tooltip.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		thumbnailVisible: PropTypes.bool,
-
-		/**
 		 * Required by the interface for moonstone/Slider.tooltip but not used here
 		 *
 		 * @type {Boolean}
@@ -156,7 +147,6 @@ const FeedbackTooltipBase = kind({
 
 	defaultProps: {
 		action: 'idle',
-		thumbnailVisible: false,
 		thumbnailDeactivated: false,
 		hidden: false
 	},
@@ -177,8 +167,8 @@ const FeedbackTooltipBase = kind({
 				thumbnailDeactivated
 			});
 		},
-		feedbackVisible: ({action, thumbnailVisible, playbackState: s}) => {
-			return !thumbnailVisible && !(action === 'blur' && states[s] === 'play');
+		feedbackVisible: ({action, playbackState}) => {
+			return (action !== 'focus' || action === 'idle') && !(action === 'blur' && playbackState === 'play');
 		},
 		thumbnailComponent: ({action, thumbnailComponent, thumbnailSrc}) => {
 			if (action === 'focus') {
@@ -207,7 +197,6 @@ const FeedbackTooltipBase = kind({
 		delete rest.proportion;
 		delete rest.thumbnailDeactivated;
 		delete rest.thumbnailSrc;
-		delete rest.thumbnailVisible;
 		delete rest.visible;
 
 		return (
@@ -227,7 +216,7 @@ const FeedbackTooltipBase = kind({
 });
 
 const FeedbackTooltip = onlyUpdateForKeys(
-	['children', 'hidden', 'thumbnailVisible', 'playbackState', 'playbackRate', 'thumbnailComponent', 'thumbnailDeactivated', 'thumbnailSrc', 'visible']
+	['action', 'children', 'hidden', 'playbackState', 'playbackRate', 'thumbnailComponent', 'thumbnailDeactivated', 'thumbnailSrc', 'visible']
 )(
 	Skinnable(
 		FeedbackTooltipBase

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.js
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.js
@@ -27,6 +27,14 @@ const FeedbackTooltipBase = kind({
 
 	propTypes: /** @lends moonstone/VideoPlayer.FeedbackTooltip.prototype */ {
 		/**
+		 * Invoke action to display or hide tooltip.
+		 *
+		 * @type {String}
+		 * @default 'idle'
+		 */
+		action: PropTypes.oneOf(['focus', 'blur', 'idle']),
+
+		/**
 		 * Duration of the curent media in seconds
 		 *
 		 * @type {Number}
@@ -54,15 +62,6 @@ const FeedbackTooltipBase = kind({
 		 * @public
 		 */
 		hidden: PropTypes.bool,
-
-		/**
-		 * When `true`, only time would appear in tooltip.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		noFeedback: PropTypes.bool,
 
 		/**
 		 * Part of the API required by `ui/Slider` but not used by FeedbackTooltip which only
@@ -108,7 +107,7 @@ const FeedbackTooltipBase = kind({
 		/**
 		 * This component will be used instead of the built-in version. The internal thumbnail style
 		 * will be applied to this component. This component follows the same rules as the built-in
-		 * version; hiding and showing according to the state of `noFeedback`.
+		 * version; hiding and showing according to the state of `thumbnailVisible`.
 		 *
 		 * This can be a tag name as a string, a rendered DOM node, a component, or a component
 		 * instance.
@@ -137,6 +136,15 @@ const FeedbackTooltipBase = kind({
 		thumbnailSrc: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
 		/**
+		 * When `true`, thumbnail would appear in tooltip.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		thumbnailVisible: PropTypes.bool,
+
+		/**
 		 * Required by the interface for moonstone/Slider.tooltip but not used here
 		 *
 		 * @type {Boolean}
@@ -147,7 +155,8 @@ const FeedbackTooltipBase = kind({
 	},
 
 	defaultProps: {
-		noFeedback: false,
+		action: 'idle',
+		thumbnailVisible: false,
 		thumbnailDeactivated: false,
 		hidden: false
 	},
@@ -168,10 +177,11 @@ const FeedbackTooltipBase = kind({
 				thumbnailDeactivated
 			});
 		},
-		thumbnailComponent: ({noFeedback, thumbnailComponent, thumbnailSrc}) => {
-			// noFeedback is effectively "tooltip mode", one mode being whether the time and icon are visible,
-			// the other being the thumbnail and time are visible.
-			if (noFeedback) {
+		feedbackVisible: ({action, thumbnailVisible, playbackState: s}) => {
+			return !thumbnailVisible && !(action === 'blur' && states[s] === 'play');
+		},
+		thumbnailComponent: ({action, thumbnailComponent, thumbnailSrc}) => {
+			if (action === 'focus') {
 				if (thumbnailComponent) {
 					return <ComponentOverride
 						component={thumbnailComponent}
@@ -188,7 +198,8 @@ const FeedbackTooltipBase = kind({
 		}
 	},
 
-	render: ({children, noFeedback, playbackState, playbackRate, thumbnailComponent, ...rest}) => {
+	render: ({children, feedbackVisible, playbackState, playbackRate, thumbnailComponent, ...rest}) => {
+		delete rest.action;
 		delete rest.duration;
 		delete rest.formatter;
 		delete rest.hidden;
@@ -196,6 +207,7 @@ const FeedbackTooltipBase = kind({
 		delete rest.proportion;
 		delete rest.thumbnailDeactivated;
 		delete rest.thumbnailSrc;
+		delete rest.thumbnailVisible;
 		delete rest.visible;
 
 		return (
@@ -203,7 +215,7 @@ const FeedbackTooltipBase = kind({
 				{thumbnailComponent}
 				<FeedbackContent
 					className={css.content}
-					feedbackVisible={!noFeedback}
+					feedbackVisible={feedbackVisible}
 					playbackRate={playbackRate}
 					playbackState={playbackState}
 				>
@@ -215,7 +227,7 @@ const FeedbackTooltipBase = kind({
 });
 
 const FeedbackTooltip = onlyUpdateForKeys(
-	['children', 'hidden', 'noFeedback', 'playbackState', 'playbackRate', 'thumbnailComponent', 'thumbnailDeactivated', 'thumbnailSrc', 'visible']
+	['children', 'hidden', 'thumbnailVisible', 'playbackState', 'playbackRate', 'thumbnailComponent', 'thumbnailDeactivated', 'thumbnailSrc', 'visible']
 )(
 	Skinnable(
 		FeedbackTooltipBase

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1824,15 +1824,15 @@ const VideoPlayerBase = class extends React.Component {
 								visible={this.state.mediaSliderVisible}
 							>
 								<FeedbackTooltip
+									action={this.state.feedbackAction}
 									duration={this.state.duration}
 									formatter={this.durfmt}
+									hidden={!this.state.feedbackVisible || this.state.sourceUnavailable}
 									playbackRate={this.selectPlaybackRate(this.speedIndex)}
 									playbackState={this.prevCommand}
 									thumbnailComponent={thumbnailComponent}
 									thumbnailDeactivated={this.props.thumbnailUnavailable}
 									thumbnailSrc={thumbnailSrc}
-									action={this.state.feedbackAction}
-									hidden={!this.state.feedbackVisible || this.state.sourceUnavailable}
 								/>
 							</MediaSlider>}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -605,7 +605,6 @@ const VideoPlayerBase = class extends React.Component {
 			// Non-standard state computed from properties
 			bottomControlsRendered: false,
 			feedbackAction: 'idle',
-			feedbackIconVisible: true,
 			feedbackVisible: false,
 			infoVisible: false,
 			mediaControlsVisible: false,
@@ -829,7 +828,7 @@ const VideoPlayerBase = class extends React.Component {
 			return {
 				announce,
 				bottomControlsRendered: true,
-				feedbackIconVisible: true,
+				feedbackAction: 'idle',
 				feedbackVisible: true,
 				mediaControlsVisible: true,
 				mediaSliderVisible: true,
@@ -852,7 +851,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopDelayedTitleHide();
 		this.stopAutoCloseTimeout();
 		this.setState({
-			feedbackIconVisible: false,
+			feedbackAction: 'idle',
 			feedbackVisible: false,
 			mediaControlsVisible: false,
 			mediaSliderVisible: false,
@@ -920,7 +919,6 @@ const VideoPlayerBase = class extends React.Component {
 	showFeedback = () => {
 		if (this.state.mediaControlsVisible) {
 			this.setState({
-				feedbackIconVisible: true,
 				feedbackVisible: true,
 				feedbackAction: 'idle'
 			});
@@ -1569,7 +1567,6 @@ const VideoPlayerBase = class extends React.Component {
 
 		this.setState({
 			feedbackAction: 'focus',
-			feedbackIconVisible: false,
 			feedbackVisible: true
 		});
 		this.stopDelayedFeedbackHide();
@@ -1591,9 +1588,7 @@ const VideoPlayerBase = class extends React.Component {
 	handleSliderBlur = () => {
 		this.sliderScrubbing = false;
 		this.startDelayedFeedbackHide();
-		this.setState(({paused, currentTime}) => ({
-			// If paused is false that means it is playing. We only want to hide on playing.
-			feedbackIconVisible: paused,
+		this.setState(({currentTime}) => ({
 			feedbackAction: 'blur',
 			feedbackVisible: true,
 			sliderTooltipTime: currentTime
@@ -1836,7 +1831,6 @@ const VideoPlayerBase = class extends React.Component {
 									thumbnailComponent={thumbnailComponent}
 									thumbnailDeactivated={this.props.thumbnailUnavailable}
 									thumbnailSrc={thumbnailSrc}
-									thumbnailVisible={!this.state.feedbackIconVisible}
 									action={this.state.feedbackAction}
 									hidden={!this.state.feedbackVisible || this.state.sourceUnavailable}
 								/>

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -604,6 +604,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			// Non-standard state computed from properties
 			bottomControlsRendered: false,
+			feedbackAction: 'idle',
 			feedbackIconVisible: true,
 			feedbackVisible: false,
 			infoVisible: false,
@@ -920,7 +921,8 @@ const VideoPlayerBase = class extends React.Component {
 		if (this.state.mediaControlsVisible) {
 			this.setState({
 				feedbackIconVisible: true,
-				feedbackVisible: true
+				feedbackVisible: true,
+				feedbackAction: 'idle'
 			});
 		} else {
 			const shouldShowSlider = this.pulsedPlaybackState !== null || calcNumberValueOfPlaybackRate(this.playbackRate) !== 1;
@@ -936,7 +938,10 @@ const VideoPlayerBase = class extends React.Component {
 
 	hideFeedback = () => {
 		if (this.state.feedbackVisible) {
-			this.setState({feedbackVisible: false});
+			this.setState({
+				feedbackVisible: false,
+				feedbackAction: 'idle'
+			});
 		}
 	}
 
@@ -1563,6 +1568,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.sliderScrubbing = true;
 
 		this.setState({
+			feedbackAction: 'focus',
 			feedbackIconVisible: false,
 			feedbackVisible: true
 		});
@@ -1588,7 +1594,8 @@ const VideoPlayerBase = class extends React.Component {
 		this.setState(({paused, currentTime}) => ({
 			// If paused is false that means it is playing. We only want to hide on playing.
 			feedbackIconVisible: paused,
-			feedbackVisible: false,
+			feedbackAction: 'blur',
+			feedbackVisible: true,
 			sliderTooltipTime: currentTime
 		}));
 	}
@@ -1824,12 +1831,13 @@ const VideoPlayerBase = class extends React.Component {
 								<FeedbackTooltip
 									duration={this.state.duration}
 									formatter={this.durfmt}
-									noFeedback={!this.state.feedbackIconVisible}
 									playbackRate={this.selectPlaybackRate(this.speedIndex)}
 									playbackState={this.prevCommand}
 									thumbnailComponent={thumbnailComponent}
 									thumbnailDeactivated={this.props.thumbnailUnavailable}
 									thumbnailSrc={thumbnailSrc}
+									thumbnailVisible={!this.state.feedbackIconVisible}
+									action={this.state.feedbackAction}
 									hidden={!this.state.feedbackVisible || this.state.sourceUnavailable}
 								/>
 							</MediaSlider>}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Feedback tooltip should display only time when hovering out from slider while playing. Currently, it hides the tooltip.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We do not have a boolean condition for showing feedback icon as "play" relies on "idle", "focus", and "blur" conditions to display either both icon and time or just time in the tooltip.

Replaced `noFeedback` prop with `action` prop in `FeedbackTooltip` to handle the state.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
