### PR TITLE
ENYO-5417: Changed overscroll color more recognizable on the focused element

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` overscroll effect color more recognizable on the focused element
+
 ### Fixed
 
 - `moonstone/ContextualPopup` to refocus its activator on close when the popup lacks spottable children

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -224,4 +224,4 @@
 
 // Scrollable
 // ---------------------------------------
-@moon-scrollable-overscroll-color: @moon-accent;
+@moon-scrollable-overscroll-color: #454545;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -230,4 +230,4 @@
 
 // Scrollable
 // ---------------------------------------
-@moon-scrollable-overscroll-color: @moon-accent;
+@moon-scrollable-overscroll-color: #ccc;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Overscroll effects are not recognizable by eye due to the color of the effect is as same as our focus effect color.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the overscroll effect color to bright gray (almost white) for a dark theme and dark gray for a light theme.

### Links
[//]: # (Related issues, references)
ENYO-5417

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)