### PR TITLE
ENYO-5682: Fix scroller stutter on page up/down

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to not stutter when page up/down key is pressed
+
 ## [2.2.1] - 2018-10-09
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to not stutter when page up/down key is pressed
+- `moonstone/Scroller` stuttering when page up/down key is pressed
 
 ## [2.2.1] - 2018-10-09
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -449,6 +449,7 @@ class ScrollableBase extends Component {
 				direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
+				ev.preventDefault();
 				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
 					Spotlight.setPointerMode(false);
 					direction = isPageUp(keyCode) ? 'up' : 'down';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When pressing page up/down key in `moonstone/Scroller` the container shakes. This is due to the browser handling the page up/down key in overflow container to reposition, but `moonstone/Scrollerable` handles `onScroll` to set `scrollTop` to the "updated" position which was not updated via the component event handler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `preventDefault()` to page up/down key handling. This is aligned with `moonstone/ScrollableNative`. https://github.com/enactjs/enact/blob/3c9cd97407de3fe8accda22f3d7201ed5bbff0ff/packages/moonstone/Scrollable/ScrollableNative.js#L526

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The current implementation does not allow scrolling by page when there's no focused item. #1936 was an attempt to support this but created a regression and was reverted. We should think about how we want to support this requirement.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
