### PR TITLE
ENYO-5493: Fix Dialog read order

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` audio guidance behavior of More button
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 - `moonstone/Popup` to spot the content after it's mounted
+- `moonstone/Dialog` to properly reading order of dialog prop `buttons` and `children`
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+## Fixed
+
+- `moonstone/Dialog` read order of dialog contents
+
 ## [2.0.0] - 2018-07-30
 
 ### Added
@@ -18,7 +24,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 - `moonstone/Popup` to spot the content after it's mounted
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via voice control in RTL locales
-- `moonstone/Dialog` to read properly with reading order of dialog prop `buttons` and `children`
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,8 +17,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` audio guidance behavior of More button
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 - `moonstone/Popup` to spot the content after it's mounted
-- `moonstone/Dialog` to properly reading order of dialog prop `buttons` and `children`
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via voice control in RTL locales
+- `moonstone/Dialog` to properly reading order of dialog prop `buttons` and `children`
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -18,7 +18,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle focus properly via page up/down keys when switching to 5-way mode
 - `moonstone/Popup` to spot the content after it's mounted
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via voice control in RTL locales
-- `moonstone/Dialog` to properly reading order of dialog prop `buttons` and `children`
+- `moonstone/Dialog` to read properly with reading order of dialog prop `buttons` and `children`
 
 ## [2.0.0-rc.3] - 2018-07-23
 

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -185,28 +185,35 @@ const DialogBase = kind({
 
 	computed: {
 		className: ({noDivider, styler}) => styler.append({showDivider: !noDivider}),
+		generateId: () => () => Math.random().toString(36).substr(2, 8),
 		titleBelow: ({title, titleBelow}) => title ? titleBelow : ''
 	},
 
-	render: ({buttons, casing, css, children, title, titleBelow, ...rest}) => {
+	render: ({buttons, casing, css, children, generateId, title, titleBelow, ...rest}) => {
 		delete rest.noDivider;
 
+		const
+			buttonsId = generateId(),
+			childrenId = generateId(),
+			titleBelowId = generateId(),
+			titleId = generateId();
+
 		return (
-			<Popup {...rest} css={css}>
+			<Popup {...rest} aria-labelledby={`${titleId} ${titleBelowId} ${childrenId} ${buttonsId}`} css={css}>
 				<div className={css.titleWrapper}>
 					<div className={css.titleBlock}>
-						<MarqueeH1 casing={casing} marqueeOn="render" marqueeOnRenderDelay={5000} className={css.title}>
+						<MarqueeH1 casing={casing} marqueeOn="render" marqueeOnRenderDelay={5000} className={css.title} id={titleId}>
 							{title}
 						</MarqueeH1>
-						<h2 className={css.titleBelow}>
+						<h2 className={css.titleBelow} id={titleBelowId}>
 							{titleBelow}
 						</h2>
 					</div>
-					<div className={css.buttons}>
+					<div className={css.buttons} id={buttonsId}>
 						{buttons}
 					</div>
 				</div>
-				<div className={css.body}>
+				<div className={css.body} id={childrenId}>
 					{children}
 				</div>
 			</Popup>

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -17,6 +17,12 @@ import Popup from '../Popup';
 
 import componentCss from './Dialog.less';
 
+/*
+ * If two or more Dialogs are rendered on one screen,
+ * the same ID can be generated.
+ */
+const id = Math.random().toString(36).substr(2, 8);
+
 const MarqueeH1 = Uppercase(MarqueeDecorator('h1'));
 
 /**
@@ -185,35 +191,28 @@ const DialogBase = kind({
 
 	computed: {
 		className: ({noDivider, styler}) => styler.append({showDivider: !noDivider}),
-		generateId: () => () => Math.random().toString(36).substr(2, 8),
 		titleBelow: ({title, titleBelow}) => title ? titleBelow : ''
 	},
 
-	render: ({buttons, casing, css, children, generateId, title, titleBelow, ...rest}) => {
+	render: ({buttons, casing, css, children, title, titleBelow, ...rest}) => {
 		delete rest.noDivider;
 
-		const
-			buttonsId = generateId(),
-			childrenId = generateId(),
-			titleBelowId = generateId(),
-			titleId = generateId();
-
 		return (
-			<Popup {...rest} aria-labelledby={`${titleId} ${titleBelowId} ${childrenId} ${buttonsId}`} css={css}>
+			<Popup {...rest} aria-labelledby={`${id}_title ${id}_titleBelow ${id}_children ${id}_buttons`} css={css}>
 				<div className={css.titleWrapper}>
 					<div className={css.titleBlock}>
-						<MarqueeH1 casing={casing} marqueeOn="render" marqueeOnRenderDelay={5000} className={css.title} id={titleId}>
+						<MarqueeH1 casing={casing} marqueeOn="render" marqueeOnRenderDelay={5000} className={css.title} id={`${id}_title`}>
 							{title}
 						</MarqueeH1>
-						<h2 className={css.titleBelow} id={titleBelowId}>
+						<h2 className={css.titleBelow} id={`${id}_titleBelow`}>
 							{titleBelow}
 						</h2>
 					</div>
-					<div className={css.buttons} id={buttonsId}>
+					<div className={css.buttons} id={`${id}_buttons`}>
 						{buttons}
 					</div>
 				</div>
-				<div className={css.body} id={childrenId}>
+				<div className={css.body} id={`${id}_children`}>
 					{children}
 				</div>
 			</Popup>

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -80,7 +80,7 @@ const DialogBase = kind({
 		css: PropTypes.object,
 
 		/**
-		 * The dialog id reference for setting aria-labelledby.
+		 * The id of dialog referred to when generating ids for `'title'`, `'titleBelow'`, `'children'`, and `'buttons'`.
 		 *
 		 * @type {String}
 		 * @private

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -6,22 +6,17 @@
  * @exports DialogBase
  */
 
+import IdProvider from '@enact/moonstone/internal/IdProvider';
 import kind from '@enact/core/kind';
-import Uppercase from '@enact/i18n/Uppercase';
-import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Slottable from '@enact/ui/Slottable';
+import Uppercase from '@enact/i18n/Uppercase';
 
 import {MarqueeDecorator} from '../Marquee';
 import Popup from '../Popup';
 
 import componentCss from './Dialog.less';
-
-/*
- * If two or more Dialogs are rendered on one screen,
- * the same ID can be generated.
- */
-const id = Math.random().toString(36).substr(2, 8);
 
 const MarqueeH1 = Uppercase(MarqueeDecorator('h1'));
 
@@ -83,6 +78,14 @@ const DialogBase = kind({
 		 * @private
 		 */
 		css: PropTypes.object,
+
+		/**
+		 * The dialog id reference for setting aria-labelledby.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		id: PropTypes.string,
 
 		/**
 		 * Disables animating the dialog on or off screen.
@@ -194,7 +197,7 @@ const DialogBase = kind({
 		titleBelow: ({title, titleBelow}) => title ? titleBelow : ''
 	},
 
-	render: ({buttons, casing, css, children, title, titleBelow, ...rest}) => {
+	render: ({buttons, casing, css, children, id, title, titleBelow, ...rest}) => {
 		delete rest.noDivider;
 
 		return (
@@ -250,9 +253,12 @@ const DialogBase = kind({
  * @ui
  * @public
  */
-const Dialog = Slottable(
-	{slots: ['title', 'titleBelow', 'buttons']},
-	DialogBase
+const Dialog = IdProvider(
+	{generateProp: null, prefix: 'd_'},
+	Slottable(
+		{slots: ['title', 'titleBelow', 'buttons']},
+		DialogBase
+	)
 );
 
 export default Dialog;

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -6,13 +6,13 @@
  * @exports DialogBase
  */
 
-import IdProvider from '@enact/moonstone/internal/IdProvider';
 import kind from '@enact/core/kind';
+import Uppercase from '@enact/i18n/Uppercase';
+import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Slottable from '@enact/ui/Slottable';
-import Uppercase from '@enact/i18n/Uppercase';
 
+import IdProvider from '../internal/IdProvider';
 import {MarqueeDecorator} from '../Marquee';
 import Popup from '../Popup';
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fixed the reading order of Dialog's prop `buttons` and `children`
- AS-IS
  - Title + TitleBelow + **Buttons + Children** + Focused button
- TO-BE
  - Title + TitleBelow + **Children + Buttons** + Focused button

### Resolution
- Set a unique id(Using IdProvider) for each props(title, titleBelow, buttons, and children)
- Set the id to aria-labelledby according to reading order

### Links
ENYO-5493

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)