### PR TITLE
ENYO-5609: Fix Scroller to set correct position when ExpandableList is closed

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to set correct scroll position when a child ExpandableList is closed
+- `moonstone/Scroller` to set correct scroll position when an expandable child is closed
 - `moonstone/Scroller` to prevent focusing children while scrolling
 
 ## [2.1.4] - 2018-09-17

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/GridListImageItem` voice control feature support
 
+### Fixed
+
+- `moonstone/Scroller` to correctly set scroll position when a child ExpandableList is closed
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -140,16 +140,17 @@ class ScrollerBase extends Component {
 			newItemTop = this.uiRef.containerRef.scrollTop + (itemTop - containerTop),
 			itemBottom = newItemTop + itemHeight,
 			scrollBottom = clientHeight + currentScrollTop;
-
-		let newScrollTop = this.uiRef.scrollPos.top;
+		let
+			newScrollTop = this.uiRef.scrollPos.top,
+			scrollHeightDecrease = 0;
 
 		// Caculations for when scrollHeight decrease.
 		if (scrollInfo) {
 			const
 				{scrollTop, previousScrollHeight} = scrollInfo,
-				{scrollHeight} = this.uiRef.scrollBounds,
-				scrollHeightDecrease = previousScrollHeight - scrollHeight;
+				{scrollHeight} = this.uiRef.scrollBounds;
 
+			scrollHeightDecrease = previousScrollHeight - scrollHeight;
 			if (scrollHeightDecrease > 0) {
 				newScrollTop = scrollTop;
 
@@ -204,7 +205,7 @@ class ScrollerBase extends Component {
 		} else if (itemBottom - scrollBottom > epsilon) {
 			// Caculate when 5-way focus down past the bottom.
 			newScrollTop += itemBottom - scrollBottom;
-		} else if (newItemTop - currentScrollTop < epsilon) {
+		} else if (newItemTop - currentScrollTop < epsilon && scrollHeightDecrease <= 0) {
 			// Caculate when 5-way focus up past the top.
 			newScrollTop += newItemTop - currentScrollTop;
 		}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -150,7 +150,7 @@ class ScrollerBase extends Component {
 			scrollBottom = clientHeight + currentScrollTop;
 		let
 			newScrollTop = this.uiRef.scrollPos.top,
-			scrollHeightDecrease = 0;
+			scrollHeightChange = 0;
 
 		// Calculations for when scrollHeight decrease.
 		if (scrollInfo) {
@@ -158,29 +158,29 @@ class ScrollerBase extends Component {
 				{scrollTop, previousScrollHeight} = scrollInfo,
 				{scrollHeight} = this.uiRef.scrollBounds;
 
-			scrollHeightDecrease = previousScrollHeight - scrollHeight;
-			if (scrollHeightDecrease > 0) {
+			scrollHeightChange = previousScrollHeight - scrollHeight;
+			if (scrollHeightChange > 0) {
 				newScrollTop = scrollTop;
 
 				const
 					itemBounds = focusedItem.getBoundingClientRect(),
 					newItemBottom = newScrollTop + itemBounds.top + itemBounds.height - containerTop;
 
-				if (newItemBottom < scrollBottom && scrollHeightDecrease + newItemBottom > scrollBottom) {
+				if (newItemBottom < scrollBottom && scrollHeightChange + newItemBottom > scrollBottom) {
 					// When `focusedItem` is not at the very bottom of the `Scroller` and
-					// `scrollHeightDecrease` caused a scroll.
+					// `scrollHeightChange` caused a scroll.
 					const
 						distanceFromBottom = scrollBottom - newItemBottom,
-						bottomOffset = scrollHeightDecrease - distanceFromBottom;
+						bottomOffset = scrollHeightChange - distanceFromBottom;
 					if (bottomOffset < newScrollTop) {
 						// guard against negative `scrollTop`
 						newScrollTop -= bottomOffset;
 					}
 				} else if (newItemBottom === scrollBottom) {
 					// when `focusedItem` is at the very bottom of the `Scroller`
-					if (scrollHeightDecrease < newScrollTop) {
+					if (scrollHeightChange < newScrollTop) {
 						// guard against negative `scrollTop`
-						newScrollTop -= scrollHeightDecrease;
+						newScrollTop -= scrollHeightChange;
 					}
 				}
 			}
@@ -213,7 +213,7 @@ class ScrollerBase extends Component {
 		} else if (itemBottom - scrollBottom > epsilon) {
 			// Calculate when 5-way focus down past the bottom.
 			newScrollTop += itemBottom - scrollBottom;
-		} else if (newItemTop - currentScrollTop < epsilon && scrollHeightDecrease <= 0) {
+		} else if (newItemTop - currentScrollTop < epsilon && scrollHeightChange <= 0) {
 			// Calculate when 5-way focus up past the top.
 			newScrollTop += newItemTop - currentScrollTop;
 		}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -144,7 +144,7 @@ class ScrollerBase extends Component {
 			newScrollTop = this.uiRef.scrollPos.top,
 			scrollHeightDecrease = 0;
 
-		// Caculations for when scrollHeight decrease.
+		// Calculations for when scrollHeight decrease.
 		if (scrollInfo) {
 			const
 				{scrollTop, previousScrollHeight} = scrollInfo,
@@ -186,10 +186,10 @@ class ScrollerBase extends Component {
 				nestedItemBottom = nestedItemTop + nestedItemHeight;
 
 			if (nestedItemBottom - scrollBottom > epsilon) {
-				// Caculate when 5-way focus down past the bottom.
+				// Calculate when 5-way focus down past the bottom.
 				newScrollTop += nestedItemBottom - scrollBottom;
 			} else if (nestedItemTop - currentScrollTop < epsilon) {
-				// Caculate when 5-way focus up past the top.
+				// Calculate when 5-way focus up past the top.
 				if (newItemTop > newScrollTop) {
 					// Ensure that the adjusted scrollTop would at least scroll the container to the top of
 					// the viewport (e.g. because the container is at the bottom of the scroller and the
@@ -203,10 +203,10 @@ class ScrollerBase extends Component {
 				newScrollTop = newItemTop - nestedItemHeight;
 			}
 		} else if (itemBottom - scrollBottom > epsilon) {
-			// Caculate when 5-way focus down past the bottom.
+			// Calculate when 5-way focus down past the bottom.
 			newScrollTop += itemBottom - scrollBottom;
 		} else if (newItemTop - currentScrollTop < epsilon && scrollHeightDecrease <= 0) {
-			// Caculate when 5-way focus up past the top.
+			// Calculate when 5-way focus up past the top.
 			newScrollTop += newItemTop - currentScrollTop;
 		}
 
@@ -221,7 +221,7 @@ class ScrollerBase extends Component {
 	 * `scrollInfo.previousScrollHeight` and `scrollInfo.scrollTop`
 	 * @param {Number} scrollPosition last target position, passed scroll animation is ongoing
 	 *
-	 * @returns {Object} with keys {top, left} containing caculated top and left positions for scroll.
+	 * @returns {Object} with keys {top, left} containing calculated top and left positions for scroll.
 	 * @private
 	 */
 	calculatePositionOnFocus = ({item, scrollInfo, scrollPosition}) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `ExpandableList` is inside `Scroller` and the focused item is far enough to make the title of `ExpandableList` out of a viewport, `Scroller` scrolls abnormally more than expected by closing `ExpandableList`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We have two logics inside `Scroller`. The first one is to re-position the scroll position when contents is shortened, the second one is to compensate position when the next focused element is passed up the top of a viewport.
This issue occurs when both logic is performed in a single focus event. We don't actually need to perform the second logic if we already handle the case in the first logic, so changed `Scroller` only perform one of two logics.


### Links
[//]: # (Related issues, references)
ENYO-5609
