### PR TITLE
ENYO-5668: Fix incorrect eval on merging paths

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 
 ### Fixed
 
-- `i18n/Loader` to use `_pathjoin` function when merging paths
+- `i18n` resource loading failure due to resolving the path incorrectly
 
 ## [2.2.0] - 2018-10-02
 

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unrelease]
+
+### Fixed
+
+- `i18n/Loader` to use `_pathjoin` function when merging paths
+
 ## [2.2.0] - 2018-10-02
 
 No significant changes.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
-## [unrelease]
+## [unreleased]
 
 ### Fixed
 

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -103,10 +103,11 @@ EnyoLoader.prototype._loadFilesAsync = function (paths, results, params, cache, 
 		} else if (cacheItem) {
 			results.push(cacheItem);
 		} else {
+			let locdata = this._pathjoin(this.base, 'locale');
 			if (this.isAvailable(_root, path)) {
 				url = this._pathjoin(_root, path);
-			} else if (this.isAvailable(this.base + 'locale', path)) {
-				url = this._pathjoin(this._pathjoin(this.base, 'locale'), path);
+			} else if (this.isAvailable(locdata, path)) {
+				url = this._pathjoin(locdata, path);
 			}
 
 			let resultFunc = (json, err) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix warning log during i18n initailization

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `this._pathjoin` function when merging paths

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I refer code from https://github.com/enactjs/enact/blob/master/packages/i18n/src/Loader.js#L186
I assume `const` is suitable here, but use `let` for now.


### Links
[//]: # (Related issues, references)
ENYO-5668

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com