### PR TITLE
ENYO-5442: Defer to reset Scrollable restore flag

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1000,7 +1000,7 @@ class ScrollableBase extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			this.scrollToInfo = null;
+			setTimeout(() => {this.scrollToInfo = null;});
 			this.start({
 				targetX: (left !== null) ? left : this.scrollLeft,
 				targetY: (top !== null) ? top : this.scrollTop,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1000,7 +1000,9 @@ class ScrollableBase extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			setTimeout(() => {this.scrollToInfo = null;});
+			setTimeout(() => {
+				this.scrollToInfo = null;
+			});
 			this.start({
 				targetX: (left !== null) ? left : this.scrollLeft,
 				targetY: (top !== null) ? top : this.scrollTop,

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1061,7 +1061,7 @@ class ScrollableBaseNative extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			this.scrollToInfo = null;
+			setTimeout(() => {this.scrollToInfo = null;});
 			this.start(
 				(left !== null) ? left : this.scrollLeft,
 				(top !== null) ? top : this.scrollTop,

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1061,7 +1061,9 @@ class ScrollableBaseNative extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			setTimeout(() => {this.scrollToInfo = null;});
+			setTimeout(() => {
+				this.scrollToInfo = null;
+			});
 			this.start(
 				(left !== null) ? left : this.scrollLeft,
 				(top !== null) ? top : this.scrollTop,


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

ui/Scrollable.componentDidUpdate tried to restore scroll position and focus, then this.scrollToInfo is equal to `null`.
But moonstone/Scrollable.componentDidUpdate also tried to sync scroll position if this.scrollToInfo is equal to `null`.
So two logics conflicted, then the VirtualList worked incorrectly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

For the case to restore scroll position, we don't need to sync scroll position in moonstone/Scrollable. To do it, I deferred to reset this.scrollToInfo to `null`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I don't want to add any flags more for this issue. So I used `setTimeout`.

### Links
[//]: # (Related issues, references)

ENYO-5442

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)