### PR TITLE
ENYO-5463: Fix pointer mode management in EditableIntegerPicker

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/EditableIntegerPicker` to not micro-manage spotlight pointer mode.
+
 ## [2.0.0] - 2018-07-30
 
 ### Added

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -97,7 +97,6 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {
 			this.setState({
 				isActive: true
 			});
-			this.pointerMode = Spotlight.getPointerMode();
 			this.freezeSpotlight(true);
 		}
 
@@ -122,11 +121,8 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {
 		freezeSpotlight = (freeze) => {
 			if (!freeze) {
 				this.paused.resume();
-				Spotlight.setPointerMode(this.pointerMode);
 			} else {
 				this.paused.pause();
-				// we temporarily set the pointer mode to false when the input field is enabled.
-				Spotlight.setPointerMode(false);
 			}
 		}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] I have included the [Enact DCO](http://enactjs.com/docs/developer-guide/contributing/dco/) sign-off on each commit or in this Pull Request
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`EditableIntegerPicker` managed its own pointer-mode, but did so incorrectly. It could set pointer mode incorrectly when restoring/unfreezing spotlight behavior after blurring the `<input />`.

### Resolution
The related (recently-merged) PR https://github.com/enactjs/enact/pull/1812 allows pointer mode to remain accurate while spotlight is paused, thus negating the need for `EditableIntegerPicker` to manage any pointer-mode state.


### Additional Considerations
- While this achieves the intended result, I did notice an unexpected behavior. If the `<input />` has focus while pointer mode is active, pointer mode will not be set to `false` if the pointer hides on TV due to a timeout. This appears to also be the case with `Input` as well, so ... a) as it is not isolated to `EditableInputPicker` and b) it's a bit more involved, I believe a separate fix should be created to deal with that issue.
- Would there be a case where `editMode` would be set specifically by a developer, while expecting focus to be moved to the `<input />`. While that prop is considered public, it doesn't appear to behave that way - rather, existing to be used internally by `EditableIntegerPickerDecorator`. It's this reason that I feel that it's safe to remove all references to `setPointerMode`, since we won't have to explicitly change focus.