### PR TITLE
ENYO-5512: Remove space between tooltipLabel and tooltipArrow

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+-`moonstone/Tooltip` to remove space between `tooltipLabel` and `tooltipArrow`
+
 ## [2.0.1] - 2018-08-01
 
 ### Fixed

--- a/packages/moonstone/TooltipDecorator/Tooltip.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.less
@@ -68,7 +68,7 @@
 	&.above {
 		&.rightArrow {
 			.tooltipArrow {
-				transform: translateY(100%) translateY(-1px) rotate(-90deg) scaleX(-1);
+				transform: translateY(99%) rotate(-90deg) scaleX(-1);
 				left: 0;
 				bottom: 0;
 			}

--- a/packages/moonstone/TooltipDecorator/Tooltip.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.less
@@ -45,8 +45,10 @@
 
 		&.leftArrow {
 			.tooltipArrow {
-				transform: translate(100%, 1%) rotate(-90deg) scaleY(-1);
+				transform-origin: 100% 0;
+				transform: rotate(90deg) rotateY(180deg);
 				right: 0;
+				top: -@moon-tooltip-point-width;
 			}
 
 			.tooltipLabel {
@@ -66,7 +68,7 @@
 	&.above {
 		&.rightArrow {
 			.tooltipArrow {
-				transform: translateY(99%) rotate(-90deg) scaleX(-1);
+				transform: translateY(100%) translateY(-1px) rotate(-90deg) scaleX(-1);
 				left: 0;
 				bottom: 0;
 			}
@@ -78,9 +80,10 @@
 
 		&.leftArrow {
 			.tooltipArrow {
-				transform: translate(100%, 99%) rotate(90deg);
-				bottom: 0;
-				right: 0;
+				transform-origin: 100% 100%;
+				transform: rotate(270deg) rotateX(180deg) rotateY(180deg);
+				right: @moon-tooltip-point-height;
+				bottom: -@moon-tooltip-point-width;
 			}
 
 			.tooltipLabel {


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `tooltip` is displayed with `ProgressBar` or `Slider`, There's a gap between `tooltipLabel` and `tooltipArrow`. (about 1 to 2 px)
To reproduce, progress value should be more than 50%. And problem arises with the `leftArrow` type.
So, we have to remove space between tooltipLabel and tooltipArrow.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Currently, arrow svg moves to the upper right corner or the bottom right by `translate()` function. But, as the width of the TooltipLabel changes in decimal units, a problem sometimes arises.
If the width value is an integer, there is no problem. But it is impossible to do so because the width varies according to the length of the text.

### Links
[//]: # (Related issues, references)
ENYO-5512

### Comments
Enact-DCO-1.0-Signed-off-by: Sangwook Lee (sangwook1203.lee@lge.com)