### PR TITLE
ENYO-5554: Fix layout of Picker components on webOS

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+
+- `ui/Marquee` to move `position: relative` back into `text` class to fix problem with flexbox
+
 ## [2.1.1] - 2018-08-27
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
 
 ### Fixed
 
-- `ui/Marquee` to move `position: relative` back into `text` class to fix problem with flexbox
+- `ui/Marquee` positioning bug when used with CSS flexbox layouts
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/ui/Marquee/Marquee.less
+++ b/packages/ui/Marquee/Marquee.less
@@ -24,10 +24,10 @@
 		will-change: left, right;
 		transition-property: left, right;
 		transition-timing-function: linear;
-
+		position: relative;
+		
 		&.animate {
 			overflow: visible;
-			position: relative;
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
For some reason on TV `flex` doesn't play well with dynamic `position: relative`. It causes overlapping text to be shown.


### Resolution
Stop dynamically setting `position: relative`. We had this in previously, but we changed it because we needed a work around for `ScrollerNative` it turns out we don't need it for `ScrollerNative` to work smoothly.


### Additional Considerations
This seems to work fine, but marquee may notice a minor performance hit since, but it doesn't seem to be noticeable.


### Links
ENYO-5554

