### PR TITLE
PLAT-62964: Add prop to control MediaSlider visibility

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/VideoPlayer` property `noMediaSliderFeedback`
+
 ### Fixed
 
 - `moonstone/Slider` to forward `onActivate` event

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -282,7 +282,7 @@ const VideoPlayerBase = class extends React.Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		noMediaSliderFeedback: PropTypes.bool,
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -278,7 +278,7 @@ const VideoPlayerBase = class extends React.Component {
 		noAutoShowMediaControls: PropTypes.bool,
 
 		/**
-		 * Prevents showing media slider feedback when fast forward or rewind.
+		 * Hides media slider feedback when fast forward or rewind while media controls are hidden.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1746,6 +1746,7 @@ const VideoPlayerBase = class extends React.Component {
 		delete mediaProps.jumpBy;
 		delete mediaProps.miniFeedbackHideDelay;
 		delete mediaProps.noAutoShowMediaControls;
+		delete mediaProps.noMediaSliderFeedback;
 		delete mediaProps.onControlsAvailable;
 		delete mediaProps.onFastForward;
 		delete mediaProps.onJumpBackward;

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -278,6 +278,15 @@ const VideoPlayerBase = class extends React.Component {
 		noAutoShowMediaControls: PropTypes.bool,
 
 		/**
+		 * Prevents showing media slider feedback when fast forward or rewind.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		noMediaSliderFeedback: PropTypes.bool,
+
+		/**
 		 * Removes the mini feedback.
 		 *
 		 * @type {Boolean}
@@ -955,7 +964,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			if (this.showMiniFeedback && (!this.state.miniFeedbackVisible || this.state.mediaSliderVisible !== shouldShowSlider)) {
 				this.setState(({loading, duration, error}) => ({
-					mediaSliderVisible: shouldShowSlider,
+					mediaSliderVisible: shouldShowSlider && !this.props.noMediaSliderFeedback,
 					miniFeedbackVisible: !(loading || !duration || error)
 				}));
 			}

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -124,7 +124,7 @@ storiesOf('Moonstone', module)
 						muted={boolean('muted', Config, true)}
 						noAutoPlay={boolean('noAutoPlay', Config)}
 						noAutoShowMediaControls={boolean('noAutoShowMediaControls', Config)}
-						noMediaSliderFeedback={boolean('noAutoShowMediaControls', Config, false)}
+						noMediaSliderFeedback={boolean('noMediaSliderFeedback', Config, false)}
 						noMiniFeedback={boolean('noMiniFeedback', Config)}
 						noSlider={boolean('noSlider', Config)}
 						pauseAtEnd={boolean('pauseAtEnd', Config)}

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -124,6 +124,7 @@ storiesOf('Moonstone', module)
 						muted={boolean('muted', Config, true)}
 						noAutoPlay={boolean('noAutoPlay', Config)}
 						noAutoShowMediaControls={boolean('noAutoShowMediaControls', Config)}
+						noMediaSliderFeedback={boolean('noAutoShowMediaControls', Config, false)}
 						noMiniFeedback={boolean('noMiniFeedback', Config)}
 						noSlider={boolean('noSlider', Config)}
 						pauseAtEnd={boolean('pauseAtEnd', Config)}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
App wants to hide the media slider when pressing "rew" or "ff" from the remote.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a new prop `noMediaSliderFeedback` to disable slider feedback 
