### PR TITLE
ENYO-5571: Fix VideoPlayer activity detection

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Icon` and `moonstone/IconButton` to require `children`
 
+### Fixed
+
+- `moonstone/VideoPlayer` so that activity is detected and the `autoCloseTimeout` timer is reset when using 5-way to navigate from the media slider
+
 ## [2.1.0] - 2018-08-20
 
 ### Added

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1636,21 +1636,26 @@ const VideoPlayerBase = class extends React.Component {
 	}, 200);
 
 	handleSliderKeyDown = (ev) => {
-		if (is('enter', ev.keyCode)) {
+		const {keyCode} = ev;
+
+		if (is('enter', keyCode)) {
 			this.setState({
 				slider5WayPressed: true
 			}, this.slider5WayPressJob.start());
-		} else if (is('down', ev.keyCode)) {
+		} else if (is('down', keyCode)) {
 			Spotlight.setPointerMode(false);
 
 			if (Spotlight.focus(this.mediaControlsSpotlightId)) {
 				stopImmediate(ev);
+				this.activityDetected();
 			}
-		} else if (is('up', ev.keyCode)) {
+		} else if (is('up', keyCode)) {
 			stopImmediate(ev);
 
 			this.handleSliderBlur();
 			this.hideControls();
+		} else {
+			this.activityDetected();
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`VideoPlayer` does not detect activity when attempting to 5-way navigate from the media slider. Attempts to 5-way left/right or down (when the media controls are available) results in the controls hiding prematurely.


### Resolution
We essentially need to call `this.activityDetected` in cases where attempts to press keys from the slider fails to do so currently. In 2 specific cases activity is correctly detected (when pressing 5-way up and when pressing 5-way down - when media controls are *not* available). In all other cases, we simply need to call `this.activityDetected`.


### Additional Considerations
This regression stems from the change here: https://github.com/enactjs/enact/pull/1890/files#diff-598514a33c478cdac5391092c58009feL1788

I've opted to avoid the potential mess of having to manage multiple keydown handlers from reverting that change, and instead and fixing this in the media slider's keydown handler directly - especially since `this.activityDetected` is already conditionally called there (via other methods).