### PR TITLE
ENYO-5560: Fix VideoPlayer to detect activity via keydown

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to fallback focusing on available media buttons if default spotlight component is disabled
 - `moonstone/VideoPlayer` to read out `infoComponents` accessibility value when `moreButtonColor` is pressed
 - `moonstone/VideoPlayer` to round the time displayed down to nearest second
+- `moonstone/VideoPlayer` to keep media controls visible when interacting with popups
 - `moonstone/Slider` to not emit `onChange` event when `value` has not changed
 
 ## [2.0.2] - 2018-13-01

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1784,7 +1784,6 @@ const VideoPlayerBase = class extends React.Component {
 			<RootContainer
 				className={css.videoPlayer + ' enact-fit' + (className ? ' ' + className : '')}
 				onClick={this.activityDetected}
-				onKeyDown={this.activityDetected}
 				ref={this.setPlayerRef}
 				spotlightDisabled={spotlightDisabled}
 				spotlightId={spotlightId}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -10,7 +10,7 @@
 
 import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {on, off} from '@enact/core/dispatcher';
-import {adaptEvent, call, forKey, forward, forwardWithPrevent, handle, stopImmediate} from '@enact/core/handle';
+import {adaptEvent, call, forKey, forward, forwardWithPrevent, handle, stopImmediate, returnsTrue} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import {platform} from '@enact/core/platform';
 import {perfNow, Job} from '@enact/core/util';
@@ -661,7 +661,6 @@ const VideoPlayerBase = class extends React.Component {
 
 	componentDidMount () {
 		on('mousemove', this.activityDetected);
-		on('keypress', this.activityDetected);
 		on('keydown', this.handleGlobalKeyDown);
 		this.startDelayedFeedbackHide();
 	}
@@ -757,7 +756,6 @@ const VideoPlayerBase = class extends React.Component {
 
 	componentWillUnmount () {
 		off('mousemove', this.activityDetected);
-		off('keypress', this.activityDetected);
 		off('keydown', this.handleGlobalKeyDown);
 		this.stopRewindJob();
 		this.stopAutoCloseTimeout();
@@ -1104,6 +1102,7 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	handleGlobalKeyDown = this.handle(
+		returnsTrue(this.activityDetected),
 		forKey('down'),
 		() => (
 			!this.state.mediaControlsVisible &&


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In #1701, we removed activity detection from the global `keydown` handler to allow 5-way down to show pointer controls. The unforseen regression of that was an inability to detect 5-way navigation in floating layers (e.g. ContextualPopup) opened from the media controls. We have a `keypress` handler but that isn't called when focus changes on `keydown` as is often the case for spotlight navigation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add back the call to `activityDetected` along with `returnsTrue` to ensure that the subsequent handlers still fire.