### PR TITLE
ENYO-5582: Fix Scroller to scroll container into view

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects only by wheel input
 - `moonstone/Icon` and `moonstone/IconButton` to require `children`
 
+### Fixed
+
+- `moonstone/Scroller` to scroll container elements into view
+
 ## [2.1.0] - 2018-08-20
 
 ### Added

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -194,6 +194,13 @@ class ScrollerBase extends Component {
 				// set scroll position so that the top of the container is at least on the top as a fallback.
 				newScrollTop = newItemTop - nestedItemHeight;
 			}
+
+			// Ensure that the adjusted scrollTop would at least scroll the container to the top of
+			// the viewport (e.g. because the container is at the bottom of the scroller and the
+			// nested item is at the top of the container)
+			if (newItemTop > newScrollTop) {
+				newScrollTop = newItemTop;
+			}
 		} else if (itemBottom - scrollBottom > epsilon) {
 			// Caculate when 5-way focus down past the bottom.
 			newScrollTop += itemBottom - scrollBottom;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When focus moves into a spotlight container in a scroller, if the container is larger than the scroller *and* the focused item is close to the top (such that the distance between the top of the container and the bottom of the focused item is less than the height of the scroller), only the focused item is scrolled into view rather than as much of the container as possible.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adjust the scroll top calculation to scroll more of the container into the view
