### PR TITLE
ENYO-5513: A11y: Not read out infoComponent when selecting more button on VideoPlayer

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,10 +6,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VideoPlayer` prop `infoComponents` to be read out when selecting more button on media control.
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
-- `moonstone/VideoPlayer` to not read out infoComponent when select more button on mediaContorls
+- `moonstone/VideoPlayer` prop `infoComponents` to be read out when selecting more button on media control.
 
 ## [2.0.1] - 2018-08-01
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` to not read out infoComponent when select more button on mediaContorls
+
 ## [2.0.1] - 2018-08-01
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VideoPlayer` to not read out infoComponent when select more button on mediaContorls
+- `moonstone/VideoPlayer` prop `infoComponents` to be read out when selecting more button on media control.
 
 ## [2.0.1] - 2018-08-01
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -443,7 +443,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			initialJumpDelay: PropTypes.number,
 
 			/**
-			 * The status of infoComponent's id is set to aria-labelledby and is ready to be read.
+			 * The status of video player when aria-labelledby and region are rendered.
 			 *
 			 * @type {Boolean}
 			 * @public
@@ -633,7 +633,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.paused = new Pause('VideoPlayer');
 
 			this.state = {
-				isFirstReadInfoComponents: true,
+				hasReadInfoComponents: false,
 				showMoreComponents: false
 			};
 
@@ -680,7 +680,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				forwardToggleMore({showMoreComponents: this.state.showMoreComponents}, this.props);
 			}
 
-			if (this.state.showMoreComponents && this.props.isRenderedAriaProps && this.state.isFirstReadInfoComponents) {
+			if (this.state.showMoreComponents && this.props.isRenderedAriaProps && !this.state.hasReadInfoComponents) {
 				// Readout the infoComponents for the first time.
 				this.focusMoreButton();
 			}
@@ -815,7 +815,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		}
 
 		toggleMoreComponents () {
-			if (!this.state.isFirstReadInfoComponents) {
+			if (this.state.hasReadInfoComponents) {
 				this.focusMoreButton();
 			}
 
@@ -832,17 +832,18 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				return;
 			}
 
-			// Readout 'more' or 'back' button explicitly.
-			let selectedButton = Spotlight.getCurrent();
+			const selectedButton = Spotlight.getCurrent();
 			if (selectedButton === this.mediaControlsNode.querySelector(`.${css.moreButton}`)) {
+				// Press enter of 5way key
 				selectedButton.blur();
 				selectedButton.focus();
 			} else {
+				// Press color key
 				Spotlight.focus(this.props.moreButtonSpotlightId);
 			}
 
 			this.setState({
-				isFirstReadInfoComponents: false
+				hasReadInfoComponents: true
 			});
 		}
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -851,7 +851,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			if (selectedButton === this.moreButtonNode) {
 				// Press enter of 5way key
 				selectedButton.blur();
-				selectedButton.focus();
+				Spotlight.focus(selectedButton);
 			} else {
 				// Press color key
 				Spotlight.focus(this.props.moreButtonSpotlightId);

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -155,6 +155,14 @@ const MediaControlsBase = kind({
 		moreButtonLabel: PropTypes.string,
 
 		/**
+		 * The method to run when the more button rendered, giving a reference to the DOM.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		moreButtonRef: PropTypes.func,
+
+		/**
 		 * A custom more button ID to use with Spotlight.
 		 *
 		 * @type {String}
@@ -349,6 +357,7 @@ const MediaControlsBase = kind({
 		moreButtonClassName,
 		moreButtonColor,
 		moreButtonDisabled,
+		moreButtonRef,
 		moreButtonSpotlightId,
 		moreIcon,
 		moreIconLabel,
@@ -402,10 +411,11 @@ const MediaControlsBase = kind({
 							color={moreButtonColor}
 							disabled={moreButtonDisabled}
 							onClick={onMoreClick}
-							tooltipProps={{role: 'dialog'}}
-							tooltipText={moreIconLabel}
+							ref={moreButtonRef}
 							spotlightId={moreButtonSpotlightId}
 							spotlightDisabled={spotlightDisabled}
+							tooltipProps={{role: 'dialog'}}
+							tooltipText={moreIconLabel}
 						>
 							{moreIcon}
 						</MediaButton>
@@ -626,6 +636,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.mediaControlsNode = null;
+			this.moreButtonNode = null;
 
 			this.keyLoop = null;
 			this.pulsingKeyCode = null;
@@ -802,6 +813,10 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.mediaControlsNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 		}
 
+		getMoreButtonRef = (node) => {
+			this.moreButtonNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
+		}
+
 		areMoreComponentsAvailable () {
 			return this.state.showMoreComponents;
 		}
@@ -833,7 +848,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			}
 
 			const selectedButton = Spotlight.getCurrent();
-			if (selectedButton === this.mediaControlsNode.querySelector(`.${css.moreButton}`)) {
+			if (selectedButton === this.moreButtonNode) {
 				// Press enter of 5way key
 				selectedButton.blur();
 				selectedButton.focus();
@@ -874,6 +889,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				<Wrapped
 					ref={this.getMediaControls}
 					{...props}
+					moreButtonRef={this.getMoreButtonRef}
 					onClose={this.handleClose}
 					onMoreClick={this.handleMoreClick}
 					onPlayButtonClick={this.handlePlayButtonClick}

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -158,7 +158,7 @@ const MediaControlsBase = kind({
 		 * The method to run when the more button rendered, giving a reference to the DOM.
 		 *
 		 * @type {Function}
-		 * @public
+		 * @private
 		 */
 		moreButtonRef: PropTypes.func,
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -612,6 +612,9 @@ const VideoPlayerBase = class extends React.Component {
 		this.selectPlaybackRates('fastForward');
 		this.sliderKnobProportion = 0;
 
+		// The status of controlsAriaProps when aria-labelledby and region are rendered
+		this.isRenderedAriaProps = false;
+
 		this.initI18n();
 
 		// Re-render-necessary State
@@ -1669,7 +1672,9 @@ const VideoPlayerBase = class extends React.Component {
 			infoVisible: showMoreComponents,
 			titleVisible: true,
 			announce: announce < AnnounceState.INFO ? AnnounceState.INFO : AnnounceState.DONE
-		}));
+		}), () => {
+			this.isRenderedAriaProps = true;
+		});
 	}
 
 	handleMediaControlsClose = (ev) => {
@@ -1695,7 +1700,8 @@ const VideoPlayerBase = class extends React.Component {
 	getControlsAriaProps () {
 		if (this.state.announce === AnnounceState.TITLE) {
 			return {
-				role: 'region',
+				role: 'alert',
+				'aria-live': 'off',
 				'aria-labelledby': `${this.id}_title`
 			};
 		} else if (this.state.announce === AnnounceState.INFO) {
@@ -1864,6 +1870,7 @@ const VideoPlayerBase = class extends React.Component {
 
 							<ComponentOverride
 								component={mediaControlsComponent}
+								isRenderedAriaProps={this.isRenderedAriaProps}
 								mediaDisabled={disabled || this.state.sourceUnavailable}
 								onBackwardButtonClick={this.handleRewind}
 								onClose={this.handleMediaControlsClose}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1700,14 +1700,14 @@ const VideoPlayerBase = class extends React.Component {
 	getControlsAriaProps () {
 		if (this.state.announce === AnnounceState.TITLE) {
 			return {
-				role: 'alert',
+				'aria-labelledby': `${this.id}_title`,
 				'aria-live': 'off',
-				'aria-labelledby': `${this.id}_title`
+				role: 'alert'
 			};
 		} else if (this.state.announce === AnnounceState.INFO) {
 			return {
-				role: 'region',
-				'aria-labelledby': `${this.id}_info`
+				'aria-labelledby': `${this.id}_info`,
+				role: 'region'
 			};
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- Fixed not read out infoComponent when select more button on VideoPlayer.
- This issue also includes the following issues:
  - Fixed an issue where InfoComponent was not read when Blue key was pressed while MediaControls panel was floating
  - Fixed an issue where infoComponent was not read when moreButton was pressed with 5way key
  - Fixed an issue that gives focus when the role, aria-* property are not applying yet in the real DOM
  - Fixed conflicts when `title` and `info` roles are region role

### Resolution
- Issues that did not read infoComponent
  - The behavior was different when handling more button and blue key in the scenario of reading infoComponent. If we press the more button, the toggleMoreComponents function changes the state of the MoreComponents and gives focus, but the Blue key gives focus before changing the state. I unified this behavior so that the state changes first and gives focus.
- `Title` and `info` role conflicts with region role
  - Since `title` and `info` give focus to the same children(buttons in MediaControls), they will not be read if they contain the same region role. It is OK to remove the button focus once. However, I applied the alert role because the alert role is applied to the first focus in the VideoPlayer scenario, so there is no change in the region role and the reading order.
- Issues that role and aria-* property did not apply to real DOM
  - Added an `isRenderedAriaProps` variable to VideoPlayer.js and added prop to MediaControls.js
  - The render cyle of VideoPlayer and MediaControls are handled at the same time, but the role and aria- * properties have not yet been applied to real DOM at the first render time. This caused an issue because the `this.state.announce` was changed so that the objects of controlsAriaProps were immediately applied at the time of rendering. 
  - I have modified MediacControls to pass `this.isRenderedAriaProps` is true after setState which changes` this.state.announce` is rendered.

### Additional Considerations

### Links
ENYO-5513

### Comments