### PR TITLE
ENYO-5508: Go to next page properly via page up/down keys in Scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to go to next page properly via page up/down keys
+
 ## [2.0.0] - 2018-07-30
 
 ### Added

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -412,7 +412,7 @@ class ScrollableBase extends Component {
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId, viewportHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 
 				if (next !== null) {
 					this.animateOnFocus = false;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -481,7 +481,7 @@ class ScrollableBaseNative extends Component {
 			/* 2. Find spottable item out of viewport */
 			// For Scroller
 			} else if (this.childRef.scrollToNextPage) {
-				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId, viewportHeight: viewportBounds.height});
+				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 
 				if (next !== null) {
 					this.animateOnFocus = false;

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -310,12 +310,11 @@ class ScrollerBase extends Component {
 		return oPoint;
 	}
 
-	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId, viewportHeight}) => {
+	scrollToNextPage = ({direction, focusedItem, reverseDirection, spotlightId}) => {
 		const endPoint = this.getNextEndPoint(direction, focusedItem.getBoundingClientRect());
 		let candidateNode = null;
 
 		/* Find a spottable item in the next page */
-		endPoint.y += (viewportHeight * (direction === 'down' ? 1 : -1));
 		candidateNode = getTargetByDirectionFromPosition(reverseDirection, endPoint, spotlightId);
 
 		/* Find a spottable item in a whole data */


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing a page down key over the last visible item in the Scroller, the Scroller jumps more than one page.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Fix to go to next page properly via page up/down keys in Scroller.

### Links
[//]: # (Related issues, references)

ENYO-5508

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)