### PR TITLE
PLAT-62882: Fix LabeledIcon test to pass proptype

### DIFF
--- a/packages/ui/LabeledIcon/tests/LabeledIcon-specs.js
+++ b/packages/ui/LabeledIcon/tests/LabeledIcon-specs.js
@@ -6,7 +6,7 @@ import css from '../LabeledIcon.less';
 
 const iconName = 'anIconName';
 const iconLabel = 'A real label';
-const iconComponent = 'div';
+const iconComponent = ({children}) => <div>{children}</div>;
 
 describe('LabeledIcon Specs', () => {
 	it('should insert the icon source into the icon when using the prop approach', function () {


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

LabeledIcon tests were warning for an invalid prop type which will fail when our mocha test util is updated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Fix the test!