### PR TITLE
ENYO-4581: Fix slowed scrolling due to duplicate scroll requests

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` slowed scrolling behavior when repeatedly requesting a scroll to the same position
+
 ## [2.2.1] - 2018-10-09
 
 ### Fixed

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -897,6 +897,23 @@ class ScrollableBase extends Component {
 			bounds = this.getScrollBounds(),
 			{maxLeft, maxTop} = bounds;
 
+		const updatedAnimationInfo = {
+			sourceX: scrollLeft,
+			sourceY: scrollTop,
+			targetX,
+			targetY,
+			duration
+		};
+
+		// bail early when scrolling to the same position
+		if (this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+			return;
+		}
+
+		// adding this member variable -- which is only referenced here -- to enable the early bail
+		// out above.
+		this.animationInfo = updatedAnimationInfo;
+
 		this.animator.stop();
 		if (!this.scrolling) {
 			this.scrolling = true;
@@ -922,13 +939,7 @@ class ScrollableBase extends Component {
 		this.showThumb(bounds);
 
 		if (animate) {
-			this.animator.animate(this.scrollAnimation({
-				sourceX: scrollLeft,
-				sourceY: scrollTop,
-				targetX,
-				targetY,
-				duration
-			}));
+			this.animator.animate(this.scrollAnimation(this.animationInfo));
 		} else {
 			this.scroll(targetX, targetY);
 			this.stop();

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -383,6 +383,9 @@ class ScrollableBase extends Component {
 
 		this.overscrollEnabled = !!(props.applyOverscrollEffect);
 
+		// Enable the early bail out of repeated scrolling to the same position
+		this.animationInfo = null;
+
 		props.cbScrollTo(this.scrollTo);
 	}
 
@@ -910,8 +913,6 @@ class ScrollableBase extends Component {
 			return;
 		}
 
-		// adding this member variable -- which is only referenced here -- to enable the early bail
-		// out above.
 		this.animationInfo = updatedAnimationInfo;
 
 		this.animator.stop();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Repeatedly attempting to scroll to the same position slows the velocity of the scroller.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Track the last requested target scroll position and bail on scroll attempts for the same position