### PR TITLE
ENYO-5648: Fix setting focus in VideoPlayer in pointer mode

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -738,6 +738,14 @@ const VideoPlayerBase = class extends React.Component {
 					current.blur();
 				}
 
+				// when in pointer mode, the focus call below will only update the last focused for
+				// the video player and not set the active container to the video player which will
+				// cause focus to land back on the media controls button when spotlight restores
+				// focus.
+				if (Spotlight.getPointerMode()) {
+					Spotlight.setActiveContainer(this.props.spotlightId);
+				}
+
 				// Set focus to the hidden spottable control - maintaining focus on available spottable
 				// controls, which prevents an addiitional 5-way attempt in order to re-show media controls
 				Spotlight.focus(`.${css.controlsHandleAbove}`);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Hovering a media controls component when they hide would cause focus to be restored to it rather than the video player.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set the active container to video player when in pointer mode

I omitted a change log since it was an additional fix to a previously reported change.