### PR TITLE
ENYO-5683: Fix handling pointer events in Scroller when spotlight disabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to not enable Spotlight by click when 'data-spotlight-container-disabled' prop is true
+- `moonstone/Scroller` to not enable Spotlight by click, flick, and wheel when 'data-spotlight-container-disabled' prop is true
 - `moonstone/Scroller` stuttering when page up/down key is pressed
 
 ## [2.2.1] - 2018-10-09

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to not enable Spotlight by click, flick, and wheel when 'data-spotlight-container-disabled' prop is true
+- `moonstone/Scroller` to not enable Spotlight by click and wheel when 'data-spotlight-container-disabled' prop is true
 - `moonstone/Scroller` stuttering when page up/down key is pressed
 
 ## [2.2.1] - 2018-10-09

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to prevent making container enabled if `data-spotlight-container-disabled` prop is true
+- `moonstone/Scroller` to not spot an item when hovering it if `data-spotlight-container-disabled` prop is true and clicking it
 
 ## [2.2.1] - 2018-10-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` not to spot an item when hovering it if `data-spotlight-container-disabled` prop is true and clicking it
+- `moonstone/Scroller` to not enable Spotlight by click when 'data-spotlight-container-disabled' prop is true
 - `moonstone/Scroller` stuttering when page up/down key is pressed
 
 ## [2.2.1] - 2018-10-09

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` to prevent making container enabled if `data-spotlight-container-disabled` prop is true
+
 ## [2.2.1] - 2018-10-09
 
 ### Fixed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -273,6 +273,12 @@ class ScrollableBase extends Component {
 		}
 	}
 
+	onMouseDown = (ev) => {
+		if (this.props['data-spotlight-container-disabled']) {
+			ev.preventDefault();
+		}
+	}
+
 	onWheel = ({delta, horizontalScrollbarRef, verticalScrollbarRef}) => {
 		const
 			focusedItem = Spotlight.getCurrent(),
@@ -744,6 +750,7 @@ class ScrollableBase extends Component {
 				clearOverscrollEffect={this.clearOverscrollEffect}
 				onFlick={this.onFlick}
 				onKeyDown={this.onKeyDown}
+				onMouseDown={this.onMouseDown}
 				onWheel={this.onWheel}
 				ref={this.initUiRef}
 				removeEventListeners={this.removeEventListeners}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -265,10 +265,10 @@ class ScrollableBase extends Component {
 			focusedItem.blur();
 		}
 
-		if (
+		if ((
 			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
 			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
-		) {
+		) && !this.props['data-spotlight-container-disabled']) {
 			this.childRef.setContainerDisabled(true);
 		}
 	}
@@ -285,7 +285,9 @@ class ScrollableBase extends Component {
 
 		if (delta !== 0) {
 			this.isWheeling = true;
-			this.childRef.setContainerDisabled(true);
+			if (!this.props['data-spotlight-container-disabled']) {
+				this.childRef.setContainerDisabled(true);
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -505,7 +505,9 @@ class ScrollableBase extends Component {
 	}
 
 	stop = () => {
-		this.childRef.setContainerDisabled(false);
+		if (!this.props['data-spotlight-container-disabled']) {
+			this.childRef.setContainerDisabled(false);
+		}
 		this.focusOnItem();
 		this.lastScrollPositionOnFocus = null;
 		this.isWheeling = false;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -246,7 +246,9 @@ class ScrollableBaseNative extends Component {
 	voiceControlDirection = 'vertical'
 
 	onMouseDown = () => {
-		this.childRef.setContainerDisabled(false);
+		if (!this.props['data-spotlight-container-disabled']) {
+			this.childRef.setContainerDisabled(false);
+		}
 	}
 
 	onFlick = ({direction}) => {
@@ -257,10 +259,10 @@ class ScrollableBaseNative extends Component {
 			focusedItem.blur();
 		}
 
-		if (
+		if ((
 			direction === 'vertical' && this.uiRef.canScrollVertically(bounds) ||
 			direction === 'horizontal' && this.uiRef.canScrollHorizontally(bounds)
-		) {
+		) && !this.props['data-spotlight-container-disabled']) {
 			this.childRef.setContainerDisabled(true);
 		}
 	}
@@ -309,7 +311,9 @@ class ScrollableBaseNative extends Component {
 				const {horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef;
 
 				if (!this.isWheeling) {
-					this.childRef.setContainerDisabled(true);
+					if (!this.props['data-spotlight-container-disabled']) {
+						this.childRef.setContainerDisabled(true);
+					}
 					this.isWheeling = true;
 				}
 
@@ -330,7 +334,9 @@ class ScrollableBaseNative extends Component {
 		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 			if (eventDelta < 0 && this.uiRef.scrollLeft > 0 || eventDelta > 0 && this.uiRef.scrollLeft < bounds.maxLeft) {
 				if (!this.isWheeling) {
-					this.childRef.setContainerDisabled(true);
+					if (!this.props['data-spotlight-container-disabled']) {
+						this.childRef.setContainerDisabled(true);
+					}
 					this.isWheeling = true;
 				}
 				delta = this.uiRef.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
@@ -579,7 +585,9 @@ class ScrollableBaseNative extends Component {
 	}
 
 	scrollStopOnScroll = () => {
-		this.childRef.setContainerDisabled(false);
+		if (!this.props['data-spotlight-container-disabled']) {
+			this.childRef.setContainerDisabled(false);
+		}
 		this.focusOnItem();
 		this.lastScrollPositionOnFocus = null;
 		this.isWheeling = false;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -245,8 +245,10 @@ class ScrollableBaseNative extends Component {
 	isVoiceControl = false
 	voiceControlDirection = 'vertical'
 
-	onMouseDown = () => {
-		if (!this.props['data-spotlight-container-disabled']) {
+	onMouseDown = (ev) => {
+		if (this.props['data-spotlight-container-disabled']) {
+			ev.preventDefault();
+		} else {
 			this.childRef.setContainerDisabled(false);
 		}
 	}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though the `data-spotlight-container-disabled` prop in Scroller is true, the Scroller Spotlight container becomes enabled when clicking the item in the Scroller.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When clicking the item in the Scroller, the `stop` in the Scroller was called, then it always made the Scroller Spotlight container enabled by calling `this.childRef.setContainerDisabled(false)`. Before calling it, I just checked if `data-spotlight-container-disabled` is false.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-5683

### Comments
