### PR TITLE
Fix marquee measure before CSS load

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Touchable` to correctly handle a hold cancelled from an onHold handler
+- `ui/Marquee.MarqueeDecorator` to handle situations where lazily loaded CSS could cause marquee to not start correctly
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -617,7 +617,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		handleResize = () => {
 			if (this.node && !this.props.marqueeDisabled) {
 				this.invalidateMetrics();
-				this.calculateMetrics();
 				if (this.state.animating) {
 					this.cancelAnimation();
 					this.resetAnimation();

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -495,10 +495,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{undefined}
 		 */
 		start = (delay = this.props.marqueeDelay) => {
-			if (this.props.marqueeDisabled || this.contentFits) {
-				// if marquee isn't necessary (contentFits), do not set `animating` but return
-				// `true` to mark it complete if its synchronized so it doesn't block other
-				// instances.
+			if (this.props.marqueeDisabled) {
+				// if marquee isn't necessary, do not set `animating` but return `true` to mark it
+				// complete if it's synchronized so it doesn't block other instances.
 				return true;
 			} else if (!this.state.animating) {
 				// Don't need to worry about this.timerState because if we're sync, we were just
@@ -638,9 +637,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		handleFocus = (ev) => {
 			this.isFocused = true;
 			if (!this.sync) {
-				this.calculateMetrics();
-
-				if (!this.state.animating && !this.contentFits) {
+				if (!this.state.animating) {
 					this.startAnimation();
 				}
 			}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -346,9 +346,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.textDirectionValidated === false) {
 				this.validateTextDirection(this.props);
 			}
-			if (this.distance === null) {
-				this.calculateMetrics();
-			}
 			if (this.shouldStartMarquee()) {
 				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
 			}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Marquee would not start in sampler when in 5-way mode (now the default). The QA
sampler shows this off best as it starts on a button that has long text.  Reloading the
page showed off the error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This removes a measurement forced when focus occurs.  There's no need to remeasure
at this time and we can safely defer it until later as we already remeasure.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The only additional downside is that now when we go to start a marquee we may unecessarily
start a timer, then measure and decided we didn't need to animate at all.

### Links
[//]: # (Related issues, references)
ENYO-5654

### Comments
