### PR TITLE
ENYO-5642: Add voice control to GridListImageItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `moonstone/GridListImageItem` support voice control feature
+- `moonstone/GridListImageItem` voice control feature support
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [] -
+## [unreleased]
 
 ### Added
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [] -
+
+### Added
+
+- `moonstone/GridListImageItem` support voice control feature
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -120,6 +120,7 @@ const GridListImageItemBase = kind({
 	},
 
 	defaultProps: {
+		'data-webos-voice-intent': 'Select',
 		placeholder: defaultPlaceholder,
 		selected: false
 	},
@@ -140,7 +141,7 @@ const GridListImageItemBase = kind({
 				{...rest}
 				captionComponent={captionComponent}
 				css={css}
-				data-webos-voice-intent={voiceIntent || 'Select'}
+				data-webos-voice-intent={voiceIntent}
 				iconComponent={Icon}
 				imageComponent={Image}
 				selectionOverlay={selectionOverlay}

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -52,6 +52,14 @@ const GridListImageItemBase = kind({
 
 	propTypes: /** @lends moonstone/GridListImageItem.GridListImageItemBase.prototype */ {
 		/**
+		 * The voice control intent.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		'data-webos-voice-intent': PropTypes.string,
+
+		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
 		 * corresponding internal Elements and states of this component.
 		 *
@@ -67,6 +75,9 @@ const GridListImageItemBase = kind({
 		 * @public
 		 */
 		css: PropTypes.object,
+
+		/**
+		 * The voice control label.
 
 		/**
 		 * Placeholder image used while [source]{@link ui/GridListImageItem.GridListImageItem#source}
@@ -121,7 +132,7 @@ const GridListImageItemBase = kind({
 		publicClassNames: ['gridListImageItem', 'icon', 'image', 'selected', 'caption', 'subCaption']
 	},
 
-	render: ({css, selectionOverlay, ...rest}) => {
+	render: ({css, 'data-webos-voice-intent': voiceIntent, selectionOverlay, ...rest}) => {
 		if (selectionOverlay) {
 			rest['role'] = 'checkbox';
 			rest['aria-checked'] = rest.selected;
@@ -132,6 +143,7 @@ const GridListImageItemBase = kind({
 				{...rest}
 				captionComponent={captionComponent}
 				css={css}
+				data-webos-voice-intent={voiceIntent || 'Select'}
 				iconComponent={Icon}
 				imageComponent={Image}
 				selectionOverlay={selectionOverlay}

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -131,7 +131,7 @@ const GridListImageItemBase = kind({
 		publicClassNames: ['gridListImageItem', 'icon', 'image', 'selected', 'caption', 'subCaption']
 	},
 
-	render: ({css, 'data-webos-voice-intent': voiceIntent, selectionOverlay, ...rest}) => {
+	render: ({css, selectionOverlay, ...rest}) => {
 		if (selectionOverlay) {
 			rest['role'] = 'checkbox';
 			rest['aria-checked'] = rest.selected;
@@ -142,7 +142,6 @@ const GridListImageItemBase = kind({
 				{...rest}
 				captionComponent={captionComponent}
 				css={css}
-				data-webos-voice-intent={voiceIntent}
 				iconComponent={Icon}
 				imageComponent={Image}
 				selectionOverlay={selectionOverlay}

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -77,9 +77,6 @@ const GridListImageItemBase = kind({
 		css: PropTypes.object,
 
 		/**
-		 * The voice control label.
-
-		/**
 		 * Placeholder image used while [source]{@link ui/GridListImageItem.GridListImageItem#source}
 		 * is loaded.
 		 *

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -55,6 +55,7 @@ const GridListImageItemBase = kind({
 		 * The voice control intent.
 		 *
 		 * @type {String}
+		 * @default 'Select'
 		 * @public
 		 */
 		'data-webos-voice-intent': PropTypes.string,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
GridListImageItem should be support voice control feature

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
data-webos-voice-intent='Select' is used as default.
But depending on the app, data-webos-voice-intent can be used another value.

### Links
[//]: # (Related issues, references)
ENYO-5642

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>