### PR TITLE
ENYO-5600: Fix GridListImageItem to properly set selected style

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,8 +9,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/Marquee` positioning bug when used with CSS flexbox layouts
 - `ui/GridListImageItem` to properly set `selected` style
 
-### Changed
-
 ## [2.1.1] - 2018-08-27
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee` positioning bug when used with CSS flexbox layouts
+- `moonstone/GridListImageItem` to properly set `selected` style
+
+### Changed
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee` positioning bug when used with CSS flexbox layouts
-- `moonstone/GridListImageItem` to properly set `selected` style
+- `ui/GridListImageItem` to properly set `selected` style
 
 ### Changed
 

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -163,9 +163,7 @@ const GridListImageItem = kind({
 
 	computed: {
 		className: ({caption, selected, styler, subCaption}) => styler.append(
-			{selected},
-			{caption},
-			{subCaption}
+			{selected, caption, subCaption}
 		),
 		selectionOverlay: ({css, iconComponent: IconComponent, selectionOverlay: SelectionOverlay, selectionOverlayShowing}) => {
 			if (selectionOverlayShowing) {

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -164,8 +164,8 @@ const GridListImageItem = kind({
 	computed: {
 		className: ({caption, selected, styler, subCaption}) => styler.append(
 			{selected},
-			caption ? 'useCaption' : null,
-			subCaption ? 'useSubCaption' : null
+			{caption},
+			{subCaption}
 		),
 		selectionOverlay: ({css, iconComponent: IconComponent, selectionOverlay: SelectionOverlay, selectionOverlayShowing}) => {
 			if (selectionOverlayShowing) {

--- a/packages/ui/GridListImageItem/GridListImageItem.less
+++ b/packages/ui/GridListImageItem/GridListImageItem.less
@@ -26,6 +26,7 @@
 	}
 
 	.caption,
+	.selected,
 	.subCaption {
 		/* Public Class Names */
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ui/GridListImageItem` was missing `.selected` definition for `publicClassName`. It affected `moonstone/GridListImageItem` to not set `selected` style properly. This is a regression from #1864

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `.selected` definition to less file. Also cleaned up cruft for setting `caption` and `subCaption` classes as well.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
