### PR TITLE
ENYO-5598: Fix support for pre-populating iLib ResBundle cache.

### DIFF
--- a/packages/i18n/locale/locale.js
+++ b/packages/i18n/locale/locale.js
@@ -80,8 +80,10 @@ const updateLocale = function (locale) {
 	if (ilib._load) ilib._load.manifest = undefined;
 	// remove the cache of the platform name to allow transition between snapshot and browser
 	delete ilib._platform;
-	// load any external ilib data
+	// load any external ilib/resbundle data
 	ilib.data = global.ilibData || ilib.data;
+	ilib.data.cache = ilib.data.cache || {};
+	ilib.data.cache['ResBundle-strings'] = global.resBundleData || {};
 	// ilib handles falsy values and automatically uses local locale when encountered which
 	// is expected and desired
 	ilib.setLocale(locale);

--- a/packages/i18n/src/resBundle.js
+++ b/packages/i18n/src/resBundle.js
@@ -39,9 +39,6 @@ function createResBundle (locale) {
  * @returns {undefined}
  */
 function setResBundleLocale (spec) {
-	// Load any ResBundle external data into cache.
-	ResBundle.strings = ResBundle.strings || {};
-	ResBundle.strings.cache = global.resBundleData || ResBundle.strings.cache;
 	// Get active bundle and if needed, (re)initialize.
 	const locale = new Locale(spec);
 	const rb = getResBundle();


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Since https://github.com/enactjs/enact/pull/1800, the location for cached ResBundle changed, breaking the experimental/private/temporary support for cache pre-populating via a window-based object.

### Resolution
* Use `ilib.cache['ResBundle-strings']` location rather than `ResBundle.strings.cache` to correctly be found by iLib and avoid XHR.


### Additional Considerations
* Verified by building/running with Enact Browser against latest iLib.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>