### PR TITLE
PLAT-48029: Added reachedEdgeInfo within `onScrollStop` callback

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -868,7 +868,7 @@ class ScrollableBase extends Component {
 				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
 
 			if (edge) { // if edge is null, no need to check which edge is reached.
-				if ((edge === 'before' && !rtl) || ((edge === 'after') && rtl)) {
+				if ((edge === 'before' && !rtl) || (edge === 'after' && rtl)) {
 					reachedEdgeInfo.left = true;
 				} else {
 					reachedEdgeInfo.right = true;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -868,10 +868,10 @@ class ScrollableBase extends Component {
 				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
 
 			if (edge) { // if edge is null, no need to check which edge is reached.
-				if ((edge === 'before') === rtl) {
-					reachedEdgeInfo.right = true;
-				} else {
+				if ((edge === 'before' && !rtl) || ((edge === 'after') && rtl)) {
 					reachedEdgeInfo.left = true;
+				} else {
+					reachedEdgeInfo.right = true;
 				}
 			}
 		}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -461,7 +461,7 @@ class ScrollableBase extends Component {
 	componentWillUnmount () {
 		// Before call cancelAnimationFrame, you must send scrollStop Event.
 		if (this.animator.isAnimating()) {
-			this.forwardScrollEvent('onScrollStop');
+			this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
 			this.animator.stop();
 		}
 
@@ -823,8 +823,8 @@ class ScrollableBase extends Component {
 
 	// call scroll callbacks
 
-	forwardScrollEvent (type) {
-		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo()}, this.props);
+	forwardScrollEvent (type, reachedEdgeInfo) {
+		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
 	}
 
 	// update scroll position
@@ -855,6 +855,38 @@ class ScrollableBase extends Component {
 		if (this.state.isVerticalScrollbarVisible) {
 			this.updateThumb(this.verticalScrollbarRef, bounds);
 		}
+	}
+
+	getReachedEdgeInfo = () => {
+		const
+			bounds = this.getScrollBounds(),
+			reachedEdgeInfo = {bottom: false, left: false, right: false, top: false};
+
+		if (this.canScrollHorizontally(bounds)) {
+			const
+				rtl = this.state.rtl,
+				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
+
+			if (edge) { // if edge is null, no need to check which edge is reached.
+				if ((edge === 'before') === rtl) {
+					reachedEdgeInfo.right = true;
+				} else {
+					reachedEdgeInfo.left = true;
+				}
+			}
+		}
+
+		if (this.canScrollVertically(bounds)) {
+			const edge = this.getEdgeFromPosition(this.scrollTop, bounds.maxTop);
+
+			if (edge === 'before') {
+				reachedEdgeInfo.top = true;
+			} else if (edge === 'after') {
+				reachedEdgeInfo.bottom = true;
+			}
+		}
+
+		return reachedEdgeInfo;
 	}
 
 	// scroll start/stop
@@ -973,7 +1005,7 @@ class ScrollableBase extends Component {
 		}
 		if (this.scrolling) {
 			this.scrolling = false;
-			this.forwardScrollEvent('onScrollStop');
+			this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
 		}
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1003,7 +1003,7 @@ class ScrollableBaseNative extends Component {
 				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
 
 			if (edge) { // if edge is null, no need to check which edge is reached.
-				if ((edge === 'before' && !rtl) || ((edge === 'after') && rtl)) {
+				if ((edge === 'before' && !rtl) || (edge === 'after' && rtl)) {
 					reachedEdgeInfo.left = true;
 				} else {
 					reachedEdgeInfo.right = true;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -460,7 +460,7 @@ class ScrollableBaseNative extends Component {
 	componentWillUnmount () {
 		// Before call cancelAnimationFrame, you must send scrollStop Event.
 		if (this.scrolling) {
-			this.forwardScrollEvent('onScrollStop');
+			this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
 		}
 		this.scrollStopJob.stop();
 		this.startScrollJob.stop();
@@ -898,8 +898,8 @@ class ScrollableBaseNative extends Component {
 
 	// call scroll callbacks
 
-	forwardScrollEvent (type) {
-		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo()}, this.props);
+	forwardScrollEvent (type, reachedEdgeInfo) {
+		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
 	}
 
 	// call scroll callbacks and update scrollbars for native scroll
@@ -920,7 +920,7 @@ class ScrollableBaseNative extends Component {
 		this.lastInputType = null;
 		this.isScrollAnimationTargetAccumulated = false;
 		this.scrolling = false;
-		this.forwardScrollEvent('onScrollStop');
+		this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
 		this.startHidingThumb();
 	}
 
@@ -990,6 +990,38 @@ class ScrollableBaseNative extends Component {
 		if (this.state.isVerticalScrollbarVisible) {
 			this.updateThumb(this.verticalScrollbarRef, bounds);
 		}
+	}
+
+	getReachedEdgeInfo = () => {
+		const
+			bounds = this.getScrollBounds(),
+			reachedEdgeInfo = {bottom: false, left: false, right: false, top: false};
+
+		if (this.canScrollHorizontally(bounds)) {
+			const
+				rtl = this.state.rtl,
+				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
+
+			if (edge) { // if edge is null, no need to check which edge is reached.
+				if ((edge === 'before') === rtl) {
+					reachedEdgeInfo.right = true;
+				} else {
+					reachedEdgeInfo.left = true;
+				}
+			}
+		}
+
+		if (this.canScrollVertically(bounds)) {
+			const edge = this.getEdgeFromPosition(this.scrollTop, bounds.maxTop);
+
+			if (edge === 'before') {
+				reachedEdgeInfo.top = true;
+			} else if (edge === 'after') {
+				reachedEdgeInfo.bottom = true;
+			}
+		}
+
+		return reachedEdgeInfo;
 	}
 
 	// scroll start

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1003,10 +1003,10 @@ class ScrollableBaseNative extends Component {
 				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
 
 			if (edge) { // if edge is null, no need to check which edge is reached.
-				if ((edge === 'before') === rtl) {
-					reachedEdgeInfo.right = true;
-				} else {
+				if ((edge === 'before' && !rtl) || ((edge === 'after') && rtl)) {
 					reachedEdgeInfo.left = true;
+				} else {
+					reachedEdgeInfo.right = true;
 				}
 			}
 		}


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have a requirement to notify a list or a scroller reached the scroll edge. With the existing APIs, an app should keep an eye on the info provided by _onScroll_ callback function and it is not good on the performance aspect.
In this PR, we provide (maybe little limited) alternative solution to provide reaching status by _onScrollStop_ callback to help apps to choose more light method if possible.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
_onScrollStop_ callback provides `reachedEdgeInfo` which contains reaching status of `top`, `bottom`, `left`, and `right` edge.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Note that if a list or a scroller is shortened and not scrollable anymore, no edge will be marked as _true_(reached)_ since apps don't need to show a visual effect for short contents.

### Links
[//]: # (Related issues, references)
PLAT-48029

### Comments
