### PR TITLE
ENYO-5432: Fix restoring focus in moonstone/VirtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` page controls to stop propagating an event if the event is handled
 - `moonstone/ProgressBar.ProgressBarTooltip` not to display unknown props warning
 - `moonstone/Scrollable` to disable container during flick events only when contents can scroll
+- `moonstone/VirtualList` and `moonstone/VirtualGridList` to restore focus on items focused by pointer
 
 ## [2.0.0-rc.1] - 2018-07-09
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -346,8 +346,8 @@ class ScrollableBase extends Component {
 			if (item && item === spotItem) {
 				this.calculateAndScrollTo(item);
 			}
-		} else if (this.childRef.setLastFocusedIndex) {
-			this.childRef.setLastFocusedIndex(ev.target);
+		} else if (this.childRef.setLastFocusedNode) {
+			this.childRef.setLastFocusedNode(ev.target);
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -415,8 +415,8 @@ class ScrollableBaseNative extends Component {
 			if (item && item === spotItem && positionFn) {
 				this.calculateAndScrollTo(item);
 			}
-		} else if (this.childRef.setLastFocusedIndex) {
-			this.childRef.setLastFocusedIndex(ev.target);
+		} else if (this.childRef.setLastFocusedNode) {
+			this.childRef.setLastFocusedNode(ev.target);
 		}
 	}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -832,8 +832,8 @@ const VirtualListBaseFactory = (type) => {
 
 		shouldPreventOverscrollEffect = () => (this.isWrappedBy5way)
 
-		setLastFocusedIndex = (param) => {
-			this.lastFocusedIndex = param;
+		setLastFocusedNode = (node) => {
+			this.lastFocusedIndex = node.dataset && node.dataset.index;
 		}
 
 		updateStatesAndBounds = ({cbScrollTo, dataSize, moreInfo, numOfItems}) => {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -833,7 +833,7 @@ const VirtualListBaseFactory = (type) => {
 		shouldPreventOverscrollEffect = () => (this.isWrappedBy5way)
 
 		setLastFocusedNode = (node) => {
-			this.lastFocusedIndex = node.dataset && node.dataset.index;
+			this.lastFocusedIndex = node.dataset && Number.parseInt(node.dataset.index);
 		}
 
 		updateStatesAndBounds = ({cbScrollTo, dataSize, moreInfo, numOfItems}) => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Last focus index of `VirtualList` was not remembered when focused by mouse

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Extract the index when focusing an item in a `VirtualList` with mouse

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I renamed an internal API used by `Scrollable`/`ScrollableNative`.

### Links
[//]: # (Related issues, references)
ENYO-5432

### Comments
