### PR TITLE
ENYO-5457: Spotlight: focus disappears when spinner is unmounted

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to exit `onKeyDown` after executing `notifyKeyDown`.
+
 ## [2.0.0-rc.2] - 2018-07-16
 
 ### Added

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` to exit `onKeyDown` after executing `notifyKeyDown`.
+- `spotlight` to track pointer mode while paused
 
 ## [2.0.0-rc.2] - 2018-07-16
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -388,9 +388,9 @@ const Spotlight = (function () {
 		const shouldPrevent = shouldPreventNavigation();
 		const keyCode = evt.keyCode;
 		const direction = getDirection(keyCode);
-		const pointerHandled = notifyKeyDown(keyCode, !shouldPrevent && handlePointerHide);
+		const pointerHandled = notifyKeyDown(keyCode, shouldPrevent ? null : handlePointerHide);
 
-		if (pointerHandled || !(direction || isEnter(keyCode)) || shouldPrevent) {
+		if (shouldPrevent || pointerHandled || !(direction || isEnter(keyCode))) {
 			return;
 		}
 
@@ -409,7 +409,10 @@ const Spotlight = (function () {
 	}
 
 	function onMouseMove ({target, clientX, clientY}) {
-		if (shouldPreventNavigation()) return;
+		if (shouldPreventNavigation()) {
+			notifyPointerMove(null, target, clientX, clientY);
+			return;
+		}
 
 		const current = getCurrent();
 		const update = notifyPointerMove(current, target, clientX, clientY);

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -385,15 +385,12 @@ const Spotlight = (function () {
 	}
 
 	function onKeyDown (evt) {
-		if (shouldPreventNavigation()) {
-			return;
-		}
-
+		const shouldPrevent = shouldPreventNavigation();
 		const keyCode = evt.keyCode;
 		const direction = getDirection(keyCode);
-		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
+		const pointerHandled = notifyKeyDown(keyCode, !shouldPrevent && handlePointerHide);
 
-		if (pointerHandled || !(direction || isEnter(keyCode))) {
+		if (pointerHandled || !(direction || isEnter(keyCode)) || shouldPrevent) {
 			return;
 		}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -385,12 +385,16 @@ const Spotlight = (function () {
 	}
 
 	function onKeyDown (evt) {
-		const shouldPrevent = shouldPreventNavigation();
+		if (shouldPreventNavigation()) {
+			notifyKeyDown(evt.keyCode);
+			return;
+		}
+
 		const keyCode = evt.keyCode;
 		const direction = getDirection(keyCode);
-		const pointerHandled = notifyKeyDown(keyCode, shouldPrevent ? null : handlePointerHide);
+		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
 
-		if (shouldPrevent || pointerHandled || !(direction || isEnter(keyCode))) {
+		if (pointerHandled || !(direction || isEnter(keyCode))) {
 			return;
 		}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix focus disappearing issue relates to pointerMode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
At least calling `notifyKeyDown` when keydown even if in spotlight pause mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5457

### Comments
