### PR TITLE
ENYO-5512: Move tooltipArrow by -1px to avoid having a gap.

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` to go to next page properly via page up/down keys
+- `moonstone/Tooltip` to transform tooltipArrow by 1px up to avoid gaps between its body and arrow
 
 ## [2.0.0] - 2018-07-30
 

--- a/packages/moonstone/TooltipDecorator/Tooltip.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.less
@@ -66,7 +66,7 @@
 	&.above {
 		&.rightArrow {
 			.tooltipArrow {
-				transform: translateY(99%) rotate(-90deg) scaleX(-1);
+				transform: translateY(100%) translateY(-1px) rotate(-90deg) scaleX(-1);
 				left: 0;
 				bottom: 0;
 			}
@@ -78,7 +78,7 @@
 
 		&.leftArrow {
 			.tooltipArrow {
-				transform: translate(100%, 99%) rotate(90deg);
+				transform: translate(100%, 100%) translateY(-1px) rotate(90deg);
 				bottom: 0;
 				right: 0;
 			}


### PR DESCRIPTION
### Issue Resolved / Feature Added
ProgressTooltip: there's gap between body and arrow (2 QE)

### Resolution
 Move tooltipArrow by -1px to avoid having a gap.