### PR TITLE
ENYO-5454 - Fix closeOnSelect spotlight action

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly when holding down paging control buttons
 - `moonstone/ExpandableItem` spotlight behavior when leaving the component via 5-way
-- `ExpandableItem` and other expandable components to spotlight correctly when switching from pointer mode to 5-way with `closeOnSelect`
+- `moonstone/ExpandableItem` and other expandable components to spotlight correctly when switching from pointer mode to 5-way with `closeOnSelect`
 
 ## [2.0.0-rc.2] - 2018-07-16
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly when holding down paging control buttons
 - `moonstone/ExpandableItem` spotlight behavior when leaving the component via 5-way
+- `ExpandableItem` and other expandable components to spotlight correctly when switching from pointer mode to 5-way with `closeOnSelect`
 
 ## [2.0.0-rc.2] - 2018-07-16
 

--- a/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
+++ b/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
@@ -115,17 +115,19 @@ const ExpandableSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		highlightLabeledItem = () => {
 			const current = Spotlight.getCurrent();
-			if (this.containerNode.contains(current)) {
-				const pointerMode = Spotlight.getPointerMode();
+			const label = this.containerNode.querySelector('[data-expandable-label]');
 
-				if (pointerMode) {
+			if (current === label) return;
+
+			if (this.containerNode.contains(current)) {
+				if (Spotlight.getPointerMode()) {
 					// If we don't clear the focus, switching back to 5-way before focusing anything
 					// will result in what appears to be lost focus
 					current.blur();
 				}
-				Spotlight.focus(this.containerNode.querySelector('[data-expandable-label]'));
+
+				Spotlight.focus(label);
 			} else {
-				const label = this.containerNode.querySelector('[data-expandable-label]');
 				const containerIds = getContainersForNode(label);
 
 				// when focus is not within the expandable (due to a cancel event or the close

--- a/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
+++ b/packages/moonstone/ExpandableItem/ExpandableSpotlightDecorator.js
@@ -116,6 +116,13 @@ const ExpandableSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		highlightLabeledItem = () => {
 			const current = Spotlight.getCurrent();
 			if (this.containerNode.contains(current)) {
+				const pointerMode = Spotlight.getPointerMode();
+
+				if (pointerMode) {
+					// If we don't clear the focus, switching back to 5-way before focusing anything
+					// will result in what appears to be lost focus
+					current.blur();
+				}
 				Spotlight.focus(this.containerNode.querySelector('[data-expandable-label]'));
 			} else {
 				const label = this.containerNode.querySelector('[data-expandable-label]');
@@ -140,9 +147,8 @@ const ExpandableSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		highlight = (callback) => {
 			if (Spotlight.isPaused()) return;
 
-			const {open} = this.props;
 			const pointerMode = Spotlight.getPointerMode();
-			const changePointerMode = pointerMode && (noPointerMode || !open);
+			const changePointerMode = pointerMode && noPointerMode;
 
 			if (changePointerMode) {
 				// we temporarily set pointer mode to `false` to ensure that focus is forced away
@@ -168,12 +174,7 @@ const ExpandableSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleHide = () => {
 			this.resume();
-			const pointerMode = Spotlight.getPointerMode();
-
-			if (!pointerMode || noPointerMode) {
-				// In `pointerMode`, only highlight `LabeledItem` when `noPointerMode` is `true`
-				this.highlight(this.highlightLabeledItem);
-			}
+			this.highlight(this.highlightLabeledItem);
 		}
 
 		handle = handle.bind(this)

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ExpandableItem` and other expandable components to spotlight correctly when switching from
+	pointer mode to 5-way with `closeOnSelect`
+
 ## [2.0.0-rc.2] - 2018-07-16
 
 ### Added

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `ExpandableItem` and other expandable components to spotlight correctly when switching from
-	pointer mode to 5-way with `closeOnSelect`
-
 ## [2.0.0-rc.2] - 2018-07-16
 
 ### Added


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When switching from pointer mode to 5-way mode after an expandable
with `closeOnSelect` collapsed it was possible for spotlight to remain
on the hidden contents of the expandable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Blur the hidden item when in pointer mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I removed an old test that would unconditionally try to spotlight the header
when in pointer mode and closing.  I believe the current solution works
better than what the previous code was trying (and failing) to do.

### Links
[//]: # (Related issues, references)
ENYO-5454

### Comments
