### PR TITLE
PLAT-64761: Full-height Scroller Samples

### DIFF
--- a/packages/sampler/stories/moonstone-stories/Scroller.js
+++ b/packages/sampler/stories/moonstone-stories/Scroller.js
@@ -29,10 +29,6 @@ storiesOf('UI', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Config, 'auto')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				style={{
-					height: ri.unit(552, 'rem'),
-					width: '100%'
-				}}
 				verticalScrollbar={select('verticalScrollbar', prop.verticalScrollbar, Config, 'auto')}
 			>
 				<div
@@ -67,10 +63,6 @@ storiesOf('Moonstone', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Config, 'auto')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				style={{
-					height: ri.unit(552, 'rem'),
-					width: '100%'
-				}}
 				verticalScrollbar={select('verticalScrollbar', prop.verticalScrollbar, Config, 'auto')}
 			>
 				<div

--- a/packages/sampler/stories/moonstone-stories/VirtualGridList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualGridList.js
@@ -93,9 +93,6 @@ storiesOf('UI', module)
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 20))}
-				style={{
-					height: '100%'
-				}}
 			/>
 		))
 	);
@@ -118,9 +115,6 @@ storiesOf('Moonstone', module)
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 20))}
-				style={{
-					height: '100%'
-				}}
 				wrap={wrapOption[select('wrap', ['false', 'true', "'noAnimation'"], Config)]}
 			/>
 		))

--- a/packages/sampler/stories/moonstone-stories/VirtualList.js
+++ b/packages/sampler/stories/moonstone-stories/VirtualList.js
@@ -67,9 +67,6 @@ storiesOf('UI', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
-					style={{
-						height: '100%'
-					}}
 				/>
 			);
 		})
@@ -91,9 +88,6 @@ storiesOf('Moonstone', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
-					style={{
-						height: '100%'
-					}}
 					wrap={wrapOption[select('wrap', ['false', 'true', "'noAnimation'"], Config)]}
 				/>
 			);

--- a/packages/sampler/stories/qa-stories/Scroller.js
+++ b/packages/sampler/stories/qa-stories/Scroller.js
@@ -31,7 +31,6 @@ storiesOf('Scroller', module)
 			<Scroller
 				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', Scroller, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
-				style={{height: ri.unit(600, 'rem')}}
 			>
 				<Group childComponent={Item}>
 					{itemData}
@@ -42,10 +41,7 @@ storiesOf('Scroller', module)
 	.add(
 		'With ExpandableList',
 		() => (
-			<Scroller
-				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
-				style={{height: ri.unit(600, 'rem')}}
-			>
+			<Scroller focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}>
 				<ExpandableList
 					closeOnSelect
 					title="Expandable List in Scroller"
@@ -64,9 +60,6 @@ storiesOf('Scroller', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Scroller, 'auto')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				style={{
-					width: '100%'
-				}}
 			>
 				<div
 					style={{
@@ -86,12 +79,7 @@ storiesOf('Scroller', module)
 	.add(
 		'With Many ExpandableList',
 		() => (
-			<Scroller
-				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
-				style={{
-					width: '100%'
-				}}
-			>
+			<Scroller focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}>
 				<Divider>Nothing selected</Divider>
 				<ExpandableList
 					noneText="Nothing Selected"

--- a/packages/sampler/stories/qa-stories/VirtualList.js
+++ b/packages/sampler/stories/qa-stories/VirtualList.js
@@ -13,21 +13,16 @@ import {mergeComponentMetadata} from '../../src/utils/propTables';
 const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBase, UiVirtualListBase);
 
 const
-	style = {
-		item: {
-			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-			boxSizing: 'border-box'
-		},
-		list: {
-			height: '100%'
-		}
+	itemStyle = {
+		borderBottom: ri.unit(3, 'rem') + ' solid #202328',
+		boxSizing: 'border-box'
 	},
 	items = [],
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
-		const itemStyle = {height: size + 'px', ...style.item};
+		const style = {height: size + 'px', ...itemStyle};
 		return (
-			<StatefulSwitchItem index={index} style={itemStyle} {...rest}>
+			<StatefulSwitchItem index={index} style={style} {...rest}>
 				{items[index].item}
 			</StatefulSwitchItem>
 		);
@@ -88,7 +83,6 @@ storiesOf('VirtualList', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
-					style={style.list}
 				/>
 			);
 		},


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Samples for Scroller use an awkward static height.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Update the samples to use the full height available in the window.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

By default, VirtualList, VirtualGridList, and Scroller stretches to fit to a window. So we don't need `width: 100%; height: 100%` style in them. I removed it.

### Links
[//]: # (Related issues, references)

PLAT-64761

### Comments
