### PR TITLE
ENYO-5586: Fix 5-way navigation into VideoPlayer

### DIFF
--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -23,7 +23,6 @@ import {countReactChildren} from './util';
 import css from './VideoPlayer.less';
 
 const OuterContainer = SpotlightContainerDecorator({
-	enterTo: 'default-element',
 	defaultElement: [
 		`.${css.leftComponents} .${spotlightDefaultClass}`,
 		`.${css.rightComponents} .${spotlightDefaultClass}`,

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -50,7 +50,14 @@ import Video from './Video';
 import css from './VideoPlayer.less';
 
 const SpottableDiv = Touchable(Spottable('div'));
-const RootContainer = SpotlightContainerDecorator('div');
+const RootContainer = SpotlightContainerDecorator(
+	{
+		enterTo: 'default-element',
+		defaultElement: [`.${css.controlsHandleAbove}`, `.${css.controlsFrame}`]
+	},
+	'div'
+);
+
 const ControlsContainer = SpotlightContainerDecorator(
 	{
 		enterTo: '',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `VideoPlayer` were focused from the outside, the default spotlight logic is ignored and spots to the closest element.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed unnecessary config option `enterTo: default-element` from outer container of `MediaControls`. This is okay as `VideoPlayer` explicitly handles the "down" arrow key to focus to `this.mediaControlsSpotlightId` which will eventually focus to `defaultElement` set by the container config.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We may need to look into `SpotlightContainer` behavior more deeply and sort out how `enterTo` options should be handled to find the next spottable item.

I did not include CHANGELOG since this does not affect the regular `VideoPlayer` use case which is supposed to be used in fullscreen.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
