### PR TITLE
ENYO-5354: Delay PickerButton hold event

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,12 +4,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Changed
-
-- `moonstone/Picker` key down hold threshold to 800ms before firing the `onChange` event
 ### Added
 
 - `moonstone/VideoPlayer` property `noMediaSliderFeedback`
+
+### Changed
+
+- `moonstone/Picker` key down hold threshold to 800ms before firing the `onChange` event
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
+- `moonstone/Picker` to correctly update its value once when button is selected
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,10 +4,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `moonstone/Picker` key down hold threshold to 800ms before firing the `onChange` event
+
 ### Fixed
 
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
-- `moonstone/Picker` to correctly update its value once when button is selected
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -22,6 +22,12 @@ import SpottablePicker from './SpottablePicker';
 
 import css from './Picker.less';
 
+const holdConfig = {
+	events: [
+		{name: 'hold', time: 800}
+	]
+};
+
 const isDown = is('down');
 const isLeft = is('left');
 const isRight = is('right');
@@ -856,6 +862,7 @@ const PickerBase = class extends React.Component {
 					data-webos-voice-label={joined ? this.calcButtonLabel(!reverse, valueText) : null}
 					disabled={incrementerDisabled}
 					hidden={reachedEnd}
+					holdConfig={holdConfig}
 					icon={incrementIcon}
 					joined={joined}
 					onDown={this.handleIncDown}
@@ -892,6 +899,7 @@ const PickerBase = class extends React.Component {
 					data-webos-voice-label={joined ? this.calcButtonLabel(reverse, valueText) : null}
 					disabled={decrementerDisabled}
 					hidden={reachedStart}
+					holdConfig={holdConfig}
 					icon={decrementIcon}
 					joined={joined}
 					onDown={this.handleDecDown}

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -88,7 +88,15 @@ const PickerButtonBase = kind({
 			);
 		} else {
 			return (
-				<IconButton {...rest} backgroundOpacity="transparent" disabled={disabled} small>
+				<IconButton
+					{...rest}
+					backgroundOpacity="transparent"
+					disabled={disabled}
+					holdConfig={{events: [
+						{name: 'hold', time: 800}
+					]}}
+					small
+				>
 					{icon}
 				</IconButton>
 			);

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -88,15 +88,7 @@ const PickerButtonBase = kind({
 			);
 		} else {
 			return (
-				<IconButton
-					{...rest}
-					backgroundOpacity="transparent"
-					disabled={disabled}
-					holdConfig={{events: [
-						{name: 'hold', time: 800}
-					]}}
-					small
-				>
+				<IconButton {...rest} backgroundOpacity="transparent" disabled={disabled} small>
 					{icon}
 				</IconButton>
 			);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
On TV-only, after a hold event `Picker` can get into a state where selecting a `PickerButton` once can result in the picker value changing multiple times.


### Resolution
This issue appears to be the result of a performance issue on TV (whether through Storybook or specifically-created app) where the `keyup` isn't able to register in time before a `holdPulse` event is able to fire (causing the additional value change). The solution for the time being appears to be delaying the hold event for the `PickerButton` so that `holdPulse` isn't fired before the actual hold event is registered.


### Additional Considerations
This is more of a remedy, as an actual fix would require preventing the TV from getting into the odd state where this issue is observed. However, it isn't obvious to us how this is happening or how to prevent this.
