### PR TITLE
ENYO-5637: Fix FormCheckboxItem style when focused and disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
-- `moonstone/FormCheckboxItem` to retain focus in `FormCheckbox` icon when disabled
+- `moonstone/FormCheckboxItem` styling when focused and disabled
 
 ## [2.1.3] - 2018-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/FormCheckboxItem` to retain focus in `FormCheckbox` icon when disabled
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/moonstone/FormCheckbox/FormCheckbox.less
+++ b/packages/moonstone/FormCheckbox/FormCheckbox.less
@@ -55,10 +55,9 @@
 		// Skin colors
 		.applySkins({
 			box-shadow: none;
+			background-color: @moon-spotlight-color;
 
 			&:not([disabled]) {
-				background-color: @moon-spotlight-color;
-
 				.icon {
 					color: @moon-spotlight-text-color;
 				}
@@ -78,4 +77,3 @@
 		}
 	}, parent);
 }, parent);
-

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.less
@@ -13,8 +13,9 @@
 	// Skin colors
 	.applySkins({
 		.focus({
+			background-color: transparent;
+
 			&:not([disabled]) {
-				background-color: transparent;
 				color: @moon-text-color;
 			}
 		});

--- a/packages/sampler/stories/qa/FormCheckboxItem.js
+++ b/packages/sampler/stories/qa/FormCheckboxItem.js
@@ -1,0 +1,37 @@
+import FormCheckboxItem from '@enact/moonstone/FormCheckboxItem';
+import Button from '@enact/moonstone/Button';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+class FormCheckboxItemView extends React.Component {
+
+	constructor (props) {
+		super(props);
+		this.state = {
+			disabled: false
+		};
+	}
+
+	handleClick = () => {
+		this.setState(prevState => ({disabled: !prevState.disabled}));
+	}
+
+	render () {
+		return (
+			<div>
+				You can change the state by clicking the Button or FormCheckboxItem.
+				<br />
+				<Button small onClick={this.handleClick}>change state</Button>
+				<FormCheckboxItem disabled={this.state.disabled} onClick={this.handleClick}>FormCheckbox Item</FormCheckboxItem>
+			</div>
+		);
+	}
+}
+
+storiesOf('FormCheckboxItem', module)
+	.add(
+		'that is focused and disabled',
+		() => (
+			<FormCheckboxItemView />
+		)
+	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight retains when it's disabled by default.
In the case of FormCheckboxItem, FormCheckbox Icon can be focused only.
But, when it's disabled, area that except for icon is focused. The background of the text area should be transparent always.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I fixed to set `background-color` of toggleItem to `transparent` always and to be retained spotlight in `FormCheckbox`. 

### Links
[//]: # (Related issues, references)
[ENYO-5637]
