### PR TITLE
ENYO-5543: Use perfNow() over Date.now()

### DIFF
--- a/packages/spotlight/Accelerator/Accelerator.js
+++ b/packages/spotlight/Accelerator/Accelerator.js
@@ -3,6 +3,7 @@
  *
  * @module spotlight/Accelerator
  */
+import {perfNow} from '@enact/core/util';
 
 /**
  * @class Accelerator
@@ -85,7 +86,7 @@ class Accelerator {
 			case 'keydown':
 				if (event.keyCode !== this.keyCode) {
 					this.reset();
-					this.time = Date.now();
+					this.time = perfNow();
 					this.keyCode = event.keyCode;
 					return callback(event);
 				} else if (this.canceled) {
@@ -94,7 +95,7 @@ class Accelerator {
 					event.preventDefault();
 					return true;
 				} else {
-					let elapsedTime = Date.now() - this.time,
+					let elapsedTime = perfNow() - this.time,
 						seconds = Math.floor(elapsedTime / 1000),
 						toSkip = 0;
 


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Use `perfNow()` over `Date.now()` in `Spotlight/Accelerator`

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
