### PR TITLE
ENYO-5426: Adjust paddings in GridListImageItem

### DIFF
--- a/packages/moonstone/GridListImageItem/GridListImageItem.less
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.less
@@ -47,9 +47,12 @@
 		}
 	}
 
-	&.useCaption,
+	&.useCaption {
+		padding-bottom: @moon-gridlist-item-caption-padding-bottom;
+	}
+
 	&.useSubCaption {
-		padding-bottom: @moon-gridlist-item-one-caption-padding-bottom;
+		padding-bottom: @moon-gridlist-item-subcaption-padding-bottom;
 	}
 
 	&.useCaption.useSubCaption {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -264,8 +264,9 @@
 @moon-gridlist-item-overlay-icon-size: 60px;
 @moon-gridlist-item-border-width: 6px;
 @moon-gridlist-item-caption-padding-top: 9px;
-@moon-gridlist-item-one-caption-padding-bottom: 42px;
-@moon-gridlist-item-two-captions-padding-bottom: 96px;
+@moon-gridlist-item-caption-padding-bottom: 45px;
+@moon-gridlist-item-subcaption-padding-bottom: 48px;
+@moon-gridlist-item-two-captions-padding-bottom: 93px;
 
 // Scrollable
 // ---------------------------------------


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

I found there were two issues in GridListImageItem.

Issue 1>
When using caption and sub-caption together, the space height for the caption and the sub-caption was 96px even though the sum of the height of the caption and the sub-caption was 93px.

Issue 2>
When using only caption or only sub-caption, the space height for them was 42px even thought the caption height was 45px and the sub-caption height was 48px.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

To fix the issue 1,
I tried to reduce the height for the caption and the sub-caption together to 93px ( 45px + 48px = 93px ).

To fix the issue 2,
I tried to change the height for only the caption to 45px, the height for only the sub-caption to 48px.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5426

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)