### PR TITLE
ENYO-5670: passing corresponding parameters

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/DurationFmt` to pass corresponding parameters for `IString.loadPlurals`
+
 ## [2.2.0] - 2018-10-02
 
 No significant changes.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 
 ### Fixed
 
-- `i18n/DurationFmt` to pass corresponding parameters for `IString.loadPlurals`
+- `i18n/ilib/DurationFmt` to respect `sync` parameter when loading strings
 
 ## [2.2.0] - 2018-10-02
 

--- a/packages/i18n/ilib/lib/DurationFmt.js
+++ b/packages/i18n/ilib/lib/DurationFmt.js
@@ -157,7 +157,7 @@ var DurationFmt = function(options) {
         sync: sync,
         loadParams: loadParams,
         onLoad: ilib.bind(this, function (sysres) {
-            IString.loadPlurals(options.sync, this.locale, options.loadParams, ilib.bind(this, function() {
+            IString.loadPlurals(sync, this.locale, loadParams, ilib.bind(this, function() {
                 switch (this.length) {
                     case 'short':
                         this.components = {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix passing unexpected parameters to `IString.loadPlurals`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Pass `sync` and `loadParams` instead of `options.sync` and `options.loadParams`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5670

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com