### PR TITLE
ENYO-5529: Limited overscroll effects to wheel input only in `moonstone`

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects only by wheel input
+
 ## [2.1.0] - 2018-08-20
 
 ### Added

--- a/packages/moonstone/Scrollable/OverscrollEffect.less
+++ b/packages/moonstone/Scrollable/OverscrollEffect.less
@@ -1,6 +1,5 @@
 // OverscrollEffect.less
 //
-
 @import '../styles/mixins.less';
 @import '../styles/variables.less';
 @import '../styles/skin.less';

--- a/packages/moonstone/Scrollable/OverscrollEffect.less
+++ b/packages/moonstone/Scrollable/OverscrollEffect.less
@@ -1,6 +1,5 @@
 // OverscrollEffect.less
 //
-@import '~@enact/ui/Scrollable/Scrollable.less';
 
 @import '../styles/mixins.less';
 @import '../styles/variables.less';

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -468,6 +468,7 @@ class ScrollableBase extends Component {
 		this.animateOnFocus = true;
 
 		if (!repeat && this.hasFocus()) {
+			const {overscrollEffectOn} = this.props;
 			let
 				overscrollEffectRequired = false,
 				direction = null;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -150,7 +150,13 @@ class ScrollableBase extends Component {
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
 		 * @type {Object}
-		 * @default {arrowKey: false, drag: false, pageKey: false, scrollbarButton: false, wheel: true}
+		 * @default {
+		 *	arrowKey: false,
+		 *	drag: false,
+		 *	pageKey: false,
+		 *	scrollbarButton: false,
+		 *	wheel: true
+		 * }
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -149,8 +149,8 @@ class ScrollableBase extends Component {
 		/**
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
-		 * @type {String[]}
-		 * @default null
+		 * @type {Object}
+		 * @default {arrowKey: false, drag: false, pageKey: false, scrollbarButton: false, wheel: true}
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -131,7 +131,13 @@ class ScrollableBaseNative extends Component {
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
 		 * @type {Object}
-		 * @default {arrowKey: false, drag: false, pageKey: false, scrollbarButton: false, wheel: true}
+		 * @default {
+		 *	arrowKey: false,
+		 *	drag: false,
+		 *	pageKey: false,
+		 *	scrollbarButton: false,
+		 *	wheel: true
+		 * }
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -130,8 +130,8 @@ class ScrollableBaseNative extends Component {
 		/**
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
-		 * @type {String[]}
-		 * @default null
+		 * @type {Object}
+		 * @default {arrowKey: false, drag: false, pageKey: false, scrollbarButton: false, wheel: true}
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -282,7 +282,7 @@ class ScrollableBaseNative extends Component {
 	 */
 	onWheel = (ev) => {
 		const
-			overscrollEffectNeeded = this.props.overscrollEffectOn.wheel,
+			overscrollEffectRequired = this.props.overscrollEffectOn.wheel,
 			bounds = this.uiRef.getScrollBounds(),
 			canScrollHorizontally = this.uiRef.canScrollHorizontally(bounds),
 			canScrollVertically = this.uiRef.canScrollVertically(bounds),
@@ -314,11 +314,11 @@ class ScrollableBaseNative extends Component {
 					(verticalScrollbarRef && verticalScrollbarRef.getContainerRef().contains(ev.target))) {
 					delta = this.uiRef.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
-				} else if (overscrollEffectNeeded) {
+				} else if (overscrollEffectRequired) {
 					this.uiRef.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 				}
 			} else {
-				if (overscrollEffectNeeded && eventDelta < 0 && this.uiRef.scrollTop <= 0 || eventDelta > 0 && this.uiRef.scrollTop >= bounds.maxTop) {
+				if (overscrollEffectRequired && (eventDelta < 0 && this.uiRef.scrollTop <= 0 || eventDelta > 0 && this.uiRef.scrollTop >= bounds.maxTop)) {
 					this.uiRef.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
@@ -332,7 +332,7 @@ class ScrollableBaseNative extends Component {
 				delta = this.uiRef.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				needToHideThumb = !delta;
 			} else {
-				if (overscrollEffectNeeded && eventDelta < 0 && this.scrollLeft <= 0 || eventDelta > 0 && this.scrollLeft >= bounds.maxLeft) {
+				if (overscrollEffectRequired && (eventDelta < 0 && this.scrollLeft <= 0 || eventDelta > 0 && this.scrollLeft >= bounds.maxLeft)) {
 					this.uiRef.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
@@ -348,7 +348,7 @@ class ScrollableBaseNative extends Component {
 				this.uiRef.isScrollAnimationTargetAccumulated = false;
 				this.uiRef.wheelDirection = direction;
 			}
-			this.uiRef.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectNeeded);
+			this.uiRef.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
 		}
 
 		if (needToHideThumb) {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -277,6 +277,19 @@ class ScrollableBase extends Component {
 		onWheel: PropTypes.func,
 
 		/**
+		 * Specifies overscroll effects shows on which type of inputs.
+		 *
+		 * @type {String[]}
+		 * @default null
+		 * @private
+		 */
+		overscrollEffectOn: PropTypes.shape({
+			drag: PropTypes.bool,
+			pageKey: PropTypes.bool,
+			wheel: PropTypes.bool
+		}),
+
+		/**
 		 * Called when removing additional event listeners in a themed component.
 		 *
 		 * @type {Function}
@@ -337,6 +350,7 @@ class ScrollableBase extends Component {
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
+		overscrollEffectOn: {drag: false, pageKey: false, wheel: false},
 		verticalScrollbar: 'auto'
 	}
 
@@ -493,6 +507,8 @@ class ScrollableBase extends Component {
 	isUpdatedScrollThumb = false
 
 	// overscroll
+	lastInputType = null
+	overscrollEnabled = false
 	overscrollStatus = {
 		horizontal: {
 			before: {type: overscrollTypeNone, ratio: 0},
@@ -554,10 +570,13 @@ class ScrollableBase extends Component {
 
 		const {direction} = this.props;
 
+		this.lastInputType = 'drag';
+
 		this.start({
 			targetX: (direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
 			targetY: (direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
-			animate: false
+			animate: false,
+			overscrollEffect: this.props.overscrollEffectOn.drag
 		});
 	}
 
@@ -569,13 +588,15 @@ class ScrollableBase extends Component {
 		if (this.flickTarget) {
 			const {targetX, targetY, duration} = this.flickTarget;
 
+			this.lastInputType = 'drag';
+
 			this.isScrollAnimationTargetAccumulated = false;
-			this.start({targetX, targetY, duration});
+			this.start({targetX, targetY, duration, overscrollEffect: this.props.overscrollEffectOn.drag});
 		} else {
 			this.stop();
 		}
 
-		if (this.overscrollEnabled) {
+		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safty
 			this.clearAllOverscrollEffects();
 		}
 
@@ -624,6 +645,8 @@ class ScrollableBase extends Component {
 				delta = 0,
 				direction;
 
+			this.lastInputType = 'wheel';
+
 			if (canScrollVertically) {
 				delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 			} else if (canScrollHorizontally) {
@@ -640,7 +663,7 @@ class ScrollableBase extends Component {
 			forward('onWheel', {delta, horizontalScrollbarRef, verticalScrollbarRef}, this.props);
 
 			if (delta !== 0) {
-				this.scrollToAccumulatedTarget(delta, canScrollVertically);
+				this.scrollToAccumulatedTarget(delta, canScrollVertically, this.props.overscrollEffectOn.wheel);
 			}
 		}
 	}
@@ -655,7 +678,9 @@ class ScrollableBase extends Component {
 			canScrollVertically = this.canScrollVertically(bounds),
 			pageDistance = (isPageUp(keyCode) ? -1 : 1) * (canScrollVertically ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
-		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically);
+		this.lastInputType = 'pageKey';
+
+		this.scrollToAccumulatedTarget(pageDistance, canScrollVertically, this.props.overscrollEffectOn.pageKey);
 	}
 
 	onKeyDown = (ev) => {
@@ -666,7 +691,7 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	scrollToAccumulatedTarget = (delta, vertical) => {
+	scrollToAccumulatedTarget = (delta, vertical, overscrollEffect) => {
 		if (!this.isScrollAnimationTargetAccumulated) {
 			this.accumulatedTargetX = this.scrollLeft;
 			this.accumulatedTargetY = this.scrollTop;
@@ -679,7 +704,7 @@ class ScrollableBase extends Component {
 			this.accumulatedTargetX += delta;
 		}
 
-		this.start({targetX: this.accumulatedTargetX, targetY: this.accumulatedTargetY});
+		this.start({targetX: this.accumulatedTargetX, targetY: this.accumulatedTargetY, overscrollEffect});
 	}
 
 	// overscroll effect
@@ -804,7 +829,7 @@ class ScrollableBase extends Component {
 
 		this.scrollLeft = clamp(0, bounds.maxLeft, value);
 
-		if (this.overscrollEnabled) {
+		if (this.overscrollEnabled && this.props.overscrollEffectOn[this.lastInputType]) {
 			this.checkAndApplyOverscrollEffectOnScroll('horizontal');
 		}
 
@@ -818,7 +843,7 @@ class ScrollableBase extends Component {
 
 		this.scrollTop = clamp(0, bounds.maxTop, value);
 
-		if (this.overscrollEnabled) {
+		if (this.overscrollEnabled && this.props.overscrollEffectOn[this.lastInputType]) {
 			this.checkAndApplyOverscrollEffectOnScroll('vertical');
 		}
 
@@ -829,7 +854,7 @@ class ScrollableBase extends Component {
 
 	// scroll start/stop
 
-	start ({targetX, targetY, animate = true, duration = animationDuration, overscrollEffect = true}) {
+	start ({targetX, targetY, animate = true, duration = animationDuration, overscrollEffect = false}) {
 		const
 			{scrollLeft, scrollTop} = this,
 			bounds = this.getScrollBounds(),
@@ -932,9 +957,10 @@ class ScrollableBase extends Component {
 
 	stop () {
 		this.animator.stop();
+		this.lastInputType = null;
 		this.isScrollAnimationTargetAccumulated = false;
 		this.startHidingThumb();
-		if (this.overscrollEnabled && !this.isDragging) {
+		if (this.overscrollEnabled && !this.isDragging) { // not check this.props.overscrollEffectOn for safty
 			this.clearAllOverscrollEffects();
 		}
 		if (this.props.stop) {
@@ -1020,8 +1046,7 @@ class ScrollableBase extends Component {
 			this.start({
 				targetX: (left !== null) ? left : this.scrollLeft,
 				targetY: (top !== null) ? top : this.scrollTop,
-				animate: opt.animate,
-				overscrollEffect: false
+				animate: opt.animate
 			});
 		} else {
 			this.scrollToInfo = opt;
@@ -1244,6 +1269,7 @@ class ScrollableBase extends Component {
 		delete rest.onScrollStart;
 		delete rest.onScrollStop;
 		delete rest.onWheel;
+		delete rest.overscrollEffectOn;
 		delete rest.removeEventListeners;
 		delete rest.scrollTo;
 		delete rest.stop;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -596,7 +596,7 @@ class ScrollableBase extends Component {
 			this.stop();
 		}
 
-		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safty
+		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safety
 			this.clearAllOverscrollEffects();
 		}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -279,8 +279,8 @@ class ScrollableBase extends Component {
 		/**
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
-		 * @type {String[]}
-		 * @default null
+		 * @type {Object}
+		 * @default {drag: false, pageKey: false, wheel: false}
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -272,8 +272,8 @@ class ScrollableBaseNative extends Component {
 		/**
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
-		 * @type {String[]}
-		 * @default null
+		 * @type {Object}
+		 * @default {drag: false, pageKey: false, wheel: false}
 		 * @private
 		 */
 		overscrollEffectOn: PropTypes.shape({

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -595,7 +595,7 @@ class ScrollableBaseNative extends Component {
 			this.stop();
 		}
 
-		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safty
+		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safety
 			this.clearAllOverscrollEffects();
 		}
 		this.isTouching = false;
@@ -648,7 +648,7 @@ class ScrollableBaseNative extends Component {
 		} else {
 			const
 				{overscrollEffectOn} = this.props,
-				overscrollEffectNeeded = this.overscrollEnabled && overscrollEffectOn.wheel,
+				overscrollEffectRequired = this.overscrollEnabled && overscrollEffectOn.wheel,
 				bounds = this.getScrollBounds(),
 				canScrollHorizontally = this.canScrollHorizontally(bounds),
 				canScrollVertically = this.canScrollVertically(bounds),
@@ -678,11 +678,11 @@ class ScrollableBaseNative extends Component {
 						(verticalScrollbarRef && verticalScrollbarRef.getContainerRef().contains(ev.target))) {
 						delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 						needToHideThumb = !delta;
-					} else if (overscrollEffectNeeded) {
+					} else if (overscrollEffectRequired) {
 						this.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 					}
 				} else {
-					if (overscrollEffectNeeded && eventDelta < 0 && this.scrollTop <= 0 || eventDelta > 0 && this.scrollTop >= bounds.maxTop) {
+					if (overscrollEffectRequired && (eventDelta < 0 && this.scrollTop <= 0 || eventDelta > 0 && this.scrollTop >= bounds.maxTop)) {
 						this.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 					}
 					needToHideThumb = true;
@@ -692,7 +692,7 @@ class ScrollableBaseNative extends Component {
 					delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
 				} else {
-					if (overscrollEffectNeeded && eventDelta < 0 && this.scrollLeft <= 0 || eventDelta > 0 && this.scrollLeft >= bounds.maxLeft) {
+					if (overscrollEffectRequired && (eventDelta < 0 && this.scrollLeft <= 0 || eventDelta > 0 && this.scrollLeft >= bounds.maxLeft)) {
 						this.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 					}
 					needToHideThumb = true;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have a requirement to show overscroll effect only on wheel input in `moonstone` so far and current our components support various types of inputs including wheel, drag, arrow key, and so on.

So, limited overscroll effects to wheel input only to meet the requirement.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We only need effects on wheel input for `moonstone` for now, but it does not mean that we don't need to support other types of input for future requirements. We also need to be ready for other theme libraries beside `moonstone`.
In this PR, a way to select types of input for overscroll effects is added and `moonstone` supports only wheel input by default. If we need to expand effects to other inputs, it will be easily accomplished by setting the default selection.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Even though `ui` does not have any overscroll effect, `ui` has a logic to support it for other theme libraries which are rely on the logic of `ui`. So most of changes by this PR is about `ui` library.

### Links
[//]: # (Related issues, references)
ENYO-5529
