### PR TITLE
Add keys to FloatingLayerDecorator

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/FloatingLayer` to apply `key`s to prevent React warnings
+
 ## [2.0.2] - 2018-13-01
 
 ### Fixed

--- a/packages/ui/FloatingLayer/FloatingLayerDecorator.js
+++ b/packages/ui/FloatingLayer/FloatingLayerDecorator.js
@@ -129,8 +129,8 @@ const FloatingLayerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {className, ...rest} = this.props;
 			return (
 				<div className={className}>
-					<Wrapped {...rest} className={wrappedClassName} />
-					<div id={floatLayerId} ref={this.setFloatingLayer} />
+					<Wrapped key="floatWrapped" {...rest} className={wrappedClassName} />
+					<div id={floatLayerId} key="floatLayer" ref={this.setFloatingLayer} />
 				</div>
 			);
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In certain circumstances React would warn of missing keys from
the FloatingLayerDecorator.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add keys to the decorator.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In theory, this should not be required.  This is very low impact, however.

### Links
[//]: # (Related issues, references)
ENYP-5550

### Comments
