### PR TITLE
ENYO-5504: Scroll page by page via Channel Up / Down keys without focused item

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll page by page via channel up or down keys without focused item
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
 - `moonstone/TooltipDecorator` to handle runtime error when setting `tooltipText` to an empty string
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -450,13 +450,19 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
-					// We need to convert to 5-way key mode to move Spot to another item manually.
-					Spotlight.setPointerMode(false);
+					const isPointerMode = Spotlight.getPointerMode();
+
+					if (isPointerMode) {
+						// We need to convert to 5-way key mode to move Spot to another item manually.
+						Spotlight.setPointerMode(false);
+					}
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 					overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
-					// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
-					// So we need to convert back to the pointer mode.
-					Spotlight.setPointerMode(true);
+					if (isPointerMode) {
+						// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+						// So we need to convert back to the pointer mode.
+						Spotlight.setPointerMode(true);
+					}
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -395,11 +395,10 @@ class ScrollableBase extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				},
-				isPointerMode = Spotlight.getPointerMode();
+				};
 			let next = null;
 
-			if (isPointerMode) {
+			if (Spotlight.getPointerMode()) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -423,7 +422,7 @@ class ScrollableBase extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (isPointerMode) {
+			if (Spotlight.getPointerMode()) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -371,7 +371,7 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	scrollByPage = (direction) => {
+	scrollByPage = (direction, keyCode) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
 		if (!this.uiRef.state.isVerticalScrollbarVisible) {
@@ -416,11 +416,11 @@ class ScrollableBase extends Component {
 			} else if (this.childRef.scrollToNextItem) {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
-
-			// Need to check whether an overscroll effect is needed
-			return true;
+		} else {
+			this.uiRef.scrollByPage(keyCode);
 		}
 
+		// Need to check whether an overscroll effect is needed
 		return false;
 	}
 
@@ -452,7 +452,7 @@ class ScrollableBase extends Component {
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
 					Spotlight.setPointerMode(false);
 					direction = isPageUp(keyCode) ? 'up' : 'down';
-					overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
+					overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -395,8 +395,14 @@ class ScrollableBase extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				};
+				},
+				isPointerMode = Spotlight.getPointerMode();
 			let next = null;
+
+			if (isPointerMode) {
+				// We need to convert to 5-way key mode to move Spot to another item manually.
+				Spotlight.setPointerMode(false);
+			}
 
 			/* 1. Find spottable item in viewport */
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
@@ -415,6 +421,12 @@ class ScrollableBase extends Component {
 			// For VirtualList
 			} else if (this.childRef.scrollToNextItem) {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
+			}
+
+			if (isPointerMode) {
+				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+				// So we need to convert back to the pointer mode.
+				Spotlight.setPointerMode(true);
 			}
 		} else {
 			this.uiRef.scrollByPage(keyCode);
@@ -450,19 +462,8 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
-					const isPointerMode = Spotlight.getPointerMode();
-
-					if (isPointerMode) {
-						// We need to convert to 5-way key mode to move Spot to another item manually.
-						Spotlight.setPointerMode(false);
-					}
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 					overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
-					if (isPointerMode) {
-						// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
-						// So we need to convert back to the pointer mode.
-						Spotlight.setPointerMode(true);
-					}
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -421,7 +421,7 @@ class ScrollableBase extends Component {
 		}
 
 		// Need to check whether an overscroll effect is needed
-		return false;
+		return true;
 	}
 
 	hasFocus () {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -395,10 +395,11 @@ class ScrollableBase extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				};
+				},
+				isPointerMode = Spotlight.getPointerMode();
 			let next = null;
 
-			if (Spotlight.getPointerMode()) {
+			if (isPointerMode) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -422,7 +423,7 @@ class ScrollableBase extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (Spotlight.getPointerMode()) {
+			if (isPointerMode) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -450,9 +450,13 @@ class ScrollableBase extends Component {
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+					// We need to convert to 5-way key mode to move Spot to another item manually.
 					Spotlight.setPointerMode(false);
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 					overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
+					// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+					// So we need to convert back to the pointer mode.
+					Spotlight.setPointerMode(true);
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -396,10 +396,10 @@ class ScrollableBase extends Component {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
 				},
-				isPointerMode = Spotlight.getPointerMode();
+				wasPointerMode = Spotlight.getPointerMode();
 			let next = null;
 
-			if (isPointerMode) {
+			if (wasPointerMode) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -423,7 +423,7 @@ class ScrollableBase extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (isPointerMode) {
+			if (wasPointerMode) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -526,13 +526,19 @@ class ScrollableBaseNative extends Component {
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			ev.preventDefault();
 			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
-				// We need to convert to 5-way key mode to move Spot to another item manually.
-				Spotlight.setPointerMode(false);
+				const isPointerMode = Spotlight.getPointerMode();
+
+				if (isPointerMode) {
+					// We need to convert to 5-way key mode to move Spot to another item manually.
+					Spotlight.setPointerMode(false);
+				}
 				direction = isPageUp(keyCode) ? 'up' : 'down';
 				overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
-				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
-				// So we need to convert back to the pointer mode.
-				Spotlight.setPointerMode(true);
+				if (isPointerMode) {
+					// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+					// So we need to convert back to the pointer mode.
+					Spotlight.setPointerMode(true);
+				}
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {
 			const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -470,8 +470,14 @@ class ScrollableBaseNative extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				};
+				},
+				isPointerMode = Spotlight.getPointerMode();
 			let next = null;
+
+			if (isPointerMode) {
+				// We need to convert to 5-way key mode to move Spot to another item manually.
+				Spotlight.setPointerMode(false);
+			}
 
 			/* 1. Find spottable item in viewport */
 			next = getTargetByDirectionFromPosition(rDirection, endPoint, spotlightId);
@@ -492,6 +498,11 @@ class ScrollableBaseNative extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
+			if (isPointerMode) {
+				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+				// So we need to convert back to the pointer mode.
+				Spotlight.setPointerMode(true);
+			}
 		} else {
 			this.uiRef.scrollByPage(keyCode);
 		}
@@ -526,19 +537,8 @@ class ScrollableBaseNative extends Component {
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			ev.preventDefault();
 			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
-				const isPointerMode = Spotlight.getPointerMode();
-
-				if (isPointerMode) {
-					// We need to convert to 5-way key mode to move Spot to another item manually.
-					Spotlight.setPointerMode(false);
-				}
 				direction = isPageUp(keyCode) ? 'up' : 'down';
 				overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
-				if (isPointerMode) {
-					// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
-					// So we need to convert back to the pointer mode.
-					Spotlight.setPointerMode(true);
-				}
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {
 			const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -470,10 +470,11 @@ class ScrollableBaseNative extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				};
+				},
+				isPointerMode = Spotlight.getPointerMode();
 			let next = null;
 
-			if (Spotlight.getPointerMode()) {
+			if (isPointerMode) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -497,7 +498,7 @@ class ScrollableBaseNative extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (Spotlight.getPointerMode()) {
+			if (isPointerMode) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -526,9 +526,13 @@ class ScrollableBaseNative extends Component {
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			ev.preventDefault();
 			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
+				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 				direction = isPageUp(keyCode) ? 'up' : 'down';
 				overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
+				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
+				// So we need to convert back to the pointer mode.
+				Spotlight.setPointerMode(true);
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {
 			const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -446,7 +446,7 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	scrollByPage = (direction) => {
+	scrollByPage = (direction, keyCode) => {
 		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
 		// scroller as a plain container
 		if (!this.uiRef.state.isVerticalScrollbarVisible) {
@@ -492,11 +492,12 @@ class ScrollableBaseNative extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			// Need to check whether an overscroll effect is needed
-			return true;
+		} else {
+			this.uiRef.scrollByPage(keyCode);
 		}
 
-		return false;
+		// Need to check whether an overscroll effect is needed
+		return true;
 	}
 
 	hasFocus () {
@@ -527,7 +528,7 @@ class ScrollableBaseNative extends Component {
 			if (!repeat && this.hasFocus() && this.props.direction === 'vertical' || this.props.direction === 'both') {
 				Spotlight.setPointerMode(false);
 				direction = isPageUp(keyCode) ? 'up' : 'down';
-				overscrollEffectRequired = this.scrollByPage(direction) && overscrollEffectOn.pageKey;
+				overscrollEffectRequired = this.scrollByPage(direction, keyCode) && overscrollEffectOn.pageKey;
 			}
 		} else if (!Spotlight.getPointerMode() && !repeat && this.hasFocus() && getDirection(keyCode)) {
 			const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -470,11 +470,10 @@ class ScrollableBaseNative extends Component {
 				endPoint = {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
-				},
-				isPointerMode = Spotlight.getPointerMode();
+				};
 			let next = null;
 
-			if (isPointerMode) {
+			if (Spotlight.getPointerMode()) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -498,7 +497,7 @@ class ScrollableBaseNative extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (isPointerMode) {
+			if (Spotlight.getPointerMode()) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -471,10 +471,10 @@ class ScrollableBaseNative extends Component {
 					x: focusedItemBounds.left + focusedItemBounds.width / 2,
 					y: viewportBounds.top + ((direction === 'up') ? focusedItemBounds.height / 2 - 1 : viewportBounds.height - focusedItemBounds.height / 2 + 1)
 				},
-				isPointerMode = Spotlight.getPointerMode();
+				wasPointerMode = Spotlight.getPointerMode();
 			let next = null;
 
-			if (isPointerMode) {
+			if (wasPointerMode) {
 				// We need to convert to 5-way key mode to move Spot to another item manually.
 				Spotlight.setPointerMode(false);
 			}
@@ -498,7 +498,7 @@ class ScrollableBaseNative extends Component {
 				this.childRef.scrollToNextItem({direction, focusedItem, reverseDirection: rDirection, spotlightId});
 			}
 
-			if (isPointerMode) {
+			if (wasPointerMode) {
 				// It is not converted to 5-way key mode even though pressing a channel up or down keys in pointer mode.
 				// So we need to convert back to the pointer mode.
 				Spotlight.setPointerMode(true);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

We did not support that VirtualList scrolls page by page when any item and any paging control in the VirtualList did not get focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If pressing Channel Up or Down keys when any item and any paging control did not get focus, VirtualList scrolls page by page.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I also fixed the following bug.

*Condition*
- the list is at the top position
- the Up Paging Control is disabled
- the cursor is on the gap between items (pointer mode)
- a Channel Down is pressed

*Expected result*: Spotlight still hides
*Actual result*: Spotlight shows because VirtualList converts to the 5-way key mode, then `Spottable` `componentDidUpdate` calls `Spotlight.focus(containerId);`.

So I converted to pointer mode before `Spottable` `componentDidUpdate` is called.

### Links
[//]: # (Related issues, references)

ENYO-5504

### Comments
