### PR TITLE
ENYO-5418: ExpandableItem handle PageUp and PageDown

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ExpandableItem` spotlight behavior when leaving the component via 5-way
+- `moonstone/ExpandableItem` behavior when paging up or paging down the component
 
 ## [2.0.0-rc.2] - 2018-07-16
 

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -304,6 +304,7 @@ const ExpandableItemBase = kind({
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
 						if (isPageDown(keyCode)) {
+							// Spot the last item when page down
 							const expandableContainer = last(getContainersForNode(target));
 							const lastElementToFocus = last(getContainerNavigableElements(expandableContainer));
 							Spotlight.focus(lastElementToFocus);

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -10,9 +10,10 @@
 import {is} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
-import {getContainersForNode} from '@enact/spotlight/src/container';
+import {getContainersForNode, getContainerNavigableElements} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import last from 'ramda/src/last';
 import React from 'react';
@@ -26,6 +27,8 @@ import css from './ExpandableItem.less';
 
 const isUp = is('up');
 const isDown = is('down');
+const isPageUp = is('pageUp');
+const isPageDown = is('pageDown');
 
 const ContainerDiv = SpotlightContainerDecorator({continue5WayHold: true}, 'div');
 
@@ -293,12 +296,20 @@ const ExpandableItemBase = kind({
 				// case here in which the children of the container are spottable and the
 				// ExpandableList use case which has an intermediate child (Group) between the
 				// spottable components and the container.
-				if (autoClose && onClose && isUp(keyCode) && wouldDirectionLeaveContainer('up', target)) {
+				// And close when `pageup` is pressed
+				if (autoClose && onClose && ((isUp(keyCode) && wouldDirectionLeaveContainer('up', target)) || isPageUp(keyCode))) {
 					onClose();
 					ev.nativeEvent.stopImmediatePropagation();
-				} else if (isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) {
+				} else if ((isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) || isPageDown(keyCode)) {
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
+						console.log('keycode');
+						if (isPageDown(keyCode)) {
+							const expandableContainer = last(getContainersForNode(target));
+							const lastElementToFocus = last(getContainerNavigableElements(expandableContainer));
+							Spotlight.focus(lastElementToFocus);
+							console.log(expandableContainer, lastElementToFocus);
+						}
 					} else if (onSpotlightDown) {
 						onSpotlightDown(ev);
 					}
@@ -306,6 +317,8 @@ const ExpandableItemBase = kind({
 			}
 		},
 		handleLabelKeyDown: (ev, {onSpotlightDown, open}) => {
+
+			console.log('keyCode', ev.keyCode);
 			if (isDown(ev.keyCode) && !open && onSpotlightDown) {
 				onSpotlightDown(ev);
 			}

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -303,12 +303,10 @@ const ExpandableItemBase = kind({
 				} else if ((isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) || isPageDown(keyCode)) {
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
-						console.log('keycode');
 						if (isPageDown(keyCode)) {
 							const expandableContainer = last(getContainersForNode(target));
 							const lastElementToFocus = last(getContainerNavigableElements(expandableContainer));
 							Spotlight.focus(lastElementToFocus);
-							console.log(expandableContainer, lastElementToFocus);
 						}
 					} else if (onSpotlightDown) {
 						onSpotlightDown(ev);
@@ -317,8 +315,6 @@ const ExpandableItemBase = kind({
 			}
 		},
 		handleLabelKeyDown: (ev, {onSpotlightDown, open}) => {
-
-			console.log('keyCode', ev.keyCode);
 			if (isDown(ev.keyCode) && !open && onSpotlightDown) {
 				onSpotlightDown(ev);
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added support for page up and page down keypresses for `ExpandableItem`.
When `autoClose` is true page up will close `ExpandableItem` and page down will spot the last item of the list (if `lockBottom` is true).



### Links
[//]: # (Related issues, references)
ENYO-5418

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com