### PR TITLE
ENYO-5434: VideoPlayer bottom control renders

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `moonstone/VideoPlayer` to allow preventing bottom control render via play event handler
+
 ### Fixed
 
 - `moonstone/Input` to not focus by *tab* key

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
-- `moonstone/VideoPlayer` to allow preventing bottom control render via play event handler
+- `moonstone/VideoPlayer` to allow preventing bottom control render via loadstart event handler
 
 ### Fixed
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1023,10 +1023,6 @@ const VideoPlayerBase = class extends React.Component {
 		}
 	}
 
-	handleEmptied = () => {
-		this.hideControls();
-	}
-
 	handlePlay = this.handle(
 		this.shouldShowMiniFeedback,
 		() => this.play()
@@ -1759,7 +1755,6 @@ const VideoPlayerBase = class extends React.Component {
 		mediaProps.mediaComponent = 'video';
 		mediaProps.onPlay = this.handlePlayEvent;
 		mediaProps.onLoadStart = this.handleLoadStart;
-		mediaProps.onEmptied = this.handleEmptied;
 		mediaProps.onUpdate = this.handleEvent;
 		mediaProps.ref = this.setVideoRef;
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -554,7 +554,6 @@ const VideoPlayerBase = class extends React.Component {
 		 *
 		 * Events:
 		 * * `onLoadStart` - Called when the video starts to load
-		 * * `onPlay` - Sent when playback of the media starts after having been paused
 		 * * `onUpdate` - Sent when any of the properties were updated
 		 *
 		 * Methods:
@@ -1007,22 +1006,29 @@ const VideoPlayerBase = class extends React.Component {
 		return true;
 	}
 
-	handleLoadStart = () => {
-		this.firstPlayReadFlag = true;
-		this.prevCommand = this.props.noAutoPlay ? 'pause' : 'play';
-		this.speedIndex = 0;
-		this.setState({
-			announce: AnnounceState.READY,
-			currentTime: 0,
-			sourceUnavailable: true,
-			proportionPlayed: 0,
-			proportionLoaded: 0
-		});
-
-		if (!this.state.bottomControlsRendered) {
-			this.renderBottomControl.idle();
+	handleLoadStart = this.handle(
+		() => {
+			this.firstPlayReadFlag = true;
+			this.prevCommand = this.props.noAutoPlay ? 'pause' : 'play';
+			this.speedIndex = 0;
+			this.setState({
+				announce: AnnounceState.READY,
+				currentTime: 0,
+				sourceUnavailable: true,
+				proportionPlayed: 0,
+				proportionLoaded: 0
+			});
+			return true;
+		},
+		forwardWithPrevent('onLoadStart'),
+		() => {
+			if (!this.state.bottomControlsRendered) {
+				this.renderBottomControl.idle();
+			} else {
+				this.showControls();
+			}
 		}
-	}
+	)
 
 	handlePlay = this.handle(
 		forwardPlay,
@@ -1108,16 +1114,6 @@ const VideoPlayerBase = class extends React.Component {
 
 		this.setState(updatedState);
 	}
-
-	handlePlayEvent = this.handle(
-		forwardPlay,
-		() => {
-			if (this.state.bottomControlsRendered && !this.state.mediaControlsVisible) {
-				// show bottom controls when playing the next video
-				this.showControls();
-			}
-		}
-	);
 
 	renderBottomControl = new Job(() => {
 		if (!this.state.bottomControlsRendered) {
@@ -1756,7 +1752,6 @@ const VideoPlayerBase = class extends React.Component {
 		mediaProps.className = css.video;
 		mediaProps.controls = false;
 		mediaProps.mediaComponent = 'video';
-		mediaProps.onPlay = this.handlePlayEvent;
 		mediaProps.onLoadStart = this.handleLoadStart;
 		mediaProps.onUpdate = this.handleEvent;
 		mediaProps.ref = this.setVideoRef;

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1024,6 +1024,7 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	handlePlay = this.handle(
+		forwardPlay,
 		this.shouldShowMiniFeedback,
 		() => this.play()
 	)

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -713,7 +713,8 @@ const VideoPlayerBase = class extends React.Component {
 			}
 		}
 
-		if (this.state.bottomControlsRendered && !prevState.bottomControlsRendered) {
+		// Once video starts loading it queues bottom control render until idle
+		if (this.state.bottomControlsRendered && !prevState.bottomControlsRendered && !this.state.mediaControlsVisible) {
 			this.showControls();
 		}
 	}
@@ -1112,6 +1113,7 @@ const VideoPlayerBase = class extends React.Component {
 		forwardPlay,
 		() => {
 			if (this.state.bottomControlsRendered && !this.state.mediaControlsVisible) {
+				// show bottom controls when playing the next video
 				this.showControls();
 			}
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some apps control the visibility of bottom controls via imperative APIs (`showControls` and `hideControls`) because there are cases where app wants to prevent showing controls upon newly loaded/played event. For example, the app does not want to display controls at everytime video changes when in store demo mode.
Because apps control the visibility of bottom controls in a similar way as frameworks do, it could render unwanted results.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apps shouldn't need to control the visibilities via calling imperative APIs if we allow them to prevent the default action via event.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The general idea behind this is that apps want to display bottom controls when initially playing a video in most cases. So instead of letting apps to take care of, we fixed the framework to support that in #1661. 
Proposed change can still break the app as long as apps try to handle the same requirement on their end. We _can_ remove supporting "auto showing controls" and let app control everything entirely, too.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
