### PR TITLE
PLAT-64864: Remove page control's composite layers

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -86,7 +86,7 @@ const ButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['button', 'bg', 'selected', 'small']
+		publicClassNames: ['button', 'bg', 'client', 'selected', 'small']
 	},
 
 	computed: {

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -75,6 +75,7 @@ const ButtonBase = kind({
 		 *
 		 * * `button` - The root class name
 		 * * `bg` - The background node of the button
+		 * * `client` - The container node of the icon
 		 * * `selected` - Applied to a `selected` button
 		 * * `small` - Applied to a `small` button
 		 *

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -73,6 +73,7 @@ const IconButtonBase = kind({
 		 *
 		 * * `iconButton` - The root class name
 		 * * `bg` - The background node of the icon button
+		 * * `client` - The container node of the icon
 		 * * `selected` - Applied to a `selected` icon button
 		 * * `small` - Applied to a `small` icon button
 		 *

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -92,7 +92,7 @@ const IconButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['iconButton', 'bg', 'selected', 'small']
+		publicClassNames: ['iconButton', 'bg', 'client','selected', 'small']
 	},
 
 	computed: {

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -92,7 +92,7 @@ const IconButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['iconButton', 'bg', 'client','selected', 'small']
+		publicClassNames: ['iconButton', 'bg', 'client', 'selected', 'small']
 	},
 
 	computed: {

--- a/packages/moonstone/IconButton/IconButton.less
+++ b/packages/moonstone/IconButton/IconButton.less
@@ -57,4 +57,8 @@
 	.selected {
 		/* Exported for customization*/
 	}
+
+	.client {
+		/* Public Class Names */
+	}
 }

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import IconButton from '../IconButton';
 
-import css from './ScrollButton.less';
+import componentCss from './ScrollButton.less';
 
 const classNameMap = {
 	down: css.scrollbarBottomButton,
@@ -88,7 +88,7 @@ const ScrollButton = kind({
 	},
 
 	styles: {
-		css,
+		css: componentCss,
 		className: 'scrollButton'
 	},
 

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -7,10 +7,10 @@ import IconButton from '../IconButton';
 import componentCss from './ScrollButton.less';
 
 const classNameMap = {
-	down: css.scrollbarBottomButton,
-	left: css.scrollbarLeftButton,
-	right: css.scrollbarRightButton,
-	up: css.scrollbarUpButton
+	down: componentCss.scrollbarBottomButton,
+	left: componentCss.scrollbarLeftButton,
+	right: componentCss.scrollbarRightButton,
+	up: componentCss.scrollbarUpButton
 };
 
 /**

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -4,13 +4,13 @@ import React from 'react';
 
 import IconButton from '../IconButton';
 
-import componentCss from './ScrollButton.less';
+import css from './ScrollButton.less';
 
 const classNameMap = {
-	down: componentCss.scrollbarBottomButton,
-	left: componentCss.scrollbarLeftButton,
-	right: componentCss.scrollbarRightButton,
-	up: componentCss.scrollbarUpButton
+	down: css.scrollbarBottomButton,
+	left: css.scrollbarLeftButton,
+	right: css.scrollbarRightButton,
+	up: css.scrollbarUpButton
 };
 
 /**
@@ -70,15 +70,6 @@ const ScrollButton = kind({
 		active: PropTypes.bool,
 
 		/**
-		 * Override [IconButton]{@link moonstone/IconButton and
-		 * [Button]{@link moonstone/Button's `'bg'` and `'client'` css classes
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		css: PropTypes.object,
-
-		/**
 		 * Disables the button.
 		 *
 		 * @type {Boolean}
@@ -88,7 +79,7 @@ const ScrollButton = kind({
 	},
 
 	styles: {
-		css: componentCss,
+		css,
 		className: 'scrollButton'
 	},
 
@@ -97,7 +88,7 @@ const ScrollButton = kind({
 		className: ({direction, styler}) => styler.append(classNameMap[direction])
 	},
 
-	render: ({css, children, disabled, ...rest}) => {
+	render: ({children, disabled, ...rest}) => {
 		delete rest.active;
 		delete rest.direction;
 

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import IconButton from '../IconButton';
 
-import css from './Scrollbar.less';
+import css from './ScrollButton.less';
 
 const classNameMap = {
 	down: css.scrollbarBottomButton,
@@ -70,6 +70,15 @@ const ScrollButton = kind({
 		active: PropTypes.bool,
 
 		/**
+		 * Override [IconButton]{@link moonstone/IconButton and
+		 * [Button]{@link moonstone/Button's `'bg'` and `'client'` css classes
+		 *
+		 * @type {Object}
+		 * @private
+		 */
+		css: PropTypes.object,
+
+		/**
 		 * Disables the button.
 		 *
 		 * @type {Boolean}
@@ -88,7 +97,7 @@ const ScrollButton = kind({
 		className: ({direction, styler}) => styler.append(classNameMap[direction])
 	},
 
-	render: ({children, disabled, ...rest}) => {
+	render: ({css, children, disabled, ...rest}) => {
 		delete rest.active;
 		delete rest.direction;
 
@@ -96,6 +105,7 @@ const ScrollButton = kind({
 			<IconButton
 				{...rest}
 				backgroundOpacity="transparent"
+				css={css}
 				disabled={disabled}
 				small
 			>

--- a/packages/moonstone/Scrollable/ScrollButton.less
+++ b/packages/moonstone/Scrollable/ScrollButton.less
@@ -1,0 +1,17 @@
+.scrollButton {
+	margin: 0;
+
+	&.small:before {
+		content: none;
+	}
+
+	.bg {
+		will-change: auto;
+		-webkit-transform: initial;
+		transform: initial;
+	}
+
+	.client {
+		overflow: hidden;
+	}
+}

--- a/packages/moonstone/Scrollable/ScrollButton.less
+++ b/packages/moonstone/Scrollable/ScrollButton.less
@@ -1,7 +1,7 @@
 .scrollButton {
 	margin: 0;
 
-	&.small:before {
+	&.small::before {
 		content: none;
 	}
 

--- a/packages/moonstone/Scrollable/Scrollbar.less
+++ b/packages/moonstone/Scrollable/Scrollbar.less
@@ -34,33 +34,6 @@
 		}
 	}
 
-	/* ScrollButton */
-	.scrollbarButtonNoCompositeLayer {
-		&,
-		&:before,
-		&:after,
-		div,
-		span {
-			will-change: auto;
-		}
-
-		&:before {
-			content: none;
-		}
-
-		div,
-		span {
-			-webkit-transform: initial;
-			transform: initial;
-		}
-	}
-
-	.scrollButton {
-		.scrollbarButtonNoCompositeLayer;
-		background-color: transparent;
-		margin: 0;
-	}
-
 	/* ScrollThumb */
 	.thumbShown {
 		opacity: 1;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

We overrided the Button's CSS styles by using CSS element selector to remove page control's composite layers and to enhance scroll performance. But the Button's DOM structure changed and some composite layers were not removed because we used the CSS element selector.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I reverted the previous patch to remove page control's composite layers.
I override the Button's CSS styles by using CSS class selector.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

1. The ScrollButton's CSS classes are defined in not ScrollButton.less but Scrollbar.less. So I moved them to the ScrollButton.less.
2. I forgot to remove `direction` prop in ScrollButton.js in  PLAT-39161. I'll do it in PLAT-64865.
3. To override Button's `client` class, I add `client` string to the `publicClassNames` of the Button and the Icon Button. If it is not proper, I could override it with the following code.

AS-IS
```
	.client {
		overflow: hidden;
	}
```

TO-BE
```
	.bg ~ div {
		overflow: hidden;
	}
```

4. To override the Button's CSS styles, I added `ccc={css}` in the ScrollButton's render function. I think we could remove it because `rest` includes `css` property. But it did not work if removing it.
==> As @0x64 mentioned, `css` is NOT enumarable.  So `rest` could not include `css` property with `render: ({children, disabled, ...rest})` code.

Before removing `css={css}`
```
	render: ({css, children, disabled, ...rest}) => {
		delete rest.active;
		delete rest.direction;

		return (
			<IconButton
				{...rest}
				backgroundOpacity="transparent"
				css={css}
				disabled={disabled}
				small
			>
				{children}
			</IconButton>
		);
	}
```

After removing `css={css}`
```
	render: ({/*css, */children, disabled, ...rest}) => {
		delete rest.active;
		delete rest.direction;

		return (
			<IconButton
				{...rest}
				backgroundOpacity="transparent"
				/*css={css}*/
				disabled={disabled}
				small
			>
				{children}
			</IconButton>
		);
	}
```

### Links
[//]: # (Related issues, references)

PLAT-64864

### Comments
