### PR TITLE
ENYO-5653: Fix Touchable to handle canceled holds correctly

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Cell` and `ui/Layout` to accept any type of children, since the `component` that may be set could accept any format of `children`
 
+### Fixed
+
+- `ui/Touchable` to correctly handle a hold cancelled from an onHold handler
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a hold is cancelled (e.g. by setting a component to disabled) by the `onHold` handler, Touchable will throw an error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a test to determine if the hold is still active before continuing to emit events.
