### PR TITLE
PLAT-64158: Fix Popup to prevent duplicated 5-way navigation

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Popup` to prevent moving twice at one 5-way key input if there is two or more button.
+- `moonstone/Popup` to prevent moving twice at one 5-way key input when the `Popup` has `spotlightRestrict='self-first'` option and there is two or more button
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Popup` to prevent duplicated key handling after `Spotlight.move` in key down handler.
+- `moonstone/Popup` to prevent to moved twice at one 5-way key input if there is two or more button.
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Popup` to prevent to moved twice at one 5-way key input if there is two or more button.
+- `moonstone/Popup` to prevent moving twice at one 5-way key input if there is two or more button.
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Popup` to prevent duplicated key handling after `Spotlight.move` in key down handler.
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,8 +6,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Popup` to prevent moving twice at one 5-way key input when the `Popup` has `spotlightRestrict='self-first'` option and there are two or more buttons
 - `moonstone/EditableIntegerPicker` management of spotlight pointer mode
+- `moonstone/Popup` to prevent duplicate 5-way navigation when `spotlightRestrict="self-first"`
 - `moonstone/Scroller` not to scroll to wrong position via 5way navigation in RTL languages
 - `moonstone/Slider` to forward `onActivate` event
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -464,8 +464,6 @@ class Popup extends React.Component {
 			if (spottables && Spotlight.getCurrent() && spotlightRestrict !== 'self-only') {
 				focusChanged = Spotlight.move(direction);
 				if (focusChanged) {
-					// prevent default page scrolling
-					ev.preventDefault();
 					// stop propagation to prevent default spotlight behavior
 					ev.stopPropagation();
 				}

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -463,6 +463,12 @@ class Popup extends React.Component {
 
 			if (spottables && Spotlight.getCurrent() && spotlightRestrict !== 'self-only') {
 				focusChanged = Spotlight.move(direction);
+				if (focusChanged) {
+					// prevent default page scrolling
+					ev.preventDefault();
+					// stop propagation to prevent default spotlight behavior
+					ev.stopPropagation();
+				}
 			}
 
 			if (!spottables || (focusChanged === false && isUp(keyCode))) {

--- a/packages/sampler/stories/qa-stories/Popup.js
+++ b/packages/sampler/stories/qa-stories/Popup.js
@@ -35,6 +35,8 @@ storiesOf('Popup', module)
 					<br />
 					<Container>
 						<Button>Button</Button>
+						<Button>Button</Button>
+						<Button>Button</Button>
 					</Container>
 				</Popup>
 			</div>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/Popup` components handle focus movement redundantly. 
In `moonstone/Popup` case with two or more buttons, focus is moved twice at one 5way-key input.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In `moonstone/Popup` keydown event handler, it called `Spotlight.move(dir)` without stopPropagation() . So `Spotlight` handle the key event redundantly.

`moonstone/Popup` is fixed to prevent additional key event handling after focus changed using stopPropagation() and preventDefault(). 
And added more button to verify the spotlight operation in Popup story of qa-sampler .

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Since the focus has been moved, the event could be regarded as consumed. Thus I added preventDefault() and stopPropagation(). But I don't have confidence it need preventDefault() because when I checked several additional cases(include scroller case), there was no difference in the behavior.


### Links
[//]: # (Related issues, references)
PLAT-64158

### Comments
