### PR TITLE
ENYO-5638: Fix VideoPlayer to show correct playback rate feedback on play or pause

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` to show correct playback rate feedback on play or pause
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1205,9 +1205,9 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		this.speedIndex = 0;
+		this.prevCommand = 'play';
 		this.setPlaybackRate(1);
 		this.send('play');
-		this.prevCommand = 'play';
 		this.announce($L('Play'));
 		this.startDelayedMiniFeedbackHide(5000);
 	}
@@ -1225,9 +1225,9 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		this.speedIndex = 0;
+		this.prevCommand = 'pause';
 		this.setPlaybackRate(1);
 		this.send('pause');
-		this.prevCommand = 'pause';
 		this.announce($L('Pause'));
 		this.stopDelayedMiniFeedbackHide();
 	}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1205,6 +1205,8 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		this.speedIndex = 0;
+		// must happen before send() to ensure feedback uses the right value
+		// TODO: refactor into this.state member
 		this.prevCommand = 'play';
 		this.setPlaybackRate(1);
 		this.send('play');
@@ -1225,6 +1227,8 @@ const VideoPlayerBase = class extends React.Component {
 		}
 
 		this.speedIndex = 0;
+		// must happen before send() to ensure feedback uses the right value
+		// TODO: refactor into this.state member
 		this.prevCommand = 'pause';
 		this.setPlaybackRate(1);
 		this.send('pause');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fix playback rate value is shown on the `FeedbackTooltip` in the middle of changing playback

`FeedbackTooltip` has `playbackRate` and `playbackState` props
1) `play`() is called during 4x(or etc) playback
2) `playbackRate` is changed to 2x and then `FeedbackTooltip` is rendered.
3) `playbackState` is changed to 'play' and then `FeedbackTooltip` is rendered.
Despite the presence of `setState` in the `play()` , it is performed synchronously.
as a result, render occur twice

### Resolution
`playbackRate` and `playbackState` must be changed at once for rendering of `FeedbackTooltip`
I think that the simplest way at this time is to do `prevCommand` variable allocation first.


### Additional Considerations


### Links


### Comments