### PR TITLE
ENYO-5524: Add container events for focus changes

### DIFF
--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -17,11 +17,10 @@
  */
 
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
-import {forward} from '@enact/core/handle';
-import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
+import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {Spotlight, getDirection} from '@enact/spotlight';
+import {Spotlight} from '@enact/spotlight';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -104,7 +104,8 @@ class ScrollerBase extends Component {
 
 	configureSpotlight () {
 		Spotlight.set(this.props.spotlightId, {
-			onBlurContainer: this.handleBlurContainer
+			onBlurContainer: this.handleBlurContainer,
+			onBlurContainerFail: this.handleBlurContainer
 		});
 	}
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -103,8 +103,8 @@ class ScrollerBase extends Component {
 
 	configureSpotlight () {
 		Spotlight.set(this.props.spotlightId, {
-			onBlurContainer: this.handleBlurContainer,
-			onBlurContainerFail: this.handleBlurContainer
+			onLeaveContainer: this.handleLeaveContainer,
+			onLeaveContainerFail: this.handleLeaveContainer
 		});
 	}
 
@@ -368,7 +368,7 @@ class ScrollerBase extends Component {
 		}
 	}
 
-	handleBlurContainer = ({direction, target}) => {
+	handleLeaveContainer = ({direction, target}) => {
 		const contentsContainer = this.uiRef.containerRef;
 		// ensure we only scroll to boundary from the contents and not a scroll button which
 		// lie outside of this.uiRef.containerRef but within the spotlight container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -61,6 +61,8 @@ let GlobalConfig = {
 	leaveFor: null,         // {left: <extSelector>, right: <extSelector>, up: <extSelector>, down: <extSelector>}
 	navigableFilter: null,
 	obliqueMultiplier: 5,
+	onBlurContainer: null,
+	onFocusContainer: null,
 	overflow: false,
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
@@ -948,6 +950,40 @@ function isWithinOverflowContainer (target, containerIds = getContainersForNode(
 		.some(config => config && config.overflow);
 }
 
+function notifyBlurContainer (direction, current, currentContainerIds, next, nextContainerIds) {
+	currentContainerIds.forEach(containerId => {
+		if (!nextContainerIds.includes(containerId)) {
+			const config = getContainerConfig(containerId);
+
+			if (config && config.onBlurContainer) {
+				config.onBlurContainer({
+					type: 'onBlurContainer',
+					direction,
+					target: current,
+					relatedTarget: next
+				});
+			}
+		}
+	});
+}
+
+function notifyFocusContainer (direction, current, currentContainerIds, next, nextContainerIds) {
+	nextContainerIds.forEach(containerId => {
+		if (!currentContainerIds.includes(containerId)) {
+			const config = getContainerConfig(containerId);
+
+			if (config && config.onFocusContainer) {
+				config.onFocusContainer({
+					type: 'onFocusContainer',
+					direction,
+					target: next,
+					relatedTarget: current
+				});
+			}
+		}
+	});
+}
+
 export {
 	// Remove
 	getAllContainerIds,
@@ -977,6 +1013,8 @@ export {
 	isNavigable,
 	isWithinOverflowContainer,
 	mayActivateContainer,
+	notifyBlurContainer,
+	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,
 	rootContainerId,

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -986,7 +986,7 @@ function notifyBlurContainer (direction, current, currentContainerIds, next, nex
  * @param {String[]} currentContainerIds Containers for current
  * @private
  */
-function notifyBlurFailContainer (direction, current, currentContainerIds) {
+function notifyBlurContainerFail (direction, current, currentContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		const config = getContainerConfig(containerId);
 
@@ -1057,7 +1057,7 @@ export {
 	isWithinOverflowContainer,
 	mayActivateContainer,
 	notifyBlurContainer,
-	notifyBlurFailContainer,
+	notifyBlurContainerFail,
 	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -61,9 +61,9 @@ let GlobalConfig = {
 	leaveFor: null,         // {left: <extSelector>, right: <extSelector>, up: <extSelector>, down: <extSelector>}
 	navigableFilter: null,
 	obliqueMultiplier: 5,
-	onBlurContainer: null,      // @private - notify the container when leaving via 5-way
-	onBlurContainerFail: null,  // @private - notify the container when failing to leave via 5-way
-	onFocusContainer: null,     // @private - notify the container when entering via 5-way
+	onEnterContainer: null,     // @private - notify the container when entering via 5-way
+	onLeaveContainer: null,      // @private - notify the container when leaving via 5-way
+	onLeaveContainerFail: null,  // @private - notify the container when failing to leave via 5-way
 	overflow: false,
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
@@ -961,14 +961,14 @@ function isWithinOverflowContainer (target, containerIds = getContainersForNode(
  * @param {String[]} nextContainerIds Containers for next
  * @private
  */
-function notifyBlurContainer (direction, current, currentContainerIds, next, nextContainerIds) {
+function notifyLeaveContainer (direction, current, currentContainerIds, next, nextContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		if (!nextContainerIds.includes(containerId)) {
 			const config = getContainerConfig(containerId);
 
-			if (config && config.onBlurContainer) {
-				config.onBlurContainer({
-					type: 'onBlurContainer',
+			if (config && config.onLeaveContainer) {
+				config.onLeaveContainer({
+					type: 'onLeaveContainer',
 					direction,
 					target: current,
 					relatedTarget: next
@@ -986,13 +986,13 @@ function notifyBlurContainer (direction, current, currentContainerIds, next, nex
  * @param {String[]} currentContainerIds Containers for current
  * @private
  */
-function notifyBlurContainerFail (direction, current, currentContainerIds) {
+function notifyLeaveContainerFail (direction, current, currentContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		const config = getContainerConfig(containerId);
 
-		if (config && config.onBlurContainerFail) {
-			config.onBlurContainerFail({
-				type: 'onBlurContainerFail',
+		if (config && config.onLeaveContainerFail) {
+			config.onLeaveContainerFail({
+				type: 'onLeaveContainerFail',
 				direction,
 				target: current
 			});
@@ -1010,14 +1010,14 @@ function notifyBlurContainerFail (direction, current, currentContainerIds) {
  * @param {String[]} currentContainerIds Containers for current
  * @private
  */
-function notifyFocusContainer (direction, previous, previousContainerIds, current, currentContainerIds) {
+function notifyEnterContainer (direction, previous, previousContainerIds, current, currentContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		if (!previousContainerIds.includes(containerId)) {
 			const config = getContainerConfig(containerId);
 
-			if (config && config.onFocusContainer) {
-				config.onFocusContainer({
-					type: 'onFocusContainer',
+			if (config && config.onEnterContainer) {
+				config.onEnterContainer({
+					type: 'onEnterContainer',
 					direction,
 					target: current,
 					relatedTarget: previous
@@ -1056,9 +1056,9 @@ export {
 	isNavigable,
 	isWithinOverflowContainer,
 	mayActivateContainer,
-	notifyBlurContainer,
-	notifyBlurContainerFail,
-	notifyFocusContainer,
+	notifyLeaveContainer,
+	notifyLeaveContainerFail,
+	notifyEnterContainer,
 	removeAllContainers,
 	removeContainer,
 	rootContainerId,

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -951,20 +951,16 @@ function isWithinOverflowContainer (target, containerIds = getContainersForNode(
 		.some(config => config && config.overflow);
 }
 
-function notifyBlurFailContainer (direction, current, currentContainerIds) {
-	currentContainerIds.forEach(containerId => {
-		const config = getContainerConfig(containerId);
-
-		if (config && config.onBlurContainerFail) {
-			config.onBlurContainerFail({
-				type: 'onBlurContainerFail',
-				direction,
-				target: current
-			});
-		}
-	});
-}
-
+/**
+ * Notifies any affected containers that focus has left one of their children for another container
+ *
+ * @param {String} direction up/down/left/right
+ * @param {Node} current currently focused element
+ * @param {String[]} currentContainerIds Containers for current
+ * @param {Node} next To be focused element
+ * @param {String[]} nextContainerIds Containers for next
+ * @private
+ */
 function notifyBlurContainer (direction, current, currentContainerIds, next, nextContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		if (!nextContainerIds.includes(containerId)) {
@@ -982,17 +978,49 @@ function notifyBlurContainer (direction, current, currentContainerIds, next, nex
 	});
 }
 
-function notifyFocusContainer (direction, current, currentContainerIds, next, nextContainerIds) {
-	nextContainerIds.forEach(containerId => {
-		if (!currentContainerIds.includes(containerId)) {
+/**
+ * Notifies any containers that focus attempted to move but failed to find a target
+ *
+ * @param {String} direction up/down/left/right
+ * @param {Node} current currently focused element
+ * @param {String[]} currentContainerIds Containers for current
+ * @private
+ */
+function notifyBlurFailContainer (direction, current, currentContainerIds) {
+	currentContainerIds.forEach(containerId => {
+		const config = getContainerConfig(containerId);
+
+		if (config && config.onBlurContainerFail) {
+			config.onBlurContainerFail({
+				type: 'onBlurContainerFail',
+				direction,
+				target: current
+			});
+		}
+	});
+}
+
+/**
+ * Notifies any affected containers that they one of their children has received focus.
+ *
+ * @param {String} direction up/down/left/right
+ * @param {Node} previous Previously focused element
+ * @param {String[]} previousContainerIds Containers for previous
+ * @param {Node} current Currently focused element
+ * @param {String[]} currentContainerIds Containers for current
+ * @private
+ */
+function notifyFocusContainer (direction, previous, previousContainerIds, current, currentContainerIds) {
+	currentContainerIds.forEach(containerId => {
+		if (!previousContainerIds.includes(containerId)) {
 			const config = getContainerConfig(containerId);
 
 			if (config && config.onFocusContainer) {
 				config.onFocusContainer({
 					type: 'onFocusContainer',
 					direction,
-					target: next,
-					relatedTarget: current
+					target: current,
+					relatedTarget: previous
 				});
 			}
 		}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -1001,7 +1001,7 @@ function notifyBlurContainerFail (direction, current, currentContainerIds) {
 }
 
 /**
- * Notifies any affected containers that they one of their children has received focus.
+ * Notifies any affected containers that one of their children has received focus.
  *
  * @param {String} direction up/down/left/right
  * @param {Node} previous Previously focused element

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -61,8 +61,9 @@ let GlobalConfig = {
 	leaveFor: null,         // {left: <extSelector>, right: <extSelector>, up: <extSelector>, down: <extSelector>}
 	navigableFilter: null,
 	obliqueMultiplier: 5,
-	onBlurContainer: null,
-	onFocusContainer: null,
+	onBlurContainer: null,      // @private - notify the container when leaving via 5-way
+	onBlurContainerFail: null,  // @private - notify the container when failing to leave via 5-way
+	onFocusContainer: null,     // @private - notify the container when entering via 5-way
 	overflow: false,
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
@@ -950,6 +951,20 @@ function isWithinOverflowContainer (target, containerIds = getContainersForNode(
 		.some(config => config && config.overflow);
 }
 
+function notifyBlurFailContainer (direction, current, currentContainerIds) {
+	currentContainerIds.forEach(containerId => {
+		const config = getContainerConfig(containerId);
+
+		if (config && config.onBlurContainerFail) {
+			config.onBlurContainerFail({
+				type: 'onBlurContainerFail',
+				direction,
+				target: current
+			});
+		}
+	});
+}
+
 function notifyBlurContainer (direction, current, currentContainerIds, next, nextContainerIds) {
 	currentContainerIds.forEach(containerId => {
 		if (!nextContainerIds.includes(containerId)) {
@@ -1014,6 +1029,7 @@ export {
 	isWithinOverflowContainer,
 	mayActivateContainer,
 	notifyBlurContainer,
+	notifyBlurFailContainer,
 	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -40,9 +40,9 @@ import {
 	isNavigable,
 	isWithinOverflowContainer,
 	mayActivateContainer,
-	notifyBlurContainer,
-	notifyBlurContainerFail,
-	notifyFocusContainer,
+	notifyLeaveContainer,
+	notifyLeaveContainerFail,
+	notifyEnterContainer,
 	removeAllContainers,
 	removeContainer,
 	rootContainerId,
@@ -327,7 +327,7 @@ const Spotlight = (function () {
 				return false;
 			}
 
-			notifyBlurContainer(
+			notifyLeaveContainer(
 				direction,
 				currentFocusedElement,
 				currentContainerIds,
@@ -344,7 +344,7 @@ const Spotlight = (function () {
 
 			const focused = focusElement(next, nextContainerIds);
 
-			notifyFocusContainer(
+			notifyEnterContainer(
 				direction,
 				currentFocusedElement,
 				currentContainerIds,
@@ -355,7 +355,7 @@ const Spotlight = (function () {
 			return focused;
 		}
 
-		notifyBlurContainerFail(direction, currentFocusedElement, currentContainerIds);
+		notifyLeaveContainerFail(direction, currentFocusedElement, currentContainerIds);
 
 		return false;
 	}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -41,7 +41,7 @@ import {
 	isWithinOverflowContainer,
 	mayActivateContainer,
 	notifyBlurContainer,
-	notifyBlurFailContainer,
+	notifyBlurContainerFail,
 	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,
@@ -355,7 +355,7 @@ const Spotlight = (function () {
 			return focused;
 		}
 
-		notifyBlurFailContainer(direction, currentFocusedElement, currentContainerIds);
+		notifyBlurContainerFail(direction, currentFocusedElement, currentContainerIds);
 
 		return false;
 	}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -41,6 +41,7 @@ import {
 	isWithinOverflowContainer,
 	mayActivateContainer,
 	notifyBlurContainer,
+	notifyBlurFailContainer,
 	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,
@@ -353,6 +354,8 @@ const Spotlight = (function () {
 
 			return focused;
 		}
+
+		notifyBlurFailContainer(direction, currentFocusedElement, currentContainerIds);
 
 		return false;
 	}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -40,6 +40,8 @@ import {
 	isNavigable,
 	isWithinOverflowContainer,
 	mayActivateContainer,
+	notifyBlurContainer,
+	notifyFocusContainer,
 	removeAllContainers,
 	removeContainer,
 	rootContainerId,
@@ -324,6 +326,14 @@ const Spotlight = (function () {
 				return false;
 			}
 
+			notifyBlurContainer(
+				direction,
+				currentFocusedElement,
+				currentContainerIds,
+				next,
+				nextContainerIds
+			);
+
 			setContainerPreviousTarget(
 				currentContainerId,
 				direction,
@@ -331,7 +341,17 @@ const Spotlight = (function () {
 				currentFocusedElement
 			);
 
-			return focusElement(next, nextContainerIds);
+			const focused = focusElement(next, nextContainerIds);
+
+			notifyFocusContainer(
+				direction,
+				currentFocusedElement,
+				currentContainerIds,
+				next,
+				nextContainerIds
+			);
+
+			return focused;
 		}
 
 		return false;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a significant performance cost of determining if focus will leave the scroller on every key down.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In order to improve scroll on focus performance of scrollers with many spottable children, this PR adds new (private, unsafe for public use!) spotlight container events to notify containers when focus enters, leaves, or fails to leave them.
