### PR TITLE
ENYO-5655: Add voice label to DayPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+
+- `moonstone/DayPicker` to fix unexpectedly collapsing during select sub items with voice
+
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [Unreleased]
-
-### Fixed
-
-- `moonstone/DayPicker` to fix unexpectedly collapsing during select sub items with voice
-
 ## [2.1.4] - 2018-09-17
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/DayPicker` to prevent closing when selecting days via voice control
 - `moonstone/VideoPlayer` to unfocus media controls when hidden
 - `moonstone/Scroller` to set correct scroll position when an expandable child is closed
 - `moonstone/Scroller` to prevent focusing children while scrolling

--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -104,11 +104,13 @@ const DayPickerBase = kind({
 		children: ({children}) => children.map(child => child['aria-label'])
 	},
 
-	render: (props) => {
+	render: ({title, ...rest}) => {
 		return (
 			<ExpandableListBase
-				{...props}
+				{...rest}
+				data-webos-voice-label={title}
 				select="multiple"
+				title={title}
 			/>
 		);
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In current status, aria-label of LabeledItem is updated when check/uncheck sub items of DayPicker.
For this reason, LabeledItem of DayPicker can be selected unexpectedly when try to check/uncheck sub items with voice.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Explicitly declare voice label to LabeledItem

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
ENYO-5655

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>