### PR TITLE
ENYO-5634: Fix title of expandable is invisible when expandable opens

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to not to adjust `scrollTop` when nested item is focused
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Panels` to always blur breadcrumbs when transitioning to a new panel
 - `moonstone/Button` and `moonstone/IconButton` to style image-based icons correctly when focused and disabled
 - `moonstone/VideoPlayer` to show correct playback rate feedback on play or pause
+- `moonstone/Scroller` to correctly set scroll position when nested item is focused
 
 ## [2.1.3] - 2018-09-10
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -189,17 +189,17 @@ class ScrollerBase extends Component {
 				newScrollTop += nestedItemBottom - scrollBottom;
 			} else if (nestedItemTop - currentScrollTop < epsilon) {
 				// Caculate when 5-way focus up past the top.
-				newScrollTop += nestedItemTop - currentScrollTop;
+				if (newItemTop > newScrollTop) {
+					// Ensure that the adjusted scrollTop would at least scroll the container to the top of
+					// the viewport (e.g. because the container is at the bottom of the scroller and the
+					// nested item is at the top of the container)
+					newScrollTop = newItemTop;
+				} else {
+					newScrollTop += nestedItemTop - currentScrollTop;
+				}
 			} else if (newItemTop - nestedItemHeight - currentScrollTop > epsilon) {
 				// set scroll position so that the top of the container is at least on the top as a fallback.
 				newScrollTop = newItemTop - nestedItemHeight;
-			}
-
-			// Ensure that the adjusted scrollTop would at least scroll the container to the top of
-			// the viewport (e.g. because the container is at the bottom of the scroller and the
-			// nested item is at the top of the container)
-			if (newItemTop > newScrollTop) {
-				newScrollTop = newItemTop;
 			}
 		} else if (itemBottom - scrollBottom > epsilon) {
 			// Caculate when 5-way focus down past the bottom.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Do not adjust `scrollTop` when nested item is focused

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When expandable opens, `calculateScrollTop` is called two times. (expandable -> nested item)
I tried to skip second adjustment because it makes title invisible.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Not sure it's right approach but I'm trying to modify as small as possible

### Links
[//]: # (Related issues, references)
ENYO-5634

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com