### PR TITLE
ENYO-5605: Fix ScrollableNative to update scroll buttons

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/ScrolllableNative` to update scroll buttons correctly on wheel
 - `ui/Marquee` positioning bug when used with CSS flexbox layouts
 
 ## [2.1.1] - 2018-08-27

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/ScrolllableNative` to update scroll buttons correctly on wheel
 - `ui/Marquee` positioning bug when used with CSS flexbox layouts
 
 ## [2.1.1] - 2018-08-27

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -383,6 +383,7 @@ class ScrollableBaseNative extends Component {
 		};
 
 		this.overscrollEnabled = !!(props.applyOverscrollEffect);
+		this.scrollTicking = false;
 
 		props.cbScrollTo(this.scrollTo);
 	}
@@ -463,7 +464,6 @@ class ScrollableBaseNative extends Component {
 			this.forwardScrollEvent('onScrollStop');
 		}
 		this.scrollStopJob.stop();
-		this.startScrollJob.stop();
 
 		this.removeEventListeners();
 		off('keydown', this.onKeyDown);
@@ -728,7 +728,13 @@ class ScrollableBaseNative extends Component {
 	onScroll = (ev) => {
 		const {scrollLeft, scrollTop} = ev.target;
 
-		this.startScrollJob.startRaf(scrollLeft, scrollTop);
+		if (!this.scrollTicking) {
+			window.requestAnimationFrame(() => {
+				this.scrollOnScroll(scrollLeft, scrollTop);
+				this.scrollTicking = false;
+			});
+		}
+		this.scrollTicking = true;
 	}
 
 	scrollByPage = (keyCode) => {
@@ -957,8 +963,6 @@ class ScrollableBaseNative extends Component {
 		this.forwardScrollEvent('onScroll');
 		this.scrollStopJob.start();
 	}
-
-	startScrollJob = new Job(this.scrollOnScroll);
 
 	scrollStopJob = new Job(this.scrollStopOnScroll, scrollStopWaiting);
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -383,7 +383,7 @@ class ScrollableBaseNative extends Component {
 		};
 
 		this.overscrollEnabled = !!(props.applyOverscrollEffect);
-		this.scrollTicking = false;
+		this.scrollRaFId = null;
 
 		props.cbScrollTo(this.scrollTo);
 	}
@@ -471,6 +471,10 @@ class ScrollableBaseNative extends Component {
 		if (this.context.Subscriber) {
 			this.context.Subscriber.unsubscribe('resize', this.handleSubscription);
 			this.context.Subscriber.unsubscribe('i18n', this.handleSubscription);
+		}
+
+		if (this.scrollRaFId) {
+			window.cancelAnimationFrame(this.scrollRaFId);
 		}
 	}
 
@@ -728,13 +732,12 @@ class ScrollableBaseNative extends Component {
 	onScroll = (ev) => {
 		const {scrollLeft, scrollTop} = ev.target;
 
-		if (!this.scrollTicking) {
-			window.requestAnimationFrame(() => {
+		if (!this.scrollRaFId) {
+			this.scrollRaFId = window.requestAnimationFrame(() => {
 				this.scrollOnScroll(scrollLeft, scrollTop);
-				this.scrollTicking = false;
+				this.scrollRaFId = null;
 			});
 		}
-		this.scrollTicking = true;
 	}
 
 	scrollByPage = (keyCode) => {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -958,7 +958,7 @@ class ScrollableBaseNative extends Component {
 		this.scrollStopJob.start();
 	}
 
-	startScrollJob = new Job(this.scrollOnScroll, 16);
+	startScrollJob = new Job(this.scrollOnScroll);
 
 	scrollStopJob = new Job(this.scrollStopOnScroll, scrollStopWaiting);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ui/ScrollableNative` needs to update scroll buttons when it scrolls. Using `requestAnimationFrame` helped us to increase performance (#1891), but setting `timeout` (i.e. 16ms) will throttle the event, and will not properly use the last input from the event.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed `timeout` parameter from the job.

### Additional Considerations
We could retain the throttling part of it to reduce the amount of work to be done while scrolling, and update the scroll buttons after scroll stop event. Note that since the wait time for scroll stop event is 200ms, there's a slight delay in a state change. But maybe it's okay as JS version scroller changes the state after scroll animation completes.

Another idea I had was to debounce job to handle the scroll event to correctly set the last position for calculation. But I haven't tried this method.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
