### PR TITLE
ENYO-5455: Fix more button audio guidance in VideoPlayer

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` not to read out what is not needed when panel disappears after clicking more button.
+
 ## [2.0.0-rc.3] - 2018-07-23
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VideoPlayer` not to read out what is not needed when panel disappears after clicking more button.
+- `moonstone/VideoPlayer` audio guidance behavior of More button
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -673,8 +673,10 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				// Readout 'more' or 'back' button explicitly.
 				let selectedButton = Spotlight.getCurrent();
 				if (selectedButton === this.mediaControlsNode.querySelector(`.${css.moreButton}`)) {
-					selectedButton.blur();
-					selectedButton.focus();
+					if (this.props.visible) {
+						selectedButton.blur();
+						selectedButton.focus();
+					}
 				} else if (!this.state.showMoreComponents) {
 					// if spotlight was not in "back" button, then focus "more" button
 					Spotlight.focus(this.props.moreButtonSpotlightId);

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1683,14 +1683,12 @@ const VideoPlayerBase = class extends React.Component {
 	getControlsAriaProps () {
 		if (this.state.announce === AnnounceState.TITLE) {
 			return {
-				role: 'alert',
-				'aria-live': 'off',
+				role: 'region',
 				'aria-labelledby': `${this.id}_title`
 			};
 		} else if (this.state.announce === AnnounceState.INFO) {
 			return {
-				role: 'alert',
-				'aria-live': 'off',
+				role: 'region',
 				'aria-labelledby': `${this.id}_info`
 			};
 		}


### PR DESCRIPTION
### Issue Resolved / Feature Added
- Fixed not to read out what is not needed when panel disappears after clicking more button of Videoplayer
- Fixed an order of information(Video information + focused button) read after clicking a more button.

### Resolution
- Add `this.props.visible` as a condition to read more button.
- Change a role from `alert` to `region`.

### Links
ENYO-5455

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)