### PR TITLE
ENYO-5481: Spotlight: Blur is not occur when exit window (5 QE)

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Added
+
+- `spotlight` webOS mouse event handler.
+
 ### Changed
 
 - `spotlight` to default to 5-way mode on initialization

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -354,6 +354,12 @@ const Spotlight = (function () {
 		_pointerMoveDuringKeyPress = false;
 	}
 
+	function webOSMouseHandler (ev) {
+		if (ev && ev.detail && ev.detail.type === 'Leave') {
+			onBlur();
+		}
+	}
+
 	function onFocus () {
 		// Normally, there isn't focus here unless the window has been blurred above. On webOS, the
 		// platform may focus the window after the app has already focused a component so we prevent
@@ -482,6 +488,7 @@ const Spotlight = (function () {
 				window.addEventListener('keyup', onKeyUp);
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
+				document.addEventListener('webOSMouse', webOSMouseHandler);
 				setLastContainer(rootContainerId);
 				configureDefaults(containerDefaults);
 				configureContainer(rootContainerId);
@@ -504,6 +511,7 @@ const Spotlight = (function () {
 			window.removeEventListener('keyup', onKeyUp);
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
+			document.removeEventListener('webOSMouse', webOSMouseHandler);
 			Spotlight.clear();
 			_initialized = false;
 		},


### PR DESCRIPTION
### Issue Resolved / Feature Added
ENYO-5481: Spotlight: Blur is not occur when exit window (5 QE)

### Resolution
Added webOSMouseHandler so that spotlight blurs when the mouse leaves.

Enact-DCO-1.0-Signed-off-by: Hailey Ryu <hangyeolryu@lge.com>: