### PR TITLE
ENYO-5681: Prevent scrolling on 5-way hold if the last item spotted

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to prevent scroll animation on 5-way hold when it reaches the boundary
+
 ## [2.2.1] - 2018-10-09
 
 ### Fixed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -137,7 +137,14 @@ const Spotlight = (function () {
 	 * @default false
 	 */
 	let _5WayKeyHold = false;
-	let _leaveContainerFail = false;
+
+	/**
+	 * Whether there is a spottable element for a given direction
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 */
+	let _noNextSpottable = false;
 
 	/*
 	 * Whether to set focus during the next window focus event
@@ -309,15 +316,13 @@ const Spotlight = (function () {
 	}
 
 	function spotNext (direction, currentFocusedElement, currentContainerIds) {
-		if (_leaveContainerFail && _5WayKeyHold) {
-			return false;
-		}
-
 		const next = getTargetByDirectionFromElement(direction, currentFocusedElement);
 
 		if (next) {
 			const currentContainerId = last(currentContainerIds);
 			const nextContainerIds = getContainersForNode(next);
+
+			_noNextSpottable = false;
 
 			// prevent focus if 5-way is being held and the next element isn't wrapped by
 			// the current element's immediate container
@@ -353,8 +358,10 @@ const Spotlight = (function () {
 			return focused;
 		}
 
-		notifyLeaveContainerFail(direction, currentFocusedElement, currentContainerIds);
-		_leaveContainerFail = true;
+		if (!_noNextSpottable) {
+			notifyLeaveContainerFail(direction, currentFocusedElement, currentContainerIds);
+			_noNextSpottable = true;
+		}
 
 		return false;
 	}
@@ -424,7 +431,6 @@ const Spotlight = (function () {
 		if (getDirection(keyCode) || isEnter(keyCode)) {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
-			_leaveContainerFail = false;
 		}
 	}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -139,12 +139,12 @@ const Spotlight = (function () {
 	let _5WayKeyHold = false;
 
 	/**
-	 * Whether there is a spottable element for a given direction
+	 * Whether there is a valid next target for a given direction
 	 *
 	 * @type {Boolean}
 	 * @default false
 	 */
-	let _noNextSpottable = false;
+	let _noNextTarget = false;
 
 	/*
 	 * Whether to set focus during the next window focus event
@@ -322,7 +322,7 @@ const Spotlight = (function () {
 			const currentContainerId = last(currentContainerIds);
 			const nextContainerIds = getContainersForNode(next);
 
-			_noNextSpottable = false;
+			_noNextTarget = false;
 
 			// prevent focus if 5-way is being held and the next element isn't wrapped by
 			// the current element's immediate container
@@ -358,9 +358,9 @@ const Spotlight = (function () {
 			return focused;
 		}
 
-		if (!_noNextSpottable) {
+		if (!_noNextTarget) {
 			notifyLeaveContainerFail(direction, currentFocusedElement, currentContainerIds);
-			_noNextSpottable = true;
+			_noNextTarget = true;
 		}
 
 		return false;

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -137,6 +137,7 @@ const Spotlight = (function () {
 	 * @default false
 	 */
 	let _5WayKeyHold = false;
+	let _leaveContainerFail = false;
 
 	/*
 	 * Whether to set focus during the next window focus event
@@ -308,6 +309,10 @@ const Spotlight = (function () {
 	}
 
 	function spotNext (direction, currentFocusedElement, currentContainerIds) {
+		if (_leaveContainerFail && _5WayKeyHold) {
+			return false;
+		}
+
 		const next = getTargetByDirectionFromElement(direction, currentFocusedElement);
 
 		if (next) {
@@ -349,6 +354,7 @@ const Spotlight = (function () {
 		}
 
 		notifyLeaveContainerFail(direction, currentFocusedElement, currentContainerIds);
+		_leaveContainerFail = true;
 
 		return false;
 	}
@@ -418,6 +424,7 @@ const Spotlight = (function () {
 		if (getDirection(keyCode) || isEnter(keyCode)) {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
+			_leaveContainerFail = false;
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Holding down 5-way directional key towards the end of the list in `moonstone/Scroller`, the last part of scroll animation is jaggy. This only happens if there's no spottable element in the direction. This is due to spotlight container firing `onLeaveContainerFail` for every `keydown` event which will  invoke `moonstone/Scroller.scrollToBoundary()`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a flag to mark next target to prevent notifying `onLeaveContainerFail` on hold.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>