### PR TITLE
ENYO-5643: Fix spotlight focus on window focus

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to correctly set focus when the window is activated
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -11,7 +11,7 @@ import {coerceArray} from '@enact/core/util';
 import intersection from 'ramda/src/intersection';
 import last from 'ramda/src/last';
 
-import {matchSelector} from './utils';
+import {contains, matchSelector, getContainerRect, getRect} from './utils';
 
 const containerAttribute = 'data-spotlight-id';
 const containerConfigs   = new Map();
@@ -740,7 +740,8 @@ function getContainerFocusTarget (containerId) {
 			return getContainerFocusTarget(nextId);
 		}
 
-		return element;
+		const {overflow} = getContainerConfig(containerId);
+		return !overflow ? element : contains(getContainerRect(containerId), getRect(element)) && element;
 	}, null) || null;
 }
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -377,13 +377,22 @@ const Spotlight = (function () {
 		// trying to focus something else (potentially) unless the window was previously blurred
 		if (_spotOnWindowFocus) {
 			setPlatformPointerMode();
+
 			// If the window was previously blurred while in pointer mode, the last active containerId may
 			// not have yet set focus to its spottable elements. For this reason we can't rely on setting focus
 			// to the last focused element of the last active containerId, so we use rootContainerId instead
-			if (!Spotlight.focus(getContainerLastFocusedElement(rootContainerId))) {
+			let lastFocusedElement = getContainerLastFocusedElement(rootContainerId);
+			while (isContainer(lastFocusedElement)) {
+				({lastFocusedElement} = getContainerConfig(lastFocusedElement));
+			}
+
+			if (!Spotlight.focus(lastFocusedElement)) {
 				// If the last focused element was previously also disabled (or no longer exists), we
-				// need to set focus somewhere
-				Spotlight.focus();
+				// need to set focus to the next target element within the same container
+				if (!Spotlight.focus(getTargetByContainer(last(getContainersForNode(lastFocusedElement))))) {
+					// If no target elements can be focused, we need to set focus somewhere
+					Spotlight.focus();
+				}
 			}
 			_spotOnWindowFocus = false;
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Spotlight can sometimes set focus to an unintended target when the application window gains focus


### Resolution
If the last-focused element is unavailable, we should try to set focus to the next logical target within the same container as the last-focused element. Spotlight also should take into account overflow containers when selecting a container's focus target.
