### PR TITLE
ENYO-5577: VirtualList> Fix to jump to the next page properly via page down key

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the next page properly via page up key
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the next or previous page properly via page up/down keys
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the next page properly via page up key
+
 ## [2.1.1] - 2018-08-27
 
 ### Changed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the next or previous page properly via page up/down keys
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -389,7 +389,7 @@ class ScrollableBase extends Component {
 		switch (direction) {
 			case 'up':
 				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top;
+				oPoint.y = viewportBounds.top + oSpotBounds.height / 2 - 1;
 				break;
 			case 'left':
 				oPoint.x = viewportBounds.left;
@@ -397,7 +397,7 @@ class ScrollableBase extends Component {
 				break;
 			case 'down':
 				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + viewportBounds.height;
+				oPoint.y = viewportBounds.top + viewportBounds.height - oSpotBounds.height / 2 + 1;
 				break;
 			case 'right':
 				oPoint.x = viewportBounds.left + viewportBounds.width;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -446,8 +446,8 @@ class ScrollableBase extends Component {
 				direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				Spotlight.setPointerMode(false);
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+					Spotlight.setPointerMode(false);
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 					overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
 				}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -40,8 +40,6 @@ const
 	overscrollTimeout = 300,
 	reverseDirections = {
 		down: 'up',
-		left: 'right',
-		right: 'left',
 		up: 'down'
 	};
 
@@ -372,41 +370,6 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	getPageDirection = (keyCode) => {
-		const
-			{direction} = this.props,
-			isRtl = this.uiRef.state.rtl,
-			isVertical = (direction === 'vertical' || direction === 'both');
-
-		return isPageUp(keyCode) ?
-			(isVertical && 'up' || isRtl && 'right' || 'left') :
-			(isVertical && 'down' || isRtl && 'left' || 'right');
-	}
-
-	getEndPoint = (direction, oSpotBounds, viewportBounds) => {
-		let oPoint = {};
-
-		switch (direction) {
-			case 'up':
-				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + oSpotBounds.height / 2 - 1;
-				break;
-			case 'left':
-				oPoint.x = viewportBounds.left;
-				oPoint.y = oSpotBounds.top;
-				break;
-			case 'down':
-				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + viewportBounds.height - oSpotBounds.height / 2 + 1;
-				break;
-			case 'right':
-				oPoint.x = viewportBounds.left + viewportBounds.width;
-				oPoint.y = oSpotBounds.top;
-				break;
-		}
-		return oPoint;
-	}
-
 	scrollByPage = (direction) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
@@ -428,7 +391,9 @@ class ScrollableBase extends Component {
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
 				focusedItemBounds = focusedItem.getBoundingClientRect(),
-				endPoint = this.getEndPoint(direction, focusedItemBounds, viewportBounds);
+				endPoint = (direction === 'up') ?
+					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + focusedItemBounds.height / 2 - 1} :
+					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + viewportBounds.height - focusedItemBounds.height / 2 + 1};
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
@@ -481,7 +446,7 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				Spotlight.setPointerMode(false);
-				direction = this.getPageDirection(keyCode);
+				direction = isPageUp(keyCode) ? 'up' : 'down'
 				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -391,9 +391,10 @@ class ScrollableBase extends Component {
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
 				focusedItemBounds = focusedItem.getBoundingClientRect(),
-				endPoint = (direction === 'up') ?
-					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + focusedItemBounds.height / 2 - 1} :
-					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + viewportBounds.height - focusedItemBounds.height / 2 + 1};
+				endPoint = {
+					x: focusedItemBounds.left + focusedItemBounds.width / 2,
+					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
+				};
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
@@ -446,8 +447,10 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				Spotlight.setPointerMode(false);
-				direction = isPageUp(keyCode) ? 'up' : 'down'
-				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
+				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+					direction = isPageUp(keyCode) ? 'up' : 'down';
+					overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
+				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -33,8 +33,6 @@ const
 	overscrollTimeout = 300,
 	reverseDirections = {
 		down: 'up',
-		left: 'right',
-		right: 'left',
 		up: 'down'
 	};
 
@@ -442,41 +440,6 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	getPageDirection = (keyCode) => {
-		const
-			{direction} = this.props,
-			isRtl = this.uiRef.state.rtl,
-			isVertical = (direction === 'vertical' || direction === 'both');
-
-		return isPageUp(keyCode) ?
-			(isVertical && 'up' || isRtl && 'right' || 'left') :
-			(isVertical && 'down' || isRtl && 'left' || 'right');
-	}
-
-	getEndPoint = (direction, oSpotBounds, viewportBounds) => {
-		let oPoint = {};
-
-		switch (direction) {
-			case 'up':
-				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + oSpotBounds.height / 2 - 1;
-				break;
-			case 'left':
-				oPoint.x = viewportBounds.left;
-				oPoint.y = oSpotBounds.top;
-				break;
-			case 'down':
-				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + viewportBounds.height - oSpotBounds.height / 2 + 1;
-				break;
-			case 'right':
-				oPoint.x = viewportBounds.left + viewportBounds.width;
-				oPoint.y = oSpotBounds.top;
-				break;
-		}
-		return oPoint;
-	}
-
 	scrollByPage = (direction) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
@@ -498,7 +461,9 @@ class ScrollableBaseNative extends Component {
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
 				focusedItemBounds = focusedItem.getBoundingClientRect(),
-				endPoint = this.getEndPoint(direction, focusedItemBounds, viewportBounds);
+				endPoint = (direction === 'up') ?
+					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + focusedItemBounds.height / 2 - 1} :
+					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + viewportBounds.height - focusedItemBounds.height / 2 + 1};
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
@@ -552,7 +517,7 @@ class ScrollableBaseNative extends Component {
 			Spotlight.setPointerMode(false);
 			ev.preventDefault();
 			if (!repeat && this.hasFocus()) {
-				direction = this.getPageDirection(keyCode);
+				direction = isPageUp(keyCode) ? 'up' : 'down'
 				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -515,9 +515,9 @@ class ScrollableBaseNative extends Component {
 		this.animateOnFocus = true;
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
-			Spotlight.setPointerMode(false);
 			ev.preventDefault();
 			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
+				Spotlight.setPointerMode(false);
 				direction = isPageUp(keyCode) ? 'up' : 'down';
 				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
 			}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -459,7 +459,7 @@ class ScrollableBaseNative extends Component {
 		switch (direction) {
 			case 'up':
 				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top;
+				oPoint.y = viewportBounds.top + oSpotBounds.height / 2 - 1;
 				break;
 			case 'left':
 				oPoint.x = viewportBounds.left;
@@ -467,7 +467,7 @@ class ScrollableBaseNative extends Component {
 				break;
 			case 'down':
 				oPoint.x = oSpotBounds.left + oSpotBounds.width / 2;
-				oPoint.y = viewportBounds.top + viewportBounds.height;
+				oPoint.y = viewportBounds.top + viewportBounds.height - oSpotBounds.height / 2 + 1;
 				break;
 			case 'right':
 				oPoint.x = viewportBounds.left + viewportBounds.width;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -461,9 +461,10 @@ class ScrollableBaseNative extends Component {
 				rDirection = reverseDirections[direction],
 				viewportBounds = containerRef.getBoundingClientRect(),
 				focusedItemBounds = focusedItem.getBoundingClientRect(),
-				endPoint = (direction === 'up') ?
-					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + focusedItemBounds.height / 2 - 1} :
-					{x: focusedItemBounds.left + focusedItemBounds.width / 2, y: viewportBounds.top + viewportBounds.height - focusedItemBounds.height / 2 + 1};
+				endPoint = {
+					x: focusedItemBounds.left + focusedItemBounds.width / 2,
+					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
+				};
 			let next = null;
 
 			/* 1. Find spottable item in viewport */
@@ -516,8 +517,8 @@ class ScrollableBaseNative extends Component {
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			Spotlight.setPointerMode(false);
 			ev.preventDefault();
-			if (!repeat && this.hasFocus()) {
-				direction = isPageUp(keyCode) ? 'up' : 'down'
+			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
+				direction = isPageUp(keyCode) ? 'up' : 'down';
 				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -405,23 +405,24 @@ const VirtualListBaseFactory = (type) => {
 		getIndexToScroll = (direction, currentIndex) => {
 			const
 				{dataSize, spacing} = this.props,
-				{dimensionToExtent, primary} = this.uiRef,
+				{dimensionToExtent, primary: {clientSize, gridSize, itemSize}, scrollPosition} = this.uiRef,
 				{findSpottableItem} = this,
-				{firstVisibleIndex, lastVisibleIndex} = this.uiRef.moreInfo,
-				numOfItemsInPage = (Math.floor((primary.clientSize + spacing) / primary.gridSize) * dimensionToExtent);
+				numOfItemsInPage = (Math.floor((clientSize + spacing) / gridSize) * dimensionToExtent),
+				firstFullyVisibleIndex = Math.ceil(scrollPosition / gridSize) * dimensionToExtent,
+				lastFullyVisibleIndex = Math.min(dataSize - 1, Math.floor((scrollPosition + clientSize - itemSize) / gridSize) * dimensionToExtent);
 			let candidateIndex = -1;
 
 			/* First, find a spottable item in this page */
 			if (direction === 'down') { // Page Down
-				if ((lastVisibleIndex - (lastVisibleIndex % dimensionToExtent)) > currentIndex) { // If a current focused item is in the last visible line.
+				if ((lastFullyVisibleIndex - (lastFullyVisibleIndex % dimensionToExtent)) > currentIndex) { // If a current focused item is in the last visible line.
 					candidateIndex = findSpottableItem(
-						lastVisibleIndex,
+						lastFullyVisibleIndex,
 						currentIndex - (currentIndex % dimensionToExtent) + dimensionToExtent - 1
 					);
 				}
-			} else if (firstVisibleIndex + dimensionToExtent <= currentIndex) { // Page Up,  if a current focused item is in the first visible line.
+			} else if (firstFullyVisibleIndex + dimensionToExtent <= currentIndex) { // Page Up,  if a current focused item is in the first visible line.
 				candidateIndex = findSpottableItem(
-					firstVisibleIndex,
+					firstFullyVisibleIndex,
 					currentIndex - (currentIndex % dimensionToExtent)
 				);
 			}
@@ -429,18 +430,18 @@ const VirtualListBaseFactory = (type) => {
 			/* Second, find a spottable item in the next page */
 			if (candidateIndex === -1) {
 				if (direction === 'down') { // Page Down
-					candidateIndex = findSpottableItem(lastVisibleIndex + numOfItemsInPage, lastVisibleIndex);
+					candidateIndex = findSpottableItem(lastFullyVisibleIndex + numOfItemsInPage, lastFullyVisibleIndex);
 				} else { // Page Up
-					candidateIndex = findSpottableItem(firstVisibleIndex - numOfItemsInPage, firstVisibleIndex);
+					candidateIndex = findSpottableItem(firstFullyVisibleIndex - numOfItemsInPage, firstFullyVisibleIndex);
 				}
 			}
 
 			/* Last, find a spottable item in a whole data */
 			if (candidateIndex === -1) {
 				if (direction === 'down') { // Page Down
-					candidateIndex = findSpottableItem(lastVisibleIndex + numOfItemsInPage + 1, dataSize);
+					candidateIndex = findSpottableItem(lastFullyVisibleIndex + numOfItemsInPage + 1, dataSize);
 				} else { // Page Up
-					candidateIndex = findSpottableItem(firstVisibleIndex - numOfItemsInPage - 1, -1);
+					candidateIndex = findSpottableItem(firstFullyVisibleIndex - numOfItemsInPage - 1, -1);
 				}
 			}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -407,7 +407,7 @@ const VirtualListBaseFactory = (type) => {
 				{dataSize, spacing} = this.props,
 				{dimensionToExtent, primary: {clientSize, gridSize, itemSize}, scrollPosition} = this.uiRef,
 				{findSpottableItem} = this,
-				numOfItemsInPage = (Math.floor((clientSize + spacing) / gridSize) * dimensionToExtent),
+				numOfItemsInPage = Math.floor((clientSize + spacing) / gridSize) * dimensionToExtent,
 				firstFullyVisibleIndex = Math.ceil(scrollPosition / gridSize) * dimensionToExtent,
 				lastFullyVisibleIndex = Math.min(dataSize - 1, Math.floor((scrollPosition + clientSize - itemSize) / gridSize) * dimensionToExtent);
 			let candidateIndex = -1;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing Page Down over the last fully visible item in VirtualList, VirtualList move focus not to the next page but to the next item which is visible partially.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I reduced the spotlight boundary as the `getTargetByDirectionFromPosition` parameter to find fully visible and spottable item in a current page.

In addition, I tried to selected the candidate items among fully visible items in the next page to which VirtualList jumps.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Scrolling horizontally via page up/down specification was out before. So I'd like to remove it and to clean up VirtualListBase.js.

### Links
[//]: # (Related issues, references)

ENYO-5577

### Comments
