### PR TITLE
ENYO-5681: Fix slowed scrolling due to duplicate scroll requests for native scroller

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Scroller` slowed scrolling behavior when repeatedly requesting a scroll to the same position
+- `ui/Scroller` and `ui/Scroller.ScrollerNative` slowed scrolling behavior when repeatedly requesting a scroll to the same position
 
 ## [2.2.1] - 2018-10-09
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Scroller` and `ui/Scroller.ScrollerNative` slowed scrolling behavior when repeatedly requesting a scroll to the same position
+- `ui/Scroller` slowed scrolling behavior when repeatedly requesting a scroll to the same position
 
 ## [2.2.1] - 2018-10-09
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -909,7 +909,7 @@ class ScrollableBase extends Component {
 		};
 
 		// bail early when scrolling to the same position
-		if (this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+		if (this.scrolling && this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
 			return;
 		}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1050,7 +1050,7 @@ class ScrollableBaseNative extends Component {
 		};
 
 		// bail early when scrolling to the same position
-		if (this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+		if (this.scrolling && this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
 			return;
 		}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -385,6 +385,9 @@ class ScrollableBaseNative extends Component {
 		this.overscrollEnabled = !!(props.applyOverscrollEffect);
 		this.scrollRaFId = null;
 
+		// Enable the early bail out of repeated scrolling to the same position
+		this.animationInfo = null;
+
 		props.cbScrollTo(this.scrollTo);
 	}
 
@@ -1040,6 +1043,18 @@ class ScrollableBaseNative extends Component {
 			childContainerRef = childRef.containerRef,
 			bounds = this.getScrollBounds(),
 			{maxLeft, maxTop} = bounds;
+
+		const updatedAnimationInfo = {
+			targetX,
+			targetY
+		};
+
+		// bail early when scrolling to the same position
+		if (this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+			return;
+		}
+
+		this.animationInfo = updatedAnimationInfo;
 
 		if (Math.abs(maxLeft - targetX) < epsilon) {
 			targetX = maxLeft;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Repeatedly attempting to scroll to the same position slows the velocity of the `NativeScroller`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Track the last requested target scroll position and bail on scroll attempts for the same position

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5681

### Comments
Same solution with #1986