### PR TITLE
ENYO-5690: Add `disableBackHistoryAPI` to appinfo.json of Storybook

### DIFF
--- a/packages/sampler/.storybook/webos-meta/appinfo.json
+++ b/packages/sampler/.storybook/webos-meta/appinfo.json
@@ -13,6 +13,7 @@
 	"visible": true,
 	"uiRevision": 2,
 	"useNativeScroll": true,
+	"disableBackHistoryAPI": true,
 	"class": {
 		"hidden": false
 	},


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We can't test with the `BACK` key manually or automatically(TAS).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I suggest adding `"disableBackHistoryAPI": true` to `appInfo.json` of Storybook.

### Links
[//]: # (Related issues, references)
ENYO-5690