### PR TITLE
PLAT-64196: Fix unexpected scrolling by 5-way key from inside an ExpandableItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/ExpandableItem` to not make scrolling of a parent scroller when `down` key is pressed on the last item
 - `moonstone/VideoPlayer` so that activity is detected and the `autoCloseTimeout` timer is reset when using 5-way to navigate from the media slider
 
 ## [2.1.0] - 2018-08-20

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/ExpandableItem` to not make scrolling of a parent scroller when `down` key is pressed on the last item
+- `moonstone/ExpandableItem` to not make scrolling of a parent scroller when 5-way key is pressed on the first item or the last item
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 
 ## [2.1.1] - 2018-08-27

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -305,6 +305,7 @@ const ExpandableItemBase = kind({
 				} else if (isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) {
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
+						ev.nativeEvent.preventDefault();
 					} else if (onSpotlightDown) {
 						onSpotlightDown(ev);
 					}

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -302,6 +302,7 @@ const ExpandableItemBase = kind({
 				if (autoClose && onClose && isUp(keyCode) && wouldDirectionLeaveContainer('up', target)) {
 					onClose();
 					ev.nativeEvent.stopImmediatePropagation();
+					ev.preventDefault();
 				} else if (isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) {
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -305,7 +305,7 @@ const ExpandableItemBase = kind({
 				} else if (isDown(keyCode) && wouldDirectionLeaveContainer('down', target)) {
 					if (lockBottom) {
 						ev.nativeEvent.stopImmediatePropagation();
-						ev.nativeEvent.preventDefault();
+						ev.preventDefault();
 					} else if (onSpotlightDown) {
 						onSpotlightDown(ev);
 					}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `ExpandableItem` has a `true` value of `lockBottom` prop and `down` key is pressed on the last item of `ExpandableItem`, a scroller which contains `ExpandableItem` scrolls unexpectedly.
Fixed not to make a scrolling in this case. Since `lockBottom` is `true`, there will be no action.

Edit:
Thanks to @MikyungKim, I found that the issue also happens on `up` key when `ExpandableItem` is located on the top of a viewport of a scroller (regardless `lockBottom` is set or not).
Added the fix for this, too.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
A scrolling is a default behavior of web engine by `up` or `down` key. So added `preventDefault()`.


### Links
[//]: # (Related issues, references)
PLAT-64196
