### PR TITLE
PLAT-64865: Remove `direction` prop in ScrollButton

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -6,13 +6,6 @@ import IconButton from '../IconButton';
 
 import css from './Scrollbar.less';
 
-const classNameMap = {
-	down: css.scrollbarBottomButton,
-	left: css.scrollbarLeftButton,
-	right: css.scrollbarRightButton,
-	up: css.scrollbarUpButton
-};
-
 /**
  * An [IconButton]{@link moonstone/IconButton.IconButton} used within
  * a [Scrollbar]{@link moonstone/Scrollable.Scrollbar}.
@@ -35,21 +28,6 @@ const ScrollButton = kind({
 		 * @public
 		 */
 		children: PropTypes.string.isRequired,
-
-		/**
-		 * Scroll direction for this button.
-		 *
-		 * Valid values are:
-		 * * `'down'`,
-		 * * `'left'`,
-		 * * `'right'`, and
-		 * * `'up'`.
-		 *
-		 * @type {String}
-		 * @required
-		 * @public
-		 */
-		direction: PropTypes.oneOf(['down', 'left', 'right', 'up']).isRequired,
 
 		/**
 		* Sets the hint string read when focusing the scroll bar button.
@@ -84,13 +62,11 @@ const ScrollButton = kind({
 	},
 
 	computed: {
-		'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel),
-		className: ({direction, styler}) => styler.append(classNameMap[direction])
+		'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel)
 	},
 
 	render: ({children, disabled, ...rest}) => {
 		delete rest.active;
-		delete rest.direction;
 
 		return (
 			<IconButton

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -316,7 +316,6 @@ class ScrollButtons extends Component {
 			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
 				data-spotlight-overflow="ignore"
-				direction={vertical ? 'up' : 'left'}
 				disabled={disabled || prevButtonDisabled}
 				key="prevButton"
 				onClick={this.onClickPrev}
@@ -335,7 +334,6 @@ class ScrollButtons extends Component {
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"
-				direction={vertical ? 'down' : 'right'}
 				disabled={disabled || nextButtonDisabled}
 				key="nextButton"
 				onClick={this.onClickNext}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

`Scrollbutton`'s `direction` prop is useless now. We had to remove it when refactoring the `ScrollButton`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I removed the `direction` prop in the `ScrollButton`.

### Links
[//]: # (Related issues, references)

PLAT-64865
