### PR TITLE
 ENYO-5364: Fixed to hide overscroll effect properly on drag

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -782,12 +782,10 @@ class ScrollableBase extends Component {
 	}
 
 	checkAndApplyOverscrollEffectOnStart = (orientation, edge, targetPosition) => {
-		if (edge) {
-			if (this.isDragging) {
-				this.applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
-			} else if (this.getOverscrollStatus(orientation, edge).type === overscrollTypeNone) {
-				this.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
-			}
+		if (this.isDragging) {
+			this.applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
+		} else if (edge && this.getOverscrollStatus(orientation, edge).type === overscrollTypeNone) {
+			this.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -869,12 +869,10 @@ class ScrollableBaseNative extends Component {
 	}
 
 	checkAndApplyOverscrollEffectOnStart = (orientation, edge, targetPosition) => {
-		if (edge) {
-			if (this.isDragging) {
-				this.applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
-			} else if (this.getOverscrollStatus(orientation, edge).type === overscrollTypeNone) {
-				this.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
-			}
+		if (this.isDragging) {
+			this.applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
+		} else if (edge && this.getOverscrollStatus(orientation, edge).type === overscrollTypeNone) {
+			this.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When overscroll is enabled on drag, if a user drags a scroller to one direction and drags to the opposite direction while the effect is displayed by the first dragging, the effect should disappear but it stays.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It was a simply bug of `if` statement. Fixed to handle it properly.


### Links
[//]: # (Related issues, references)
ENYO-5364

### Comments
