### PR TITLE
PLAT-66183: Add agate-related enhancements

### DIFF
--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -23,6 +23,15 @@ const contextTypes = {
 	updateLocale: PropTypes.func
 };
 
+/**
+ * A [context]{@link https://reactjs.org/docs/context.html} for communicating locale changes.
+ *
+ * Provides an object containing a `rtl` member, which is `true` if the current context is RTL and
+ * an `updateLocal` member, which is a function that can be called with a locale string.
+ *
+ * @memberof i18n/I18nDecorator
+ * @class
+ */
 const I18nContext = React.createContext(null);
 
 /**

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -4,7 +4,6 @@
  * @module i18n/I18nDecorator
  * @exports I18nDecorator
  * @exports I18nContextDecorator
- * @exports I18nContext
  */
 
 import {on, off} from '@enact/core/dispatcher';
@@ -23,15 +22,6 @@ const contextTypes = {
 	updateLocale: PropTypes.func
 };
 
-/**
- * A [context]{@link https://reactjs.org/docs/context.html} for communicating locale changes.
- *
- * Provides an object containing a `rtl` member, which is `true` if the current context is RTL and
- * an `updateLocal` member, which is a function that can be called with a locale string.
- *
- * @memberof i18n/I18nDecorator
- * @class
- */
 const I18nContext = React.createContext(null);
 
 /**

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,9 +6,12 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
+- `ui/Skinnable` config option `prop` to configure the property in which to pass the current skin to the wrapped component
+- `ui/Transition` prop `css` to support customizable styling
+
+### Changed
+
 - `ui/Cell` and `ui/Layout` to accept any type of children, since the `component` that may be set could accept any format of `children`
-- `ui/Skinnable` offering a context hook to allow ancestors to change skin and children to be notified –and possibly take action– without passing props all the way down directly
-- `ui/Transition` support for customizable styling via the `css` prop
 
 ## [2.1.3] - 2018-09-10
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/Cell` and `ui/Layout` to accept any type of children, since the `component` that may be set could accept any format of `children`
+- `ui/Skinnable` offering a context hook to allow ancestors to change skin and children to be notified –and possibly take action– without passing props all the way down directly
+- `ui/Transition` support for customizable styling via the `css` prop
+
 ## [2.1.3] - 2018-09-10
 
 ### Fixed

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -42,10 +42,10 @@ const CellBase = kind({
 		/**
 		 * Any valid [Node]{@link /docs/developer-guide/glossary/#node} that should be positioned in this `Cell`.
 		 *
-		 * @type {Node}
+		 * @type {Any}
 		 * @public
 		 */
-		children: PropTypes.node,
+		children: PropTypes.any,
 
 		/**
 		 * The type of component to use to render as the `Cell`. May be a DOM node name (e.g 'div',

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -85,10 +85,10 @@ const LayoutBase = kind({
 		/**
 		 * Only [Cell]{@link ui/Layout.Cell} components are supported as children.
 		 *
-		 * @type {Node}
+		 * @type {Any}
 		 * @public
 		 */
-		children: PropTypes.node,
+		children: PropTypes.any,
 
 		/**
 		 * The type of component to use to render as the `Layout`. May be a DOM node name (e.g 'div',

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -23,7 +23,7 @@ import React from 'react';
  */
 const defaultConfig = {
 	/**
-	 * The prop in which to pass the effective skin to the wrapped component
+	 * The prop in which to pass the effective skin to the wrapped component.
 	 *
 	 * @type {string}
 	 * @memberof ui/Skinnable.Skinnable.defaultConfig

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -25,6 +25,8 @@ const defaultConfig = {
 	/**
 	 * The prop in which to pass the effective skin to the wrapped component.
 	 *
+	 * If left unset, the current skin will not be passed to the wrapped component.
+	 *
 	 * @type {string}
 	 * @memberof ui/Skinnable.Skinnable.defaultConfig
 	 */

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -124,6 +124,5 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 export default Skinnable;
 export {
-	Skinnable,
-	SkinContext
+	Skinnable
 };

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -23,6 +23,14 @@ import React from 'react';
  */
 const defaultConfig = {
 	/**
+	 * The prop in which to pass the effective skin to the wrapped component
+	 *
+	 * @type {string}
+	 * @memberof ui/Skinnable.Skinnable.defaultConfig
+	 */
+	prop: null,
+
+	/**
 	 * A hash mapping the available skin names to their CSS class name.
 	 *
 	 * The keys are accepted as the only valid values for the `skin` prop on the wrapped component.
@@ -68,7 +76,7 @@ const SkinContext = React.createContext(null);
  * @public
  */
 const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
-	const {skins, defaultSkin} = config;
+	const {prop, skins, defaultSkin} = config;
 
 	function determineSkin (authorSkin, parentSkin) {
 		return authorSkin || defaultSkin || parentSkin;
@@ -97,6 +105,10 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 				{parentSkin => {
 					const effectiveSkin = determineSkin(skin, parentSkin);
 
+					if (prop) {
+						rest[prop] = effectiveSkin;
+					}
+
 					return (
 						<SkinContext.Provider value={effectiveSkin}>
 							<Wrapped className={getClassName(skin, parentSkin, className)} {...rest} />
@@ -110,5 +122,6 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 export default Skinnable;
 export {
-	Skinnable
+	Skinnable,
+	SkinContext
 };

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -23,7 +23,7 @@ import {contextTypes} from '@enact/core/internal/PubSub';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import css from './Transition.less';
+import componentCss from './Transition.less';
 
 const forwardTransitionEnd = forward('onTransitionEnd');
 const forwardOnShow = forward('onShow');
@@ -82,6 +82,39 @@ const TransitionBase = kind({
 		 * @public
 		 */
 		clipWidth: PropTypes.number,
+
+		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal Elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `transition`     - The root component class
+		 * * `inner`          - The element inside the transition. This is the container for the transitioning content.
+		 * * `shown`          - Applied when content is present (visible), related to the `visible` prop/state
+		 * * `hidden`         - Applied when content is not present (hiding), related to the `visible` prop/state
+		 * * `slide`          - Applied when the `slide` `type` is set
+		 * * `fade`           - Applied when the `fade` `type` is set
+		 * * `clip`           - Applied when the `clip` `type` is set
+		 * * `up`             - Applied when the `direction` `up` is set
+		 * * `right`          - Applied when the `direction` `right` is set
+		 * * `down`           - Applied when the `direction` `down` is set
+		 * * `left`           - Applied when the `direction` `left` is set
+		 * * `short`          - Applied when the `duration` `short` is set
+		 * * `medium`         - Applied when the `duration` `medium` is set
+		 * * `long`           - Applied when the `duration` `long` is set
+		 * * `ease`           - Applied when the `timingFunction` `ease` is set
+		 * * `ease-in`        - Applied when the `timingFunction` `ease-in` is set
+		 * * `ease-out`       - Applied when the `timingFunction` `ease-out` is set
+		 * * `ease-in-out`    - Applied when the `timingFunction` `ease-in-out` is set
+		 * * `ease-in-quart`  - Applied when the `timingFunction` `ease-in-quart` is set
+		 * * `ease-out-quart` - Applied when the `timingFunction` `ease-out-quart` is set
+		 * * `linear`         - Applied when the `timingFunction` `linear` is set
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object,
 
 		/**
 		 * Sets the direction of transition. Where the component will move *to*; the destination.
@@ -184,12 +217,13 @@ const TransitionBase = kind({
 	},
 
 	styles: {
-		css,
-		className: 'transition'
+		css: componentCss,
+		className: 'transition',
+		publicClassNames: true
 	},
 
 	computed: {
-		className: ({direction, duration, timingFunction, type, visible, styler}) => styler.append(
+		className: ({css, direction, duration, timingFunction, type, visible, styler}) => styler.append(
 			visible ? 'shown' : 'hidden',
 			direction && css[direction],
 			duration && css[duration],
@@ -203,7 +237,7 @@ const TransitionBase = kind({
 				};
 			}
 		},
-		style: ({clipHeight, direction, duration, type, visible, style}) => {
+		style: ({css, clipHeight, direction, duration, type, visible, style}) => {
 			if (type === 'clip') {
 				style = {
 					...style,
@@ -225,7 +259,7 @@ const TransitionBase = kind({
 		childRef: ({childRef, noAnimation, children}) => (noAnimation || !children) ? null : childRef
 	},
 
-	render: ({childRef, children, innerStyle, noAnimation, visible, ...rest}) => {
+	render: ({css, childRef, children, innerStyle, noAnimation, visible, ...rest}) => {
 		delete rest.clipHeight;
 		delete rest.clipWidth;
 		delete rest.direction;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
A collection of changes are needed to support other work and extend the base components to allow more dynamic usage outside of moonstone.


### Resolution
* `Cell` and `Layout` now accept any type of children, since the `component` that may be set could accept any format of `children`.
* Transition now supports customizable styling via the `css` prop.
* Add `prop` HOC config to `ui/Skinnable` to support passing the effective skin to the wrapped component