### PR TITLE
ENYO-5455: Fix audio guidance issue about more button in video player

### DIFF
--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -674,8 +674,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				// Readout 'more' or 'back' button explicitly.
 				let selectedButton = Spotlight.getCurrent();
 				if (selectedButton === this.mediaControlsNode.querySelector(`.${css.moreButton}`)) {
-					selectedButton.blur();
-					selectedButton.focus();
+					if (this.props.visible) {
+						setTimeout(() => {
+							selectedButton.blur();
+							selectedButton.focus();
+						}, 100);
+					}
 				} else if (!this.state.showMoreComponents) {
 					// if spotlight was not in "back" button, then focus "more" button
 					Spotlight.focus(this.props.moreButtonSpotlightId);


### PR DESCRIPTION
### Issue Resolved / Feature Added
1) When the `more button` is blurred and focused for audio guidance, it  must be `visible === true`
2) `blur()` and `focus()` of the button requires a brief delay for readout `infoComponents` first

### Resolution
1) Add condition to `this.props.visible`
2) Add `setTimeout` for delay

### Additional Considerations

### Links
ENYO-5455

### Comments
Enact-DCO-1.0-Signed-off-by: Hyeok Jo hyeok.jo@lge.com