### PR TITLE
ENYO-5635: Fix Panels to blur breadcrumbs on transition

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Panels` to always blur breadcrumbs when transitioning to a new panel
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/moonstone/Panels/Breadcrumb.js
+++ b/packages/moonstone/Panels/Breadcrumb.js
@@ -1,9 +1,11 @@
+import {handle, forward, adaptEvent} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import Spottable from '@enact/spotlight/Spottable';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import $L from '../internal/$L';
+
 import css from './Panels.less';
 
 // Since we expose `onSelect` to handle breadcrumb selection, we need that handler to be set on a
@@ -69,13 +71,10 @@ const BreadcrumbBase = kind({
 	},
 
 	handlers: {
-		onSelect: (ev, {index, onSelect, onClick}) => {
-			// clear Spotlight focus
-			ev.target.blur();
-
-			if (onClick) onClick(ev);
-			if (onSelect) onSelect({index});
-		}
+		onSelect: handle(
+			forward('onClick'),
+			adaptEvent((ev, {index}) => ({type: 'onSelect', index}), forward('onSelect'))
+		)
 	},
 
 	render: ({children, index, onSelect, ...rest}) => (

--- a/packages/moonstone/Panels/BreadcrumbDecorator.js
+++ b/packages/moonstone/Panels/BreadcrumbDecorator.js
@@ -1,10 +1,11 @@
-import {coerceFunction} from '@enact/core/util';
 import hoc from '@enact/core/hoc';
-import invariant from 'invariant';
 import kind from '@enact/core/kind';
+import {coerceFunction} from '@enact/core/util';
 import ViewManager from '@enact/ui/ViewManager';
-import React from 'react';
+import Spotlight from '@enact/spotlight';
+import invariant from 'invariant';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import IdProvider from '../internal/IdProvider';
 import Skinnable from '../Skinnable';
@@ -152,6 +153,18 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			className: cfgClassName
 		},
 
+		handlers: {
+			handleBreadcrumbWillTransition: (ev, {id}) => {
+				const current = Spotlight.getCurrent();
+				if (!current) return;
+
+				const breadcrumbs = document.querySelector(`#${id} .${css.breadcrumbs}`);
+				if (breadcrumbs.contains(current)) {
+					current.blur();
+				}
+			}
+		},
+
 		computed: {
 			// Invokes the breadcrumb generator, if provided
 			breadcrumbs: ({breadcrumbs, id, index, onSelectBreadcrumb}) => {
@@ -202,7 +215,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		},
 
-		render: ({breadcrumbs, childProps, children, className, generateId, id, index, noAnimation, ...rest}) => {
+		render: ({breadcrumbs, childProps, children, className, generateId, handleBreadcrumbWillTransition, id, index, noAnimation, ...rest}) => {
 			delete rest.onSelectBreadcrumb;
 
 			const count = React.Children.count(children);
@@ -220,6 +233,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 						end={calcMax()}
 						index={index - 1}
 						noAnimation={noAnimation}
+						onWillTransition={handleBreadcrumbWillTransition}
 						start={0}
 					>
 						{breadcrumbs}

--- a/packages/moonstone/Panels/BreadcrumbDecorator.js
+++ b/packages/moonstone/Panels/BreadcrumbDecorator.js
@@ -159,7 +159,7 @@ const BreadcrumbDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				if (!current) return;
 
 				const breadcrumbs = document.querySelector(`#${id} .${css.breadcrumbs}`);
-				if (breadcrumbs.contains(current)) {
+				if (breadcrumbs && breadcrumbs.contains(current)) {
 					current.blur();
 				}
 			}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/ViewManager` to emit `onWillTransition` when either views or added or removed
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -288,7 +288,7 @@ class TransitionGroup extends React.Component {
 			});
 		}
 
-		if (this.keysToEnter.length) {
+		if (this.keysToEnter.length || this.keysToLeave.length) {
 			forwardOnWillTransition(null, this.props);
 		}
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The root cause here is the interplay between popup and breadcrumb. Currently, breadcrumb blurs itself when selected to ensure that it isn't focused when the panel transition completes. Popup refocuses its activator (or the last focused component if there isn't an activator or the activator has been unmounted) when closed. Since the breadcrumb is focused when the popup is shown, it's stored as the activator and refocused when the popup closes. If you blur the breadcrumb before opening the popup, it still receives the focus when the popup closes because it was the last focused element. As a result, even though the breadcrumb blurs itself on select, it is refocused by the popup and still has focus when the panel attempts to focus itself.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move the logic to blur breadcrumbs from the individual breadcrumb to the `BreadcrumbDecorator`. By hooking `onWillTransition` on `ViewManager` (and fixing a little bug there as well), we can determine if the current focus is within the breadcrumbs and blur it before the transition occurs.