### PR TITLE
ENYO-5563: SpotlightContainerDecorator: container config is removed when spotlightId prop is changed

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightContainerDecorator` to unmount config instead of remove when spotlightId is changed if it preserves id
+
 ## [2.0.2] - 2018-13-01
 
 ### Fixed

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -201,7 +201,11 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			let id = nextProps.spotlightId;
 			if (prevId !== id) {
-				Spotlight.remove(prevId);
+				if (this.state.preserveId) {
+					Spotlight.unmount(prevId);
+				} else {
+					Spotlight.remove(prevId);
+				}
 				id = Spotlight.add(id);
 
 				this.setState(stateFromProps({spotlightId: id}));

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -201,11 +201,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			let id = nextProps.spotlightId;
 			if (prevId !== id) {
-				if (this.state.preserveId) {
-					Spotlight.unmount(prevId);
-				} else {
-					Spotlight.remove(prevId);
-				}
+				this.releaseContainer(prevId);
 				id = Spotlight.add(id);
 
 				this.setState(stateFromProps({spotlightId: id}));
@@ -219,10 +215,14 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
+			this.releaseContainer(this.state.id);
+		}
+
+		releaseContainer (spotlightId) {
 			if (this.state.preserveId) {
-				Spotlight.unmount(this.state.id);
+				Spotlight.unmount(spotlightId);
 			} else {
-				Spotlight.remove(this.state.id);
+				Spotlight.remove(spotlightId);
 			}
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix unexpected removing container config when `spotlightId` is changed

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check `this.state.preserveId` to execute `Spotlight.remove()` or `Spotlight.unmount()`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5563

### Comments

Enact-DCO-1.0-Signed-off-by: Yeram Choi <yeram.choi@lge.com>