### PR TITLE
ENYO-5551: When comparing Slider value against min, ensure value is set

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
-- `moonstone/Slider` not to fire `onChange` event when `value` has not changed
+- `moonstone/Slider` to not emit `onChange` event when `value` has not changed
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
+- `moonstone/Slider` not to fire `onChange` event when `value` has not changed
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/moonstone/Slider/tests/Slider-specs.js
+++ b/packages/moonstone/Slider/tests/Slider-specs.js
@@ -219,6 +219,37 @@ describe('Slider', () => {
 		expect(actual).to.equal(expected);
 	});
 
+	// these tests validate behavior relating to `value` defaulting to `min`
+	it('should not emit onChange when decrementing at the lower bound when value is unset', () => {
+		const handleChange = sinon.spy();
+		const subject = mount(
+			<Slider min={0} max={10} onChange={handleChange} />
+		);
+
+		activate(subject);
+		leftKeyDown(subject);
+
+		const expected = 'onChange not emitted';
+		const actual = handleChange.called ? 'onChange emitted' : 'onChange not emitted';
+
+		expect(actual).to.equal(expected);
+	});
+
+	it('should increment from the lower bound when value is unset', () => {
+		const handleChange = sinon.spy();
+		const subject = mount(
+			<Slider min={0} max={10} onChange={handleChange} />
+		);
+
+		activate(subject);
+		rightKeyDown(subject);
+
+		const expected = 1;
+		const actual = subject.find('Slider').prop('value');
+
+		expect(actual).to.equal(expected);
+	});
+
 	it('should call onSpotlightLeft on horizontal slider at min value', () => {
 		const handleSpotlight = sinon.spy();
 		const subject = mount(

--- a/packages/moonstone/Slider/utils.js
+++ b/packages/moonstone/Slider/utils.js
@@ -29,7 +29,7 @@ const isNotMax = (ev, {value, max}) => {
 	return value !== max;
 };
 
-const isNotMin = (ev, {value, min}) => {
+const isNotMin = (ev, {min, value = min}) => {
 	return value !== min;
 };
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Slider` can emit an `onChange` event when `value` has not actually changed. The issue is a result of `value` being unset and `Slider` incorrectly checking `value` against `min` before firing the `onChange` event.


### Resolution
Since `value` (when unset) should default to `min`, we need to ensure that is the case when we compare these values in the `isNotMin` method of `Slider/utils`.