### PR TITLE
ENYO-5601: Fix SpotlightRootDecorator to initialize after mount

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [Fixed]
+
+- `spotlight/SpotlightRootDecorator` to initialize spotlight after the component mounts to allow replacing a root instance with another
+
 ## [2.2.0] - 2018-10-02
 
 ### Changed

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -54,7 +54,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'SpotlightRootDecorator';
 
-		componentWillMount () {
+		componentDidMount () {
 			if (typeof window === 'object') {
 				Spotlight.initialize({
 					selector: '.' + spottableClass,
@@ -65,9 +65,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					overflow: true
 				});
 			}
-		}
 
-		componentDidMount () {
 			if (!noAutoFocus) {
 				Spotlight.focus();
 			}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -241,7 +241,7 @@ const Spotlight = (function () {
 			setLastContainer(containerId);
 		}
 
-		if (__DEV__) {
+		if (__DEV__ && elem.closest('.debug.spotlight')) {
 			assignFocusPreview(elem);
 		}
 	}


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When swapping root nodes (as is done in `enact-all-samples`), the new node would fail to initialize because its `componentWillMount` ran before the departing node's `componentWillUnmount`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move the initialization logic to `componentDidMount` (`componentWillMount` is going away anyway).
