### PR TITLE
ENYO-5523: Update pointer mode after hiding VKB

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## unreleased
+
+### Fixed
+
+- `spotlight` to update pointer mode after hiding webOS VKB
+
 ## [2.0.1] - 2018-08-01
 
 ### Fixed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -361,6 +361,12 @@ const Spotlight = (function () {
 		}
 	}
 
+	function handleKeyboardStateChangeEvent ({visibility}) {
+		if (!visibility) {
+			setPlatformPointerMode();
+		}
+	}
+
 	function onFocus () {
 		// Normally, there isn't focus here unless the window has been blurred above. On webOS, the
 		// platform may focus the window after the app has already focused a component so we prevent
@@ -489,7 +495,10 @@ const Spotlight = (function () {
 				window.addEventListener('keyup', onKeyUp);
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
-				if (platform.webos) document.addEventListener('webOSMouse', handleWebOSMouseEvent);
+				if (platform.webos) {
+					document.addEventListener('webOSMouse', handleWebOSMouseEvent);
+					document.addEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
+				}
 				setLastContainer(rootContainerId);
 				configureDefaults(containerDefaults);
 				configureContainer(rootContainerId);
@@ -512,7 +521,10 @@ const Spotlight = (function () {
 			window.removeEventListener('keyup', onKeyUp);
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
-			if (platform.webos) document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
+			if (platform.webos) {
+				document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
+				document.removeEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
+			}
 			Spotlight.clear();
 			_initialized = false;
 		},

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -496,8 +496,8 @@ const Spotlight = (function () {
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
 				if (platform.webos) {
-					document.addEventListener('webOSMouse', handleWebOSMouseEvent);
-					document.addEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
+					window.top.document.addEventListener('webOSMouse', handleWebOSMouseEvent);
+					window.top.document.addEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
 				}
 				setLastContainer(rootContainerId);
 				configureDefaults(containerDefaults);
@@ -522,8 +522,8 @@ const Spotlight = (function () {
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
 			if (platform.webos) {
-				document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
-				document.removeEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
+				window.top.document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
+				window.top.document.removeEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
 			}
 			Spotlight.clear();
 			_initialized = false;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Spotlight's pointer mode isn't updated when attempting to switch modes while the VKB is visible (ex: when an input has focus).


### Resolution
While the VKB is visible, spotlight or currently-focused components (ex: `Input`) are unable to receive key events (`keydown`) events. During this time a user can change from pointer to 5-way mode. This prevents spotlight from restoring focus in some cases after dismissing the VKB, since spotlight falsely thinks it is still in pointer mode - which prevents programmatic focus changes.

Since we know pointer-mode can change while the VKB is open, we can remedy this issue by setting the platform pointer mode as a response to the webOS event `keyboardStateChange` when the VKB closes.

