### PR TITLE
Attach spotlight listener to topmost document

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to properly detect when pointer leaves inside an iframe
+
 ## [2.0.0] - 2018-07-30
 
 ### Changed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -489,7 +489,7 @@ const Spotlight = (function () {
 				window.addEventListener('keyup', onKeyUp);
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
-				if (platform.webos) document.addEventListener('webOSMouse', handleWebOSMouseEvent);
+				if (platform.webos) window.top.document.addEventListener('webOSMouse', handleWebOSMouseEvent);
 				setLastContainer(rootContainerId);
 				configureDefaults(containerDefaults);
 				configureContainer(rootContainerId);
@@ -512,7 +512,7 @@ const Spotlight = (function () {
 			window.removeEventListener('keyup', onKeyUp);
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
-			if (platform.webos) document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
+			if (platform.webos) window.top.document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
 			Spotlight.clear();
 			_initialized = false;
 		},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Our tests did not reveal the bug with ENYO-5519 because the webos mouse
leave event did not fire because of tests running in an iframe.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Get topmost window's document to attach listeners to.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In theory, the topmost window could be on another domain from the code while
running on webOS...  And, if that were the case, we couldn't catch the pointer
leave anyhow, so...

### Links
[//]: # (Related issues, references)
ENYO-5519

### Comments
