### PR TITLE
PLAT-64866: Allow configurable nav multipliers for containers

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to show correct playback rate feedback on play or pause
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to handle 5way navigation properly when `focusableScrollbar` is true
 
 ## [2.1.3] - 2018-09-10
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -272,6 +272,8 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		configureSpotlight = (spotlightId) => {
+			const {spacing} = this.props;
+
 			Spotlight.set(spotlightId, {
 				enterTo: 'last-focused',
 				/*
@@ -282,7 +284,12 @@ const VirtualListBaseFactory = (type) => {
 				 * Restores the data-index into the placeholder if its the only element. Tries to find a
 				 * matching child otherwise.
 				 */
-				lastFocusedRestore: this.lastFocusedRestore
+				lastFocusedRestore: this.lastFocusedRestore,
+				/*
+				 * Directs spotlight focus to favor straight elements that are within range of `spacing`
+				 * over oblique elements, like scroll buttons.
+				 */
+				obliqueMultiplier: spacing > 0 ? spacing : 1
 			});
 		}
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -60,11 +60,13 @@ let GlobalConfig = {
 	},
 	leaveFor: null,         // {left: <extSelector>, right: <extSelector>, up: <extSelector>, down: <extSelector>}
 	navigableFilter: null,
+	obliqueMultiplier: 5,
 	overflow: false,
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
 	selector: '',           // can be a valid <extSelector> except "@" syntax.
 	selectorDisabled: false,
+	straightMultiplier: 1,
 	straightOnly: false,
 	straightOverlapThreshold: 0.5,
 	tabIndexIgnoreList: 'a, input, select, textarea, button, iframe, [contentEditable=true]'

--- a/packages/spotlight/src/navigate.js
+++ b/packages/spotlight/src/navigate.js
@@ -1,8 +1,6 @@
 
 const obliqueMinDistance = 1;
-const obliqueMultiplier = 5;
 const straightMinDistance = 0;
-const straightMultiplier = 1;
 
 const calcGroupId = ({x, y}) => y * 3 + x;
 
@@ -225,11 +223,12 @@ function navigate (targetRect, direction, rects, config) {
 	}
 
 	const distanceFunction = generateDistancefunction(targetRect);
+	const {obliqueMultiplier, straightMultiplier, straightOnly, straightOverlapThreshold} = config;
 
 	const groups = partition(
 		rects,
 		targetRect,
-		config.straightOverlapThreshold,
+		straightOverlapThreshold,
 		(rect, destRect) => (
 			calcGroupId(
 				direction === 'up' || direction === 'down' ? calcNextExtendedGridPosition(rect, destRect) : calcNextGridPosition(rect, destRect)
@@ -240,7 +239,7 @@ function navigate (targetRect, direction, rects, config) {
 	const internalGroups = partition(
 		groups[4],
 		targetRect.center,
-		config.straightOverlapThreshold,
+		straightOverlapThreshold,
 		(rect, destRect) => calcGroupId(calcNextGridPosition(rect, destRect))
 	);
 
@@ -487,7 +486,7 @@ function navigate (targetRect, direction, rects, config) {
 			return null;
 	}
 
-	if (config.straightOnly) {
+	if (straightOnly) {
 		priorities.splice(2, 2);
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`VirtualList` and `VirtualGridList` can experience unexpected results when 5way navigating container items where focus incorrectly changes to a focusable scroll button instead of the next expected item.

### Resolution
PR #1495 added a spotlight change where it added an algorithm that helps decide which "next" element should gain focus. Generally we use a 1px/5px-relative multiplier for straight/oblique elements - where a straight element will be favored over an oblique one unless the oblique one is closer than 5x the amount of the next eligible straight one. This works in most cases, but in `VirtualGridList`, the default spacing between items is 12px. If the scroll buttons are focusable, there are positions the scroller can be in which will cause the scroll button to be favored over the next eligible item in the list. We should change the multiplier used in the algorithm as a configurable value that container can use to properly direct focus.


### Additional Considerations
This is not meant to be a public property, so I am not adding public documentation - rather documenting its use in `VirtualList` (and this PR) - to help explain its purpose.

