### PR TITLE
ENYO-5614: Fix Scrollable to notify user when scrolling is not possible via voice command

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,13 +2,38 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
+
+### Added
+
+- `moonstone/GridListImageItem` voice control feature support
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
+
+### Fixed
+
+- `moonstone/VideoPlayer` to unfocus media controls when hidden
+- `moonstone/Scroller` to set correct scroll position when an expandable child is closed
+- `moonstone/Scroller` to prevent focusing children while scrolling
+
+## [2.1.4] - 2018-09-17
+
+### Fixed
+
+- `moonstone/Button` and `moonstone/IconButton` to style image-based icons correctly when focused and disabled
+- `moonstone/FormCheckboxItem` styling when focused and disabled
+- `moonstone/Panels` to always blur breadcrumbs when transitioning to a new panel
+- `moonstone/Scroller` to correctly set scroll position when nested item is focused
+- `moonstone/Scroller` to not adjust `scrollTop` when nested item is focused
+- `moonstone/VideoPlayer` to show correct playback rate feedback on play or pause
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle 5way navigation properly when `focusableScrollbar` is true
+
+## [2.1.3] - 2018-09-10
 
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
 - `moonstone/TooltipDecorator` to handle runtime error when setting `tooltipText` to an empty string
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
+- `moonstone/VideoPlayer` timing to read out `infoComponents` accessibility value when `moreButton` or `moreButtonColor` is pressed
 
 ## [2.1.2] - 2018-09-04
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
 - `moonstone/TooltipDecorator` to handle runtime error when setting `tooltipText` to an empty string
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
 
 ## [2.1.2] - 2018-09-04
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify user when scrolling is not possible via voice command
+
 ## [2.2.0] - 2018-10-02
 
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,7 +13,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify user when scrolling is not possible via voice command
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify message when scroll is not possible with voice
 
 ### Fixed
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -667,9 +667,8 @@ class ScrollableBase extends Component {
 	}
 
 	notifyVoiceException = (e, type) => {
-		const param = {'voiceUi': {'exception': type}};
 		if (window.webOSVoiceReportActionResult) {
-			window.webOSVoiceReportActionResult(param);
+			window.webOSVoiceReportActionResult({'voiceUi': {'exception': type}});
 			e.preventDefault();
 		}
 	}
@@ -688,7 +687,7 @@ class ScrollableBase extends Component {
 				return false;
 			}
 		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop === scrollBounds.maxTop) {
+			if (scrollTop >= scrollBounds.maxTop - 1) {
 				notifyAlreadyCompleted();
 				return false;
 			}
@@ -719,39 +718,46 @@ class ScrollableBase extends Component {
 				case 'up':
 					this.voiceControlDirection = 'vertical';
 					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
+					e.preventDefault();
 					break;
 				case 'down':
 					this.voiceControlDirection = 'vertical';
 					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
+					e.preventDefault();
 					break;
 				case 'left':
 					this.voiceControlDirection = 'horizontal';
 					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
+					e.preventDefault();
 					break;
 				case 'right':
 					this.voiceControlDirection = 'horizontal';
 					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
+					e.preventDefault();
 					break;
 				case 'top':
 					this.voiceControlDirection = 'vertical';
 					this.uiRef.scrollTo({align: 'top'});
+					e.preventDefault();
 					break;
 				case 'bottom':
 					this.voiceControlDirection = 'vertical';
 					this.uiRef.scrollTo({align: 'bottom'});
+					e.preventDefault();
 					break;
 				case 'leftmost':
 					this.voiceControlDirection = 'horizontal';
 					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
+					e.preventDefault();
 					break;
 				case 'rightmost':
 					this.voiceControlDirection = 'horizontal';
 					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
+					e.preventDefault();
 					break;
 				default:
 					this.isVoiceControl = false;
 			}
-			e.preventDefault();
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -666,49 +666,71 @@ class ScrollableBase extends Component {
 		}
 	}
 
+	canVoiceScroll = (scroll) => {
+		const
+			{scrollTop, scrollLeft} = this.uiRef,
+			isRtl = this.uiRef.state.rtl;
+		const scrollBounds = this.uiRef.getScrollBounds();
+
+		if (scroll === 'up' || scroll === 'top') {
+			if (scrollTop === 0) return false;
+		} else if (scroll === 'down' || scroll === 'bottom') {
+			if (scrollTop === scrollBounds.maxTop) return false;
+		} else if (scroll === 'left' || scroll === 'leftmost') {
+			const limit = isRtl ? scrollBounds.maxLeft : 0;
+			if (scrollLeft === limit) return false;
+		} else if (scroll === 'right' || scroll === 'rightmost') {
+			const limit = isRtl ? 0 : scrollBounds.maxLeft;
+			if (scrollLeft === limit) return false;
+		}
+		return true;
+	}
+
 	onVoice = (e) => {
 		const
 			scroll = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl;
-		this.isVoiceControl = true;
 
-		switch (scroll) {
-			case 'up':
-				this.voiceControlDirection = 'vertical';
-				this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
-				break;
-			case 'down':
-				this.voiceControlDirection = 'vertical';
-				this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
-				break;
-			case 'left':
-				this.voiceControlDirection = 'horizontal';
-				this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
-				break;
-			case 'right':
-				this.voiceControlDirection = 'horizontal';
-				this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
-				break;
-			case 'top':
-				this.voiceControlDirection = 'vertical';
-				this.uiRef.scrollTo({align: 'top'});
-				break;
-			case 'bottom':
-				this.voiceControlDirection = 'vertical';
-				this.uiRef.scrollTo({align: 'bottom'});
-				break;
-			case 'leftmost':
-				this.voiceControlDirection = 'horizontal';
-				this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
-				break;
-			case 'rightmost':
-				this.voiceControlDirection = 'horizontal';
-				this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
-				break;
-			default:
-				this.isVoiceControl = false;
+		if (this.canVoiceScroll(scroll)) {
+			this.isVoiceControl = true;
+			switch (scroll) {
+				case 'up':
+					this.voiceControlDirection = 'vertical';
+					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
+					break;
+				case 'down':
+					this.voiceControlDirection = 'vertical';
+					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
+					break;
+				case 'left':
+					this.voiceControlDirection = 'horizontal';
+					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
+					break;
+				case 'right':
+					this.voiceControlDirection = 'horizontal';
+					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
+					break;
+				case 'top':
+					this.voiceControlDirection = 'vertical';
+					this.uiRef.scrollTo({align: 'top'});
+					break;
+				case 'bottom':
+					this.voiceControlDirection = 'vertical';
+					this.uiRef.scrollTo({align: 'bottom'});
+					break;
+				case 'leftmost':
+					this.voiceControlDirection = 'horizontal';
+					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
+					break;
+				case 'rightmost':
+					this.voiceControlDirection = 'horizontal';
+					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
+					break;
+				default:
+					this.isVoiceControl = false;
+			}
+			e.preventDefault();
 		}
-		e.preventDefault();
 	}
 
 	render () {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -666,22 +666,44 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	canVoiceScroll = (scroll) => {
+	notifyVoiceException = (e, type) => {
+		const param = {'voiceUi': {'exception': type}};
+		if (window.webOSVoiceReportActionResult) {
+			window.webOSVoiceReportActionResult(param);
+			e.preventDefault();
+		}
+	}
+
+	canVoiceScroll = (e) => {
 		const
+			scroll = e && e.detail && e.detail.scroll,
 			{scrollTop, scrollLeft} = this.uiRef,
 			isRtl = this.uiRef.state.rtl;
 		const scrollBounds = this.uiRef.getScrollBounds();
+		const notifyAlreadyCompleted = () => this.notifyVoiceException(e, 'alreadyCompleted');
 
 		if (scroll === 'up' || scroll === 'top') {
-			if (scrollTop === 0) return false;
+			if (scrollTop === 0) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop === scrollBounds.maxTop) return false;
+			if (scrollTop === scrollBounds.maxTop) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'left' || scroll === 'leftmost') {
 			const limit = isRtl ? scrollBounds.maxLeft : 0;
-			if (scrollLeft === limit) return false;
+			if (scrollLeft === limit) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'right' || scroll === 'rightmost') {
 			const limit = isRtl ? 0 : scrollBounds.maxLeft;
-			if (scrollLeft === limit) return false;
+			if (scrollLeft === limit) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		}
 		return true;
 	}
@@ -691,7 +713,7 @@ class ScrollableBase extends Component {
 			scroll = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl;
 
-		if (this.canVoiceScroll(scroll)) {
+		if (this.canVoiceScroll(e)) {
 			this.isVoiceControl = true;
 			switch (scroll) {
 				case 'up':

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -666,98 +666,48 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	notifyVoiceException = (e, type) => {
-		if (window.webOSVoiceReportActionResult) {
-			window.webOSVoiceReportActionResult({'voiceUi': {'exception': type}});
-			e.preventDefault();
-		}
-	}
-
-	canVoiceScroll = (e) => {
-		const
-			scroll = e && e.detail && e.detail.scroll,
-			{scrollTop, scrollLeft} = this.uiRef,
-			isRtl = this.uiRef.state.rtl;
-		const scrollBounds = this.uiRef.getScrollBounds();
-		const notifyAlreadyCompleted = () => this.notifyVoiceException(e, 'alreadyCompleted');
-
-		if (scroll === 'up' || scroll === 'top') {
-			if (scrollTop === 0) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop >= scrollBounds.maxTop - 1) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'left' || scroll === 'leftmost') {
-			const limit = isRtl ? scrollBounds.maxLeft : 0;
-			if (scrollLeft === limit) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'right' || scroll === 'rightmost') {
-			const limit = isRtl ? 0 : scrollBounds.maxLeft;
-			if (scrollLeft === limit) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		}
-		return true;
+	isReachedEdge = (scrollPos, ltrBound, rtlBound, isRtl = false) => {
+		const bound = isRtl ? rtlBound : ltrBound;
+		return (bound === 0 && scrollPos === 0) || (bound > 0 && scrollPos >= bound - 1);
 	}
 
 	onVoice = (e) => {
 		const
 			scroll = e && e.detail && e.detail.scroll,
-			isRtl = this.uiRef.state.rtl;
+			isRtl = this.uiRef.state.rtl,
+			{scrollTop, scrollLeft} = this.uiRef,
+			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
+			verticalDirection = ['up', 'down', 'top', 'bottom'],
+			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'];
 
-		if (this.canVoiceScroll(e)) {
-			this.isVoiceControl = true;
-			switch (scroll) {
-				case 'up':
-					this.voiceControlDirection = 'vertical';
-					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
-					e.preventDefault();
-					break;
-				case 'down':
-					this.voiceControlDirection = 'vertical';
-					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
-					e.preventDefault();
-					break;
-				case 'left':
-					this.voiceControlDirection = 'horizontal';
-					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
-					e.preventDefault();
-					break;
-				case 'right':
-					this.voiceControlDirection = 'horizontal';
-					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
-					e.preventDefault();
-					break;
-				case 'top':
-					this.voiceControlDirection = 'vertical';
-					this.uiRef.scrollTo({align: 'top'});
-					e.preventDefault();
-					break;
-				case 'bottom':
-					this.voiceControlDirection = 'vertical';
-					this.uiRef.scrollTo({align: 'bottom'});
-					e.preventDefault();
-					break;
-				case 'leftmost':
-					this.voiceControlDirection = 'horizontal';
-					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
-					e.preventDefault();
-					break;
-				case 'rightmost':
-					this.voiceControlDirection = 'horizontal';
-					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
-					e.preventDefault();
-					break;
-				default:
-					this.isVoiceControl = false;
+		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
+
+		// Case 1. Invalid direction
+		if (this.voiceControlDirection === null) {
+			this.isVoiceControl = false;
+
+		// Case 2. Cannot scroll
+		} else if (
+			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
+			(['down', 'bottom'].includes(scroll) && this.isReachedEdge(scrollTop, maxTop)) ||
+			(['left', 'leftmost'].includes(scroll) && this.isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
+			(['right', 'rightmost'].includes(scroll) && this.isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
+		) {
+			if (window.webOSVoiceReportActionResult) {
+				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
+				e.preventDefault();
 			}
+
+		// Case 3. Can scroll
+		} else {
+			this.isVoiceControl = true;
+			if (['up', 'down', 'left', 'right'].includes(scroll)) {
+				const isPreviousScrollButton = (scroll === 'up') || (scroll === 'left' && !isRtl) || (scroll === 'right' && isRtl);
+				this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
+			} else { // ['top', 'bottom', 'leftmost', 'rightmost'].includes(scroll)
+				this.uiRef.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
+			}
+			e.preventDefault();
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -685,7 +685,6 @@ class ScrollableBase extends Component {
 		// Case 1. Invalid direction
 		if (this.voiceControlDirection === null) {
 			this.isVoiceControl = false;
-
 		// Case 2. Cannot scroll
 		} else if (
 			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
@@ -697,7 +696,6 @@ class ScrollableBase extends Component {
 				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
 				e.preventDefault();
 			}
-
 		// Case 3. Can scroll
 		} else {
 			this.isVoiceControl = true;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -744,22 +744,44 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	canVoiceScroll = (scroll) => {
+	notifyVoiceException = (e, type) => {
+		const param = {'voiceUi': {'exception': type}};
+		if (window.webOSVoiceReportActionResult) {
+			window.webOSVoiceReportActionResult(param);
+			e.preventDefault();
+		}
+	}
+
+	canVoiceScroll = (e) => {
 		const
+			scroll = e && e.detail && e.detail.scroll,
 			{scrollTop, scrollLeft} = this.uiRef,
 			isRtl = this.uiRef.state.rtl;
 		const scrollBounds = this.uiRef.getScrollBounds();
+		const notifyAlreadyCompleted = () => this.notifyVoiceException(e, 'alreadyCompleted');
 
 		if (scroll === 'up' || scroll === 'top') {
-			if (scrollTop === 0) return false;
+			if (scrollTop === 0) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop === scrollBounds.maxTop) return false;
+			if (scrollTop === scrollBounds.maxTop) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'left' || scroll === 'leftmost') {
 			const limit = isRtl ? scrollBounds.maxLeft : 0;
-			if (scrollLeft === limit) return false;
+			if (scrollLeft === limit) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		} else if (scroll === 'right' || scroll === 'rightmost') {
 			const limit = isRtl ? 0 : scrollBounds.maxLeft;
-			if (scrollLeft === limit) return false;
+			if (scrollLeft === limit) {
+				notifyAlreadyCompleted();
+				return false;
+			}
 		}
 		return true;
 	}
@@ -769,7 +791,7 @@ class ScrollableBaseNative extends Component {
 			scroll = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl;
 
-		if (this.canVoiceScroll(scroll)) {
+		if (this.canVoiceScroll(e)) {
 			this.isVoiceControl = true;
 			switch (scroll) {
 				case 'up':

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -763,7 +763,6 @@ class ScrollableBaseNative extends Component {
 		// Case 1. Invalid direction
 		if (this.voiceControlDirection === null) {
 			this.isVoiceControl = false;
-
 		// Case 2. Cannot scroll
 		} else if (
 			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
@@ -775,7 +774,6 @@ class ScrollableBaseNative extends Component {
 				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
 				e.preventDefault();
 			}
-
 		// Case 3. Can scroll
 		} else {
 			this.isVoiceControl = true;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -744,98 +744,48 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	notifyVoiceException = (e, type) => {
-		if (window.webOSVoiceReportActionResult) {
-			window.webOSVoiceReportActionResult({'voiceUi': {'exception': type}});
-			e.preventDefault();
-		}
-	}
-
-	canVoiceScroll = (e) => {
-		const
-			scroll = e && e.detail && e.detail.scroll,
-			{scrollTop, scrollLeft} = this.uiRef,
-			isRtl = this.uiRef.state.rtl;
-		const scrollBounds = this.uiRef.getScrollBounds();
-		const notifyAlreadyCompleted = () => this.notifyVoiceException(e, 'alreadyCompleted');
-
-		if (scroll === 'up' || scroll === 'top') {
-			if (scrollTop === 0) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop >= scrollBounds.maxTop - 1) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'left' || scroll === 'leftmost') {
-			const limit = isRtl ? scrollBounds.maxLeft : 0;
-			if (scrollLeft === limit) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		} else if (scroll === 'right' || scroll === 'rightmost') {
-			const limit = isRtl ? 0 : scrollBounds.maxLeft;
-			if (scrollLeft === limit) {
-				notifyAlreadyCompleted();
-				return false;
-			}
-		}
-		return true;
+	isReachedEdge = (scrollPos, ltrBound, rtlBound, isRtl = false) => {
+		const bound = isRtl ? rtlBound : ltrBound;
+		return (bound === 0 && scrollPos === 0) || (bound > 0 && scrollPos >= bound - 1);
 	}
 
 	onVoice = (e) => {
 		const
 			scroll = e && e.detail && e.detail.scroll,
-			isRtl = this.uiRef.state.rtl;
+			isRtl = this.uiRef.state.rtl,
+			{scrollTop, scrollLeft} = this.uiRef,
+			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
+			verticalDirection = ['up', 'down', 'top', 'bottom'],
+			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'];
 
-		if (this.canVoiceScroll(e)) {
-			this.isVoiceControl = true;
-			switch (scroll) {
-				case 'up':
-					this.voiceControlDirection = 'vertical';
-					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
-					e.preventDefault();
-					break;
-				case 'down':
-					this.voiceControlDirection = 'vertical';
-					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
-					e.preventDefault();
-					break;
-				case 'left':
-					this.voiceControlDirection = 'horizontal';
-					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
-					e.preventDefault();
-					break;
-				case 'right':
-					this.voiceControlDirection = 'horizontal';
-					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
-					e.preventDefault();
-					break;
-				case 'top':
-					this.voiceControlDirection = 'vertical';
-					this.uiRef.scrollTo({align: 'top'});
-					e.preventDefault();
-					break;
-				case 'bottom':
-					this.voiceControlDirection = 'vertical';
-					this.uiRef.scrollTo({align: 'bottom'});
-					e.preventDefault();
-					break;
-				case 'leftmost':
-					this.voiceControlDirection = 'horizontal';
-					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
-					e.preventDefault();
-					break;
-				case 'rightmost':
-					this.voiceControlDirection = 'horizontal';
-					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
-					e.preventDefault();
-					break;
-				default:
-					this.isVoiceControl = false;
+		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
+
+		// Case 1. Invalid direction
+		if (this.voiceControlDirection === null) {
+			this.isVoiceControl = false;
+
+		// Case 2. Cannot scroll
+		} else if (
+			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
+			(['down', 'bottom'].includes(scroll) && this.isReachedEdge(scrollTop, maxTop)) ||
+			(['left', 'leftmost'].includes(scroll) && this.isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
+			(['right', 'rightmost'].includes(scroll) && this.isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
+		) {
+			if (window.webOSVoiceReportActionResult) {
+				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
+				e.preventDefault();
 			}
+
+		// Case 3. Can scroll
+		} else {
+			this.isVoiceControl = true;
+			if (['up', 'down', 'left', 'right'].includes(scroll)) {
+				const isPreviousScrollButton = (scroll === 'up') || (scroll === 'left' && !isRtl) || (scroll === 'right' && isRtl);
+				this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
+			} else { // ['top', 'bottom', 'leftmost', 'rightmost'].includes(scroll)
+				this.uiRef.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
+			}
+			e.preventDefault();
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -744,49 +744,71 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
+	canVoiceScroll = (scroll) => {
+		const
+			{scrollTop, scrollLeft} = this.uiRef,
+			isRtl = this.uiRef.state.rtl;
+		const scrollBounds = this.uiRef.getScrollBounds();
+
+		if (scroll === 'up' || scroll === 'top') {
+			if (scrollTop === 0) return false;
+		} else if (scroll === 'down' || scroll === 'bottom') {
+			if (scrollTop === scrollBounds.maxTop) return false;
+		} else if (scroll === 'left' || scroll === 'leftmost') {
+			const limit = isRtl ? scrollBounds.maxLeft : 0;
+			if (scrollLeft === limit) return false;
+		} else if (scroll === 'right' || scroll === 'rightmost') {
+			const limit = isRtl ? 0 : scrollBounds.maxLeft;
+			if (scrollLeft === limit) return false;
+		}
+		return true;
+	}
+
 	onVoice = (e) => {
 		const
 			scroll = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl;
-		this.isVoiceControl = true;
 
-		switch (scroll) {
-			case 'up':
-				this.voiceControlDirection = 'vertical';
-				this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
-				break;
-			case 'down':
-				this.voiceControlDirection = 'vertical';
-				this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
-				break;
-			case 'left':
-				this.voiceControlDirection = 'horizontal';
-				this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
-				break;
-			case 'right':
-				this.voiceControlDirection = 'horizontal';
-				this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
-				break;
-			case 'top':
-				this.voiceControlDirection = 'vertical';
-				this.uiRef.scrollTo({align: 'top'});
-				break;
-			case 'bottom':
-				this.voiceControlDirection = 'vertical';
-				this.uiRef.scrollTo({align: 'bottom'});
-				break;
-			case 'leftmost':
-				this.voiceControlDirection = 'horizontal';
-				this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
-				break;
-			case 'rightmost':
-				this.voiceControlDirection = 'horizontal';
-				this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
-				break;
-			default:
-				this.isVoiceControl = false;
+		if (this.canVoiceScroll(scroll)) {
+			this.isVoiceControl = true;
+			switch (scroll) {
+				case 'up':
+					this.voiceControlDirection = 'vertical';
+					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
+					break;
+				case 'down':
+					this.voiceControlDirection = 'vertical';
+					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
+					break;
+				case 'left':
+					this.voiceControlDirection = 'horizontal';
+					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
+					break;
+				case 'right':
+					this.voiceControlDirection = 'horizontal';
+					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
+					break;
+				case 'top':
+					this.voiceControlDirection = 'vertical';
+					this.uiRef.scrollTo({align: 'top'});
+					break;
+				case 'bottom':
+					this.voiceControlDirection = 'vertical';
+					this.uiRef.scrollTo({align: 'bottom'});
+					break;
+				case 'leftmost':
+					this.voiceControlDirection = 'horizontal';
+					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
+					break;
+				case 'rightmost':
+					this.voiceControlDirection = 'horizontal';
+					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
+					break;
+				default:
+					this.isVoiceControl = false;
+			}
+			e.preventDefault();
 		}
-		e.preventDefault();
 	}
 
 	render () {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -745,9 +745,8 @@ class ScrollableBaseNative extends Component {
 	}
 
 	notifyVoiceException = (e, type) => {
-		const param = {'voiceUi': {'exception': type}};
 		if (window.webOSVoiceReportActionResult) {
-			window.webOSVoiceReportActionResult(param);
+			window.webOSVoiceReportActionResult({'voiceUi': {'exception': type}});
 			e.preventDefault();
 		}
 	}
@@ -766,7 +765,7 @@ class ScrollableBaseNative extends Component {
 				return false;
 			}
 		} else if (scroll === 'down' || scroll === 'bottom') {
-			if (scrollTop === scrollBounds.maxTop) {
+			if (scrollTop >= scrollBounds.maxTop - 1) {
 				notifyAlreadyCompleted();
 				return false;
 			}
@@ -797,39 +796,46 @@ class ScrollableBaseNative extends Component {
 				case 'up':
 					this.voiceControlDirection = 'vertical';
 					this.onScrollbarButtonClick({isPreviousScrollButton: true, isVerticalScrollBar: true});
+					e.preventDefault();
 					break;
 				case 'down':
 					this.voiceControlDirection = 'vertical';
 					this.onScrollbarButtonClick({isPreviousScrollButton: false, isVerticalScrollBar: true});
+					e.preventDefault();
 					break;
 				case 'left':
 					this.voiceControlDirection = 'horizontal';
 					this.onScrollbarButtonClick({isPreviousScrollButton: !isRtl, isVerticalScrollBar: false});
+					e.preventDefault();
 					break;
 				case 'right':
 					this.voiceControlDirection = 'horizontal';
 					this.onScrollbarButtonClick({isPreviousScrollButton: isRtl, isVerticalScrollBar: false});
+					e.preventDefault();
 					break;
 				case 'top':
 					this.voiceControlDirection = 'vertical';
 					this.uiRef.scrollTo({align: 'top'});
+					e.preventDefault();
 					break;
 				case 'bottom':
 					this.voiceControlDirection = 'vertical';
 					this.uiRef.scrollTo({align: 'bottom'});
+					e.preventDefault();
 					break;
 				case 'leftmost':
 					this.voiceControlDirection = 'horizontal';
 					this.uiRef.scrollTo({align: isRtl ? 'right' : 'left'});
+					e.preventDefault();
 					break;
 				case 'rightmost':
 					this.voiceControlDirection = 'horizontal';
 					this.uiRef.scrollTo({align: isRtl ? 'left' : 'right'});
+					e.preventDefault();
 					break;
 				default:
 					this.isVoiceControl = false;
 			}
-			e.preventDefault();
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Base on UX requirement of Voice Control, proper message has to shown when scrolling is not possible

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In enact side, we need to check scroll is possible or not before control scroll position with voice.

### Links
[//]: # (Related issues, references)
ENYO-5614

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee changgi.lee@lge.com