### PR TITLE
PLAT-63668: Revise Scrollable-related patches

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -569,7 +569,7 @@ class ScrollableBase extends Component {
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
 		// For Scroller
-		if (this.uiRef.scrollToInfo === null && !this.hasOwnProperty(this.childRef.restoreLastFocused) && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -207,12 +207,6 @@ class ScrollableBase extends Component {
 		configureSpotlightContainer(nextProps);
 	}
 
-	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null) {
-			this.calculateAndScrollTo(Spotlight.getCurrent());
-		}
-	}
-
 	componentWillUnmount () {
 		this.stopOverscrollJob('horizontal', 'before');
 		this.stopOverscrollJob('horizontal', 'after');
@@ -291,8 +285,10 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	calculateAndScrollTo = (spotItem) => {
-		const positionFn = this.childRef.calculatePositionOnFocus,
+	calculateAndScrollTo = () => {
+		const
+			spotItem = Spotlight.getCurrent(),
+			positionFn = this.childRef.calculatePositionOnFocus,
 			{containerRef} = this.uiRef.childRef;
 
 		if (spotItem && positionFn && containerRef && containerRef.contains(spotItem)) {
@@ -344,7 +340,7 @@ class ScrollableBase extends Component {
 				spotItem = Spotlight.getCurrent();
 
 			if (item && item === spotItem) {
-				this.calculateAndScrollTo(item);
+				this.calculateAndScrollTo();
 			}
 		} else if (this.childRef.setLastFocusedNode) {
 			this.childRef.setLastFocusedNode(ev.target);
@@ -571,8 +567,9 @@ class ScrollableBase extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null && Spotlight.getPointerMode()) {
-			this.calculateAndScrollTo(Spotlight.getCurrent());
+		// For Scroller
+		if (this.uiRef.scrollToInfo === null && !this.hasOwnProperty(this.childRef.restoreLastFocused) && Spotlight.getPointerMode()) {
+			this.calculateAndScrollTo();
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -568,7 +568,6 @@ class ScrollableBase extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		// For Scroller
 		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -638,7 +638,7 @@ class ScrollableBaseNative extends Component {
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
 		// For Scroller
-		if (this.uiRef.scrollToInfo === null && !this.hasOwnProperty(this.childRef.restoreLastFocused) && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -188,12 +188,6 @@ class ScrollableBaseNative extends Component {
 		configureSpotlightContainer(nextProps);
 	}
 
-	componentDidUpdate () {
-		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null) {
-			this.calculateAndScrollTo(Spotlight.getCurrent());
-		}
-	}
-
 	componentWillUnmount () {
 		this.stopOverscrollJob('horizontal', 'before');
 		this.stopOverscrollJob('horizontal', 'after');
@@ -364,8 +358,10 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	calculateAndScrollTo = (spotItem) => {
-		const positionFn = this.childRef.calculatePositionOnFocus,
+	calculateAndScrollTo = () => {
+		const
+			spotItem = Spotlight.getCurrent(),
+			positionFn = this.childRef.calculatePositionOnFocus,
 			{containerRef} = this.uiRef.childRef;
 
 		if (spotItem && positionFn && containerRef && containerRef.contains(spotItem)) {
@@ -413,7 +409,7 @@ class ScrollableBaseNative extends Component {
 				spotItem = Spotlight.getCurrent();
 
 			if (item && item === spotItem && positionFn) {
-				this.calculateAndScrollTo(item);
+				this.calculateAndScrollTo();
 			}
 		} else if (this.childRef.setLastFocusedNode) {
 			this.childRef.setLastFocusedNode(ev.target);
@@ -640,8 +636,9 @@ class ScrollableBaseNative extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollToInfo === null && this.childRef.nodeIndexToBeFocused == null && Spotlight.getPointerMode()) {
-			this.calculateAndScrollTo(Spotlight.getCurrent());
+		// For Scroller
+		if (this.uiRef.scrollToInfo === null && !this.hasOwnProperty(this.childRef.restoreLastFocused) && Spotlight.getPointerMode()) {
+			this.calculateAndScrollTo();
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -637,7 +637,6 @@ class ScrollableBaseNative extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		// For Scroller
 		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -639,6 +639,8 @@ const VirtualListBaseFactory = (type) => {
 		onKeyDown = (ev) => {
 			const {keyCode, repeat, target} = ev;
 
+			this.isScrolledByJump = false;
+
 			if (getDirection(keyCode)) {
 				ev.preventDefault();
 				this.setSpotlightContainerRestrict(keyCode, target);
@@ -825,22 +827,10 @@ const VirtualListBaseFactory = (type) => {
 				numOfItems > 0 &&
 				(preservedIndex < dataSize) &&
 				(preservedIndex < moreInfo.firstVisibleIndex || preservedIndex > moreInfo.lastVisibleIndex)) {
-				const {firstIndex} = this.uiRef.state;
-
-				// If the preserved index item is already rendered
-				if (firstIndex <= preservedIndex && preservedIndex < firstIndex + numOfItems) {
-					const node = this.uiRef.containerRef.querySelector(`[data-index='${preservedIndex}'].spottable`);
-
-					if (node) {
-						Spotlight.focus(node);
-					}
-				// If the preserved index item is needed to render
-				} else {
-					// If we need to restore last focus and the index is beyond the screen,
-					// we call `scrollTo` to create DOM for it.
-					cbScrollTo({index: preservedIndex, animate: false, focus: true});
-					this.isScrolledByJump = true;
-				}
+				// If we need to restore last focus and the index is beyond the screen,
+				// we call `scrollTo` to create DOM for it.
+				cbScrollTo({index: preservedIndex, animate: false, focus: true});
+				this.isScrolledByJump = true;
 
 				return true;
 			} else {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -843,10 +843,22 @@ const VirtualListBaseFactory = (type) => {
 				numOfItems > 0 &&
 				(preservedIndex < dataSize) &&
 				(preservedIndex < moreInfo.firstVisibleIndex || preservedIndex > moreInfo.lastVisibleIndex)) {
-				// If we need to restore last focus and the index is beyond the screen,
-				// we call `scrollTo` to create DOM for it.
-				cbScrollTo({index: preservedIndex, animate: false, focus: true});
-				this.isScrolledByJump = true;
+				const {firstIndex} = this.uiRef.state;
+
+				// If the preserved index item is already rendered
+				if (firstIndex <= preservedIndex && preservedIndex < firstIndex + numOfItems) {
+					const node = this.uiRef.containerRef.querySelector(`[data-index='${preservedIndex}'].spottable`);
+
+					if (node) {
+						Spotlight.focus(node);
+					}
+				// If the preserved index item is needed to render
+				} else {
+					// If we need to restore last focus and the index is beyond the screen,
+					// we call `scrollTo` to create DOM for it.
+					cbScrollTo({index: preservedIndex, animate: false, focus: true});
+					this.isScrolledByJump = true;
+				}
 
 				return true;
 			} else {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1000,9 +1000,7 @@ class ScrollableBase extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			setTimeout(() => {
-				this.scrollToInfo = null;
-			});
+			this.scrollToInfo = null;
 			this.start({
 				targetX: (left !== null) ? left : this.scrollLeft,
 				targetY: (top !== null) ? top : this.scrollTop,

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1061,9 +1061,7 @@ class ScrollableBaseNative extends Component {
 			if (this.props.scrollTo) {
 				this.props.scrollTo(opt);
 			}
-			setTimeout(() => {
-				this.scrollToInfo = null;
-			});
+			this.scrollToInfo = null;
 			this.start(
 				(left !== null) ? left : this.scrollLeft,
 				(top !== null) ? top : this.scrollTop,


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

1. The patch for ENYO-5442: Needed to remove `setTimeout` if possible and created a new patch
2. The patches for ENYO-3984 and ENYO-5339:  We found some unnecessary code while creating several patches (`moonstone/Scrollable.componentDidUpdate()` is not needed anymore)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

1. The patch for ENYO-5442
: `this.isScrolledByJump` variable could not get a chance to be `false`. Then the bug in ENYO-5442 was reproduced. I fixed it to set `this.isScrolledByJump` variable to `false` when receiving a key event

2. The patches for ENYO-3984 and ENYO-5339
- Removed `moonstone/Scrollable.componentDidUpdate()` because we already covered in `moonstone/Scrollable.handleScrollerUpdate()`.
- Cleanup code.

I verified the bugs in ENYO-5442, ENYO-3984 and ENYO-5339 with this PR.

### Links
[//]: # (Related issues, references)

PLAT-63668

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)