### PR TITLE
ENYO-5489: Fix Scrollable to ignore native drag events

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scroller` to prevent scrolling via page up/down keys if there is no spottable component in that direction
 - `moonstone/Dialog` to hide `titleBelow` when `title` is not set
+- `moonstone/Image` to suppress drag and drop support by default
 - `moonstone/VideoPlayer` audio guidance behavior of More button
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 

--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -57,6 +57,7 @@ const ImageBase = kind({
 	render: ({css, ...rest}) => {
 		return (
 			<UiImage
+				draggable="false"
 				{...rest}
 				css={css}
 			/>

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scrollable` to ignore native drag events which interfered with touch drag support
+
 ## [2.0.0-rc.3] - 2018-07-23
 
 No significant changes.

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -531,6 +531,8 @@ class ScrollableBase extends Component {
 	}
 
 	onDragStart = (ev) => {
+		if (ev.type === 'dragstart') return;
+
 		this.stop();
 		this.isDragging = true;
 		this.dragStartX = this.scrollLeft + this.getRtlX(ev.x);
@@ -538,6 +540,8 @@ class ScrollableBase extends Component {
 	}
 
 	onDrag = (ev) => {
+		if (ev.type === 'drag') return;
+
 		const {direction} = this.props;
 
 		this.start({
@@ -547,7 +551,9 @@ class ScrollableBase extends Component {
 		});
 	}
 
-	onDragEnd = () => {
+	onDragEnd = (ev) => {
+		if (ev.type === 'dragend') return;
+
 		this.isDragging = false;
 
 		if (this.flickTarget) {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Certain elements (selected text, images, links) are draggable by default in the web platform. When dragging on those within a scroller, the scroller did not function correctly (at least for scrolling by focus) because the scroller was stuck in "drag" mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Only handle Touchable's synthetic drag events in Scrollable
* Prevent dragging for `moonstone/Image` to minimize future exposure

Enact-DCO-1.0-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)