### PR TITLE
ENYO-5496: Reset key down hold when media becomes unavailable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VideoPlayer` to reset key down hold when media becomes unavailable
 - `moonstone/Scroller` to prevent scrolling via page up/down keys if there is no spottable component in that direction
 - `moonstone/Dialog` to hide `titleBelow` when `title` is not set
 - `moonstone/Image` to suppress drag and drop support by default

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -682,6 +682,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 					Spotlight.focus(this.props.moreButtonSpotlightId);
 				}
 			}
+
+			// if media controls disabled, reset key loop
+			if (!prevProps.mediaDisabled && this.props.mediaDisabled) {
+				this.stopListeningForPulses();
+				this.paused.resume();
+			}
 		}
 
 		componentWillUnmount () {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In many cases, apps switch to the next video when the media has reached the end.  When switching videos, `VideoPlayer/MediaControls` will be disabled until there's enough data loaded to play. And if it were caused by a jump with the right key down, then there's a chance the key up handle is ignored because key events do not get handled while disabled.

related:  #1713

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reset key down hold loop when `MediaControls` becomes disabled.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
