### PR TITLE
PLAT-62487: Add inline support to kinds

### DIFF
--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -124,6 +124,18 @@ const kind = (config) => {
 	// Decorate the Component with the computed property object in DEV for easier testability
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;
 
+	Component.inline = (props, context) => {
+		if (__DEV__ && handlers) {
+			// eslint-disable-next-line
+			console.warn('Cannot use handlers with inline');
+		}
+
+		return Component.prototype.render.apply({
+			props,
+			context,
+			handlers: null
+		});
+	};
 
 	return Component;
 };

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -129,11 +129,19 @@ const kind = (config) => {
 	// Decorate the Component with the computed property object in DEV for easier testability
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;
 
+	const defaultPropKeys = Object.keys(defaultProps);
+
 	Component.inline = (props, context) => {
 		let updated = {
-			...defaultProps,
 			...props
 		};
+
+		defaultPropKeys.forEach(key => {
+			// eslint-disable-next-line no-undefined
+			if (props[key] === undefined) {
+				updated[key] = defaultProps[key];
+			}
+		});
 
 		if (handlers) {
 			// generate a handler with a clone of updated to ensure each handler receives the same

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -130,15 +130,18 @@ const kind = (config) => {
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;
 
 	Component.inline = (props, context) => {
-		const updated = {
+		let updated = {
 			...defaultProps,
 			...props
 		};
 
 		if (handlers) {
-			Object.keys(handlers).forEach(key => {
-				updated[key] = (ev) => handlers[key](ev, props, context);
-			});
+			// generate a handler with a clone of updated to ensure each handler receives the same
+			// props without the kind.handlers injected.
+			updated = Object.keys(handlers).reduce((_props, key) => {
+				_props[key] = (ev) => handlers[key](ev, updated, context);
+				return _props;
+			}, {...updated});
 		}
 
 		return renderKind(updated, context);

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -129,19 +129,21 @@ const kind = (config) => {
 	// Decorate the Component with the computed property object in DEV for easier testability
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;
 
-	const defaultPropKeys = Object.keys(defaultProps);
+	const defaultPropKeys = defaultProps ? Object.keys(defaultProps) : null;
 
 	Component.inline = (props, context) => {
 		let updated = {
 			...props
 		};
 
-		defaultPropKeys.forEach(key => {
-			// eslint-disable-next-line no-undefined
-			if (props[key] === undefined) {
-				updated[key] = defaultProps[key];
-			}
-		});
+		if (defaultPropKeys && defaultPropKeys.length > 0) {
+			defaultPropKeys.forEach(key => {
+				// eslint-disable-next-line no-undefined
+				if (props[key] === undefined) {
+					updated[key] = defaultProps[key];
+				}
+			});
+		}
 
 		if (handlers) {
 			// generate a handler with a clone of updated to ensure each handler receives the same

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -130,6 +130,7 @@ const kind = (config) => {
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;
 
 	const defaultPropKeys = defaultProps ? Object.keys(defaultProps) : null;
+	const handlerKeys = handlers ? Object.keys(handlers) : null;
 
 	Component.inline = (props, context) => {
 		let updated = {
@@ -139,16 +140,16 @@ const kind = (config) => {
 		if (defaultPropKeys && defaultPropKeys.length > 0) {
 			defaultPropKeys.forEach(key => {
 				// eslint-disable-next-line no-undefined
-				if (props[key] === undefined) {
+				if (props == null || props[key] === undefined) {
 					updated[key] = defaultProps[key];
 				}
 			});
 		}
 
-		if (handlers) {
+		if (handlerKeys && handlerKeys.length > 0) {
 			// generate a handler with a clone of updated to ensure each handler receives the same
 			// props without the kind.handlers injected.
-			updated = Object.keys(handlers).reduce((_props, key) => {
+			updated = handlerKeys.reduce((_props, key) => {
 				_props[key] = (ev) => handlers[key](ev, updated, context);
 				return _props;
 			}, {...updated});

--- a/packages/core/kind/tests/kind-specs.js
+++ b/packages/core/kind/tests/kind-specs.js
@@ -93,6 +93,32 @@ describe('kind', () => {
 	});
 
 	describe('inline', function () {
+		it('should support a minimal kind', function () {
+			const Minimal = kind({
+				name: 'Minimal',
+				render: () => <div />
+			});
+
+			const component = Minimal.inline();
+
+			const expected = 'div';
+			const actual = component.type;
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should set default props when prop is not passed', function () {
+			const component = Kind.inline();
+
+			// since we're inlining the output, we have to reference where the label prop lands --
+			// the title prop of the <div> -- rather than the label prop on the component (which
+			// doesn't exist due to inlining).
+			const expected = 'Label';
+			const actual = component.props.title;
+
+			expect(actual).to.equal(expected);
+		});
+
 		it('should set default props when passed prop is undefined', function () {
 			const component = Kind.inline({
 				// explicitly testing settings undefined in this test case
@@ -100,11 +126,17 @@ describe('kind', () => {
 				label: undefined
 			});
 
-			// since we're inlining the output, we have to reference where the label prop lands --
-			// the title prop of the <div> -- rather than the label prop on the component (which
-			// doesn't exist due to inlining).
 			const expected = 'Label';
 			const actual = component.props.title;
+
+			expect(actual).to.equal(expected);
+		});
+
+		it('should include handlers', function () {
+			const component = Kind.inline();
+
+			const expected = 'function';
+			const actual = typeof component.props.onClick;
 
 			expect(actual).to.equal(expected);
 		});

--- a/packages/core/kind/tests/kind-specs.js
+++ b/packages/core/kind/tests/kind-specs.js
@@ -92,4 +92,22 @@ describe('kind', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	describe('inline', function () {
+		it('should set default props when passed prop is undefined', function () {
+			const component = Kind.inline({
+				// explicitly testing settings undefined in this test case
+				// eslint-disable-next-line no-undefined
+				label: undefined
+			});
+
+			// since we're inlining the output, we have to reference where the label prop lands --
+			// the title prop of the <div> -- rather than the label prop on the component (which
+			// doesn't exist due to inlining).
+			const expected = 'Label';
+			const actual = component.props.title;
+
+			expect(actual).to.equal(expected);
+		});
+	});
+
 });

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -11,7 +11,6 @@
  */
 
 import deprecate from '@enact/core/internal/deprecate';
-import {forProp, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import Uppercase from '@enact/i18n/Uppercase';
 import Spottable from '@enact/spotlight/Spottable';
@@ -19,7 +18,6 @@ import {ButtonBase as UiButtonBase, ButtonDecorator as UiButtonDecorator} from '
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import React from 'react';
 
 import Icon from '../Icon';
 import {MarqueeDecorator} from '../Marquee';
@@ -92,13 +90,6 @@ const ButtonBase = kind({
 	styles: {
 		css: componentCss,
 		publicClassNames: ['button', 'bg', 'selected', 'small']
-	},
-
-	handlers: {
-		onClick: handle(
-			forProp('disabled', false),
-			forward('onClick')
-		)
 	},
 
 	computed: {

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -11,6 +11,7 @@
  */
 
 import deprecate from '@enact/core/internal/deprecate';
+import {forProp, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import Uppercase from '@enact/i18n/Uppercase';
 import Spottable from '@enact/spotlight/Spottable';
@@ -93,6 +94,13 @@ const ButtonBase = kind({
 		publicClassNames: ['button', 'bg', 'selected', 'small']
 	},
 
+	handlers: {
+		onClick: handle(
+			forProp('disabled', false),
+			forward('onClick')
+		)
+	},
+
 	computed: {
 		className: ({backgroundOpacity, color, styler}) => styler.append(
 			backgroundOpacity,
@@ -108,14 +116,12 @@ const ButtonBase = kind({
 			deprecation();
 		}
 
-		return (
-			<UiButtonBase
-				data-webos-voice-intent="Select"
-				{...rest}
-				css={css}
-				iconComponent={Icon}
-			/>
-		);
+		return UiButtonBase.inline({
+			'data-webos-voice-intent': 'Select',
+			...rest,
+			css: css,
+			iconComponent: Icon
+		});
 	}
 });
 

--- a/packages/moonstone/Icon/Icon.js
+++ b/packages/moonstone/Icon/Icon.js
@@ -15,7 +15,6 @@ import kind from '@enact/core/kind';
 import UiIcon from '@enact/ui/Icon';
 import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
-import React from 'react';
 
 import Skinnable from '../Skinnable';
 
@@ -34,13 +33,11 @@ import componentCss from './Icon.less';
 const IconBase = kind({
 	name: 'Icon',
 
-	render: (props) => (
-		<UiIcon
-			{...props}
-			css={componentCss}
-			iconList={iconList}
-		/>
-	)
+	render: (props) => UiIcon.inline({
+		...props,
+		css: componentCss,
+		iconList
+	})
 });
 
 // Let's find a way to import this list directly, and bonus feature, render our icons in the docs

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -98,18 +98,15 @@ const IconButtonBase = kind({
 	},
 
 	render: ({children, css, tooltipNode, ...rest}) => {
-		return (
-			<UiIconButtonBase
-				data-webos-voice-intent="Select"
-				{...rest}
-				buttonComponent={<ButtonBase css={css} />}
-				css={css}
-				icon={children}
-				iconComponent={Icon}
-			>
-				{tooltipNode}
-			</UiIconButtonBase>
-		);
+		return UiIconButtonBase.inline({
+			'data-webos-voice-intent': 'Select',
+			...rest,
+			buttonComponent: <ButtonBase css={css} />,
+			css: css,
+			icon: children,
+			iconComponent: Icon,
+			children: tooltipNode
+		});
 	}
 });
 

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -50,10 +50,10 @@ const ButtonBase = kind({
 		css: PropTypes.object,
 
 		/**
-		 * Disables the [ButtonBase]{@link ui/Button.ButtonBase}
+		 * Applies the `disabled` class.
 		 *
-		 * When `true`, the button is shown as disabled and does not
-		 * `onClick` [events]{@link /docs/developer-guide/glossary/#event}.
+		 * Note: Unless wrapped by `Touchable`, the component will still generate `onClick`
+		 * [events]{@link /docs/developer-guide/glossary/#event}.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -7,7 +7,6 @@
  * @exports ButtonDecorator
  */
 
-import {forProp, forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -154,13 +153,6 @@ const ButtonBase = kind({
 				<Icon small={small} className={css.icon}>{icon}</Icon>
 			) : icon;
 		}
-	},
-
-	handlers: {
-		onClick: handle(
-			forProp('disabled', false),
-			forward('onClick')
-		)
 	},
 
 	render: ({children, css, disabled, icon, ...rest}) => {

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -157,17 +157,16 @@ const IconButtonBase = kind({
 			children = null;
 		}
 
-		return (
-			<ComponentOverride
-				{...rest}
-				component={buttonComponent}
-				small={small}
-				minWidth={false}
-			>
-				<Icon small={small} className={css.icon}>{icon}</Icon>
-				{children}
-			</ComponentOverride>
-		);
+		return ComponentOverride({
+			...rest,
+			component: buttonComponent,
+			small: small,
+			minWidth: false,
+			children: [
+				<Icon small={small} className={css.icon}>{icon}</Icon>,
+				children
+			]
+		});
 	}
 });
 

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -164,7 +164,7 @@ const IconButtonBase = kind({
 			minWidth: false,
 			children: [
 				<Icon small={small} className={css.icon}>{icon}</Icon>,
-				children
+				...React.Children.toArray(children)
 			]
 		});
 	}

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -163,7 +163,7 @@ const IconButtonBase = kind({
 			small: small,
 			minWidth: false,
 			children: [
-				<Icon small={small} className={css.icon}>{icon}</Icon>,
+				<Icon key="icon" small={small} className={css.icon}>{icon}</Icon>,
 				...React.Children.toArray(children)
 			]
 		});

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -58,11 +58,11 @@ describe('Slottable Specs', () => {
 	it('should distribute children whose \'type\' has a \'defaultSlot\' property that matches a slot', function () {
 		const Custom = kind({
 			name: 'Custom',
-			render: (props) => {
-				return <div>{props.children}</div>;
+			render: ({children}) => {
+				return <div>{children}</div>;
 			}
 		});
-		Custom.defaultSlot = 'a';
+		Custom.defaultSlot = 'c';
 
 		const Component = Slottable({slots: ['a', 'b', 'c']}, ({a, b, c}) => (
 			<div>
@@ -71,16 +71,16 @@ describe('Slottable Specs', () => {
 				{a}
 			</div>
 		));
+
 		const subject = mount(
 			<Component>
 				<div slot="a">A</div>
 				<div slot="b">B</div>
-				<Custom>D</Custom>
-				<div slot="c">C</div>
+				<Custom>C</Custom>
 			</Component>
 		);
 
-		const expected = 'CBAD';
+		const expected = 'CBA';
 		const actual = subject.text();
 
 		expect(actual).to.equal(expected);


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On low powered devices, the overhead of component layers add up and result in a material performance degradation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
While we can eliminate layers in places, it's beneficial to be able to "inline" functional components, particularly in the `ui` layer, in the themes to reduce layers. This PR adds a currently private static `inline()` method to components created with `core/kind` which can be called to inline the contents of the component into the host rather than introducing another component boundary within React.

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)