### PR TITLE
ENYO-5579: Changed to call focus() function of the target element with `preventScroll` option

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `spotlight` to call focus() function of the target element with `{preventScroll: true}` option
+
 ### Fixed
 
 - `spotlight/SpotlightContainerDecorator` to unmount config instead of remove when spotlightId is changed if it preserves id

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -202,7 +202,7 @@ const Spotlight = (function () {
 			if (currentFocusedElement) {
 				currentFocusedElement.blur();
 			}
-			elem.focus();
+			elem.focus({preventScroll: true});
 			focusChanged(elem, containerIds);
 		};
 
@@ -223,7 +223,7 @@ const Spotlight = (function () {
 			currentFocusedElement.blur();
 		}
 
-		elem.focus();
+		elem.focus({preventScroll: true});
 
 		_duringFocusChange = false;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Not only native versions but also JS version of lists has an issue that the container node is scrolled to show up the focused element is located in the center of the container's viewport when a child element's `focus` API is called.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
So far, we applied some device-specific way to prevent scrolling by focus for native lists, but the legacy solution does not work on JS versions.
We have a few ways to try and it looks that the best way is to implement the standard way to prevent scroll by focus. (See the second link at the bottom.)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Beside `spotlight`, there are several `focus()` calls in `ui` and `moonstone` and it looks okay to change only `spotlight` regarding purposes of each code blocks.

### Links
[//]: # (Related issues, references)
ENYO-5579
https://html.spec.whatwg.org/multipage/interaction.html#dom-focusoptions-preventscroll
