### PR TITLE
ENYO-5692: Fix VideoPlayer to clamp knob position

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` to position the slider knob correctly when beyond the left or right edge of the slider
+
 ## [2.2.2] - 2018-10-15
 
 ### Fixed

--- a/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
+++ b/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
@@ -1,6 +1,7 @@
 import {adaptEvent, call, handle, forKey, forward, oneOf, preventDefault, returnsTrue, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {calcProportion} from '@enact/ui/Slider/utils';
+import clamp from 'ramda/src/clamp';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -125,11 +126,10 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 
 		move (clientX) {
 			this.setState((state) => {
-				if (clientX >= state.minX && clientX <= state.maxX) {
-					return {
-						x: calcProportion(state.minX, state.maxX, clientX)
-					};
-				}
+				const value = clamp(state.minX, state.maxX, clientX);
+				return {
+					x: calcProportion(state.minX, state.maxX, value)
+				};
 			});
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When pointer is located on the left side of the progress bar,
Knob is located to minimum X position

### Resolution
clamp `clientX` of pointer

### Additional Considerations

### Links

### Comments
