### PR TITLE
ENYO-5648: Blur active element when container becomes spotlightDisabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VideoPlayer` to unfocus all slotted components when media controls hide
 - `moonstone/Scroller` to set correct scroll position when an expandable child is closed
 - `moonstone/Scroller` to prevent focusing children while scrolling
 

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -405,7 +405,7 @@ const MediaControlsBase = kind({
 
 		return (
 			<OuterContainer {...rest} spotlightId={spotlightId}>
-				<div className={css.leftComponents}>{leftComponents}</div>
+				<Container className={css.leftComponents} spotlightDisabled={spotlightDisabled}>{leftComponents}</Container>
 				<div className={css.centerComponentsContainer}>
 					<div className={centerClassName}>
 						<Container className={css.mediaControls} spotlightDisabled={showMoreComponents || spotlightDisabled}>
@@ -420,7 +420,7 @@ const MediaControlsBase = kind({
 						</Container>
 					</div>
 				</div>
-				<div className={css.rightComponents}>
+				<Container className={css.rightComponents} spotlightDisabled={spotlightDisabled}>
 					{rightComponents}
 					{countReactChildren(children) ? (
 						<MediaButton
@@ -438,7 +438,7 @@ const MediaControlsBase = kind({
 							{moreIcon}
 						</MediaButton>
 					) : null}
-				</div>
+				</Container>
 			</OuterContainer>
 		);
 	}

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight/SpotlightContainerDecorator` to blur active element when becomes `spotlightDisabled`
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -203,6 +203,18 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
+		componentDidUpdate (prevProps) {
+			const current = Spotlight.getCurrent();
+
+			if (!prevProps.spotlightDisabled && this.props.spotlightDisabled && current) {
+				const containerNode = document.querySelector(`[data-spotlight-id='${this.state.id}']`);
+
+				if (containerNode && containerNode.contains(current)) {
+					current.blur();
+				}
+			}
+		}
+
 		componentWillUnmount () {
 			this.releaseContainer(this.state.id);
 		}


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a spotlight container component manages, `spotlightDisabled` are normally propagated to its children to prevent from getting focused.
`moonstone/VideoPlayer` sets `MediaControls`'s `spotlightDisabled` prop to `true`
This state is all spread across the known controls (e.g. MediaButtons like play, rew/ff, etc.)
However, spottable components specified by the users (e.g. `leftComponents`, `rightComponents`, `children`) do not.

If the last focused item was one of those user specified spottable components and `MediaControls` is hidden, you can still interact with the component even though it’s hidden.

A real world example would be in P&V video player. Let’s say you have a focus on the icon button that opens up a contextual popup (e.g. subtitle) in the `rightComponents`, wait for MediaControls to disappear after timeout, press “enter”, then you would have a contextual popup being opened.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Blur active element from the container when `SpotlightContainerDecorator` receives `spotlightDisabled` changed to true.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>