### PR TITLE
ENYO-5488: ui/Image to require either src or placeholder props

### DIFF
--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -79,7 +79,7 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 		static displayName = 'ResponsiveImageDecorator'
 
 		static propTypes = {
-			src: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
+			src: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 		}
 
 		constructor (props) {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Image` to not require `src` prop if `placeholder` is specified
+- `ui/GridListImageItem` to not require `source` prop
+
 ## [2.0.1] - 2018-08-01
 
 No significant changes.
@@ -15,11 +22,6 @@ No significant changes.
 ### Removed
 
 - `ui/Skinnable.withSkinnableProps` higher-order component
-
-### Changed
-
-- `ui/Image` to require either `placeholder` or `src` props
-- `ui/GridListImageItem` to not require `source` prop
 
 ### Fixed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Image` to require either `placeholder` or `src` props
+
 ## [2.0.0-rc.3] - 2018-07-23
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,13 +4,14 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Removed
+
+- `ui/Skinnable.withSkinnableProps` higher-order component
+
 ### Changed
 
 - `ui/Image` to require either `placeholder` or `src` props
 - `ui/GridListImageItem` to not require `source` prop
-### Removed
-
-- `ui/Skinnable.withSkinnableProps` higher-order component
 
 ### Fixed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Changed
 
 - `ui/Image` to require either `placeholder` or `src` props
+- `ui/GridListImageItem` to not require `source` prop
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -27,15 +27,6 @@ const GridListImageItem = kind({
 
 	propTypes: /** @lends ui/GridListImageItem.GridListImageItem.prototype */ {
 		/**
-		 * The absolute URL path to the image.
-		 *
-		 * @type {String}
-		 * @required
-		 * @public
-		 */
-		source: PropTypes.string.isRequired,
-
-		/**
 		 * The primary caption to be displayed with the image.
 		 *
 		 * @type {String}
@@ -137,6 +128,14 @@ const GridListImageItem = kind({
 		 * @public
 		 */
 		selectionOverlayShowing: PropTypes.bool,
+
+		/**
+		 * The absolute URL path to the image.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		source: PropTypes.string,
 
 		/**
 		 * The second caption line to be displayed with the image.

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -8,6 +8,8 @@
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
+import warning from 'warning';
+
 import {selectSrc} from '../resolution';
 
 import componentCss from './Image.less';
@@ -44,16 +46,6 @@ const ImageBase = kind({
 	name: 'ui:Image',
 
 	propTypes: /** @lends ui/Image.Image.prototype */ {
-		/**
-		 * String value or Object of values used to determine which image will appear on
-		 * a specific screenSize.
-		 *
-		 * @type {String|Object}
-		 * @required
-		 * @public
-		 */
-		src: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-
 		/**
 		 * Sets the aria-label for the image. If unset, it defaults to the value of `alt`
 		 *
@@ -132,12 +124,23 @@ const ImageBase = kind({
 		 * @default 'fill'
 		 * @public
 		 */
-		sizing: PropTypes.oneOf(['fit', 'fill', 'none'])
+		sizing: PropTypes.oneOf(['fit', 'fill', 'none']),
+
+		/**
+		 * String value or Object of values used to determine which image will appear on
+		 * a specific screenSize.
+		 *
+		 * @type {String|Object}
+		 * @required
+		 * @public
+		 */
+		src: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 	},
 
 	defaultProps: {
 		placeholder: '',
-		sizing: 'fill'
+		sizing: 'fill',
+		src: ''
 	},
 
 	styles: {
@@ -147,10 +150,11 @@ const ImageBase = kind({
 	},
 
 	computed: {
-		bgImage: ({src, placeholder}) => {
-			const imageSrc = selectSrc(src);
+		bgImage: ({placeholder, src}) => {
+			const imageSrc = selectSrc(src) || placeholder;
+			warning(imageSrc, 'Image requires that either the "placeholder" or "src" props be specified.');
 			if (!imageSrc) return null;
-			return placeholder ? `url("${imageSrc}"), url("${placeholder}")` : `url("${imageSrc}")`;
+			return placeholder && imageSrc !== placeholder ? `url("${imageSrc}"), url("${placeholder}")` : `url("${imageSrc}")`;
 		},
 		className: ({className, sizing, styler}) => {
 			return sizing !== 'none' ? styler.append(sizing) : className;

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -46,7 +46,9 @@ const ImageBase = kind({
 
 	propTypes: /** @lends ui/Image.Image.prototype */ {
 		/**
-		 * Sets the aria-label for the image. If unset, it defaults to the value of `alt`
+		 * The aria-label for the image.
+		 *
+		 * If unset, it defaults to the value of `alt`.
 		 *
 		 * @type {String}
 		 * @public
@@ -104,6 +106,7 @@ const ImageBase = kind({
 
 		/**
 		 * A placeholder image to be displayed before the image is loaded.
+		 *
 		 * For performance purposes, it should be pre-loaded or be a data url. If `src` is
 		 * unset, this value will be used as the `background-image`.
 		 *

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -131,7 +131,6 @@ const ImageBase = kind({
 		 * a specific screenSize.
 		 *
 		 * @type {String|Object}
-		 * @required
 		 * @public
 		 */
 		src: PropTypes.oneOfType([PropTypes.string, PropTypes.object])

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -105,7 +105,8 @@ const ImageBase = kind({
 
 		/**
 		 * A placeholder image to be displayed before the image is loaded.
-		 * For performance purposes, it should be pre-loaded or be a data url.
+		 * For performance purposes, it should be pre-loaded or be a data url. If `src` is
+		 * unset, this value will be used as the `background-image`.
 		 *
 		 * @type {String}
 		 * @default ''
@@ -138,8 +139,7 @@ const ImageBase = kind({
 
 	defaultProps: {
 		placeholder: '',
-		sizing: 'fill',
-		src: ''
+		sizing: 'fill'
 	},
 
 	styles: {


### PR DESCRIPTION
### Issue Resolved / Feature Added
`ui/Image` cannot display placeholder images when `src` is not set.

### Resolution
The `src` prop was marked as required before the implementation of `placeholder`. Since then, we were unable to display placeholders in cases where the source is not yet known. This fix provides a fallback to `placeholder` in those cases, which aids developers when dealing with delayed images. A `warning` is applied, requiring either of the 2 props to be specified, to make up for removing `.isRequired` on the `src` prop-type.

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>