### PR TITLE
ENYO-5656: Correctly focus last-focused elements when entering restricted containers

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight` to correctly set focus when the window is activated
+- `spotlight` to correctly set focus when entering a restricted container
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight` to correctly set focus when the window is activated
-- `spotlight` to correctly set focus when entering a restricted container
 
 ## [2.1.4] - 2018-09-17
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -641,13 +641,16 @@ function getContainerLastFocusedElement (containerId) {
 	}
 
 	// lastFocusedElement may be a container ID so try to convert it to a node to test navigability
-	const {lastFocusedElement} = config;
+	const {lastFocusedElement, overflow} = config;
 	let node = lastFocusedElement;
 	if (typeof node === 'string') {
 		node = getContainerNode(lastFocusedElement);
 	}
 
-	return isNavigable(node, containerId, true) ? lastFocusedElement : null;
+	return isNavigable(node, containerId, true) &&
+			(!overflow || contains(getContainerRect(containerId), getRect(node))) ?
+		lastFocusedElement :
+		null;
 }
 
 /**

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -696,14 +696,15 @@ function getContainerNavigableElements (containerId) {
 	const {enterTo, overflow} = config;
 
 	const enterLast = enterTo === 'last-focused';
-	const enterDefault = enterTo === 'default-element';
 	let next;
 
 	// if the container has a preferred entry point, try to find it first
 	if (enterLast) {
-		// fall back to default element if last focused can't be focused
-		next = getContainerLastFocusedElement(containerId) || getContainerDefaultElement(containerId);
-	} else if (enterDefault) {
+		next = getContainerLastFocusedElement(containerId);
+	}
+
+	// try default element if last focused can't be focused
+	if (!next) {
 		next = getContainerDefaultElement(containerId);
 	}
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -715,14 +715,7 @@ function getContainerNavigableElements (containerId) {
 		// in view
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.reduce((result, element) => {
-				if (result) {
-					return result;
-				}
-				if (contains(containerRect, getRect(element))) {
-					return element;
-				}
-			}, null);
+			next = spottables.find(element => contains(containerRect, getRect(element)));
 		}
 
 		// otherwise, return all spottables within the container

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -388,11 +388,8 @@ const Spotlight = (function () {
 
 			if (!Spotlight.focus(lastFocusedElement)) {
 				// If the last focused element was previously also disabled (or no longer exists), we
-				// need to set focus to the next target element within the same container
-				if (!Spotlight.focus(last(getContainersForNode(lastFocusedElement)))) {
-					// If no target elements can be focused, we need to set focus somewhere
-					Spotlight.focus();
-				}
+				// need to set focus somewhere
+				Spotlight.focus();
 			}
 			_spotOnWindowFocus = false;
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
#1956 introduced a regression where you could not enter a restricted (overflow/last-focused) container when the last-focused element was outside the view of the overflow container.


### Resolution
The validation we were using was in the wrong location. By returning this value in `getContainerNavigableElements`, we are able to more conveniently/accurately return which elements should gain focus next depending on their container configs. In this case, we check for what priority should be used when entering another container: we should focus last-focused > default > first in-view.

