### PR TITLE
ENYO-5521: Defer promoting marquee composite layers

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
+- `ui/Marquee.MarqueeBase` prop `willAnimate` to improve app performance by deferring animation preparation styling such as composite layer promotion.
 - `ui/Skinnable` config option `prop` to configure the property in which to pass the current skin to the wrapped component
 - `ui/Transition` prop `css` to support customizable styling
 

--- a/packages/ui/Marquee/Marquee.less
+++ b/packages/ui/Marquee/Marquee.less
@@ -23,16 +23,14 @@
 		white-space: pre !important;
 		transition-property: left, right;
 		transition-timing-function: linear;
+		position: relative;
+
+		&.willAnimate {
+			will-change: left, right;
+		}
 		
 		&.animate {
 			overflow: visible;
-		}
-	}
-
-	&.willAnimate {
-		.text {
-			will-change: left, right;
-			position: relative;
 		}
 	}
 

--- a/packages/ui/Marquee/Marquee.less
+++ b/packages/ui/Marquee/Marquee.less
@@ -21,13 +21,18 @@
 		overflow: hidden;
 		width: 100%;
 		white-space: pre !important;
-		will-change: left, right;
 		transition-property: left, right;
 		transition-timing-function: linear;
-		position: relative;
 		
 		&.animate {
 			overflow: visible;
+		}
+	}
+
+	&.promoted {
+		.text {
+			will-change: left, right;
+			position: relative;
 		}
 	}
 

--- a/packages/ui/Marquee/Marquee.less
+++ b/packages/ui/Marquee/Marquee.less
@@ -29,7 +29,7 @@
 		}
 	}
 
-	&.promoted {
+	&.willAnimate {
 		.text {
 			will-change: left, right;
 			position: relative;

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -105,8 +105,6 @@ const MarqueeBase = kind({
 		 */
 		overflow: PropTypes.oneOf(['clip', 'ellipsis']),
 
-		promoted: PropTypes.bool,
-
 		/**
 		 * `true` if the directionality of the content is right-to-left
 		 *
@@ -122,12 +120,24 @@ const MarqueeBase = kind({
 		 * @type {Number}
 		 * @public
 		 */
-		speed: PropTypes.number
+		speed: PropTypes.number,
+
+		/**
+		 * Indicates the marquee will animate soon.
+		 *
+		 * Should be used by the component to prepare itself for animation such as promoting
+		 * composite layers for improved performance.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 * @default false
+		 */
+		willAnimate: PropTypes.bool
 	},
 
 	defaultProps: {
-		promoted: false,
-		rtl: false
+		rtl: false,
+		willAnimate: false
 	},
 
 	styles: {
@@ -145,7 +155,7 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
-		className: ({promoted, styler}) => styler.append({promoted}),
+		className: ({willAnimate, styler}) => styler.append({willAnimate}),
 		clientClassName: ({animating}) => animating ? animated : css.text,
 		clientStyle: ({alignment, animating, distance, overflow, rtl, speed}) => {
 			// If the components content directionality doesn't match the context, we need to set it
@@ -179,6 +189,7 @@ const MarqueeBase = kind({
 		delete rest.overflow;
 		delete rest.rtl;
 		delete rest.speed;
+		delete rest.willAnimate;
 
 		return (
 			<div {...rest}>

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -105,6 +105,8 @@ const MarqueeBase = kind({
 		 */
 		overflow: PropTypes.oneOf(['clip', 'ellipsis']),
 
+		promoted: PropTypes.bool,
+
 		/**
 		 * `true` if the directionality of the content is right-to-left
 		 *
@@ -124,6 +126,7 @@ const MarqueeBase = kind({
 	},
 
 	defaultProps: {
+		promoted: false,
 		rtl: false
 	},
 
@@ -142,6 +145,7 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
+		className: ({promoted, styler}) => styler.append({promoted}),
 		clientClassName: ({animating}) => animating ? animated : css.text,
 		clientStyle: ({alignment, animating, distance, overflow, rtl, speed}) => {
 			// If the components content directionality doesn't match the context, we need to set it

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -5,8 +5,6 @@ import React from 'react';
 
 import css from './Marquee.less';
 
-const animated = css.text + ' ' + css.animate;
-
 const isEventSource = (ev) => ev.target === ev.currentTarget;
 
 /**
@@ -73,6 +71,7 @@ const MarqueeBase = kind({
 		 * * `marquee` - The root component class
 		 * * `animate` - Applied to the inner content node when the text is animating
 		 * * `text` - The inner content node
+		 * * `willAnimate` - Applied to the inner content node shortly before animation
 		 *
 		 * @type {Object}
 		 * @public
@@ -155,8 +154,11 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
-		className: ({willAnimate, styler}) => styler.append({willAnimate}),
-		clientClassName: ({animating}) => animating ? animated : css.text,
+		clientClassName: ({animating, willAnimate, styler}) => styler.join({
+			animate: animating,
+			text: true,
+			willAnimate
+		}),
 		clientStyle: ({alignment, animating, distance, overflow, rtl, speed}) => {
 			// If the components content directionality doesn't match the context, we need to set it
 			// inline

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -329,10 +329,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (next.disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
 			}
-
-			// if (next.marqueeOn === 'render' && !this.state.promoted) {
-			// 	this.setState({promoted: true});
-			// }
 		}
 
 		shouldComponentUpdate (nextProps, nextState) {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -388,7 +388,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.demoteJob.idle();
 		}
 
-		promote (delay) {
+		promote (delay = this.props.marqueeDelay) {
 			this.demoteJob.stop();
 			this.promoteJob.startAfter(Math.max(0, delay - 200));
 		}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -359,6 +359,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		componentWillUnmount () {
 			this.clearTimeout();
+			this.promoteJob.stop();
+			this.demoteJob.stop();
 			if (this.sync) {
 				this.sync = false;
 				this.context.unregister(this);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Many composite layers with a scroller impact scroll performance on low powered hardware due to the need to frequently update the layer tree.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Defer promoting the marquee layers to the compositor until shortly before they are needed to reduce the memory consumed and time required to update layer tree.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Fixed - ~Currently, this breaks synchronized marquees but I haven't had a chance to investigate yet.~
Added - ~It also naively skips deferment for `marqueeOn="render"` instances which could be optimized further~
