### PR TITLE
ENYO-5561: Fix VirtualList to restore focus correctly

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VirtualList` to restore last focused correctly
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll by dragging
 - `moonstone/GridListImageItem` to properly vertically align when the content varies in size
 - `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -38,7 +38,7 @@ const configureSpotlight = (spotlightId, instance) => {
 			}
 
 			return all.reduce((focused, node) => {
-				return focused || node.dataset.index === key && node;
+				return focused || Number(node.dataset.index) === key && node;
 			}, null);
 		}
 	});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix `VirtualList` couldn't restore last focused in case of no placeholder scenario

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Convert `data-index` to `Number` to be compared correctly

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5561
https://jsperf.com/number-vs-parseint-vs-plus/24

### Comments

Enact-DCO-1.0-Signed-off-by: Yeram Choi <yeram.choi@lge.com>