### PR TITLE
ENYO-5626: Fix Spottable to respect pause state when it becomes enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/IncrementSlider` to prevent focusing to other components while dragging.
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -151,6 +151,14 @@ const IncrementSliderBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
+		 * Indicates that the slider knob is being dragged.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		dragging: PropTypes.bool,
+
+		/**
 		 * Shows the tooltip, when present.
 		 * @type {Boolean}
 		 * @public
@@ -471,6 +479,7 @@ const IncrementSliderBase = kind({
 		decrementDisabled,
 		decrementIcon,
 		disabled,
+		dragging,
 		focused,
 		id,
 		incrementAriaLabel,
@@ -514,7 +523,7 @@ const IncrementSliderBase = kind({
 					disabled={decrementDisabled}
 					onTap={onDecrement}
 					onSpotlightDisappear={onDecrementSpotlightDisappear}
-					spotlightDisabled={spotlightDisabled}
+					spotlightDisabled={spotlightDisabled || dragging}
 				>
 					{decrementIcon}
 				</IncrementSliderButton>
@@ -551,7 +560,7 @@ const IncrementSliderBase = kind({
 					disabled={incrementDisabled}
 					onTap={onIncrement}
 					onSpotlightDisappear={onIncrementSpotlightDisappear}
-					spotlightDisabled={spotlightDisabled}
+					spotlightDisabled={spotlightDisabled || dragging}
 				>
 					{incrementIcon}
 				</IncrementSliderButton>

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -86,6 +86,14 @@ const SliderBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Indicates that the slider knob is being dragged.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		dragging: PropTypes.bool,
+
+		/**
 		 * Indicates that the slider has gained focus and if the tooltip is present, it will be
 		 * shown.
 		 *
@@ -259,6 +267,7 @@ const SliderBase = kind({
 	render: ({css, focused, tooltip, ...rest}) => {
 		delete rest.activateOnFocus;
 		delete rest.active;
+		delete rest.dragging;
 		delete rest.knobStep;
 		delete rest.onActivate;
 

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -164,6 +164,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					{...props}
 					active={this.state.active}
 					aria-valuetext={this.getValueText()}
+					dragging={this.state.dragging}
 					focused={this.state.focused || this.state.dragging}
 					onActivate={this.handleActivate}
 					onBlur={this.handleBlur}

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -1,6 +1,37 @@
 import IncrementSliderDelayValue from './components/IncrementSliderDelayValue';
 import React from 'react';
+import IncrementSlider from '@enact/moonstone/IncrementSlider';
+import Button from '@enact/moonstone/Button';
+import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
+
+class IncrementSliderView extends React.Component {
+
+	constructor (props) {
+		super(props);
+		this.state = {
+			value: 0
+		};
+	}
+
+	handleChange = (ev) => {
+		setTimeout(() => {
+			this.setState({value: ev.value});
+		}, 200);
+	}
+
+	render () {
+		return (
+			<div style={{display: 'flex', marginTop: ri.unit(180, 'rem')}}>
+				<div style={{width: '300px'}}>
+					<Button>button</Button>
+					<Button>button</Button>
+				</div>
+				<IncrementSlider style={{flex: 1, width: ri.unit(510, 'rem')}} onChange={this.handleChange} value={this.state.value} />
+			</div>
+		);
+	}
+}
 
 storiesOf('IncrementSlider', module)
 	.add(
@@ -9,6 +40,15 @@ storiesOf('IncrementSlider', module)
 			<div>
 				Focus on one of the IncrementSlider buttons. Every 5 seconds, the value will toggle between 0 and 100. Ensure that focus does not leave the IncrementSlider when this happens.
 				<IncrementSliderDelayValue />
+			</div>
+		)
+	)
+	.add(
+		'spotlight behavior while dragging',
+		() => (
+			<div>
+				While holding down the knob(dargging), move the cursor quickly between knob and SliderButtons.
+				<IncrementSliderView />
 			</div>
 		)
 	);

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -47,7 +47,7 @@ storiesOf('IncrementSlider', module)
 		'spotlight behavior while dragging',
 		() => (
 			<div>
-				While holding down the knob(dargging), move the cursor quickly between knob and SliderButtons.
+				While holding down the knob(dargging), move the cursor quickly between knob and SliderButtons. Ensure the buttons do not receive spotligh.
 				<IncrementSliderView />
 			</div>
 		)


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The knob is blurred while dragging. So, it can focus to other components while dragging.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I fixed to pass `dragging` props from `SliderBehaviorDecorator` to `IncrementSlider`.
So, when `dragging` prop is `true`, it's impossible to spotlight to the increment/decrement buttons.

### Links
[//]: # (Related issues, references)
[ENYO-5626]