### PR TITLE
ENYO-5524: Change Spotlight to not explicitly blur the currently focused element

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight` to not explicitly `blur()` the currently focused element when focusing another allowing the platform to manage blurring before focus.
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -203,9 +203,6 @@ const Spotlight = (function () {
 		const focusOptions = isWithinOverflowContainer(elem, containerIds) ? {preventScroll: true} : null;
 
 		let silentFocus = function () {
-			if (currentFocusedElement) {
-				currentFocusedElement.blur();
-			}
 			elem.focus(focusOptions);
 			focusChanged(elem, containerIds);
 		};
@@ -221,10 +218,6 @@ const Spotlight = (function () {
 			silentFocus();
 			_duringFocusChange = false;
 			return true;
-		}
-
-		if (currentFocusedElement) {
-			currentFocusedElement.blur();
 		}
 
 		elem.focus(focusOptions);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The separate `blur()` and `focus()` calls caused a second style recalculation that impacted performance on rapid focus changes on low powered hardware.

![image](https://user-images.githubusercontent.com/788456/46115710-090ab600-c1ad-11e8-8861-1a0951da56b3.png)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the explicit focus and rely on the platform to manage the blur and focus actions.

![image](https://user-images.githubusercontent.com/788456/46115716-0f009700-c1ad-11e8-9f2e-53d59a20b47d.png)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This provides the added benefit of correctly populating the `relatedTarget` member of the `focus` and `blur` events to inform consumers of where focus was moving from or to.