### PR TITLE
ENYO-5518: Fix year picker when min year and max year don't exist

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/DatePicker` property `yearFormatter` to accept a function to handle different types of calendar years
+
 ### Fixed
 
 - `moonstone/Slider` to forward `onActivate` event

--- a/packages/moonstone/DatePicker/DatePicker.js
+++ b/packages/moonstone/DatePicker/DatePicker.js
@@ -22,7 +22,7 @@ import Skinnable from '../Skinnable';
 import DatePickerBase from './DatePickerBase';
 
 const dateTimeConfig = {
-	customProps: function (i18n, value, props) {
+	customProps: function (i18n, value) {
 		const values = {
 			maxMonths: 12,
 			maxDays: 31,
@@ -37,8 +37,7 @@ const dateTimeConfig = {
 			values.day = value.getDays();
 			values.maxMonths = i18n.formatter.cal.getNumMonths(values.year);
 			values.maxDays = i18n.formatter.cal.getMonLength(values.month, values.year);
-			values.maxYear = i18n.toLocalYear(props.maxYear);
-			values.minYear = i18n.toLocalYear(props.minYear);
+			values.yearFormatter = i18n.toLocalYear;
 		}
 
 		return values;

--- a/packages/moonstone/DatePicker/DatePickerBase.js
+++ b/packages/moonstone/DatePicker/DatePickerBase.js
@@ -258,6 +258,14 @@ const DatePickerBase = kind({
 		yearAriaLabel: PropTypes.string,
 
 		/**
+		 * The function to format the year to handle different types of calendar.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		yearFormatter: PropTypes.func,
+
+		/**
 		 * The label displayed below the year picker.
 		 *
 		 * This prop will also be appended to the current value and set as "aria-valuetext" on the
@@ -288,6 +296,11 @@ const DatePickerBase = kind({
 		)
 	},
 
+	computed: {
+		maxYear: ({maxYear, yearFormatter}) => yearFormatter ? yearFormatter(maxYear) : maxYear,
+		minYear: ({minYear, yearFormatter}) => yearFormatter ? yearFormatter (minYear) : minYear
+	},
+
 	render: ({
 		'data-webos-voice-disabled': voiceDisabled,
 		day,
@@ -316,6 +329,7 @@ const DatePickerBase = kind({
 		yearLabel = $L('year'),
 		...rest
 	}) => {
+		delete rest.yearFormatter;
 
 		return (
 			<ExpandableItemBase


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `minYear` or `maxYear` were provided, then `DatePicker` disables the year picker. Recent change expects `minYear` and `maxYear` prop will be transformed into a local calendar year without a default value provided.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `yearFormatter` prop to `DateTimePickerBase` which will transform year value to local calendar year if it exists. 

### Additional Considerations
Adding defaultProps to `DateTimeDecorator` would've been an easier way to fix it, but `minYear` and `maxYear` is irrelevant to `TimePicker` so it's not the right place to handle this.

Would like to add a unit test case, but wasn't sure what the right test would be. Any thoughts?

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
