### PR TITLE
Spotlight: Clean up unused spotlight code

### DIFF
--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -77,13 +77,6 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			Spotlight.terminate();
 		}
 
-		navigableFilter = (elem) => {
-			while (elem && elem !== document && elem.nodeType === 1) {
-				if (elem.getAttribute('data-spotlight-container-disabled') === 'true') return false;
-				elem = elem.parentNode;
-			}
-		}
-
 		render () {
 			return <Wrapped {...this.props} />;
 		}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -71,8 +71,7 @@ let GlobalConfig = {
 	selectorDisabled: false,
 	straightMultiplier: 1,
 	straightOnly: false,
-	straightOverlapThreshold: 0.5,
-	tabIndexIgnoreList: 'a, input, select, textarea, button, iframe, [contentEditable=true]'
+	straightOverlapThreshold: 0.5
 };
 
 /**


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
I removed a couple areas of old/unused code from spotlight.
1) The `SpotlightRootDecorator`'s `navigableFilter` method was removed from the container in #703 but the method remained.

2) The container's `tabIndexIgnoreList` property was a remnant of spatial navigation and was used to ignore specific element types when `makeFocusable()` was called (which would modify the dom to add `tabindex` to elements). We don't explicitly edit the dom to make things focusable in enact (as that's react's job via `Spottable)` and we didn't carry over that method anyway, so it's safe to remove this reference.