### PR TITLE
ENYO-5515: Make story sizing rule selectors more specific

### DIFF
--- a/packages/sampler/.qa-storybook/config.js
+++ b/packages/sampler/.qa-storybook/config.js
@@ -10,7 +10,7 @@ setOptions({
 	showStoriesPanel: true,
 	showAddonPanel: true,
 	showSearchBox: false,
-	addonPanelInRight: false,
+	addonPanelInRight: false
 });
 
 configure(stories, module);

--- a/packages/sampler/.storybook/config.js
+++ b/packages/sampler/.storybook/config.js
@@ -10,7 +10,7 @@ setOptions({
 	showStoriesPanel: true,
 	showAddonPanel: true,
 	showSearchBox: false,
-	addonPanelInRight: false,
+	addonPanelInRight: false
 });
 
 configure(stories, module);

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
@@ -50,8 +50,11 @@
 // applies position:relative, which doesn't help us when we have stories that should fill the entire
 // panel body. This targets that inaccessible node using Panel's structure and storybook's structure
 // to update that goofy rule to a rational one.
-.panel > section > div > div:first-child {
+// The :not() bit targets only non-enact elements, so if a story doesn't use withInfo, and a `div`
+// isn't added, the components aren't being told to be a different size/position.
+.panel > section > div:not([class]):first-child,
+.panel > section > div > div:not([class]):first-child {
 	width: 100%;
 	height: 100%;
-	position: absolute !important;
+	position: relative !important;
 }

--- a/packages/sampler/stories/moonstone-stories/About.js
+++ b/packages/sampler/stories/moonstone-stories/About.js
@@ -52,8 +52,9 @@ storiesOf('About', module)
 	.add(
 		'A Tour of Sampler',
 		withInfo('A Tour of Sampler')(() => (
-			<div>
+			<div style={{overflow: 'hidden', height: '100%'}}>
 				<BodyText
+					style={{margin: `0 ${riSafe(12)} 0.8em`}}
 					centered={boolean('text centered', BodyText)}
 				>
 					Welcome to the Enact sampler! Explore Enact components.
@@ -67,7 +68,7 @@ storiesOf('About', module)
 						Click <b>Show Info</b> to see the live source code for the sample
 					</div>
 				</aside>
-				<aside className={css.hintDialog} style={riSafe({position: 'relative', top: 60, left: 30})}>
+				<aside className={css.hintDialog} style={riSafe({position: 'relative', top: 60, left: 33})}>
 					<Pointer length={30} angle="90deg" style={riSafe({left: 0, top: 9})} />
 					<div className={css.text}>
 						Select any component from the <b>sidebar</b> to see how it works


### PR DESCRIPTION
### Issue Resolved / Feature Added
QA Sampler was imposing the wrong sizes on components in stories.


### Resolution
Develop more specific rules to only target the offending `addon-info` div when it's present.