### PR TITLE
ENYO-5672: Fix navigating into a spotlight container with overflow 

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` navigation into an overflow container which contains elements or containers larger than the containers bounds
+- `spotlight` navigation into an overflow container which contains elements or containers larger than the container's bounds
 
 ## [2.2.0] - 2018-10-02
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` navigation into an overflow container which contains elements or containers larger than the containers bounds
+
 ## [2.2.0] - 2018-10-02
 
 ### Changed

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -1,4 +1,4 @@
-changeimport last from 'ramda/src/last';
+import last from 'ramda/src/last';
 
 import {
 	getAllContainerIds,

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -1,4 +1,4 @@
-import last from 'ramda/src/last';
+changeimport last from 'ramda/src/last';
 
 import {
 	getAllContainerIds,

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -115,6 +115,35 @@ function filterRects (elementRects, boundingRect) {
 			// For elements, use contains with the center to include mostly visible elements
 			return contains(boundingRect, rect.center);
 		}
+	}).map(rect => {
+		let topUpdate = rect.top < boundingRect.top;
+		let bottomUpdate = rect.bottom > boundingRect.bottom;
+		let leftUpdate = rect.left < boundingRect.left;
+		let rightUpdate = rect.right > boundingRect.right;
+
+		// if the element's rect is larger than the bounding rect, clamp it to the bounding rect and
+		// recalculate the center based on the new bounds.
+		if (topUpdate || bottomUpdate || leftUpdate || rightUpdate) {
+			const updated = {...rect};
+			if (topUpdate) updated.top = boundingRect.top;
+			if (bottomUpdate) updated.bottom = boundingRect.bottom;
+			if (leftUpdate) updated.left = boundingRect.left;
+			if (rightUpdate) updated.right = boundingRect.right;
+
+			if (leftUpdate || rightUpdate) {
+				const centerX = (updated.right - updated.left) / 2;
+				updated.center.x = updated.center.left = updated.center.right = centerX;
+			}
+
+			if (topUpdate || bottomUpdate) {
+				const centerY = (updated.bottom - updated.top) / 2;
+				updated.center.y = updated.center.top = updated.center.bottom = centerY;
+			}
+
+			return updated;
+		}
+
+		return rect;
 	});
 }
 

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -124,7 +124,8 @@ function filterRects (elementRects, boundingRect) {
 		// if the element's rect is larger than the bounding rect, clamp it to the bounding rect and
 		// recalculate the center based on the new bounds.
 		if (topUpdate || bottomUpdate || leftUpdate || rightUpdate) {
-			const updated = {...rect};
+			const updated = {...rect, center: {...rect.center}};
+
 			if (topUpdate) updated.top = boundingRect.top;
 			if (bottomUpdate) updated.bottom = boundingRect.bottom;
 			if (leftUpdate) updated.left = boundingRect.left;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It is impossible to navigate into a spotlight container with overflow configured when the focusable element inside the container is much larger than the container itself. The result can be that the center of the large item is below the source element causing it to be skipped when navigating 5-way up.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add clamping to element rects to "resize" them based on the bounding rect of the overflow container.
