### PR TITLE
PLAT-64857: Replace moonstone/Item with ui/Item in ui/VirtualList sampler

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 ### Fixed
 
-- `ui/VirtualList` sampler's item not to have focus
+- `ui/VirtualList` sampler to replace `moonstone/Item` with `ui/Item`
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 ### Fixed
 
-- `ui/VirtualList` sampler to replace `moonstone/Item` with `ui/Item`
+- `ui/VirtualList` sampler to use `ui/Item` instead of `moonstone/Item`
 
 ## [2.0.2] - 2018-13-01
 

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` sampler's item not to have focus
+
 ## [2.0.2] - 2018-13-01
 
 No significant changes.

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -1,3 +1,4 @@
+import {Item as UiItem} from '@enact/ui/Item';
 import Item from '@enact/moonstone/Item';
 import {VirtualList as UiVirtualList} from '@enact/ui/VirtualList';
 import VirtualList from '@enact/moonstone/VirtualList';
@@ -19,11 +20,25 @@ const
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
+	uiRenderItem = (size) => ({index, ...rest}) => {
+		const itemStyle = {
+			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
+			boxSizing: 'border-box',
+			height: size + 'px'
+		};
+
+		return (
+			<UiItem {...rest} style={itemStyle}>
+				{items[index]}
+			</UiItem>
+		);
+	},
+	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {
-			height: size + 'px',
 			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-			boxSizing: 'border-box'
+			boxSizing: 'border-box',
+			height: size + 'px'
 		};
 
 		return (
@@ -62,7 +77,7 @@ storiesOf('UI', module)
 			return (
 				<UiVirtualList
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					itemRenderer={renderItem(itemSize)}
+					itemRenderer={uiRenderItem(itemSize)}
 					itemSize={itemSize}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

`moonstone/Item` was used in `ui/VirtualList` sampler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Replaced `moonstone/Item` with `ui/Item`.

### Links
[//]: # (Related issues, references)

PLAT-64857

### Comments
