### PR TITLE
ENYO-5536: Fix ui/LabeledIcon alignment and spacing

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Popup` to prevent duplicate 5-way navigation when `spotlightRestrict="self-first"`
 - `moonstone/Scroller` not to scroll to wrong position via 5way navigation in RTL languages
 - `moonstone/Slider` to forward `onActivate` event
+- `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` to have proper spacing and label-alignment with all label positions
 
 ## [2.0.1] - 2018-08-01
 

--- a/packages/moonstone/LabeledIcon/LabeledIcon.less
+++ b/packages/moonstone/LabeledIcon/LabeledIcon.less
@@ -8,12 +8,24 @@
 	margin: @moon-spotlight-outset;
 	padding: 0 @moon-spotlight-outset;
 
-	.icon {
-		// Margin top is handled by the parent's mrgin. An app setting the parent margin to 0 would
-		// not expect icon's margin to protrude past the outer component boundary. This ensures that
-		// won't happen.
+	// The following rules adjust the margin of icon so it behaves in a predictable way for users of
+	// this component, when applying their own styling/layout rules.
+	&.below .icon {
 		margin-top: 0;
 		margin-bottom: @moon-spotlight-outset;
+	}
+	&.above .icon {
+		margin-top: @moon-spotlight-outset;
+		margin-bottom: 0;
+	}
+	&.after,
+	&.before,
+	&.left,
+	&.right {
+		.icon {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
 
 	.label {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Labels in the horizontal arrangements appear off-center due to unbalanced margin around the `Icon` component. "Above" is particularly broken as it had extra space below but none between the label and the icon.


### Resolution
Built a comprehensive set of margin rules for all scenarios so no margin is applied when there shouldn't be, and correct margins are added always. This means that the label is always aligned and the external styling rules (application of margin) always behave in a predictable manner.