### PR TITLE
PLAT-64864: Remove the unexpected Scrollbar button composite layer

### DIFF
--- a/packages/moonstone/Scrollable/Scrollbar.less
+++ b/packages/moonstone/Scrollable/Scrollbar.less
@@ -53,6 +53,10 @@
 			-webkit-transform: initial;
 			transform: initial;
 		}
+
+		div:nth-child(2) {
+			overflow: hidden;
+		}
 	}
 
 	.scrollButton {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is the unexpected Scrollbar button composite layer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The ScrollButton size is 40px X 40px. But the "arrow" icon size of the ScrollButton is 24px X 48px, which makes the new composite layer for it. So I tried to clip the icon with 40px X 40px. But the icon was not clipped visually.

### Links
[//]: # (Related issues, references)

PLAT-64864

### Comments
