### PR TITLE
Remove unused withSkinnableProps import/export.

### DIFF
--- a/packages/moonstone/Skinnable/Skinnable.js
+++ b/packages/moonstone/Skinnable/Skinnable.js
@@ -6,7 +6,7 @@
  */
 
 import hoc from '@enact/core/hoc';
-import SkinnableBase, {withSkinnableProps} from '@enact/ui/Skinnable';
+import SkinnableBase from '@enact/ui/Skinnable';
 
 const defaultConfig = {
 	skins: {
@@ -49,6 +49,5 @@ const Skinnable = hoc(defaultConfig, SkinnableBase);
 
 export default Skinnable;
 export {
-	Skinnable,
-	withSkinnableProps
+	Skinnable
 };

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -8,7 +8,6 @@
  *
  * @module ui/Skinnable
  * @exports Skinnable
- * @exports withSkinnableProps
  * @public
  */
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* `@enact/moonstone/Skinnable` is importing and exporting `withSkinnableProps` which was removed with the recent https://github.com/enactjs/enact/pull/1827. This is purely a simple cleanup PR.

### Resolution
* Remove the unused withSkinnableProps import/export.  

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>