### PR TITLE
ENYO-5671: Fix TimePicker to not read meridem label when changing value

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to notify user when scrolling is not possible via voice command
+- `moonstone/TimePicker` to not read out meridiem label when changing the value
 
 ## [2.2.0] - 2018-10-02
 

--- a/packages/moonstone/TimePicker/TimePickerBase.js
+++ b/packages/moonstone/TimePicker/TimePickerBase.js
@@ -398,7 +398,6 @@ const TimePickerBase = kind({
 								case 'a':
 									return (
 										<DateComponentPicker
-											accessibilityHint={meridiemLabel}
 											aria-label={meridiemAriaLabel}
 											aria-valuetext={meridiems ? meridiems[meridiem] : null}
 											className={css.meridiemComponent}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When changing the value on webOS with audio guidance enabled, the picker would announce the current value plus the meridiem label. This is consistent with the other pickers (hour and minute) but doesn't make much sense given the meridem label.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the `accessibilityHint` property from the `DateComponentPicker` to suppress the extra text read out.