### PR TITLE
ENYO-5480: Prevent unexpected scrolling when updated by app

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to prevent scrolling when hovering the truncated spottable item
+- `moonstone/Scroller` to prevent unexpected scrolling when updated by app
 - `moonstone/Scroller` to go to next page properly via page up/down keys
 
 ## [2.0.0] - 2018-07-30

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to prevent scrolling based on focused item when hovering the item
+- `moonstone/Scroller` to prevent scrolling hovering the truncated spottable item
 
 ## [2.0.0] - 2018-07-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [2.0.1] - 2018-08-01
+## [unreleased]
 
 ### Fixed
 
 - `moonstone/Scroller` to prevent unexpected scrolling when updated by app
+
+## [2.0.1] - 2018-08-01
+
+### Fixed
+
 - `moonstone/Dialog` read order of dialog contents
 - `moonstone/Scroller` to go to next page properly via page up/down keys
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to prevent scrolling hovering the truncated spottable item
+- `moonstone/Scroller` to prevent scrolling when hovering the truncated spottable item
 
 ## [2.0.0] - 2018-07-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to prevent scrolling based on focused item when hovering the item
+
 ## [2.0.0] - 2018-07-30
 
 ### Added

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -311,7 +311,6 @@ class ScrollableBase extends Component {
 
 			if (pos && (pos.left !== this.uiRef.scrollLeft || pos.top !== this.uiRef.scrollTop)) {
 				this.startScrollOnFocus(pos);
-				this.uiRef.isInvalidated = false;
 			}
 
 			// update `scrollHeight`
@@ -551,6 +550,7 @@ class ScrollableBase extends Component {
 	handleScrollerUpdate = () => {
 		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
+			this.uiRef.isInvalidated = false;
 		}
 	}
 
@@ -735,6 +735,7 @@ class ScrollableBase extends Component {
 				clearOverscrollEffect={this.clearOverscrollEffect}
 				onFlick={this.onFlick}
 				onKeyDown={this.onKeyDown}
+				onUpdate={this.handleScrollerUpdate}
 				onWheel={this.onWheel}
 				ref={this.initUiRef}
 				removeEventListeners={this.removeEventListeners}
@@ -773,7 +774,6 @@ class ScrollableBase extends Component {
 									initUiChildRef,
 									isVerticalScrollbarVisible,
 									onScroll: handleScroll,
-									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
 									rtl,
 									spotlightId

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -548,9 +548,8 @@ class ScrollableBase extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollOnFocusInPointerMode && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
-			this.uiRef.scrollOnFocusInPointerMode = false;
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -311,6 +311,7 @@ class ScrollableBase extends Component {
 
 			if (pos && (pos.left !== this.uiRef.scrollLeft || pos.top !== this.uiRef.scrollTop)) {
 				this.startScrollOnFocus(pos);
+				this.uiRef.isInvalidated = false;
 			}
 
 			// update `scrollHeight`
@@ -548,7 +549,7 @@ class ScrollableBase extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -548,9 +548,9 @@ class ScrollableBase extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollOnFocusInPointerMode && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
-			this.uiRef.isInvalidated = false;
+			this.uiRef.scrollOnFocusInPointerMode = false;
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -384,6 +384,7 @@ class ScrollableBaseNative extends Component {
 
 			if (pos && (pos.left !== this.uiRef.scrollLeft || pos.top !== this.uiRef.scrollTop)) {
 				this.startScrollOnFocus(pos);
+				this.uiRef.isInvalidated = false;
 			}
 
 			// update `scrollHeight`
@@ -617,7 +618,7 @@ class ScrollableBaseNative extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -617,9 +617,9 @@ class ScrollableBaseNative extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollOnFocusInPointerMode && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
-			this.uiRef.isInvalidated = false;
+			this.uiRef.scrollOnFocusInPointerMode = false;
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -617,9 +617,8 @@ class ScrollableBaseNative extends Component {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
-		if (this.uiRef.scrollOnFocusInPointerMode && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
+		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
-			this.uiRef.scrollOnFocusInPointerMode = false;
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -384,7 +384,6 @@ class ScrollableBaseNative extends Component {
 
 			if (pos && (pos.left !== this.uiRef.scrollLeft || pos.top !== this.uiRef.scrollTop)) {
 				this.startScrollOnFocus(pos);
-				this.uiRef.isInvalidated = false;
 			}
 
 			// update `scrollHeight`
@@ -620,6 +619,7 @@ class ScrollableBaseNative extends Component {
 	handleScrollerUpdate = () => {
 		if (this.uiRef.isInvalidated && this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			this.calculateAndScrollTo();
+			this.uiRef.isInvalidated = false;
 		}
 	}
 
@@ -809,6 +809,7 @@ class ScrollableBaseNative extends Component {
 				onFlick={this.onFlick}
 				onKeyDown={this.onKeyDown}
 				onMouseDown={this.onMouseDown}
+				onUpdate={this.handleScrollerUpdate}
 				onWheel={this.onWheel}
 				ref={this.initUiRef}
 				removeEventListeners={this.removeEventListeners}
@@ -846,7 +847,6 @@ class ScrollableBaseNative extends Component {
 									className: componentCss.scrollableFill,
 									isVerticalScrollbarVisible,
 									initUiChildRef,
-									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
 									rtl,
 									spotlightId

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -59,27 +59,12 @@ class ScrollerBase extends Component {
 		initUiChildRef: PropTypes.func,
 
 		/**
-		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
-		 *
-		 * @type {function}
-		 * @private
-		 */
-		onUpdate: PropTypes.func,
-
-		/**
 		 * `true` if rtl, `false` if ltr.
 		 *
 		 * @type {Boolean}
 		 * @private
 		 */
 		rtl: PropTypes.bool
-	}
-
-	componentDidUpdate () {
-		const {onUpdate} = this.props;
-		if (onUpdate) {
-			onUpdate();
-		}
 	}
 
 	componentWillUnmount () {

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -143,24 +143,4 @@ describe('Scroller', () => {
 			expect(actual).to.equal(expected);
 		});
 	});
-
-	describe('ScrollerBase API', () => {
-		it('should call onUpdate when Scroller updates', function () {
-			const handleUpdate = sinon.spy();
-			const subject = shallow(
-				<ScrollerBase
-					onUpdate={handleUpdate}
-				>
-					{contents}
-				</ScrollerBase>
-			);
-
-			subject.setProps({children: ''});
-
-			const expected = true;
-			const actual = handleUpdate.calledOnce;
-
-			expect(expected).to.equal(actual);
-		});
-	});
 });

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -1,8 +1,7 @@
-import sinon from 'sinon';
-import {mount, shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import React from 'react';
 
-import Scroller, {ScrollerBase} from '../Scroller';
+import Scroller from '../Scroller';
 
 describe('Scroller', () => {
 	let contents;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -418,7 +418,7 @@ class ScrollableBase extends Component {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
 		} else if (!this.updateScrollbars()) {
-			if (this.shouldUpdateScroller === true && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			if (this.shouldUpdateScroller && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
 				// For Scroller
 				onUpdate();
 			}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -446,6 +446,7 @@ class ScrollableBase extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
+		this.isInvalidated = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -481,6 +482,7 @@ class ScrollableBase extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
+	isInvalidated = false
 
 	// overscroll
 	overscrollStatus = {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -260,7 +260,7 @@ class ScrollableBase extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when invalidating [Scroller]{@link moonstone/Scroller.Scroller}'s bounds
+		 * Called when invalidating [Scroller]{@link ui/Scroller.Scroller}'s bounds
 		 *
 		 * @type {function}
 		 * @private
@@ -335,6 +335,7 @@ class ScrollableBase extends Component {
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
+		onUpdate: nop,
 		verticalScrollbar: 'auto'
 	}
 
@@ -413,10 +414,15 @@ class ScrollableBase extends Component {
 			hasDataSizeChanged === false &&
 			(isHorizontalScrollbarVisible && !prevState.isHorizontalScrollbarVisible || isVerticalScrollbarVisible && !prevState.isVerticalScrollbarVisible)
 		) {
+			// For VirtualList
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else if (!this.updateScrollbars() && onUpdate && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
-			onUpdate();
+		} else if (!this.updateScrollbars()) {
+			if (this.shouldUpdateScroller === true && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+				// For Scroller
+				onUpdate();
+			}
+			this.shouldUpdateScroller = false;
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -455,7 +461,7 @@ class ScrollableBase extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
-		this.scrollOnFocusInPointerMode = true;
+		this.shouldUpdateScroller = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -491,7 +497,7 @@ class ScrollableBase extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	scrollOnFocusInPointerMode = false
+	shouldUpdateScroller = false
 
 	// overscroll
 	overscrollStatus = {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -260,6 +260,14 @@ class ScrollableBase extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
+		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
+		 *
+		 * @type {function}
+		 * @private
+		 */
+		onUpdate: PropTypes.func,
+
+		/**
 		 * Called when wheeling.
 		 *
 		 * @type {Function}
@@ -406,8 +414,8 @@ class ScrollableBase extends Component {
 		) {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else {
-			this.updateScrollbars();
+		} else if (!this.updateScrollbars() && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			this.props.onUpdate();
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -1085,6 +1093,8 @@ class ScrollableBase extends Component {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
 		}
+
+		return isVisibilityChanged;
 	}
 
 	updateScrollThumbSize = () => {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -260,7 +260,7 @@ class ScrollableBase extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
+		 * Called when invalidating [Scroller]{@link moonstone/Scroller.Scroller}'s bounds
 		 *
 		 * @type {function}
 		 * @private
@@ -393,6 +393,7 @@ class ScrollableBase extends Component {
 
 	componentDidUpdate (prevProps, prevState) {
 		const
+			{onUpdate} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			{hasDataSizeChanged} = this.childRef;
 
@@ -414,8 +415,8 @@ class ScrollableBase extends Component {
 		) {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else if (!this.updateScrollbars() && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
-			this.props.onUpdate();
+		} else if (!this.updateScrollbars() && onUpdate && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			onUpdate();
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -454,7 +455,7 @@ class ScrollableBase extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
-		this.isInvalidated = true;
+		this.scrollOnFocusInPointerMode = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -490,7 +491,7 @@ class ScrollableBase extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	isInvalidated = false
+	scrollOnFocusInPointerMode = false
 
 	// overscroll
 	overscrollStatus = {
@@ -1229,6 +1230,7 @@ class ScrollableBase extends Component {
 		delete rest.onScroll;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
+		delete rest.onUpdate;
 		delete rest.onWheel;
 		delete rest.removeEventListeners;
 		delete rest.scrollTo;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -417,7 +417,7 @@ class ScrollableBaseNative extends Component {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
 		} else if (!this.updateScrollbars()) {
-			if (this.shouldUpdateScroller === true && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			if (this.shouldUpdateScroller && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
 				// For Scroller
 				onUpdate();
 			}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -253,7 +253,7 @@ class ScrollableBaseNative extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when invalidating [Scroller]{@link moonstone/Scroller.Scroller}'s bounds
+		 * Called when invalidating [Scroller]{@link ui/Scroller.Scroller}'s bounds
 		 *
 		 * @type {function}
 		 * @private
@@ -336,6 +336,7 @@ class ScrollableBaseNative extends Component {
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
+		onUpdate: nop,
 		verticalScrollbar: 'auto'
 	}
 
@@ -412,10 +413,15 @@ class ScrollableBaseNative extends Component {
 			hasDataSizeChanged === false &&
 			(isHorizontalScrollbarVisible && !prevState.isHorizontalScrollbarVisible || isVerticalScrollbarVisible && !prevState.isVerticalScrollbarVisible)
 		) {
+			// For VirtualList
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else if (!this.updateScrollbars() && onUpdate && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
-			onUpdate();
+		} else if (!this.updateScrollbars()) {
+			if (this.shouldUpdateScroller === true && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+				// For Scroller
+				onUpdate();
+			}
+			this.shouldUpdateScroller = false;
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -454,7 +460,7 @@ class ScrollableBaseNative extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
-		this.scrollOnFocusInPointerMode = true;
+		this.shouldUpdateScroller = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -478,7 +484,7 @@ class ScrollableBaseNative extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	scrollOnFocusInPointerMode = false
+	shouldUpdateScroller = false
 
 	// overscroll
 	overscrollStatus = {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -253,6 +253,14 @@ class ScrollableBaseNative extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
+		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
+		 *
+		 * @type {function}
+		 * @private
+		 */
+		onUpdate: PropTypes.func,
+
+		/**
 		 * Called when wheeling.
 		 *
 		 * @type {Function}
@@ -405,8 +413,8 @@ class ScrollableBaseNative extends Component {
 		) {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else {
-			this.updateScrollbars();
+		} else if (!this.updateScrollbars() && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			this.props.onUpdate();
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -1140,6 +1148,8 @@ class ScrollableBaseNative extends Component {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
 		}
+
+		return isVisibilityChanged;
 	}
 
 	updateScrollThumbSize = () => {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -253,7 +253,7 @@ class ScrollableBaseNative extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when invalidating [Scroller]{@link ui/Scroller.Scroller}'s bounds
+		 * Called when invalidating [Scroller]{@link ui/Scroller.ScrollerNative}'s bounds
 		 *
 		 * @type {function}
 		 * @private

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -253,7 +253,7 @@ class ScrollableBaseNative extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when invalidating [Scroller]{@link ui/Scroller.ScrollerNative}'s bounds
+		 * Called when invalidating [ScrollerNative]{@link ui/Scroller.ScrollerNative}'s bounds
 		 *
 		 * @type {function}
 		 * @private

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -253,7 +253,7 @@ class ScrollableBaseNative extends Component {
 		onScrollStop: PropTypes.func,
 
 		/**
-		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} updates.
+		 * Called when invalidating [Scroller]{@link moonstone/Scroller.Scroller}'s bounds
 		 *
 		 * @type {function}
 		 * @private
@@ -394,6 +394,7 @@ class ScrollableBaseNative extends Component {
 
 	componentDidUpdate (prevProps, prevState) {
 		const
+			{onUpdate} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			{hasDataSizeChanged} = this.childRef;
 
@@ -413,8 +414,8 @@ class ScrollableBaseNative extends Component {
 		) {
 			this.deferScrollTo = false;
 			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
-		} else if (!this.updateScrollbars() && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
-			this.props.onUpdate();
+		} else if (!this.updateScrollbars() && onUpdate && !this.childRef.hasOwnProperty('hasDataSizeChanged')) {
+			onUpdate();
 		}
 
 		if (this.scrollToInfo !== null) {
@@ -453,7 +454,7 @@ class ScrollableBaseNative extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
-		this.isInvalidated = true;
+		this.scrollOnFocusInPointerMode = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -477,7 +478,7 @@ class ScrollableBaseNative extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
-	isInvalidated = false
+	scrollOnFocusInPointerMode = false
 
 	// overscroll
 	overscrollStatus = {
@@ -1278,6 +1279,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.onScroll;
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
+		delete rest.onUpdate;
 		delete rest.onWheel;
 		delete rest.removeEventListeners;
 		delete rest.scrollStopOnScroll;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -445,6 +445,7 @@ class ScrollableBaseNative extends Component {
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
 	enqueueForceUpdate = () => {
+		this.isInvalidated = true;
 		this.childRef.calculateMetrics();
 		this.forceUpdate();
 	}
@@ -468,6 +469,7 @@ class ScrollableBaseNative extends Component {
 	deferScrollTo = true
 	isScrollAnimationTargetAccumulated = false
 	isUpdatedScrollThumb = false
+	isInvalidated = false
 
 	// overscroll
 	overscrollStatus = {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

`onUpdate` prop in moonstone/Scroller.componentDidUpdate() is designed to be called after ui/Scrollable.enqueueForceUpdate() is called. But `this.setState()` from app can also execute this function and lead Scroller to scroll unexpectedly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I prevent calling `onUpdate` in `ui/Scrollable.componentDidUpdate()` by adding the `shouldUpdateScroller` flag. The `shouldUpdateScroller` flag could be set to `true` when `ui/Scrollable.enqueueForceUpdate()` is called.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

If `onUpdate` is called from Scroller, the `onUpdate` could be called twice.
The first time when calling `this.forceUpdate()` in `ui/Scrollable.enqueueForceUpdate()`.
The second time when calling `this.setState()` in `ui/Scrollable.componentDidUpdate()` to update scrollbar visibility.

So I moved `onUpdate()` from moonstone/Scroller to ui/Scrollable and called it depending on the visibility change of the scrollbar

In addition, I removed the Scroller test case related with `onUpdate`.

### Links
[//]: # (Related issues, references)

ENYO-5480

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)