### PR TITLE
ENYO-5419: Sync page up/down navigation spec between VirtualList and Scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to set a 5 way key mode when pressing a key
+- `moonstone/Scroller` not to scroll via page up/down keys if there is no spottable component in that direction
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -413,12 +413,11 @@ class ScrollableBase extends Component {
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
 
 			if (next !== focusedItem) {
-				this.animateOnFocus = false;
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId, viewportHeight: viewportBounds.height});
 
 				if (next !== null) {
 					this.animateOnFocus = false;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -395,7 +395,6 @@ class ScrollableBase extends Component {
 
 		const
 			{childRef, containerRef} = this.uiRef,
-			bounds = this.uiRef.getScrollBounds(),
 			focusedItem = Spotlight.getCurrent();
 
 		// Should skip scroll by page when focusedItem is paging control button of Scrollbar

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -386,7 +386,7 @@ class ScrollableBase extends Component {
 		return oPoint;
 	}
 
-	scrollByPage = (keyCode) => {
+	scrollByPage = (direction) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
 		if (!this.uiRef.state.isVerticalScrollbarVisible) {
@@ -396,30 +396,29 @@ class ScrollableBase extends Component {
 		const
 			{childRef, containerRef} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
-			spotItem = Spotlight.getCurrent();
+			focusedItem = Spotlight.getCurrent();
 
-		// Should skip scroll by page when spotItem is paging control button of Scrollbar
-		if (spotItem && childRef.containerRef.contains(spotItem)) {
+		// Should skip scroll by page when focusedItem is paging control button of Scrollbar
+		if (focusedItem && childRef.containerRef.contains(focusedItem)) {
 			const
 				// VirtualList and Scroller have a spotlightId on containerRef
 				spotlightId = containerRef.dataset.spotlightId,
-				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
-				spotItemBounds = spotItem.getBoundingClientRect(),
-				endPoint = this.getEndPoint(direction, spotItemBounds, viewportBounds);
+				focusedItemBounds = focusedItem.getBoundingClientRect(),
+				endPoint = this.getEndPoint(direction, focusedItemBounds, viewportBounds);
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
 
-			if (next !== spotItem) {
+			if (next !== focusedItem) {
 				this.animateOnFocus = false;
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem: spotItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
 
 				if (next !== null) {
 					this.animateOnFocus = false;
@@ -427,7 +426,7 @@ class ScrollableBase extends Component {
 				}
 			// For VirtualList
 			} else if (this.childRef.scrollToNextItem) {
-				this.childRef.scrollToNextItem({direction, focusedItem: spotItem, reverseDirection: rDirection, spotlightId});
+				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
 			// Need to check whether an overscroll effect is needed
@@ -460,7 +459,7 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				direction = this.getPageDirection(keyCode);
-				overscrollEffectRequired = !this.scrollByPage(keyCode);
+				overscrollEffectRequired = !this.scrollByPage(direction);
 			} else {
 				direction = getDirection(keyCode);
 				if (direction) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -408,30 +408,30 @@ class ScrollableBase extends Component {
 				viewportBounds = containerRef.getBoundingClientRect(),
 				spotItemBounds = spotItem.getBoundingClientRect(),
 				endPoint = this.getEndPoint(direction, spotItemBounds, viewportBounds);
-			let next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
+			let next = null;
 
 			/* 1. Find spottable item in viewport */
+			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
+
 			if (next !== spotItem) {
 				this.animateOnFocus = false;
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				const nodeToScroll = this.childRef.scrollToNextPage({direction, focusedItem: spotItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem: spotItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
 
-				if (nodeToScroll !== null) {
+				if (next !== null) {
 					this.animateOnFocus = false;
-					Spotlight.focus(nodeToScroll);
+					Spotlight.focus(next);
 				}
-
-				return false;
 			// For VirtualList
 			} else if (this.childRef.scrollToNextItem) {
-				// For VirtualList, need to check whether an overscroll effect is needed
 				this.childRef.scrollToNextItem({direction, focusedItem: spotItem, reverseDirection: rDirection, spotlightId});
-
-				return false;
 			}
+
+			// Need to check whether an overscroll effect is needed
+			return false;
 		}
 
 		return true;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -394,18 +394,12 @@ class ScrollableBase extends Component {
 		}
 
 		const
-			{childRef, containerRef, scrollToAccumulatedTarget} = this.uiRef,
+			{childRef, containerRef} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
-			canScrollVertically = this.uiRef.canScrollVertically(bounds),
-			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier,
 			spotItem = Spotlight.getCurrent();
 
-		if (spotItem) {
-			// Should skip scroll by page when spotItem is paging control button of Scrollbar
-			if (!childRef.containerRef.contains(spotItem)) {
-				return true;
-			}
-
+		// Should skip scroll by page when spotItem is paging control button of Scrollbar
+		if (spotItem && childRef.containerRef.contains(spotItem)) {
 			const
 				// VirtualList and Scroller have a spotlightId on containerRef
 				spotlightId = containerRef.dataset.spotlightId,
@@ -413,42 +407,31 @@ class ScrollableBase extends Component {
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
 				spotItemBounds = spotItem.getBoundingClientRect(),
-				endPoint = this.getEndPoint(direction, spotItemBounds, viewportBounds),
-				next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
+				endPoint = this.getEndPoint(direction, spotItemBounds, viewportBounds);
+			let next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
 
-			// If there is no next spottable DOM elements, scroll one page with animation
-			if (!next) {
-				scrollToAccumulatedTarget(pageDistance, canScrollVertically);
-			// If there is a next spottable DOM element vertically or horizontally, focus it without animation
-			} else if (next !== spotItem && this.childRef.scrollToNextPage) {
+			/* 1. Find spottable item in viewport */
+			if (next !== spotItem) {
 				this.animateOnFocus = false;
-				if (Spotlight.getPointerMode()) {
-					// When changing from "pointer" mode to "5way key" mode,
-					// a pointer is hidden and a last focused item get focused after 30ms.
-					// To make sure the item to be focused after that, we used 50ms.
-					setTimeout(() => {
-						Spotlight.focus(next);
-					}, 50);
-				} else {
-					Spotlight.focus(next);
-				}
-			// If a next spottable DOM element is equals to the current spottable item, we need to find a next item
-			} else {
-				const
-					scrollFn = this.childRef.scrollToNextPage || this.childRef.scrollToNextItem,
-					nextPage = scrollFn({direction, reverseDirection: rDirection, focusedItem: spotItem, spotlightId});
+				Spotlight.focus(next);
+			/* 2. Find spottable item out of viewport */
+			// For Scroller
+			} else if (this.childRef.scrollToNextPage) {
+				const nodeToScroll = this.childRef.scrollToNextPage({direction, focusedItem: spotItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
 
-				if (typeof nextPage === 'object') { // If finding a next spottable item in a Scroller, focus it
+				if (nodeToScroll !== null) {
 					this.animateOnFocus = false;
-					Spotlight.focus(nextPage);
-				} else if (nextPage === false) { // Scroll one page with animation if nextPage is equals to `false`
-					scrollToAccumulatedTarget(pageDistance, canScrollVertically);
-				} else if (nextPage === true) { // For a VirtualList, need to check whether an overscroll effect is needed
-					return false;
+					Spotlight.focus(nodeToScroll);
 				}
+
+				return false;
+			// For VirtualList
+			} else if (this.childRef.scrollToNextItem) {
+				// For VirtualList, need to check whether an overscroll effect is needed
+				this.childRef.scrollToNextItem({direction, focusedItem: spotItem, reverseDirection: rDirection, spotlightId});
+
+				return false;
 			}
-		} else {
-			scrollToAccumulatedTarget(pageDistance, canScrollVertically);
 		}
 
 		return true;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -455,7 +455,7 @@ class ScrollableBaseNative extends Component {
 		return oPoint;
 	}
 
-	scrollByPage = (keyCode) => {
+	scrollByPage = (direction) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
 		if (!this.uiRef.state.isVerticalScrollbarVisible) {
@@ -465,30 +465,29 @@ class ScrollableBaseNative extends Component {
 		const
 			{childRef, containerRef} = this.uiRef,
 			bounds = this.uiRef.getScrollBounds(),
-			spotItem = Spotlight.getCurrent();
+			focusedItem = Spotlight.getCurrent();
 
-		// Should skip scroll by page when spotItem is paging control button of Scrollbar
-		if (spotItem && childRef.containerRef.contains(spotItem)) {
+		// Should skip scroll by page when focusedItem is paging control button of Scrollbar
+		if (focusedItem && childRef.containerRef.contains(focusedItem)) {
 			const
 				// VirtualList and Scroller have a spotlightId on containerRef
 				spotlightId = containerRef.dataset.spotlightId,
-				direction = this.getPageDirection(keyCode),
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
-				spotItemBounds = spotItem.getBoundingClientRect(),
-				endPoint = this.getEndPoint(direction, spotItemBounds, viewportBounds);
+				focusedItemBounds = focusedItem.getBoundingClientRect(),
+				endPoint = this.getEndPoint(direction, focusedItemBounds, viewportBounds);
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
 
-			if (next !== spotItem) {
+			if (next !== focusedItem) {
 				this.animateOnFocus = false;
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem: spotItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
 
 				if (next !== null) {
 					this.animateOnFocus = false;
@@ -496,7 +495,7 @@ class ScrollableBaseNative extends Component {
 				}
 			// For VirtualList
 			} else if (this.childRef.scrollToNextItem) {
-				this.childRef.scrollToNextItem({direction, focusedItem: spotItem, reverseDirection: rDirection, spotlightId});
+				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
 			// Need to check whether an overscroll effect is needed
@@ -529,7 +528,7 @@ class ScrollableBaseNative extends Component {
 			ev.preventDefault();
 			if (!repeat && this.hasFocus()) {
 				direction = this.getPageDirection(keyCode);
-				overscrollEffectRequired = !this.scrollByPage(keyCode);
+				overscrollEffectRequired = !this.scrollByPage(direction);
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus()) {
 			direction = getDirection(keyCode);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -482,12 +482,11 @@ class ScrollableBaseNative extends Component {
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
 
 			if (next !== focusedItem) {
-				this.animateOnFocus = false;
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, scrollBoundHeight: bounds.scrollHeight, spotlightId, viewportBoundHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId, viewportHeight: viewportBounds.height});
 
 				if (next !== null) {
 					this.animateOnFocus = false;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -464,7 +464,6 @@ class ScrollableBaseNative extends Component {
 
 		const
 			{childRef, containerRef} = this.uiRef,
-			bounds = this.uiRef.getScrollBounds(),
 			focusedItem = Spotlight.getCurrent();
 
 		// Should skip scroll by page when focusedItem is paging control button of Scrollbar

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -310,12 +310,12 @@ class ScrollerBase extends Component {
 		return oPoint;
 	}
 
-	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId, viewportBoundHeight}) => {
+	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId, viewportHeight}) => {
 		const endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
 		let candidateNode = null;
 
 		/* Find a spottable item in the next page */
-		endPoint.y += (viewportBoundHeight * (direction === 'down' ? 1 : -1));
+		endPoint.y += (viewportHeight * (direction === 'down' ? 1 : -1));
 		candidateNode = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
 
 		/* Find a spottable item in a whole data */

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -311,26 +311,20 @@ class ScrollerBase extends Component {
 	}
 
 	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId, viewportBoundHeight}) => {
-		const
-			spotItem = Spotlight.getCurrent(),
-			endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
+		const endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
 		let candidateNode = null;
 
 		/* Find a spottable item in the next page */
-		if (direction === 'down') {
-			endPoint.y += viewportBoundHeight;
-		} else {
-			endPoint.y -= viewportBoundHeight;
-		}
+		endPoint.y += (viewportBoundHeight * (direction === 'down' ? 1 : -1));
 		candidateNode = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
 
 		/* Find a spottable item in a whole data */
-		if (candidateNode === spotItem) {
+		if (candidateNode === focusedItem) {
 			candidateNode = getTargetByDirectionFromPosition(direction, endPoint, spotlightId);
 		}
 
 		/* If there is no spottable item next to the current item */
-		if (candidateNode === spotItem) {
+		if (candidateNode === focusedItem) {
 			return null;
 		}
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -316,21 +316,20 @@ class ScrollerBase extends Component {
 			endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
 		let candidateNode = null;
 
-		/* 2. Find spottable item out of viewport */
-		/* 2-1 First, find a spottable item in the next page */
-		if (direction === 'down' || direction === 'right') {
+		/* Find a spottable item in the next page */
+		if (direction === 'down') {
 			endPoint.y += viewportBoundHeight;
 		} else {
 			endPoint.y -= viewportBoundHeight;
 		}
 		candidateNode = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
 
-		/* 2-2 Last, find a spottable item in a whole data */
+		/* Find a spottable item in a whole data */
 		if (candidateNode === spotItem) {
 			candidateNode = getTargetByDirectionFromPosition(direction, endPoint, spotlightId);
 		}
 
-		/* 2-3 If there is no spottable item next to the current item */
+		/* If there is no spottable item next to the current item */
 		if (candidateNode === spotItem) {
 			return null;
 		}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -310,16 +310,32 @@ class ScrollerBase extends Component {
 		return oPoint;
 	}
 
-	scrollToNextPage = ({direction, reverseDirection, focusedItem, spotlightId}) => {
+	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId, viewportBoundHeight}) => {
 		const
-			endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect()),
-			next = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
+			spotItem = Spotlight.getCurrent(),
+			endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
+		let candidateNode = null;
 
-		if (next === focusedItem) {
-			return false; // Scroll one page with animation
+		/* 2. Find spottable item out of viewport */
+		/* 2-1 First, find a spottable item in the next page */
+		if (direction === 'down' || direction === 'right') {
+			endPoint.y += viewportBoundHeight;
 		} else {
-			return next; // Focus a next item
+			endPoint.y -= viewportBoundHeight;
 		}
+		candidateNode = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
+
+		/* 2-2 Last, find a spottable item in a whole data */
+		if (candidateNode === spotItem) {
+			candidateNode = getTargetByDirectionFromPosition(direction, endPoint, spotlightId);
+		}
+
+		/* 2-3 If there is no spottable item next to the current item */
+		if (candidateNode === spotItem) {
+			return null;
+		}
+
+		return candidateNode;
 	}
 
 	scrollToBoundary = (direction) => {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -460,10 +460,6 @@ const VirtualListBaseFactory = (type) => {
 				indexToScroll = this.getIndexToScroll(direction, focusedIndex);
 
 			if (indexToScroll !== -1 && focusedIndex !== indexToScroll) {
-				const
-					isRtl = this.props.rtl,
-					isForward = (direction === 'down' || isRtl && direction === 'left' || !isRtl && direction === 'right');
-
 				if (firstIndex <= indexToScroll && indexToScroll < firstIndex + numOfItems) {
 					const node = this.uiRef.containerRef.querySelector(`[data-index='${indexToScroll}'].spottable`);
 
@@ -478,7 +474,7 @@ const VirtualListBaseFactory = (type) => {
 					focusedItem.blur();
 					this.nodeIndexToBeFocused = this.lastFocusedIndex = indexToScroll;
 				}
-				cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
+				cbScrollTo({index: indexToScroll, stickTo: direction === 'down' ? 'end' : 'start', animate: false});
 			}
 		}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -408,12 +408,11 @@ const VirtualListBaseFactory = (type) => {
 				{dimensionToExtent, primary} = this.uiRef,
 				{findSpottableItem} = this,
 				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo,
-				numOfItemsInPage = (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent),
-				isPageDown = (direction === 'down' || direction === 'right') ? 1 : -1;
+				numOfItemsInPage = (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent);
 			let candidateIndex = -1;
 
 			/* First, find a spottable item in this page */
-			if (isPageDown === 1) { // Page Down
+			if (direction === 'down') { // Page Down
 				if ((lastVisibleIndex - (lastVisibleIndex % dimensionToExtent)) > currentIndex) { // If a current focused item is in the last visible line.
 					candidateIndex = findSpottableItem(
 						lastVisibleIndex,
@@ -429,7 +428,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/* Second, find a spottable item in the next page */
 			if (candidateIndex === -1) {
-				if (isPageDown === 1) { // Page Down
+				if (direction === 'down') { // Page Down
 					candidateIndex = findSpottableItem(lastVisibleIndex + numOfItemsInPage, lastVisibleIndex);
 				} else { // Page Up
 					candidateIndex = findSpottableItem(firstVisibleIndex - numOfItemsInPage, firstVisibleIndex);
@@ -438,7 +437,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/* Last, find a spottable item in a whole data */
 			if (candidateIndex === -1) {
-				if (isPageDown === 1) { // Page Down
+				if (direction === 'down') { // Page Down
 					candidateIndex = findSpottableItem(lastVisibleIndex + numOfItemsInPage + 1, dataSize);
 				} else { // Page Up
 					candidateIndex = findSpottableItem(firstVisibleIndex - numOfItemsInPage - 1, -1);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -486,8 +486,6 @@ const VirtualListBaseFactory = (type) => {
 				}
 				cbScrollTo({index: indexToScroll, stickTo: isForward ? 'end' : 'start', animate: false});
 			}
-
-			return true;
 		}
 
 		/**


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Scroller scrolls differently from VirtualList via page up or down key if it has disabled items.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

1. Find spottable item in viewport
2. Find a spottable item in the next page
3. Find a spottable item in the whole content to the key direction

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

VirtualList and Scroller support page up and down key navigation when they scrolls vertically. So I removed the code to scroll horizontally via page up/down keys in the VirtualList.

### Links
[//]: # (Related issues, references)

ENYO-5419

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)