### PR TITLE
ENYO-5616: Added exception for cases where refs don't exist

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
+- `moonstone/TooltipDecorator` to add exception handling for cases where tooltipRef or clientRef don't exist
 
 ## [2.1.2] - 2018-09-04
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
-- `moonstone/TooltipDecorator` to add exception handling for cases where tooltipRef or clientRef don't exist
+- `moonstone/TooltipDecorator` to handle runtime error when setting `tooltipText` to an empty string
 
 ## [2.1.2] - 2018-09-04
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -187,6 +187,10 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		setTooltipLayout () {
+			if (!(this.tooltipRef && this.clientRef)) {
+				return;
+			}
+
 			const position = this.props.tooltipPosition;
 			const arr = position.split(' ');
 			let tooltipDirection = null;

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -187,9 +187,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		setTooltipLayout () {
-			if (!(this.tooltipRef && this.clientRef)) {
-				return;
-			}
+			if (!this.tooltipRef || !this.clientRef) return;
 
 			const position = this.props.tooltipPosition;
 			const arr = position.split(' ');

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -57,6 +57,8 @@ class ChangeableTooltip extends React.Component {
 			this.setState({text: 'long text'});
 		} else if (text === 'long text') {
 			this.setState({text: 'very loooooooooooong text'});
+		} else if (text === 'very loooooooooooong text') {
+			this.setState({text: ''});
 		} else {
 			this.setState({text: 'short'});
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's the problem when tooltipText is changed to an empty string or changed from an empty string to a string.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added exception handling for cases where refs don't exist. If there's no ref, that returns.

### Links
[ENYO-5616]
[GT-25843]