### PR TITLE
ENYO-5505 - Added back the class for button tap area

### DIFF
--- a/packages/sampler/stories/qa-stories/Button.js
+++ b/packages/sampler/stories/qa-stories/Button.js
@@ -99,6 +99,7 @@ storiesOf('Button', module)
 		() => (
 			<div>
 				<Button
+					className={css.tapArea}
 					onClick={action('onClick')}
 					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 					casing={select('casing', prop.casing, Config, 'upper')}
@@ -111,6 +112,7 @@ storiesOf('Button', module)
 					Normal Button
 				</Button>
 				<Button
+					className={css.tapArea}
 					onClick={action('onClick')}
 					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 					casing={select('casing', prop.casing, Config, 'upper')}


### PR DESCRIPTION
### Issue Resolved / Feature Added
We accidentally removed the class for tap area on QA Sampler.


### Resolution
Added tap area back to the sample

### Links
ENYO-5505


