### PR TITLE
ENYO-5604: Tooltip is not repositioned when text changed

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 - `moonstone/VirtuaList` to allow `onKeyDown` events to bubble
 - `moonstone/Scrollable` to forward `onKeyDown` event
-- `moonstone/TooltipDecorator` to calculate position when `tooltipText` changed
+- `moonstone/TooltipDecorator` to update position when `tooltipText` is changed
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to jump to the previous or next page properly via page up or down keys
 - `moonstone/VirtuaList` to allow `onKeyDown` events to bubble
 - `moonstone/Scrollable` to forward `onKeyDown` event
+- `moonstone/TooltipDecorator` to calculate position when `tooltipText` changed
 
 ## [2.1.1] - 2018-08-27
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -169,6 +169,12 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			};
 		}
 
+		componentDidUpdate (prevProps) {
+			if (prevProps.tooltipText !== this.props.tooltipText) {
+				this.setTooltipLayout();
+			}
+		}
+
 		componentWillUnmount () {
 			if (currentTooltip === this) {
 				currentTooltip = null;

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -170,7 +170,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			if (prevProps.tooltipText !== this.props.tooltipText) {
+			if (this.state.showing && prevProps.tooltipText !== this.props.tooltipText) {
 				this.setTooltipLayout();
 			}
 		}

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -1,5 +1,8 @@
 import Button from '@enact/moonstone/Button';
 import TooltipDecorator from '@enact/moonstone/TooltipDecorator';
+import Input from '@enact/moonstone/Input';
+import IconButton from '@enact/moonstone/IconButton';
+import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
@@ -36,11 +39,89 @@ class TooltipTest extends React.Component {
 	}
 }
 
+class ChangeableTooltip extends React.Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			text: 'short',
+			position: {
+				top: 0,
+				left: 0
+			}
+		};
+	}
+
+	changeTooltipText = () => {
+		const {text} = this.state;
+		if (text === 'short') {
+			this.setState({text: 'long text'});
+		} else if (text === 'long text') {
+			this.setState({text: 'very loooooooooooong text'});
+		} else {
+			this.setState({text: 'short'});
+		}
+	}
+
+	handleChangeLeft = (ev) => {
+		this.setState(prevState => ({
+			position: {
+				...prevState.position,
+				left: parseInt(ev.value)
+			}
+		}));
+	}
+
+	handleChangeTop = (ev) => {
+		this.setState(prevState => ({
+			position: {
+				...prevState.position,
+				top: parseInt(ev.value)
+			}
+		}));
+	}
+
+	render () {
+		const {left, top} = this.state.position;
+		const style = {
+			position: 'absolute',
+			width: ri.unit(390, 'rem'),
+			left: '50%',
+			transform: 'translateX(-50%)'
+		};
+		return (
+			<div>
+				<div style={style}>
+					<div>LEFT : </div>
+					<Input id="left" small type="number" onChange={this.handleChangeLeft} value={left} />
+					<div>TOP : </div>
+					<Input id="top" small type="number" onChange={this.handleChangeTop} value={top} />
+				</div>
+				<IconButton
+					tooltipText={this.state.text}
+					onClick={this.changeTooltipText}
+					style={{
+						position: 'absolute',
+						left,
+						top
+					}}
+				>
+					{'drawer'}
+				</IconButton>
+			</div>
+		);
+	}
+}
+
 storiesOf('Tooltip', module)
 	.add(
 		'that shows after Button is unmounted (ENYO-3809)',
 		() => (
 			<TooltipTest />
 		)
+	)
+	.add(
+		'tooltipDecorator with changeable tooltipText',
+		() => (
+			<ChangeableTooltip />
+		)
 	);
-

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -62,20 +62,20 @@ class ChangeableTooltip extends React.Component {
 		}
 	}
 
-	handleChangeLeft = (ev) => {
+	handleChangeLeft = ({value}) => {
 		this.setState(prevState => ({
 			position: {
 				...prevState.position,
-				left: parseInt(ev.value)
+				left: value
 			}
 		}));
 	}
 
-	handleChangeTop = (ev) => {
+	handleChangeTop = ({value}) => {
 		this.setState(prevState => ({
 			position: {
 				...prevState.position,
-				top: parseInt(ev.value)
+				top: value
 			}
 		}));
 	}
@@ -95,14 +95,15 @@ class ChangeableTooltip extends React.Component {
 					<Input id="left" small type="number" onChange={this.handleChangeLeft} value={left} />
 					<div>TOP : </div>
 					<Input id="top" small type="number" onChange={this.handleChangeTop} value={top} />
+					<Button onClick={this.changeTooltipText}>Change Text</Button>
 				</div>
 				<IconButton
 					tooltipText={this.state.text}
 					onClick={this.changeTooltipText}
 					style={{
 						position: 'absolute',
-						left,
-						top
+						left: parseInt(left || 0),
+						top: parseInt(top || 0)
 					}}
 				>
 					{'drawer'}

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -88,6 +88,7 @@ class ChangeableTooltip extends React.Component {
 			left: '50%',
 			transform: 'translateX(-50%)'
 		};
+
 		return (
 			<div>
 				<div style={style}>
@@ -106,7 +107,7 @@ class ChangeableTooltip extends React.Component {
 						top: parseInt(top || 0)
 					}}
 				>
-					{'drawer'}
+					drawer
 				</IconButton>
 			</div>
 		);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Even if length of tooltipText, the position of tooltip is not recalculated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added  function to calculate position when text changed.

### Links
[//]: # (Related issues, references)
ENYO-5604
