### PR TITLE
ENYO-5687: Enact core Job.idle() should stop an existing job before scheduling a new job

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [Unreleased]
+
+### Changed
+
+- `core/util.Job.idle` to cancel existing scheduled jobs before scheduling a new job and to use `startAfter` when there is no `window` object or no `window.requestIdleCallback` method
+
 ## [2.2.1] - 2018-10-09
 
 No significant changes.

--- a/packages/core/util/Job.js
+++ b/packages/core/util/Job.js
@@ -147,14 +147,13 @@ class Job {
 	 * @public
 	 */
 	idleUntil = (timeout, ...args) => {
-		if (typeof window !== 'undefined') {
-			if (window.requestIdleCallback) {
-				this.type = 'idle';
-				this.id = window.requestIdleCallback(() => this.run(args), {timeout});
-			} else {
-				// If requestIdleCallback is not supported just run the function immediately
-				this.fn(...args);
-			}
+		if (typeof window !== 'undefined' && window.requestIdleCallback) {
+			this.stop();
+			this.type = 'idle';
+			this.id = window.requestIdleCallback(() => this.run(args), {timeout});
+		} else {
+			// since we can't request an idle callback, just pass to startAfter()
+			this.startAfter(timeout, ...args);
 		}
 	}
 

--- a/packages/core/util/tests/Job-specs.js
+++ b/packages/core/util/tests/Job-specs.js
@@ -91,7 +91,7 @@ describe('Job', function () {
 			};
 			window.cancelIdleCallback = windowCancel || function (id) {
 				clearTimeout(id);
-			}
+			};
 		});
 
 		after(() => {

--- a/packages/core/util/tests/Job-specs.js
+++ b/packages/core/util/tests/Job-specs.js
@@ -99,5 +99,21 @@ describe('Job', function () {
 			const j = new Job(fn, 10);
 			j.idle(value);
 		});
+
+		it('should clear an existing job id before starting job', function (done) {
+			let jobRun = 0;
+			const fn = function (complete) {
+				jobRun += 1;
+				if (jobRun > 1) {
+					done(new Error('too many jobs'));
+				}
+				if (complete) {
+					complete();
+				}
+			};
+			const j = new Job(fn);
+			j.idle();
+			j.idle(done);
+		});
 	});
 });

--- a/packages/moonstone/ExpandableList/tests/ExpandableList-specs.js
+++ b/packages/moonstone/ExpandableList/tests/ExpandableList-specs.js
@@ -21,7 +21,7 @@ describe('ExpandableList', () => {
 		const children = ['option1', 'option2', 'option3'];
 
 		const expandableList = mount(
-			<ExpandableListBase title="Item">
+			<ExpandableListBase title="Item" open>
 				{children}
 			</ExpandableListBase>
 		);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It is possible for a race condition to be exposed when multiple calls to a `Job`'s `idle` method are executed when the main thread is overloaded and finally released.  Multiple jobs can end up with the same `id` and if the component that the `Job` is operating on is unmounted at the time the thread is released, a console warning can occur:

```
Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`Job`'s `idle` method is updated to stop any existing jobs before scheduling a new one.

### Links
[//]: # (Related issues, references)
ENYO-5687

Enact-DCO-1.0-Signed-off-by: Dave Freeman dave.freeman@lge.com