### PR TITLE
ENYO-5569: Handle less in onScroll event

### DIFF
--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1210,7 +1210,7 @@ class ScrollableBaseNative extends Component {
 
 		if (childRef && childRef.containerRef) {
 			if (childRef.containerRef.addEventListener) {
-				childRef.containerRef.addEventListener('scroll', this.onScroll, {capture: true});
+				childRef.containerRef.addEventListener('scroll', this.onScroll, {capture: true, passive: true});
 				childRef.containerRef.addEventListener('mousedown', this.onMouseDown);
 			}
 			this.childRef.containerRef.style.scrollBehavior = 'smooth';
@@ -1230,7 +1230,7 @@ class ScrollableBaseNative extends Component {
 		}
 
 		if (childRef && childRef.containerRef && childRef.containerRef.removeEventListener) {
-			childRef.containerRef.removeEventListener('scroll', this.onScroll, {capture: true});
+			childRef.containerRef.removeEventListener('scroll', this.onScroll, {capture: true, passive: true});
 			childRef.containerRef.removeEventListener('mousedown', this.onMouseDown);
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`onScroll` event handler is responsible for updating scroller's scroll thumb position and scroller button disabled state.

Each event handling takes up about ~16ms on TV.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Refactored `onScroll` handler to do less amount of work and used `requestAnimationFrame` to handle UI updates.
The `onScroll` event handler now takes up about ~3ms, and each UI update (which takes about ~10ms) occurs less.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
