### PR TITLE
ENYO-5426: Fix the GridListImageItem's image height

### DIFF
--- a/packages/moonstone/GridListImageItem/GridListImageItem.less
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.less
@@ -25,18 +25,14 @@
 		height: ~"calc(100% - " @moon-gridlist-item-two-captions-padding-bottom ~")";
 	}
 
-	&.selected {
-		.icon {
-			opacity: 1;
-		}
-	}
-
 	div:first-child:nth-last-child(-n+2) {
 		height: ~"calc(100% - " @moon-gridlist-item-one-caption-padding-bottom ~")";
 	}
 
-	div:nth-child(3) {
-		.moon-body-text();
+	&.selected {
+		.icon {
+			opacity: 1;
+		}
 	}
 
 	// Skin colors

--- a/packages/moonstone/GridListImageItem/GridListImageItem.less
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.less
@@ -31,14 +31,12 @@
 		}
 	}
 
-	.caption {
-		.moon-sub-header-text();
-		padding-top: @moon-gridlist-item-caption-padding-top;
+	div:first-child:nth-last-child(-n+2) {
+		height: ~"calc(100% - " @moon-gridlist-item-one-caption-padding-bottom ~")";
 	}
 
-	.subCaption {
+	div:nth-child(3) {
 		.moon-body-text();
-		padding-top: @moon-gridlist-item-caption-padding-top;
 	}
 
 	// Skin colors

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -267,8 +267,8 @@
 @moon-gridlist-item-overlay-icon-size: 60px;
 @moon-gridlist-item-border-width: 6px;
 @moon-gridlist-item-caption-padding-top: 9px;
-@moon-gridlist-item-one-caption-padding-bottom: 42px;
-@moon-gridlist-item-two-captions-padding-bottom: 96px;
+@moon-gridlist-item-one-caption-padding-bottom: 36px;
+@moon-gridlist-item-two-captions-padding-bottom: 72px;
 
 // Scrollable
 // ---------------------------------------

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -193,8 +193,8 @@ const GridListImageItem = kind({
 				<ImageComponent className={css.image} placeholder={placeholder} src={source}>
 					{selectionOverlay}
 				</ImageComponent>
-				{caption ? (<Caption className={css.caption}>{caption}</Caption>) : null}
-				{subCaption ? (<Caption className={css.subCaption}>{subCaption}</Caption>) : null}
+				{caption ? (<Caption>{caption}</Caption>) : null}
+				{subCaption ? (<Caption>{subCaption}</Caption>) : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

- If using only a caption or a subCaption, there is the gap between its text and the GridListImageItem border.
- `.caption` and `.subCaption` css classes are not needed any more.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Increase the image height if using only a caption or a subCaption.
- Remove useless css classes. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- Add CSS styles for subCaption that we used before. (I don't know the exact history for the styles, but we defined the styles for subCaption before and it is not applied to the subCaption now.)

### Links
[//]: # (Related issues, references)

ENYO-5426

### Comments

The target branch for this PR is not `develop` but `feature/ENYO-5426-same-height`. So I did not update `CHANGELOG.md` and no test case is needed.