### PR TITLE
PLAT-62228: Set a 5way key mode when pressing a key to focus an item

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to set a 5 way key mode when pressing a key
+
 ## [2.0.0-rc.3] - 2018-07-23
 
 ### Fixed

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -259,6 +259,7 @@ class ScrollButtons extends Component {
 
 		if (isPageDown(keyCode) && !nextButtonDisabled) {
 			if (focusableScrollButtons) {
+				Spotlight.setPointerMode(false);
 				Spotlight.focus(this.nextButtonNodeRef);
 			} else {
 				this.onClickNext(ev);
@@ -276,6 +277,7 @@ class ScrollButtons extends Component {
 
 		if (isPageUp(keyCode) && !prevButtonDisabled) {
 			if (focusableScrollButtons) {
+				Spotlight.setPointerMode(false);
 				Spotlight.focus(this.prevButtonNodeRef);
 			} else {
 				this.onClickPrev(ev);

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -476,6 +476,7 @@ class ScrollableBase extends Component {
 				direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
+				Spotlight.setPointerMode(false);
 				direction = this.getPageDirection(keyCode);
 				overscrollEffectRequired = !this.scrollByPage(keyCode);
 			} else {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -543,6 +543,7 @@ class ScrollableBaseNative extends Component {
 		this.animateOnFocus = true;
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
+			Spotlight.setPointerMode(false);
 			ev.preventDefault();
 			if (!repeat && this.hasFocus()) {
 				direction = this.getPageDirection(keyCode);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -469,12 +469,7 @@ const VirtualListBaseFactory = (type) => {
 					const node = this.uiRef.containerRef.querySelector(`[data-index='${indexToScroll}'].spottable`);
 
 					if (node) {
-						// When changing from "pointer" mode to "5way key" mode,
-						// a pointer is hidden and a last focused item get focused after 30ms.
-						// To make sure the item to be focused after that, we used 50ms.
-						setTimeout(() => {
-							Spotlight.focus(node);
-						}, 50);
+						Spotlight.focus(node);
 					}
 				} else {
 					// Scroll to the next spottable item without animation

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -620,20 +620,7 @@ const VirtualListBaseFactory = (type) => {
 						Spotlight.pause();
 					}
 
-					if (isWrapped) {
-						// In case of 'wrapping-around',
-						// we need to blur the current focus immediately
-						// since it can be a very long scroll (from one edge to the other edge)
-						// and definitely it's not a case of changing "pointer" mode to "5way key" mode.
-						target.blur();
-					} else {
-						// When changing from "pointer" mode to "5way key" mode,
-						// a pointer is hidden and a last focused item get focused after 30ms.
-						// To make sure the item to be blurred after that, we used 50ms.
-						setTimeout(() => {
-							target.blur();
-						}, 50);
-					}
+					target.blur();
 
 					this.isScrolledBy5way = true;
 					cbScrollTo({


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing a page up or down key over the item in a VirtualList with a pointer mode, VirtualList could not move focus properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

VirtualList called Spotlight.focus(). But the VirtualList could not move focus because it was in a pointer mode.
As we did in a VirtualList with the #1778, I forced to call `Spotlight.setPointerMode(false) ` when pressing a key.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When pressing a 4 direction key over the page control in a VirtualList with a pointer mode to move another page control, VirtualList could not move focus properly. So I fixed it in a same way.

### Links
[//]: # (Related issues, references)

PLAT-62228

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)