### PR TITLE
ENYO-5612: Fix VideoPlayer a11y for infoComponents

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+- `moonstone/VideoPlayer` timing to read out `infoComponents` accessibility value when `moreButton` or `moreButtonColor` is pressed
+
 ## [2.1.2] - 2018-09-04
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,12 +5,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [unreleased]
 
 ### Fixed
-- `moonstone/VideoPlayer` timing to read out `infoComponents` accessibility value when `moreButton` or `moreButtonColor` is pressed
-## [Unreleased]
-
-### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to show overscroll effects properly on repeating wheel input
+- `moonstone/VideoPlayer` timing to read out `infoComponents` accessibility value when `moreButton` or `moreButtonColor` is pressed
 
 ## [2.1.2] - 2018-09-04
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -745,12 +745,14 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		if (this.state.mediaControlsVisible && prevState.infoVisible !== this.state.infoVisible) {
-			const current = Spotlight.getCurrent();
-			if (current && current.dataset.spotlightId === this.moreButtonSpotlightId) {
-				// need to blur manually to read out `infoComponent`
-				current.blur();
-			}
-			Spotlight.focus(this.moreButtonSpotlightId);
+			setTimeout(() => {
+				const current = Spotlight.getCurrent();
+				if (current && current.dataset.spotlightId === this.moreButtonSpotlightId) {
+					// need to blur manually to read out `infoComponent`
+					current.blur();
+				}
+				Spotlight.focus(this.moreButtonSpotlightId);
+			}, 50);
 		}
 	}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -752,7 +752,7 @@ const VideoPlayerBase = class extends React.Component {
 					current.blur();
 				}
 				Spotlight.focus(this.moreButtonSpotlightId);
-			}, 50);
+			}, 1);
 		}
 	}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -745,12 +745,12 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		if (this.state.mediaControlsVisible && prevState.infoVisible !== this.state.infoVisible) {
+			const current = Spotlight.getCurrent();
+			if (current && current.dataset && current.dataset.spotlightId === this.moreButtonSpotlightId) {
+				// need to blur manually to read out `infoComponent`
+				current.blur();
+			}
 			setTimeout(() => {
-				const current = Spotlight.getCurrent();
-				if (current && current.dataset && current.dataset.spotlightId === this.moreButtonSpotlightId) {
-					// need to blur manually to read out `infoComponent`
-					current.blur();
-				}
 				Spotlight.focus(this.moreButtonSpotlightId);
 			}, 1);
 		}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -747,7 +747,7 @@ const VideoPlayerBase = class extends React.Component {
 		if (this.state.mediaControlsVisible && prevState.infoVisible !== this.state.infoVisible) {
 			setTimeout(() => {
 				const current = Spotlight.getCurrent();
-				if (current && current.dataset.spotlightId === this.moreButtonSpotlightId) {
+				if (current && current.dataset && current.dataset.spotlightId === this.moreButtonSpotlightId) {
 					// need to blur manually to read out `infoComponent`
 					current.blur();
 				}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### This PR is option 2 of ENYO-5612.
handle blur() before setTimeout and live with spotlight blinking issue
Do not merge with PR below. (option 1)
https://github.com/enactjs/enact/pull/1931

### Issue Resolved / Feature Added
Fixed the timing to read out `infoComponents` accessibility value when `moreButton` or `moreButtonColor` is pressed.

### Resolution
I have fixed the timing of reading `infoComponents` temporarily using setTimeout due to an unknown cause.
(The unknown cause is being tracked in the web engine, and a framework-side workaround until web engine fix is identified and implemented.)


### Links
ENYO-5612