### PR TITLE
ENYO-5580 - It is impossible to handle up/down keycode when using isItemDisabled in virtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ExpandableItem` to not make scrolling of a parent scroller when 5-way key is pressed on the first item or the last item
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 - `moonstone/VirtuaList` to allow `onKeyDown` events to bubble
+- `moonstone/Scrollable` to forward `onKeyDown` event
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/ExpandableItem` to not make scrolling of a parent scroller when 5-way key is pressed on the first item or the last item
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
+## [Unreleased]
+
+### Changed
+- `moonstone/VirtuaList` to allow `onKeyDown` events to bubble
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/ExpandableItem` to not make scrolling of a parent scroller when 5-way key is pressed on the first item or the last item
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
-## [Unreleased]
 
 ### Changed
 - `moonstone/VirtuaList` to allow `onKeyDown` events to bubble

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -12,6 +12,7 @@ import {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {Job} from '@enact/core/util';
 import platform from '@enact/core/platform';
+import {forward} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
@@ -436,6 +437,8 @@ class ScrollableBase extends Component {
 
 	onKeyDown = (ev) => {
 		const {keyCode, repeat} = ev;
+
+		forward('onKeyDown', ev, this.props);
 
 		this.animateOnFocus = true;
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -4,6 +4,7 @@ import {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {Job} from '@enact/core/util';
 import platform from '@enact/core/platform';
+import {forward} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
@@ -511,6 +512,8 @@ class ScrollableBaseNative extends Component {
 		let
 			overscrollEffectRequired = false,
 			direction = null;
+
+		forward('onKeyDown', ev, this.props);
 
 		this.animateOnFocus = true;
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -604,7 +604,7 @@ const VirtualListBaseFactory = (type) => {
 				if (isWrapped) {
 					this.isWrappedBy5way = true;
 				}
-
+				
 				if (firstIndex <= nextIndex && nextIndex < firstIndex + numOfItems) {
 					this.focusOnItem(nextIndex);
 				} else {
@@ -639,8 +639,12 @@ const VirtualListBaseFactory = (type) => {
 				ev.preventDefault();
 				this.setSpotlightContainerRestrict(keyCode, target);
 				Spotlight.setPointerMode(false);
+				this.jumpToSpottableItem(keyCode, repeat, target)
 				if (this.jumpToSpottableItem(keyCode, repeat, target)) {
-					ev.stopPropagation();
+					// Pause Spotlight so we don't focus twice
+					// Resume after a short delay so Spotlight will work as intended
+					Spotlight.pause();
+					setTimeout(Spotlight.resume, 0);
 				}
 			}
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -274,7 +274,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (containerNode && containerNode.removeEventListener) {
 				containerNode.removeEventListener('keydown', this.onKeyDown);
-				containerNode.removeEventListener('keyup', this.revertSpotlightState);
+				containerNode.removeEventListener('keyup', this.resumeSpotlight);
 			}
 
 			this.setContainerDisabled(false);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -614,6 +614,7 @@ const VirtualListBaseFactory = (type) => {
 
 					if (!Spotlight.isPaused()) {
 						Spotlight.pause();
+						document.addEventListener('keyup', this.resumeSpotlight);
 					}
 
 					target.blur();
@@ -643,16 +644,14 @@ const VirtualListBaseFactory = (type) => {
 				Spotlight.setPointerMode(false);
 				if (this.jumpToSpottableItem(keyCode, repeat, target)) {
 					// Pause Spotlight temporarily so we don't focus twice
-					this.virtualListPause = new Pause('VirtualList');
-					this.virtualListPause.pause();
-
+					Spotlight.pause();
 					document.addEventListener('keyup', this.resumeSpotlight);
 				}
 			}
 		}
 
 		resumeSpotlight = () => {
-			this.virtualListPause.resume();
+			Spotlight.resume();
 			document.removeEventListener('keyup', this.resumeSpotlight);
 		}
 		/**

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -604,7 +604,7 @@ const VirtualListBaseFactory = (type) => {
 				if (isWrapped) {
 					this.isWrappedBy5way = true;
 				}
-				
+
 				if (firstIndex <= nextIndex && nextIndex < firstIndex + numOfItems) {
 					this.focusOnItem(nextIndex);
 				} else {
@@ -639,7 +639,6 @@ const VirtualListBaseFactory = (type) => {
 				ev.preventDefault();
 				this.setSpotlightContainerRestrict(keyCode, target);
 				Spotlight.setPointerMode(false);
-				this.jumpToSpottableItem(keyCode, repeat, target)
 				if (this.jumpToSpottableItem(keyCode, repeat, target)) {
 					// Pause Spotlight so we don't focus twice
 					// Resume after a short delay so Spotlight will work as intended

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -640,10 +640,13 @@ const VirtualListBaseFactory = (type) => {
 				this.setSpotlightContainerRestrict(keyCode, target);
 				Spotlight.setPointerMode(false);
 				if (this.jumpToSpottableItem(keyCode, repeat, target)) {
-					// Pause Spotlight so we don't focus twice
-					// Resume after a short delay so Spotlight will work as intended
+					// Pause Spotlight temporarily so we don't focus twice
+					const prevPausedState = Spotlight.isPaused();
 					Spotlight.pause();
-					setTimeout(Spotlight.resume, 16);
+					// If spotlight was not previously paused resume at a later time
+					if (!prevPausedState) {
+						setTimeout(Spotlight.resume, 16);
+					}
 				}
 			}
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -644,7 +644,7 @@ const VirtualListBaseFactory = (type) => {
 					// Pause Spotlight so we don't focus twice
 					// Resume after a short delay so Spotlight will work as intended
 					Spotlight.pause();
-					setTimeout(Spotlight.resume, 0);
+					setTimeout(Spotlight.resume, 16);
 				}
 			}
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -275,9 +275,8 @@ const VirtualListBaseFactory = (type) => {
 			if (containerNode && containerNode.removeEventListener) {
 				containerNode.removeEventListener('keydown', this.onKeyDown);
 			}
-			if (document) {
-				document.removeEventListener('keyup', this.resumeSpotlight);
-			}
+
+			document.removeEventListener('keyup', this.resumeSpotlight);
 
 			this.setContainerDisabled(false);
 		}
@@ -647,18 +646,14 @@ const VirtualListBaseFactory = (type) => {
 					this.virtualListPause = new Pause('VirtualList');
 					this.virtualListPause.pause();
 
-					if (document) {
-						document.addEventListener('keyup', this.resumeSpotlight);
-					}
+					document.addEventListener('keyup', this.resumeSpotlight);
 				}
 			}
 		}
 
 		resumeSpotlight = () => {
 			this.virtualListPause.resume();
-			if (document) {
-				document.removeEventListener('keyup', this.resumeSpotlight);
-			}
+			document.removeEventListener('keyup', this.resumeSpotlight);
 		}
 		/**
 		 * Handle global `onKeyDown` event

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -274,7 +274,9 @@ const VirtualListBaseFactory = (type) => {
 
 			if (containerNode && containerNode.removeEventListener) {
 				containerNode.removeEventListener('keydown', this.onKeyDown);
-				containerNode.removeEventListener('keyup', this.resumeSpotlight);
+			}
+			if (document) {
+				document.removeEventListener('keyup', this.resumeSpotlight);
 			}
 
 			this.setContainerDisabled(false);
@@ -645,19 +647,18 @@ const VirtualListBaseFactory = (type) => {
 					this.virtualListPause = new Pause('VirtualList');
 					this.virtualListPause.pause();
 
-					const containerNode = this.uiRef.containerRef;
-
-					if (containerNode && containerNode.addEventListener) {
-						containerNode.addEventListener('keyup', this.resumeSpotlight);
+					if (document) {
+						document.addEventListener('keyup', this.resumeSpotlight);
 					}
 				}
 			}
 		}
 
 		resumeSpotlight = () => {
-			const containerNode = this.uiRef.containerRef;
 			this.virtualListPause.resume();
-			containerNode.removeEventListener('keyup', this.resumeSpotlight);
+			if (document) {
+				document.removeEventListener('keyup', this.resumeSpotlight);
+			}
 		}
 		/**
 		 * Handle global `onKeyDown` event

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -276,7 +276,7 @@ const VirtualListBaseFactory = (type) => {
 				containerNode.removeEventListener('keydown', this.onKeyDown);
 			}
 
-			document.removeEventListener('keyup', this.resumeSpotlight);
+			this.resumeSpotlight();
 
 			this.setContainerDisabled(false);
 		}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -3,7 +3,6 @@ import {is} from '@enact/core/keymap';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Spotlight, {getDirection} from '@enact/spotlight';
-import {Pause} from '@enact/spotlight/Pause';
 import Spottable from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -613,7 +613,6 @@ const VirtualListBaseFactory = (type) => {
 
 					if (!Spotlight.isPaused()) {
 						Spotlight.pause();
-						document.addEventListener('keyup', this.resumeSpotlight);
 					}
 
 					target.blur();

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -184,6 +184,7 @@ const Spotlight = (function () {
 	}
 
 	function focusElement (elem, containerIds, fromPointer) {
+		console.trace('focus');
 		if (!elem) {
 			return false;
 		}
@@ -403,6 +404,7 @@ const Spotlight = (function () {
 	}
 
 	function onKeyDown (evt) {
+		console.log(evt);
 		if (shouldPreventNavigation()) {
 			notifyKeyDown(evt.keyCode);
 			return;

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -184,7 +184,6 @@ const Spotlight = (function () {
 	}
 
 	function focusElement (elem, containerIds, fromPointer) {
-		console.trace('focus');
 		if (!elem) {
 			return false;
 		}
@@ -404,7 +403,6 @@ const Spotlight = (function () {
 	}
 
 	function onKeyDown (evt) {
-		console.log(evt);
 		if (shouldPreventNavigation()) {
 			notifyKeyDown(evt.keyCode);
 			return;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`VirtualList` stops `onKeyDown` from propagating so other components can't receive the event. This is done to prevent spotlight from calling focus again on its `onKeyDown`.


### Resolution
Instead of using stopPropagation we can pause spotlight temporarily so we don't get two `focus` calls, but we can still have the event propagate. We pause Spotlight `onKeyDown` and remove it `onKeyUp`.


### Links
ENYO-5580