### PR TITLE
ENYO-5519: dont blur window when pointer leaves while paused

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## unreleased
+
+### Fixed
+
+- `spotlight` to not blur when pointer leaves floating webOS app while paused
+
 ## [2.0.0] - 2018-07-30
 
 ### Changed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -356,7 +356,7 @@ const Spotlight = (function () {
 	}
 
 	function handleWebOSMouseEvent (ev) {
-		if (ev && ev.detail && ev.detail.type === 'Leave') {
+		if (!isPaused() && ev && ev.detail && ev.detail.type === 'Leave') {
 			onBlur();
 		}
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When on TV, using pointer-mode to focus an input, then moving the pointer to the VKB results in the VKB hiding.


### Resolution
This is a result of #1826  calling the window `onBlur` event when the pointer leaves the window. Spotlight is attempting to blur the currently-focused control, which is causing the VKB to immediately hide. We prevent this by checking if spotlight is paused or not.


### Additional Considerations
Ideally, this check would be done from within the `onBlur` method directly, however - I'm noticing some inconsistencies in behavior when blurring the window (via VKB or via the remote menu button) then switching pointer-mode status, then re-activating the application. Sometimes some internal vars like `_spotOnWindowFocus` can get into a bad state where the application will not set focus when the window re-gains focus. This will likely need a little more attention and also additionally handling the pointer's `Enter` and window `onFocus` events.

For now, this solution is narrow enough to fix the root cause while not introducing any new issues.

