### PR TITLE
ENYO-5648: VideoPlayer: focus stays in control button even if hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `moonstone/VideoPlayer` to focus to `controlsHandleAbove` when controls and cursor disappear at the same time 
-
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` to focus to `controlsHandleAbove` when controls and cursor disappear at the same time 
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Fixed
+
+- `moonstone/VideoPlayer` to lose focus on media controls when hidden 
+
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,13 +4,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `moonstone/VideoPlayer` to lose focus on media controls when hidden 
-
 ### Added
 
 - `moonstone/GridListImageItem` voice control feature support
+
+### Fixed
+
+- `moonstone/VideoPlayer` to unfocus media controls when hidden
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -733,7 +733,8 @@ const VideoPlayerBase = class extends React.Component {
 				// rightComponents, children, etc.), we need to explicitly blur the element when
 				// MediaControls hide. See ENYO-5454
 				const current = Spotlight.getCurrent();
-				if (current) {
+				const mediaControls = document.querySelector(`[data-spotlight-id="${this.mediaControlsSpotlightId}"]`);
+				if (current && mediaControls && mediaControls.contains(current)) {
 					current.blur();
 				}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -731,7 +731,13 @@ const VideoPlayerBase = class extends React.Component {
 			if (!this.props.spotlightDisabled ) {
 				// Set focus to the hidden spottable control - maintaining focus on available spottable
 				// controls, which prevents an addiitional 5-way attempt in order to re-show media controls
-				Spotlight.focus(`.${css.controlsHandleAbove}`);
+				if (Spotlight.getPointerMode()) {
+					Spotlight.setPointerMode(false);
+					Spotlight.focus(`.${css.controlsHandleAbove}`);
+					Spotlight.setPointerMode(true);
+				} else {
+					Spotlight.focus(`.${css.controlsHandleAbove}`);
+				}
 			}
 		} else if (this.state.mediaControlsVisible && !prevState.mediaControlsVisible) {
 			forwardControlsAvailable({available: true}, this.props);

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -728,22 +728,24 @@ const VideoPlayerBase = class extends React.Component {
 			forwardControlsAvailable({available: false}, this.props);
 			this.stopAutoCloseTimeout();
 
-			if (!this.props.spotlightDisabled ) {
+			if (!this.props.spotlightDisabled) {
+				// If last focused item were in a user specified components (e.g. leftComponents,
+				// rightComponents, children, etc.), we need to explicitly blur the element when
+				// MediaControls hide. See ENYO-5454
+				const current = Spotlight.getCurrent();
+				if (current) {
+					current.blur();
+				}
+
 				// Set focus to the hidden spottable control - maintaining focus on available spottable
 				// controls, which prevents an addiitional 5-way attempt in order to re-show media controls
-				if (Spotlight.getPointerMode()) {
-					Spotlight.setPointerMode(false);
-					Spotlight.focus(`.${css.controlsHandleAbove}`);
-					Spotlight.setPointerMode(true);
-				} else {
-					Spotlight.focus(`.${css.controlsHandleAbove}`);
-				}
+				Spotlight.focus(`.${css.controlsHandleAbove}`);
 			}
 		} else if (this.state.mediaControlsVisible && !prevState.mediaControlsVisible) {
 			forwardControlsAvailable({available: true}, this.props);
 			this.startAutoCloseTimeout();
 
-			if (!this.props.spotlightDisabled ) {
+			if (!this.props.spotlightDisabled) {
 				const current = Spotlight.getCurrent();
 				if (!current || this.player.contains(current)) {
 					// Set focus within media controls when they become visible.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The spotlight focus stays in control button even if media controls are hidden.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added exception for checking pointer mode when focus to `controlsHandleAbove`.

### Links
ENYO-5648