### PR TITLE
ENYO-5530: Surgically target the info add-on div

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.less
@@ -52,8 +52,7 @@
 // to update that goofy rule to a rational one.
 // The :not() bit targets only non-enact elements, so if a story doesn't use withInfo, and a `div`
 // isn't added, the components aren't being told to be a different size/position.
-.panel > section > div:not([class]):first-child,
-.panel > section > div > div:not([class]):first-child {
+.panel > section > div:not([class]):not([style]):first-child {
 	width: 100%;
 	height: 100%;
 	position: relative !important;

--- a/packages/sampler/src/configure.js
+++ b/packages/sampler/src/configure.js
@@ -1,13 +1,30 @@
 import {configure, addDecorator} from '@storybook/react';
 import {withKnobsOptions} from '@storybook/addon-knobs';
+import {setDefaults} from '@storybook/addon-info';
+
 import Moonstone from '../src/MoonstoneEnvironment';
 
 function config (stories, mod) {
+
 	addDecorator(Moonstone);
 	addDecorator(withKnobsOptions({
 		// debounce: {wait: 500}, // Same as lodash debounce.
 		timestamps: true // Doesn't emit events while user is typing.
 	}));
+
+	// Set addon-info defaults
+	setDefaults({
+		propTables: null, // Disable all propTables
+		// header: false, // Global configuration for the info addon across all of your stories.
+		// inline: true,
+		styles: {
+			children: {
+				// backgroundColor: 'purple',  // For easier debugging
+				width: '100%',
+				height: '100%'
+			}
+		}
+	});
 
 	function loadStories () {
 		stories.keys().forEach((filename) => stories(filename));

--- a/packages/sampler/stories/moonstone-stories/BodyText.js
+++ b/packages/sampler/stories/moonstone-stories/BodyText.js
@@ -11,7 +11,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'BodyText',
 		withInfo({
-			propTablesExclude: [BodyText],
 			text: 'The basic BodyText'
 		})(() => (
 			<BodyText

--- a/packages/sampler/stories/moonstone-stories/Button.js
+++ b/packages/sampler/stories/moonstone-stories/Button.js
@@ -24,7 +24,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Button',
 		withInfo({
-			propTablesExclude: [Button],
 			text: 'The basic Button'
 		})(() => (
 			<Button

--- a/packages/sampler/stories/moonstone-stories/CheckboxItem.js
+++ b/packages/sampler/stories/moonstone-stories/CheckboxItem.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'CheckboxItem',
 		withInfo({
-			propTablesExclude: [CheckboxItem],
 			text: 'Basic usage of CheckboxItem'
 		})(() => (
 			<CheckboxItem

--- a/packages/sampler/stories/moonstone-stories/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/moonstone-stories/ContextualPopupDecorator.js
@@ -33,7 +33,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ContextualPopupDecorator',
 		withInfo({
-			propTablesExclude: [BodyText, ContextualButton],
 			text: 'Basic usage of ContextualPopupDecorator'
 		})(() => (
 			<div style={{textAlign: 'center', marginTop: ri.unit(99, 'rem')}}>

--- a/packages/sampler/stories/moonstone-stories/DatePicker.js
+++ b/packages/sampler/stories/moonstone-stories/DatePicker.js
@@ -16,7 +16,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'DatePicker',
 		withInfo({
-			propTablesExclude: [DatePicker],
 			text: 'The basic DatePicker'
 		})(() => (
 			<DatePicker

--- a/packages/sampler/stories/moonstone-stories/DayPicker.js
+++ b/packages/sampler/stories/moonstone-stories/DayPicker.js
@@ -12,7 +12,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'DayPicker',
 		withInfo({
-			propTablesExclude: [DayPicker],
 			text: 'The basic DayPicker'
 		})(() => (
 			<DayPicker

--- a/packages/sampler/stories/moonstone-stories/DaySelector.js
+++ b/packages/sampler/stories/moonstone-stories/DaySelector.js
@@ -21,7 +21,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'DaySelector',
 		withInfo({
-			propTablesExclude: [DaySelector],
 			text: 'Basic usage of DaySelector'
 		})(() => (
 			<DaySelector

--- a/packages/sampler/stories/moonstone-stories/Dialog.js
+++ b/packages/sampler/stories/moonstone-stories/Dialog.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Dialog',
 		withInfo({
-			propTablesExclude: [BodyText, Button, Dialog],
 			text: 'Basic usage of Dialog'
 		})(() => (
 			<div>

--- a/packages/sampler/stories/moonstone-stories/Divider.js
+++ b/packages/sampler/stories/moonstone-stories/Divider.js
@@ -20,7 +20,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Divider',
 		withInfo({
-			propTablesExclude: [Divider],
 			text: 'Basic usage of Divider'
 		})(() => (
 			<Divider

--- a/packages/sampler/stories/moonstone-stories/EditableIntegerPicker.js
+++ b/packages/sampler/stories/moonstone-stories/EditableIntegerPicker.js
@@ -22,7 +22,6 @@ storiesOf('Moonstone', module)
 		'EditableIntegerPicker',
 
 		withInfo({
-			propTablesExclude: [EditableIntegerPicker],
 			text: 'Basic usage of EditableIntegerPicker'
 		})(() => (
 			<EditableIntegerPicker

--- a/packages/sampler/stories/moonstone-stories/ExpandableInput.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandableInput.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ExpandableInput',
 		withInfo({
-			propTablesExclude: [ExpandableInput],
 			text: 'Basic usage of divider'
 		})(() => (
 			<ExpandableInput

--- a/packages/sampler/stories/moonstone-stories/ExpandableItem.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandableItem.js
@@ -18,7 +18,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ExpandableItem',
 		withInfo({
-			propTablesExclude: [ExpandableItem, Icon, Item],
 			text: 'Basic usage of ExpandableItem'
 		})(() => (
 			<ExpandableItem

--- a/packages/sampler/stories/moonstone-stories/ExpandableList.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandableList.js
@@ -14,7 +14,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ExpandableList',
 		withInfo({
-			propTablesExclude: [ExpandableList],
 			text: 'Basic usage of ExpandableList'
 		})(() => (
 			<ExpandableList

--- a/packages/sampler/stories/moonstone-stories/ExpandablePicker.js
+++ b/packages/sampler/stories/moonstone-stories/ExpandablePicker.js
@@ -16,7 +16,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ExpandablePicker',
 		withInfo({
-			propTablesExclude: [ExpandablePicker],
 			text: 'Basic usage of ExpandablePicker'
 		})(() => (
 			<ExpandablePicker

--- a/packages/sampler/stories/moonstone-stories/FormCheckboxItem.js
+++ b/packages/sampler/stories/moonstone-stories/FormCheckboxItem.js
@@ -13,7 +13,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'FormCheckboxItem',
 		withInfo({
-			propTablesExclude: [FormCheckboxItem],
 			text: 'Basic usage of FormCheckboxItem'
 		})(() => (
 			<FormCheckboxItem

--- a/packages/sampler/stories/moonstone-stories/Group.js
+++ b/packages/sampler/stories/moonstone-stories/Group.js
@@ -31,7 +31,6 @@ storiesOf('UI', module)
 	.add(
 		'Group',
 		withInfo({
-			propTablesExclude: [Group],
 			text: 'Basic usage of Group'
 		})(() => (
 			<Group

--- a/packages/sampler/stories/moonstone-stories/Icon.js
+++ b/packages/sampler/stories/moonstone-stories/Icon.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Icon',
 		withInfo({
-			propTablesExclude: [Divider, Icon],
 			text: 'Basic usage of Icon'
 		})(() => {
 			const small = boolean('small', Icon);

--- a/packages/sampler/stories/moonstone-stories/IconButton.js
+++ b/packages/sampler/stories/moonstone-stories/IconButton.js
@@ -24,7 +24,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'IconButton',
 		withInfo({
-			propTablesExclude: [IconButton],
 			text: 'The basic IconButton'
 		})(() => (
 			<IconButton

--- a/packages/sampler/stories/moonstone-stories/Image.js
+++ b/packages/sampler/stories/moonstone-stories/Image.js
@@ -20,7 +20,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Image',
 		withInfo({
-			propTablesExclude: [Image],
 			text: 'The basic Image'
 		})(() => (
 			<Image

--- a/packages/sampler/stories/moonstone-stories/IncrementSlider.js
+++ b/packages/sampler/stories/moonstone-stories/IncrementSlider.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'IncrementSlider',
 		withInfo({
-			propTablesExclude: [IncrementSlider],
 			text: 'Basic usage of IncrementSlider'
 		})(() => {
 			const side = select('side', ['after', 'before', 'left', 'right'], IncrementSliderTooltipConfig, 'after');

--- a/packages/sampler/stories/moonstone-stories/Input.js
+++ b/packages/sampler/stories/moonstone-stories/Input.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Input',
 		withInfo({
-			propTablesExclude: [Input],
 			text: 'The basic Input'
 		})(() => (
 			<Input

--- a/packages/sampler/stories/moonstone-stories/Item.js
+++ b/packages/sampler/stories/moonstone-stories/Item.js
@@ -14,7 +14,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Item',
 		withInfo({
-			propTablesExclude: [Item],
 			text: 'Basic usage of Item'
 		})(() => (
 			<Item

--- a/packages/sampler/stories/moonstone-stories/LabeledIcon.js
+++ b/packages/sampler/stories/moonstone-stories/LabeledIcon.js
@@ -2,9 +2,7 @@ import LabeledIcon from '@enact/moonstone/LabeledIcon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
-import Scroller from '@enact/ui/Scroller';
 import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
-import Layout, {Cell} from '@enact/ui/Layout';
 
 import iconNames from './icons';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/moonstone-stories/LabeledIcon.js
+++ b/packages/sampler/stories/moonstone-stories/LabeledIcon.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'LabeledIcon',
 		withInfo({
-			propTablesExclude: [LabeledIcon, Scroller, Layout, Cell],
 			text: 'Basic usage of LabeledIcon'
 		})(() => (
 			<LabeledIcon

--- a/packages/sampler/stories/moonstone-stories/LabeledIconButton.js
+++ b/packages/sampler/stories/moonstone-stories/LabeledIconButton.js
@@ -15,7 +15,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'LabeledIconButton',
 		withInfo({
-			propTablesExclude: [LabeledIconButton],
 			text: 'Basic usage of LabeledIconButton'
 		})(() => (
 			<LabeledIconButton

--- a/packages/sampler/stories/moonstone-stories/LabeledItem.js
+++ b/packages/sampler/stories/moonstone-stories/LabeledItem.js
@@ -10,7 +10,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'LabeledItem',
 		withInfo({
-			propTablesExclude: [LabeledItem],
 			text: 'Basic usage of LabeledItem'
 		})(() => (
 			<LabeledItem

--- a/packages/sampler/stories/moonstone-stories/Layout.js
+++ b/packages/sampler/stories/moonstone-stories/Layout.js
@@ -14,7 +14,6 @@ storiesOf('UI', module)
 	.add(
 		'Layout',
 		withInfo({
-			propTablesExclude: [Button, Cell, Item, Layout],
 			text: 'Basic usage of Layout'
 		})(() => (
 			<div className="debug" style={{height: ri.unit(399, 'rem')}}>

--- a/packages/sampler/stories/moonstone-stories/Marquee.js
+++ b/packages/sampler/stories/moonstone-stories/Marquee.js
@@ -11,7 +11,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Marquee',
 		withInfo({
-			propTablesExclude: [Marquee],
 			text: 'The basic MarqueeText'
 		})(() => {
 			const disabled = boolean('disabled', Marquee);

--- a/packages/sampler/stories/moonstone-stories/MediaOverlay.js
+++ b/packages/sampler/stories/moonstone-stories/MediaOverlay.js
@@ -67,7 +67,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'MediaOverlay',
 		withInfo({
-			propTablesExclude: [MediaOverlay],
 			text: 'The basic MediaOverlay'
 		})(() => {
 			const videoTitle = select('source', prop.videoTitles, Config, 'Sintel');

--- a/packages/sampler/stories/moonstone-stories/Notification.js
+++ b/packages/sampler/stories/moonstone-stories/Notification.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Notification',
 		withInfo({
-			propTablesExclude: [Button, Notification],
 			text: 'Basic usage of Notification'
 		})(() => (
 			<Notification

--- a/packages/sampler/stories/moonstone-stories/Picker.js
+++ b/packages/sampler/stories/moonstone-stories/Picker.js
@@ -27,7 +27,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Picker',
 		withInfo({
-			propTablesExclude: [Picker],
 			text: 'Basic usage of Picker'
 		})(() => (
 			<Picker

--- a/packages/sampler/stories/moonstone-stories/Popup.js
+++ b/packages/sampler/stories/moonstone-stories/Popup.js
@@ -14,7 +14,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Popup',
 		withInfo({
-			propTablesExclude: [Popup],
 			text: 'Basic usage of Popup'
 		})(() => (
 			<div>

--- a/packages/sampler/stories/moonstone-stories/ProgressBar.js
+++ b/packages/sampler/stories/moonstone-stories/ProgressBar.js
@@ -16,7 +16,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ProgressBar',
 		withInfo({
-			propTablesExclude: [ProgressBar, ProgressBarTooltip],
 			text: 'The basic ProgressBar'
 		})(() => {
 			const side = select('side', ['after', 'before', 'left', 'right'], ProgressBarTooltipConfig, 'before');

--- a/packages/sampler/stories/moonstone-stories/RadioItem.js
+++ b/packages/sampler/stories/moonstone-stories/RadioItem.js
@@ -16,7 +16,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'RadioItem',
 		withInfo({
-			propTablesExclude: [RadioItem],
 			text: 'Basic usage of RadioItem'
 		})(() => (
 			<RadioItem

--- a/packages/sampler/stories/moonstone-stories/RangePicker.js
+++ b/packages/sampler/stories/moonstone-stories/RangePicker.js
@@ -30,7 +30,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'RangePicker',
 		withInfo({
-			propTablesExclude: [RangePicker],
 			text: 'Basic usage of RangePicker'
 		})(() => (
 			<RangePicker

--- a/packages/sampler/stories/moonstone-stories/Scroller.js
+++ b/packages/sampler/stories/moonstone-stories/Scroller.js
@@ -22,7 +22,6 @@ storiesOf('UI', module)
 	.add(
 		'Scroller',
 		withInfo({
-			propTablesExclude: [UiScroller],
 			text: 'Basic usage of Scroller'
 		})(() => (
 			<UiScroller
@@ -60,7 +59,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Scroller',
 		withInfo({
-			propTablesExclude: [Scroller],
 			text: 'Basic usage of Scroller'
 		})(() => (
 			<Scroller

--- a/packages/sampler/stories/moonstone-stories/SelectableItem.js
+++ b/packages/sampler/stories/moonstone-stories/SelectableItem.js
@@ -14,7 +14,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'SelectableItem',
 		withInfo({
-			propTablesExclude: [SelectableItem],
 			text: 'Basic usage of SelectableItem'
 		})(() => (
 			<SelectableItem

--- a/packages/sampler/stories/moonstone-stories/Slider.js
+++ b/packages/sampler/stories/moonstone-stories/Slider.js
@@ -17,7 +17,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Slider',
 		withInfo({
-			propTablesExclude: [Slider, SliderTooltip],
 			text: 'Basic usage of Slider'
 		})(() => {
 			const side = select('side', ['after', 'before', 'left', 'right'], SliderTooltipConfig, 'before');

--- a/packages/sampler/stories/moonstone-stories/SlotItem.js
+++ b/packages/sampler/stories/moonstone-stories/SlotItem.js
@@ -19,7 +19,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'SlotItem',
 		withInfo({
-			propTablesExclude: [Icon, SlotItem],
 			text: 'Basic usage of SlotItem'
 		})(() => (
 			<SlotItem

--- a/packages/sampler/stories/moonstone-stories/Spinner.js
+++ b/packages/sampler/stories/moonstone-stories/Spinner.js
@@ -15,7 +15,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'Spinner',
 		withInfo({
-			propTablesExclude: [Spinner],
 			text: 'Basic usage of Spinner'
 		})(() => (
 			<div

--- a/packages/sampler/stories/moonstone-stories/SwitchItem.js
+++ b/packages/sampler/stories/moonstone-stories/SwitchItem.js
@@ -13,7 +13,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'SwitchItem',
 		withInfo({
-			propTablesExclude: [SwitchItem],
 			text: 'Basic usage of SwitchItem'
 		})(() => (
 			<SwitchItem

--- a/packages/sampler/stories/moonstone-stories/TimePicker.js
+++ b/packages/sampler/stories/moonstone-stories/TimePicker.js
@@ -14,7 +14,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'TimePicker',
 		withInfo({
-			propTablesExclude: [TimePicker],
 			text: 'The basic TimePicker'
 		})(() => (
 			<TimePicker

--- a/packages/sampler/stories/moonstone-stories/ToggleButton.js
+++ b/packages/sampler/stories/moonstone-stories/ToggleButton.js
@@ -20,7 +20,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'ToggleButton',
 		withInfo({
-			propTablesExclude: [ToggleButton],
 			text: 'The basic ToggleButton'
 		})(() => (
 			<ToggleButton

--- a/packages/sampler/stories/moonstone-stories/TooltipDecorator.js
+++ b/packages/sampler/stories/moonstone-stories/TooltipDecorator.js
@@ -39,7 +39,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'TooltipDecorator',
 		withInfo({
-			propTablesExclude: [Button],
 			text: 'The basic TooltipDecorator'
 		})(() => (
 			<div style={{textAlign: 'center'}}>

--- a/packages/sampler/stories/moonstone-stories/VideoPlayer.js
+++ b/packages/sampler/stories/moonstone-stories/VideoPlayer.js
@@ -86,7 +86,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'VideoPlayer',
 		withInfo({
-			propTablesExclude: [Button, IconButton, MediaControls, VideoPlayer],
 			text: 'The basic VideoPlayer'
 		})(() => {
 			const videoTitle = select('source', prop.videoTitles, Config, 'Sintel');

--- a/packages/sampler/stories/moonstone-stories/VirtualGridList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualGridList.js
@@ -80,7 +80,6 @@ storiesOf('UI', module)
 	.add(
 		'VirtualList.VirtualGridList',
 		withInfo({
-			propTablesExclude: [UiVirtualGridList],
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<UiVirtualGridList
@@ -105,7 +104,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'VirtualList.VirtualGridList',
 		withInfo({
-			propTablesExclude: [VirtualGridList],
 			text: 'Basic usage of VirtualGridList'
 		})(() => (
 			<VirtualGridList

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -56,7 +56,6 @@ storiesOf('UI', module)
 	.add(
 		'VirtualList',
 		withInfo({
-			propTablesExclude: [UiVirtualList],
 			text: 'Basic usage of VirtualList'
 		})(() => {
 			const itemSize = ri.scale(number('itemSize', Config, 72));
@@ -80,7 +79,6 @@ storiesOf('Moonstone', module)
 	.add(
 		'VirtualList',
 		withInfo({
-			propTablesExclude: [VirtualList],
 			text: 'Basic usage of VirtualList'
 		})(() => {
 			const itemSize = ri.scale(number('itemSize', Config, 72));

--- a/packages/sampler/stories/qa-stories/LabeledIcon.js
+++ b/packages/sampler/stories/qa-stories/LabeledIcon.js
@@ -2,7 +2,6 @@ import LabeledIcon from '@enact/moonstone/LabeledIcon';
 import Divider from '@enact/moonstone/Divider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {withInfo} from '@storybook/addon-info';
 import Scroller from '@enact/ui/Scroller';
 import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import Layout, {Cell} from '@enact/ui/Layout';
@@ -12,22 +11,19 @@ import iconNames from '../moonstone-stories/icons';
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select, text} from '../../src/enact-knobs';
 
+LabeledIcon.displayName = 'LabeledIcon';
 const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, LabeledIcon);
-Config.displayName = 'LabeledIcon';
 
 storiesOf('LabeledIcon', module)
 	.add(
 		'with all icons',
-		withInfo({
-			propTablesExclude: [LabeledIcon, Scroller, Layout, Cell],
-			text: 'Basic usage of LabeledIcon'
-		})(() => {
+		() => {
 			const disabled = boolean('disabled', Config);
 			const inline = boolean('inline', Config);
 			const labelPosition = select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config);
 			const small = boolean('small', Config);
 			return (
-				<Layout orientation="vertical" style={{height: '100%'}}>
+				<Layout orientation="vertical">
 					<Cell shrink>
 						<LabeledIcon
 							disabled={disabled}
@@ -58,5 +54,5 @@ storiesOf('LabeledIcon', module)
 						</Scroller>
 					</Cell>
 				</Layout>);
-		})
+		}
 	);

--- a/packages/sampler/stories/qa-stories/LabeledIconButton.js
+++ b/packages/sampler/stories/qa-stories/LabeledIconButton.js
@@ -2,10 +2,8 @@ import LabeledIconButton from '@enact/moonstone/LabeledIconButton';
 import Divider from '@enact/moonstone/Divider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {withInfo} from '@storybook/addon-info';
 import Scroller from '@enact/ui/Scroller';
 import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
-
 import Layout, {Cell} from '@enact/ui/Layout';
 
 import iconNames from '../moonstone-stories/icons';
@@ -13,23 +11,20 @@ import iconNames from '../moonstone-stories/icons';
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select, text} from '../../src/enact-knobs';
 
+LabeledIconButton.displayName = 'LabeledIconButton';
 const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, LabeledIconButton);
-Config.displayName = 'LabeledIconButton';
 
 storiesOf('LabeledIconButton', module)
 	.add(
 		'with all icons',
-		withInfo({
-			propTablesExclude: [LabeledIconButton, Scroller, Layout, Cell],
-			text: 'Basic usage of LabeledIconButton'
-		})(() => {
+		() => {
 			const disabled = boolean('disabled', Config);
 			const inline = boolean('inline', Config);
 			const labelPosition = select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config);
 			const selected = boolean('selected', Config);
 			const small = boolean('small', Config);
 			return (
-				<Layout orientation="vertical" style={{height: '100%'}}>
+				<Layout orientation="vertical">
 					<Cell shrink>
 						<LabeledIconButton
 							disabled={disabled}
@@ -62,5 +57,5 @@ storiesOf('LabeledIconButton', module)
 						</Scroller>
 					</Cell>
 				</Layout>);
-		})
+		}
 	);


### PR DESCRIPTION
### Issue Resolved / Feature Added
Some samples are receiving styling rules that change their layout beyond what their creator intended.


### Resolution
Set the culprit (storybook addon info) to use specific defaults that override its poor internal styling to allow for stories to choose their own layout, rather than being trapped inside its tiny static prison.