### PR TITLE
ENYO-5691: Fix rendering blurry text issue

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Notification` to use flex layout for alignment instead of 3d transform
+- `moonstone/Notification` rendering bug that caused text to be blurry
 
 ## [2.2.2] - 2018-10-15
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Notification` to use flex layout for alignment instead of 3d transform
+
 ## [2.2.2] - 2018-10-15
 
 ### Fixed

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -139,12 +139,14 @@ const NotificationBase = kind({
 	render: ({buttons, children, css, ...rest}) => {
 		return (
 			<Popup noAnimation {...rest}>
-				<div className={css.body}>
-					{children}
+				<div className={css.container}>
+					<div className={css.body}>
+						{children}
+					</div>
+					{buttons ? <div className={css.buttons}>
+						{buttons}
+					</div> : null}
 				</div>
-				{buttons ? <div className={css.buttons}>
-					{buttons}
-				</div> : null}
 			</Popup>
 		);
 	}

--- a/packages/moonstone/Notification/Notification.less
+++ b/packages/moonstone/Notification/Notification.less
@@ -5,80 +5,89 @@
 @import '../styles/skin.less';
 
 .notification {
-	position: relative;
-	left: 50%;
-	width: fit-content;
-	min-width: @moon-notification-min-width;
-	max-width: @moon-notification-max-width;
-	text-align: center;
-	border-radius: @moon-notification-border-radius;
-	margin-bottom: @moon-notification-margin-bottom;
-	transform: translate3d(-50%, 50%, 0);
-	padding: @moon-notification-padding-top-botton @moon-notification-padding-left-right;
+	width: 100%;
+	height: @moon-notification-margin-bottom * 2;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	&.wide {
-		max-width: @moon-notification-wide-width; // 4 button case
-	}
-
-	&::before {
-		content: '';
-		display: block;
-		position: absolute;
-		border-width: @moon-notification-border-width;
-		border-style: solid;
-		border-radius: @moon-notification-out-border-radius;
-		top: -@moon-notification-border-width;
-		right: -@moon-notification-border-width;
-		bottom: -@moon-notification-border-width;
-		left: -@moon-notification-border-width;
-		z-index: -1;
-	}
-
-	.body {
-		.moon-notification-content();
-
-		:global(.enact-locale-ja) &,
-		:global(.enact-locale-zh) & {
-			overflow-wrap: normal;
-			word-break: normal;
+		.container {
+			max-width: @moon-notification-wide-width; // 4 button case
 		}
 	}
 
-	.buttons {
+	.container {
+		position: relative;
 		box-sizing: border-box;
+		width: fit-content;
+		min-width: @moon-notification-min-width;
+		max-width: @moon-notification-max-width;
+		text-align: center;
+		border-radius: @moon-notification-border-radius;
+		padding: @moon-notification-padding-top-botton @moon-notification-padding-left-right;
 
-		& > * {
-			// Applying the margin to the children allows for the case of no children without needing removing the margin
-			margin-top: 24px;
-			.margin-start-end(@moon-notification-button-gap, 0);
+		&::before {
+			content: '';
+			display: block;
+			position: absolute;
+			border-width: @moon-notification-border-width;
+			border-style: solid;
+			border-radius: @moon-notification-out-border-radius;
+			top: -@moon-notification-border-width;
+			right: -@moon-notification-border-width;
+			bottom: -@moon-notification-border-width;
+			left: -@moon-notification-border-width;
+			z-index: -1;
 		}
 
-		& > :first-child {
-			margin-left: 0;
+		.body {
+			.moon-notification-content();
 
-			:global(.enact-locale-right-to-left) & {
+			:global(.enact-locale-ja) &,
+			:global(.enact-locale-zh) & {
+				overflow-wrap: normal;
+				word-break: normal;
+			}
+		}
+
+		.buttons {
+			box-sizing: border-box;
+
+			& > * {
+				// Applying the margin to the children allows for the case of no children without needing removing the margin
+				margin-top: 24px;
+				.margin-start-end(@moon-notification-button-gap, 0);
+			}
+
+			& > :first-child {
+				margin-left: 0;
+
+				:global(.enact-locale-right-to-left) & {
+					margin-right: 0;
+				}
+			}
+
+			& > :last-child {
 				margin-right: 0;
+
+				:global(.enact-locale-right-to-left) & {
+					margin-right: @moon-notification-button-gap;
+				}
 			}
 		}
-
-		& > :last-child {
-			margin-right: 0;
-
-			:global(.enact-locale-right-to-left) & {
-				margin-right: @moon-notification-button-gap;
-			}
-		}
-	}
-
-	:global(.enact-locale-right-to-left) & {
-		right: 50%;
-		transform: translate3d(50%, 50%, 0);
 	}
 
 	// Skin colors
 	.applySkins({
-		&::before {
-			border-color: @moon-notification-border-color;
+		background-color: transparent;
+
+		.container {
+			background-color: fade(@moon-popup-bg-color, @moon-popup-bg-opacity);
+
+			&::before {
+				border-color: @moon-notification-border-color;
+			}
 		}
 	});
 }

--- a/packages/moonstone/Notification/Notification.less
+++ b/packages/moonstone/Notification/Notification.less
@@ -23,6 +23,9 @@
 		width: fit-content;
 		min-width: @moon-notification-min-width;
 		max-width: @moon-notification-max-width;
+		max-height: (@moon-notification-margin-bottom - @moon-notification-border-width) * 2;
+		display: flex;
+		flex-direction: column;
 		text-align: center;
 		border-radius: @moon-notification-border-radius;
 		padding: @moon-notification-padding-top-botton @moon-notification-padding-left-right;
@@ -43,6 +46,8 @@
 
 		.body {
 			.moon-notification-content();
+
+			overflow: hidden;
 
 			:global(.enact-locale-ja) &,
 			:global(.enact-locale-zh) & {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix rendering blurry text issue when `Notification` is rendered on a non-integer boundary

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Using `flex` layout instead of 3d `transform`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It inserts `div` element between `Popup` and `body`

### Links
[//]: # (Related issues, references)
ENYO-5691
ENYO-3473
https://stackoverflow.com/questions/31109299/css-transform-translate-50-50-makes-texts-blurry

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com