### PR TITLE
ENYO-5531: Fix not to scroll to wrong position via 5way navigation in RTL languages

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to consider RTL case when preventing scroll by focus
+- `moonstone/Scroller` not to scroll to wrong position via 5way navigation in RTL languages
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller` to support RTL to prevent scrolls originating from focus events
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to support RTL to prevent scrolls originating from focus events
+- `moonstone/Scroller` to consider RTL case when preventing scroll by focus
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -410,14 +410,16 @@ class ScrollableBase extends Component {
 			if (next !== focusedItem) {
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
-			} else if (this.childRef.scrollToNextPage) { // For Scroller
+			// For Scroller
+			} else if (this.childRef.scrollToNextPage) {
 				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 
 				if (next !== null) {
 					this.animateOnFocus = false;
 					Spotlight.focus(next);
 				}
-			} else if (this.childRef.scrollToNextItem) { // For VirtualList
+			// For VirtualList
+			} else if (this.childRef.scrollToNextItem) {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -410,16 +410,14 @@ class ScrollableBase extends Component {
 			if (next !== focusedItem) {
 				Spotlight.focus(next);
 			/* 2. Find spottable item out of viewport */
-			// For Scroller
-			} else if (this.childRef.scrollToNextPage) {
+			} else if (this.childRef.scrollToNextPage) { // For Scroller
 				next = this.childRef.scrollToNextPage({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 
 				if (next !== null) {
 					this.animateOnFocus = false;
 					Spotlight.focus(next);
 				}
-			// For VirtualList
-			} else if (this.childRef.scrollToNextItem) {
+			} else if (this.childRef.scrollToNextItem) { // For VirtualList
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1197,8 +1197,6 @@ class ScrollableBase extends Component {
 		// Prevent scroll by focus.
 		// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
 		// Only Scroller could get `onscroll` event.
-		// In addition, VirtualListNative, VirtualGridListNative, and ScrollerNative are
-		// based on not Scrollable but ScrollableNative. So `handleScroll` will not be called for them.
 		if (!this.animator.isAnimating() && childRef && childRef.containerRef && this.childRef.getRtlPositionX) {
 			// For Scroller
 			childRef.containerRef.scrollTop = this.scrollTop;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1194,12 +1194,13 @@ class ScrollableBase extends Component {
 	handleScroll = () => {
 		const childRef = this.childRef;
 
+		// Prevent scroll by focus.
+		// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
+		// Only Scroller could get `onscroll` event.
+		// In addition, VirtualListNative, VirtualGridListNative, and ScrollerNative are
+		// based on not Scrollable but ScrollableNative. So `handleScroll` will not be called for them.
 		if (!this.animator.isAnimating() && childRef && childRef.containerRef && this.childRef.getRtlPositionX) {
 			// For Scroller
-			// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
-			// Only Scroller could get `onscroll` event.
-			// In addition, VirtualListNative, VirtualGridListNative, and ScrollerNative are
-			// based on not Scrollable but ScrollableNative. So `handleScroll` will not be called for them.
 			childRef.containerRef.scrollTop = this.scrollTop;
 			childRef.containerRef.scrollLeft = this.childRef.getRtlPositionX(this.scrollLeft);
 		}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1197,10 +1197,10 @@ class ScrollableBase extends Component {
 		// Prevent scroll by focus.
 		// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
 		// Only Scroller could get `onscroll` event.
-		if (!this.animator.isAnimating() && childRef && childRef.containerRef && this.childRef.getRtlPositionX) {
+		if (!this.animator.isAnimating() && childRef && childRef.containerRef && childRef.getRtlPositionX) {
 			// For Scroller
 			childRef.containerRef.scrollTop = this.scrollTop;
-			childRef.containerRef.scrollLeft = this.childRef.getRtlPositionX(this.scrollLeft);
+			childRef.containerRef.scrollLeft = childRef.getRtlPositionX(this.scrollLeft);
 		}
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1194,9 +1194,14 @@ class ScrollableBase extends Component {
 	handleScroll = () => {
 		const childRef = this.childRef;
 
-		if (!this.animator.isAnimating() && childRef && childRef.containerRef) {
+		if (!this.animator.isAnimating() && childRef && childRef.containerRef && this.childRef.getRtlPositionX) {
+			// For Scroller
+			// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
+			// Only Scroller could get `onscroll` event.
+			// In addition, VirtualListNative, VirtualGridListNative, and ScrollerNative are
+			// based on not Scrollable but ScrollableNative. So `handleScroll` will not be called for them.
 			childRef.containerRef.scrollTop = this.scrollTop;
-			childRef.containerRef.scrollLeft = this.scrollLeft;
+			childRef.containerRef.scrollLeft = this.childRef.getRtlPositionX(this.scrollLeft);
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

A horizontal Scroller scrolls to unexpected position during 5-way key navigation in RTL mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

To prevent scrolls originating from focus events, we reset the `scrollLeft` of the Scroller when receiving `onscroll` event. But we did not consider the RTL case. So I update the `scrollLeft` properly based on the scrollbounds and the RTL mode of the Scroller

### Links
[//]: # (Related issues, references)

ENYO-5531

### Comments
