### PR TITLE
ENYO-5579: Prevent browser scrolling components into view on focus

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to prevent the browser from scrolling elements into view when focused within a spotlight container configured with `overflow: true`
+
 ## [2.1.1] - 2018-08-27
 
 ### Fixed

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -383,7 +383,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			return (
 				<Wrapped
-					data-preventscrollonfocus="true"
 					{...rest}
 					onBlur={this.handleBlur}
 					onFocus={this.handleFocus}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -933,6 +933,16 @@ function setLastContainerFromTarget (current, target) {
 	}
 }
 
+function isWithinOverflowContainer (target, containerIds = getContainersForNode(target)) {
+	return containerIds
+		// ignore the root container id which is set to overflow by the root decorator
+		.filter(id => id !== rootContainerId)
+		// get the config for each container
+		.map(getContainerConfig)
+		// and check if any are set to overflow
+		.some(config => config && config.overflow);
+}
+
 export {
 	// Remove
 	getAllContainerIds,
@@ -960,6 +970,7 @@ export {
 	getSpottableDescendants,
 	isContainer,
 	isNavigable,
+	isWithinOverflowContainer,
 	mayActivateContainer,
 	removeAllContainers,
 	removeContainer,

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -38,6 +38,7 @@ import {
 	isContainer,
 	isContainer5WayHoldable,
 	isNavigable,
+	isWithinOverflowContainer,
 	mayActivateContainer,
 	removeAllContainers,
 	removeContainer,
@@ -199,11 +200,13 @@ const Spotlight = (function () {
 			return true;
 		}
 
+		const focusOptions = isWithinOverflowContainer(elem, containerIds) ? {preventScroll: true} : null;
+
 		let silentFocus = function () {
 			if (currentFocusedElement) {
 				currentFocusedElement.blur();
 			}
-			elem.focus();
+			elem.focus(focusOptions);
 			focusChanged(elem, containerIds);
 		};
 
@@ -224,7 +227,7 @@ const Spotlight = (function () {
 			currentFocusedElement.blur();
 		}
 
-		elem.focus();
+		elem.focus(focusOptions);
 
 		_duringFocusChange = false;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
webOS applications using VirtualList were experiencing focus problems when using `isItemDisabled` event when native scrolling wasn't enabled for the app.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Support using the [focusOptions param of the `focus()` API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) to suppress scrolling focused elements into view. This PR "connects" the usage of the API with the `overflow` spotlight container config which indicates that the container supports focusable components out of view (e.g. from a scroller).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* A future additive API should support passing the focus options to `Spotlight.focus()` to override this default behavior.
* This PR also removes the `data-preventscrollonfocus` key which was a stopgap until the new focus options API was supported. @0x64 - can you confirm this is appropriate here?