### PR TITLE
PLAT-62418: Fixed to scroll properly when holding down paging control buttons

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly when holding down paging control buttons
 - `moonstone/ExpandableItem` spotlight behavior when leaving the component via 5-way
 
 ## [2.0.0-rc.2] - 2018-07-16

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -1,6 +1,5 @@
 import {Announce} from '@enact/ui/AnnounceDecorator';
 import {is} from '@enact/core/keymap';
-import {off, on} from '@enact/core/dispatcher';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
@@ -141,36 +140,12 @@ class ScrollButtons extends Component {
 		};
 	}
 
-	componentWillUnmount () {
-		this.setIgnoreMode(false); // To remove event handler
-	}
-
-	ignoreMode = false
-	pressed = false
 	announce = null
 
 	// elements
 
 	prevButtonNodeRef = null
 	nextButtonNodeRef = null
-
-	setPressStatus = (isPressed) => {
-		this.pressed = isPressed;
-	}
-
-	setIgnoreMode = (shouldIgnore) => {
-		if (shouldIgnore !== this.ignoreMode) {
-			if (shouldIgnore) {
-				this.ignoreMode = true;
-				on('mousemove', this.onUp);
-				on('mouseup', this.onUp);
-			} else {
-				this.ignoreMode = false;
-				off('mousemove', this.onUp);
-				off('mouseup', this.onUp);
-			}
-		}
-	}
 
 	updateButtons = (bounds) => {
 		const
@@ -180,8 +155,7 @@ class ScrollButtons extends Component {
 			shouldDisablePrevButton = currentPos <= 0,
 			/* If a scroll size or a client size is not integer,
 			   browsers's max scroll position could be smaller than maxPos by 1 pixel.*/
-			shouldDisableNextButton = maxPos - currentPos <= 1,
-			spotItem = Spotlight.getCurrent();
+			shouldDisableNextButton = maxPos - currentPos <= 1;
 
 		this.setState((prevState) => {
 			const
@@ -196,13 +170,6 @@ class ScrollButtons extends Component {
 				return {nextButtonDisabled: shouldDisableNextButton};
 			}
 		});
-
-		if (this.pressed && (
-			shouldDisablePrevButton && spotItem && spotItem === this.prevButtonNodeRef ||
-			shouldDisableNextButton && spotItem && spotItem === this.nextButtonNodeRef
-		)) {
-			this.setIgnoreMode(true);
-		}
 	}
 
 	isOneOfScrollButtonsFocused = () => {
@@ -212,8 +179,6 @@ class ScrollButtons extends Component {
 	}
 
 	onDownPrev = () => {
-		this.setPressStatus(true);
-
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
 			this.announce(vertical && $L('UP') || rtl && $L('RIGHT') || $L('LEFT'));
@@ -221,8 +186,6 @@ class ScrollButtons extends Component {
 	}
 
 	onDownNext = () => {
-		this.setPressStatus(true);
-
 		if (this.announce) {
 			const {rtl, vertical} = this.props;
 			this.announce(vertical && $L('DOWN') || rtl && $L('LEFT') || $L('RIGHT'));
@@ -239,22 +202,6 @@ class ScrollButtons extends Component {
 		const {onNextScroll, vertical} = this.props;
 
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
-	}
-
-	onHoldPulsePrev = (ev) => {
-		const {onPrevScroll, vertical} = this.props;
-
-		if (!this.ignoreMode) {
-			onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
-		}
-	}
-
-	onHoldPulseNext = (ev) => {
-		const {onNextScroll, vertical} = this.props;
-
-		if (!this.ignoreMode) {
-			onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
-		}
 	}
 
 	focusOnOppositeScrollButton = (ev, direction) => {
@@ -302,11 +249,6 @@ class ScrollButtons extends Component {
 				Spotlight.move(direction);
 			}
 		}
-	}
-
-	onUp = () => {
-		this.setPressStatus(false);
-		this.setIgnoreMode(false);
 	}
 
 	onKeyDownPrev = (ev) => {
@@ -377,13 +319,12 @@ class ScrollButtons extends Component {
 				key="prevButton"
 				onClick={this.onClickPrev}
 				onDown={this.onDownPrev}
-				onHoldPulse={this.onHoldPulsePrev}
+				onHoldPulse={this.onClickPrev}
 				onKeyDown={this.onKeyDownPrev}
 				onSpotlightDown={this.onSpotlight}
 				onSpotlightLeft={this.onSpotlight}
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
-				onUp={this.onUp}
 				ref={this.initPrevButtonRef}
 			>
 				{prevIcon}
@@ -397,13 +338,12 @@ class ScrollButtons extends Component {
 				key="nextButton"
 				onClick={this.onClickNext}
 				onDown={this.onDownNext}
-				onHoldPulse={this.onHoldPulseNext}
+				onHoldPulse={this.onClickNext}
 				onKeyDown={this.onKeyDownNext}
 				onSpotlightDown={this.onSpotlight}
 				onSpotlightLeft={this.onSpotlight}
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
-				onUp={this.onUp}
 				ref={this.initNextButtonRef}
 			>
 				{nextIcon}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed a bug that a list or a scroller does not scroll until a user releases the button if a user holds down a paging control button right after pressing the opposite paging control button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
After #1570, a focus does not move to the opposite paired button but it stays on the current button even if the button is disabled by scrolling. This bug occurs by old code to prevent scrolling from `holdpulse` events when a focus moved to the opposite button during holding down.
So, removed the old code.


### Links
[//]: # (Related issues, references)
PLAT-62418

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)