### PR TITLE
ENYO-5603: Clean up spotlight container disabled prop propagation

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -264,13 +264,6 @@ class ScrollableBase extends Component {
 		if (focusedItem) {
 			focusedItem.blur();
 		}
-
-		if (
-			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
-			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
-		) {
-			this.childRef.setContainerDisabled(true);
-		}
 	}
 
 	onWheel = ({delta, horizontalScrollbarRef, verticalScrollbarRef}) => {
@@ -285,7 +278,6 @@ class ScrollableBase extends Component {
 
 		if (delta !== 0) {
 			this.isWheeling = true;
-			this.childRef.setContainerDisabled(true);
 		}
 	}
 
@@ -505,7 +497,6 @@ class ScrollableBase extends Component {
 	}
 
 	stop = () => {
-		this.childRef.setContainerDisabled(false);
 		this.focusOnItem();
 		this.lastScrollPositionOnFocus = null;
 		this.isWheeling = false;
@@ -782,8 +773,7 @@ class ScrollableBase extends Component {
 									onScroll: handleScroll,
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
-									rtl,
-									spotlightId
+									rtl
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -257,8 +257,7 @@ class ScrollableBase extends Component {
 		vertical: {before: null, after: null}
 	}
 
-	onFlick = ({direction}) => {
-		const bounds = this.uiRef.getScrollBounds();
+	onFlick = () => {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -245,23 +245,12 @@ class ScrollableBaseNative extends Component {
 	isVoiceControl = false
 	voiceControlDirection = 'vertical'
 
-	onMouseDown = () => {
-		this.childRef.setContainerDisabled(false);
-	}
-
 	onFlick = ({direction}) => {
 		const bounds = this.uiRef.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
 			focusedItem.blur();
-		}
-
-		if (
-			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
-			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
-		) {
-			this.childRef.setContainerDisabled(true);
 		}
 	}
 
@@ -309,7 +298,6 @@ class ScrollableBaseNative extends Component {
 				const {horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef;
 
 				if (!this.isWheeling) {
-					this.childRef.setContainerDisabled(true);
 					this.isWheeling = true;
 				}
 
@@ -330,7 +318,6 @@ class ScrollableBaseNative extends Component {
 		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 			if (eventDelta < 0 && this.uiRef.scrollLeft > 0 || eventDelta > 0 && this.uiRef.scrollLeft < bounds.maxLeft) {
 				if (!this.isWheeling) {
-					this.childRef.setContainerDisabled(true);
 					this.isWheeling = true;
 				}
 				delta = this.uiRef.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
@@ -579,7 +566,6 @@ class ScrollableBaseNative extends Component {
 	}
 
 	scrollStopOnScroll = () => {
-		this.childRef.setContainerDisabled(false);
 		this.focusOnItem();
 		this.lastScrollPositionOnFocus = null;
 		this.isWheeling = false;
@@ -860,8 +846,7 @@ class ScrollableBaseNative extends Component {
 									isVerticalScrollbarVisible,
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
-									rtl,
-									spotlightId
+									rtl
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -245,8 +245,7 @@ class ScrollableBaseNative extends Component {
 	isVoiceControl = false
 	voiceControlDirection = 'vertical'
 
-	onFlick = ({direction}) => {
-		const bounds = this.uiRef.getScrollBounds();
+	onFlick = () => {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -27,7 +27,6 @@ import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
 
 const
-	dataContainerDisabledAttribute = 'data-spotlight-container-disabled',
 	epsilon = 1,
 	reverseDirections = {
 		left: 'right',
@@ -76,14 +75,7 @@ class ScrollerBase extends Component {
 	}
 
 	componentDidUpdate () {
-		const {onUpdate} = this.props;
-		if (onUpdate) {
-			onUpdate();
-		}
-	}
-
-	componentWillUnmount () {
-		this.setContainerDisabled(false);
+		forward('onUpdate', {}, this.props);
 	}
 
 	isScrolledToBoundary = false
@@ -274,24 +266,6 @@ class ScrollerBase extends Component {
 		return nextSpottable && this.uiRef.containerRef.contains(nextSpottable);
 	}
 
-	handleGlobalKeyDown = () => {
-		this.setContainerDisabled(false);
-	}
-
-	setContainerDisabled = (bool) => {
-		const containerNode = this.uiRef && this.uiRef.containerRef;
-
-		if (containerNode) {
-			containerNode.setAttribute(dataContainerDisabledAttribute, bool);
-
-			if (bool) {
-				document.addEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
-			} else {
-				document.removeEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
-			}
-		}
-	}
-
 	getNextEndPoint = (direction, oSpotBounds) => {
 		const bounds = this.uiRef.getScrollBounds();
 
@@ -410,8 +384,6 @@ const Scroller = (props) => (
 	<Scrollable
 		{...props}
 		childRenderer={(scrollerProps) => { // eslint-disable-line react/jsx-no-bind
-			delete scrollerProps.spotlightId;
-
 			return <ScrollerBase {...scrollerProps} />;
 		}}
 	/>
@@ -457,8 +429,6 @@ const ScrollerNative = (props) => (
 	<ScrollableNative
 		{...props}
 		childRenderer={(scrollerProps) => { // eslint-disable-line react/jsx-no-bind
-			delete scrollerProps.spotlightId;
-
 			return <ScrollerBase {...scrollerProps} />;
 		}}
 	/>

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -75,7 +75,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', Scroller, false)}
+				spotlightDisabled={boolean('spotlightDisabled', Scroller, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 			>
 				<Group childComponent={Item}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`SpotlightContainer` is declared in `Scrollable`s and yet it's propagating `data-spotlight-disabled` property down to its children. I believe this is a cruft left over from #1553

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed all `setContainerDisabled` from `moonstone/Scrollable`, `moonstone/Scroller` and `moonstone/ScrollableNative`

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
