### PR TITLE
ENYO-5511: Add VideoPlayer prop to disable play/pause button

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
+
 ## [2.0.1] - 2018-08-01
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/VideoPlayer.MediaControls` property `playPauseButtonDisabled`
+
+### Fixed
+
+- `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
+
 ## [2.0.0] - 2018-07-30
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [2.0.2] - 2018-13-01
+## [unreleased]
 
 ### Added
 
@@ -11,6 +11,11 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
+
+## [2.0.2] - 2018-13-01
+
+### Fixed
+
 - `moonstone/DatePicker` to correctly change year when `minYear` and `maxYear` aren't provided
 - `moonstone/EditableIntegerPicker` management of spotlight pointer mode
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` to have proper spacing and label-alignment with all label positions

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,14 +7,11 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VideoPlayer.MediaControls` property `playPauseButtonDisabled`
-
-### Fixed
-
-- `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
 - `moonstone/VideoPlayer` property `noMediaSliderFeedback`
 
 ### Fixed
 
+- `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
 
 ## [2.0.2] - 2018-13-01

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,8 +11,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
-### Fixed
-
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -277,7 +277,7 @@ const MediaControlsBase = kind({
 		playIcon: PropTypes.string,
 
 		/**
-		 * Disables state on the media "play"/"pause" button
+		 * Disables the media "play"/"pause" button.
 		 *
 		 * @type {Boolean}
 		 * @public
@@ -317,7 +317,7 @@ const MediaControlsBase = kind({
 		spotlightDisabled: PropTypes.bool,
 
 		/**
-		 * A custom media controls container ID to use with Spotlight.
+		 * The spotlight ID for the media controls container.
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -584,6 +584,14 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			paused: PropTypes.bool,
 
 			/**
+			 * Disables state on the media "play"/"pause" button
+			 *
+			 * @type {Boolean}
+			 * @public
+			 */
+			playPauseButtonDisabled: PropTypes.bool,
+
+			/**
 			 * Disables the media playback-rate control buttons; the inner pair.
 			 *
 			 * @type {Boolean}
@@ -730,6 +738,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				moreButtonSpotlightId,
 				no5WayJump,
 				noRateButtons,
+				playPauseButtonDisabled,
 				rateButtonsDisabled,
 				visible
 			} = this.props;
@@ -741,10 +750,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				this.toggleMoreComponents();
 			}
 
-			if (is('play', ev.keyCode)) {
-				forward('onPlay', ev, this.props);
-			} else if (is('pause', ev.keyCode)) {
-				forward('onPause', ev, this.props);
+			if (!playPauseButtonDisabled) {
+				if (is('play', ev.keyCode)) {
+					forward('onPlay', ev, this.props);
+				} else if (is('pause', ev.keyCode)) {
+					forward('onPause', ev, this.props);
+				}
 			}
 
 			if (!no5WayJump && (is('left', ev.keyCode) || is('right', ev.keyCode))) {

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -22,6 +22,15 @@ import {countReactChildren} from './util';
 
 import css from './VideoPlayer.less';
 
+const OuterContainer = SpotlightContainerDecorator({
+	enterTo: 'default-element',
+	defaultElement: [
+		`.${css.leftComponents} .${spotlightDefaultClass}`,
+		`.${css.rightComponents} .${spotlightDefaultClass}`,
+		`.${spotlightDefaultClass}`,
+		`.${css.mediaControls} > .spottable`
+	]
+}, 'div');
 const Container = SpotlightContainerDecorator({enterTo: ''}, 'div');
 const MediaButton = onlyUpdateForKeys([
 	'children',
@@ -308,6 +317,15 @@ const MediaControlsBase = kind({
 		spotlightDisabled: PropTypes.bool,
 
 		/**
+		 * A custom media controls container ID to use with Spotlight.
+		 *
+		 * @type {String}
+		 * @public
+		 * @default 'mediaControls'
+		 */
+		spotlightId: PropTypes.string,
+
+		/**
 		 * The visibility of the component. When `false`, the component will be hidden.
 		 *
 		 * @type {Boolean}
@@ -322,6 +340,7 @@ const MediaControlsBase = kind({
 		forwardIcon: 'forward',
 		jumpBackwardIcon: 'skipbackward',
 		jumpForwardIcon: 'skipforward',
+		spotlightId: 'mediaControls',
 		moreButtonCloseLabel: $L('Back'),
 		moreButtonColor: 'blue',
 		moreButtonLabel: $L('More'),
@@ -377,6 +396,7 @@ const MediaControlsBase = kind({
 		rightComponents,
 		showMoreComponents,
 		spotlightDisabled,
+		spotlightId,
 		...rest
 	}) => {
 		delete rest.moreButtonCloseLabel;
@@ -385,7 +405,7 @@ const MediaControlsBase = kind({
 		delete rest.visible;
 
 		return (
-			<div {...rest} data-media-controls>
+			<OuterContainer {...rest} spotlightId={spotlightId}>
 				<div className={css.leftComponents}>{leftComponents}</div>
 				<div className={css.centerComponentsContainer}>
 					<div className={centerClassName}>
@@ -420,7 +440,7 @@ const MediaControlsBase = kind({
 						</MediaButton>
 					) : null}
 				</div>
-			</div>
+			</OuterContainer>
 		);
 	}
 });

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -28,7 +28,7 @@ const OuterContainer = SpotlightContainerDecorator({
 		`.${css.leftComponents} .${spotlightDefaultClass}`,
 		`.${css.rightComponents} .${spotlightDefaultClass}`,
 		`.${spotlightDefaultClass}`,
-		`.${css.mediaControls} > .spottable`
+		`.${css.mediaControls} *`
 	]
 }, 'div');
 const Container = SpotlightContainerDecorator({enterTo: ''}, 'div');

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -268,6 +268,14 @@ const MediaControlsBase = kind({
 		playIcon: PropTypes.string,
 
 		/**
+		 * Disables state on the media "play"/"pause" button
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		playPauseButtonDisabled: PropTypes.bool,
+
+		/**
 		 * Disables the media playback-rate control buttons; the inner pair.
 		 *
 		 * @type {Boolean}
@@ -363,6 +371,7 @@ const MediaControlsBase = kind({
 		paused,
 		pauseIcon,
 		playIcon,
+		playPauseButtonDisabled,
 		playPauseClassName,
 		rateButtonsDisabled,
 		rightComponents,
@@ -383,7 +392,7 @@ const MediaControlsBase = kind({
 						<Container className={css.mediaControls} spotlightDisabled={showMoreComponents || spotlightDisabled}>
 							{noJumpButtons ? null : <MediaButton aria-label={$L('Previous')} backgroundOpacity="translucent" disabled={mediaDisabled || jumpButtonsDisabled} onClick={onJumpBackwardButtonClick} spotlightDisabled={spotlightDisabled}>{jumpBackwardIcon}</MediaButton>}
 							{noRateButtons ? null : <MediaButton aria-label={$L('Rewind')} backgroundOpacity="translucent" disabled={mediaDisabled || rateButtonsDisabled} onClick={onBackwardButtonClick} spotlightDisabled={spotlightDisabled}>{backwardIcon}</MediaButton>}
-							<MediaButton aria-label={paused ? $L('Play') : $L('Pause')} className={playPauseClassName} backgroundOpacity="translucent" disabled={mediaDisabled} onClick={onPlayButtonClick} spotlightDisabled={spotlightDisabled}>{paused ? playIcon : pauseIcon}</MediaButton>
+							<MediaButton aria-label={paused ? $L('Play') : $L('Pause')} className={playPauseClassName} backgroundOpacity="translucent" disabled={mediaDisabled || playPauseButtonDisabled} onClick={onPlayButtonClick} spotlightDisabled={spotlightDisabled}>{paused ? playIcon : pauseIcon}</MediaButton>
 							{noRateButtons ? null : <MediaButton aria-label={$L('Fast Forward')} backgroundOpacity="translucent" disabled={mediaDisabled || rateButtonsDisabled} onClick={onForwardButtonClick} spotlightDisabled={spotlightDisabled}>{forwardIcon}</MediaButton>}
 							{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="translucent" disabled={mediaDisabled || jumpButtonsDisabled} onClick={onJumpForwardButtonClick} spotlightDisabled={spotlightDisabled}>{jumpForwardIcon}</MediaButton>}
 						</Container>

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -154,6 +154,7 @@ storiesOf('Moonstone', module)
 							noRateButtons={boolean('noRateButtons', MediaControlsConfig)}
 							pauseIcon={select('pauseIcon', icons, MediaControlsConfig, 'pause')}
 							playIcon={select('playIcon', icons, MediaControlsConfig, 'play')}
+							playPauseButtonDisabled={boolean('playPauseButtonDisabled', MediaControlsConfig)}
 							rateButtonsDisabled={boolean('rateButtonsDisabled', MediaControlsConfig)}
 						>
 							<leftComponents><IconButton backgroundOpacity="translucent">fullscreen</IconButton></leftComponents>


### PR DESCRIPTION
### Checklist

- [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
- [x] I have included the [Enact DCO](http://enactjs.com/docs/developer-guide/contributing/dco/) sign-off on each commit or in this Pull Request
- [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
- [ ] At least one test case is included for this feature or bug fix
- [x] Documentation was added or is not needed

- [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's no way to only disable play/pause button. Added `playPauseButtonDisabled` property in `MediaControlsBase`.

Note that if play/pause button is disabled, spotlight needs to fallback to focus on other spottable item in playback controls. Changed the outer wrapper of `MediaControls` to `SpotlightContainer` with the default spotlight behavior configured to the spec.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>