### PR TITLE
ENYO-5647: Fixed Scroller not to scroll stops when focusing on a child element while scrolling

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` not to scroll stops when focusing to element while scrolling
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` not to scroll stops when focusing to element while scrolling
+- `moonstone/Scroller` not to scroll stops when focusing on a child element while scrolling
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,16 +2,15 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [Unreleased]
-
-### Fixed
-
-- `moonstone/Scroller` not to scroll stops when focusing on a child element while scrolling
 ## [unreleased]
 
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
+
+### Fixed
+
+- `moonstone/Scroller` not to scroll stops when focusing on a child element while scrolling
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` not to scroll stops when focusing on a child element while scrolling
+- `moonstone/Scroller` to prevent focusing children while scrolling
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -72,7 +72,15 @@ class ScrollerBase extends Component {
 		 * @type {Boolean}
 		 * @private
 		 */
-		rtl: PropTypes.bool
+		rtl: PropTypes.bool,
+
+		/**
+		 * Spotlight Id. It would be the same with [Scrollable]{@link ui/Scrollable.Scrollable}'s.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		spotlightId: PropTypes.string
 	}
 
 	componentDidUpdate () {
@@ -279,7 +287,9 @@ class ScrollerBase extends Component {
 	}
 
 	setContainerDisabled = (bool) => {
-		const containerNode = this.uiRef && this.uiRef.containerRef;
+		const
+			{spotlightId} = this.props,
+			containerNode = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 
 		if (containerNode) {
 			containerNode.setAttribute(dataContainerDisabledAttribute, bool);
@@ -380,6 +390,7 @@ class ScrollerBase extends Component {
 
 		delete props.initUiChildRef;
 		delete props.onUpdate;
+		delete props.spotlightId;
 
 		return (
 			<UiScrollerBase
@@ -410,8 +421,6 @@ const Scroller = (props) => (
 	<Scrollable
 		{...props}
 		childRenderer={(scrollerProps) => { // eslint-disable-line react/jsx-no-bind
-			delete scrollerProps.spotlightId;
-
 			return <ScrollerBase {...scrollerProps} />;
 		}}
 	/>
@@ -457,8 +466,6 @@ const ScrollerNative = (props) => (
 	<ScrollableNative
 		{...props}
 		childRenderer={(scrollerProps) => { // eslint-disable-line react/jsx-no-bind
-			delete scrollerProps.spotlightId;
-
 			return <ScrollerBase {...scrollerProps} />;
 		}}
 	/>

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -75,7 +75,7 @@ class ScrollerBase extends Component {
 		rtl: PropTypes.bool,
 
 		/**
-		 * Spotlight Id. It would be the same with [Scrollable]{@link ui/Scrollable.Scrollable}'s.
+		 * The spotlight id for the component.
 		 *
 		 * @type {String}
 		 * @private


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed moonstone/Scroller not to scroll stops when focusing on a child element while scrolling

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`setContainerDisabled` function of moonstone/Scroller is not working properly since it set `data-spotlight-container-disabled` to the wrong element.
It seems we did not change the code for finding the spotlight container node inside of the function after we combined spotlight containers.
So, fixed above problem by adding private prop `spotlightId` to get the right node like the same way of VirtualList.

### Links
[//]: # (Related issues, references)
ENYO-5647
