### PR TITLE
ENYO-5480: Fix prevent scrolling on focus in pointer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` to have proper spacing and label-alignment with all label positions
 - `moonstone/Popup` to prevent duplicate 5-way navigation when `spotlightRestrict="self-first"`
 - `moonstone/Scroller` not to scroll to wrong position via 5way navigation in RTL languages
+- `moonstone/Scroller` not to scroll when focusing in pointer mode
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/VideoPlayer` to reset key down hold when media becomes unavailable
 - `spotlight` to update pointer mode after hiding webOS VKB

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` to have proper spacing and label-alignment with all label positions
 - `moonstone/Popup` to prevent duplicate 5-way navigation when `spotlightRestrict="self-first"`
 - `moonstone/Scroller` not to scroll to wrong position via 5way navigation in RTL languages
+- `moonstone/Scroller` not to scroll when focusing in pointer mode
 - `moonstone/Slider` to forward `onActivate` event
 - `moonstone/VideoPlayer` to reset key down hold when media becomes unavailable
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -546,6 +546,7 @@ class ScrollableBase extends Component {
 		}
 	}
 
+	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
 		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
 			const scrollHeight = this.uiRef.getScrollBounds().scrollHeight;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -546,11 +546,18 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
 		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
-			this.calculateAndScrollTo();
+			const scrollHeight = this.uiRef.getScrollBounds().scrollHeight;
+			if (scrollHeight !== this.uiRef.bounds.scrollHeight) {
+				this.calculateAndScrollTo();
+			}
 		}
+
+		// oddly, Scroller manages this.uiRef.bounds so if we don't update it here (it is also
+		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
+		// out of date when we land back in this method next time.
+		this.uiRef.bounds.scrollHeight = this.uiRef.getScrollBounds().scrollHeight;
 	}
 
 	clearOverscrollEffect = (orientation, edge) => {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -618,8 +618,16 @@ class ScrollableBaseNative extends Component {
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	handleScrollerUpdate = () => {
 		if (this.uiRef.scrollToInfo === null && Spotlight.getPointerMode()) {
-			this.calculateAndScrollTo();
+			const scrollHeight = this.uiRef.getScrollBounds().scrollHeight;
+			if (scrollHeight !== this.uiRef.bounds.scrollHeight) {
+				this.calculateAndScrollTo();
+			}
 		}
+
+		// oddly, Scroller manages this.uiRef.bounds so if we don't update it here (it is also
+		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
+		// out of date when we land back in this method next time.
+		this.uiRef.bounds.scrollHeight = this.uiRef.getScrollBounds().scrollHeight;
 	}
 
 	clearOverscrollEffect = (orientation, edge) => {

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -150,9 +150,9 @@ class ScrollerBase extends Component {
 				{scrollHeight} = this.uiRef.scrollBounds,
 				scrollHeightDecrease = previousScrollHeight - scrollHeight;
 
-			newScrollTop = scrollTop;
-
 			if (scrollHeightDecrease > 0) {
+				newScrollTop = scrollTop;
+
 				const
 					itemBounds = focusedItem.getBoundingClientRect(),
 					newItemBottom = newScrollTop + itemBounds.top + itemBounds.height - containerTop;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I noticed a disconnect between the original requirement for adding onUpdate and the way in which it was implemented. The requirement surfaced due to a need to scroll a Component (in that case, the entire ExpandableList) into view when that component caused a change in scroll bounds. It appears in the original implementation that we asserted that nearly any update of the component should cause this behavior but discovered that updates introduced upstream (as was described in this ticket) would inadvertently cause scrolling.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The gap in my view is that we didn't verify that the scroll bounds changed before invoking this logic. I adjusted the callback to verify the bounds have changed as well as updating the Scrollable-managed scrollHeight value.

### Additional Considerations

I also made an update to Scroller to only update the scroll top when the scroll size decreases. This fixed a bug in which repeatedly opening and closing an ExpandableList in a Scroller would alternately scroll it into view on open and then fail to scroll on open. We need to validate this change with the work in ENYO-5539 (PR yet to be created).