### PR TITLE
ENYO-5623: Fix ui/Marquee to stop when blurred during restart timer

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to stop when blurred during restart timer
+
 ## [2.1.2] - 2018-09-04
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeController.js
+++ b/packages/ui/Marquee/MarqueeController.js
@@ -230,7 +230,6 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 		handleComplete = (component) => {
 			const complete = this.markReady(component);
 			if (complete) {
-				this.cancelJob.stop();
 				this.markAll(STATE.ready);
 				this.dispatch('start');
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In #1301, we added a `Job` to manage cancelling marquee instances in `MarqueeController` to allow synchronized marquees to continue when a stop event (e.g. blurring) was immediately followed by a start event (focusing, pointer enter). As a result, it became possible (either through impeccable timing or sluggishness on lower powered hardware) to blur a synchronized marquee during the restart timer causing the job to be scheduled but then reset by the "complete" trigger before it fires.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Remove the call to stop the cancel job on "complete"

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I couldn't come up with a reason that the "complete" trigger would stop the cancel job. The purpose of the complete trigger is to inform the controller that one instance is done in order to coordinate restarting all instances at the same time. It isn't a trigger to initiate marquee and so shouldn't prevent cancelling (as far as i can tell).