### PR TITLE
ENYO-5626: Fix Spottable to respect pause state when it becomes enabled

### DIFF
--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -33,6 +33,7 @@ import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
 import {boolean, select} from '../../src/enact-knobs';
+import Pause from '@enact/spotlight/Pause';
 
 const Container = SpotlightContainerDecorator(
 	{enterTo: 'last-focused'},
@@ -115,6 +116,53 @@ class DisappearTest extends React.Component {
 				>
 					Restore Button
 				</Button>
+			</div>
+		);
+	}
+}
+
+class DisableTest extends React.Component {
+	constructor (props) {
+		super(props);
+
+		this.state = {
+			disabled: false
+		};
+	}
+
+	componentDidMount () {
+		Spotlight.resume();
+		this.id = setInterval(() => this.setState(state => ({disabled: !state.disabled})), 5000);
+	}
+
+	componentWillUnmount () {
+		clearInterval(this.id);
+		this.paused.resume();
+	}
+
+	paused = new Pause('Pause Test')
+
+	handleToggle = () => {
+		if (this.paused.isPaused()) {
+			this.paused.resume();
+		} else {
+			this.paused.pause();
+		}
+	}
+
+	render () {
+		return (
+			<div>
+				<p>Timed Button is alternately enabled and disabled every 5 seconds. Pressing the Active/Paused button will resume and pause Spotlight, respectively.</p>
+				<Button disabled={this.state.disabled}>
+					Timed Button
+				</Button>
+				<ToggleButton
+					defaultSelected
+					toggleOnLabel="Active"
+					toggleOffLabel="Paused"
+					onToggle={this.handleToggle}
+				/>
 			</div>
 		);
 	}
@@ -279,6 +327,12 @@ storiesOf('Spotlight', module)
 		'Disappearing Spottable',
 		() => (
 			<DisappearTest />
+		)
+	)
+	.add(
+		'Disabled with Pause',
+		() => (
+			<DisableTest />
 		)
 	)
 	.add(

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to respect paused state when it becomes enabled
+
 ## [2.1.3] - 2018-09-10
 
 No significant changes.

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -208,14 +208,14 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			// if the component became enabled, notify spotlight to enable restoring "lost" focus
-			if (isSpottable(this.props) && !isSpottable(prevProps)) {
+			if (isSpottable(this.props) && !isSpottable(prevProps) && !Spotlight.isPaused()) {
 				if (Spotlight.getPointerMode()) {
 					if (this.isHovered) {
 						Spotlight.setPointerMode(false);
 						Spotlight.focus(this.node);
 						Spotlight.setPointerMode(true);
 					}
-				} else if (!Spotlight.getCurrent() && !Spotlight.isPaused()) {
+				} else if (!Spotlight.getCurrent()) {
 					const containers = getContainersForNode(this.node);
 					const containerId = Spotlight.getActiveContainer();
 					if (containers.indexOf(containerId) >= 0) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When spotlight is paused and a spottable component becomes enabled while the pointer is over it, it will focus itself effectively ignoring the paused state.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move the paused condition up to guard against focusing when enabled for both pointer and 5-way.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Added a qa sample (Spotlight > Disabled with Pause) which can be used to test this sort of scenario.