### PR TITLE
PLAT-61006: QA-Sampler add forceDirection knob to Marquee

### DIFF
--- a/packages/sampler/stories/qa-stories/Marquee.js
+++ b/packages/sampler/stories/qa-stories/Marquee.js
@@ -39,6 +39,7 @@ storiesOf('Marquee', module)
 					<Marquee
 						style={{width: ri.unit(399, 'rem')}}
 						disabled={disabled}
+						forceDirection={select('forceDirection', ['', 'ltr', 'rtl'], Marquee, '')}
 						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
 						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
@@ -63,6 +64,7 @@ storiesOf('Marquee', module)
 					<Marquee
 						style={{width: ri.unit(399, 'rem')}}
 						disabled={disabled}
+						forceDirection={select('forceDirection', ['', 'ltr', 'rtl'], Marquee, '')}
 						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
 						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
@@ -87,6 +89,7 @@ storiesOf('Marquee', module)
 					{LTR.map((children, index) => (
 						<Marquee
 							disabled={disabled}
+							forceDirection={select('forceDirection', ['', 'ltr', 'rtl'], Marquee, '')}
 							key={index}
 							marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 							marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add `forceDirection` knob to Marquee's QA-sampler


### Links
[//]: # (Related issues, references)
PLAT-61006

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com