### PR TITLE
ENYO-5691: Implement alternate centering to avoid GPU layer "blurring"

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VideoPlayer` to position the slider knob correctly when beyond the left or right edge of the slider
+- `moonstone/Notification` rendering bug that caused text to be blurry
 
 ## [2.2.2] - 2018-10-15
 

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -138,7 +138,7 @@ const NotificationBase = kind({
 
 	render: ({buttons, children, css, ...rest}) => {
 		return (
-			<Popup noAnimation {...rest}>
+			<Popup noAnimation {...rest} css={css}>
 				<div className={css.body}>
 					{children}
 				</div>

--- a/packages/moonstone/Notification/Notification.less
+++ b/packages/moonstone/Notification/Notification.less
@@ -1,19 +1,23 @@
 // Notification.less
 //
-@import '../styles/variables.less';
-@import '../styles/text.less';
-@import '../styles/skin.less';
+@import "../styles/variables.less";
+@import "../styles/text.less";
+@import "../styles/skin.less";
+
+.transition .inner {
+	height: (@moon-notification-margin-bottom * 2);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
 
 .notification {
 	position: relative;
-	left: 50%;
 	width: fit-content;
 	min-width: @moon-notification-min-width;
 	max-width: @moon-notification-max-width;
 	text-align: center;
 	border-radius: @moon-notification-border-radius;
-	margin-bottom: @moon-notification-margin-bottom;
-	transform: translate3d(-50%, 50%, 0);
 	padding: @moon-notification-padding-top-botton @moon-notification-padding-left-right;
 
 	&.wide {

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -76,6 +76,8 @@ const PopupBase = kind({
 		 *
 		 * * `popup` - The root class name
 		 * * `reserveClose` - Applied when the close button is shown and space must be allocated for it
+		 * * `transition` - Comes from the {@link ui/Transition.Transition} component
+		 * * `inner` - Comes from the {@link ui/Transition.Transition} component
 		 *
 		 * @type {Object}
 		 * @private

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -169,7 +169,7 @@ const PopupBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'popup',
-		publicClassNames: ['popup', 'reserveClose']
+		publicClassNames: ['popup', 'reserveClose', 'transition', 'inner']
 	},
 
 	computed: {
@@ -200,6 +200,7 @@ const PopupBase = kind({
 
 		return (
 			<TransitionContainer
+				css={css}
 				className={css.popupTransitionContainer}
 				direction="down"
 				duration="short"

--- a/packages/moonstone/Popup/Popup.less
+++ b/packages/moonstone/Popup/Popup.less
@@ -57,3 +57,8 @@
 	width: 100%;
 	pointer-events: none;
 }
+
+.transition,
+.inner {
+	/* Make available for customization of the transition elements */
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix rendering blurry text issue when `Notification` is rendered on a non-integer boundary

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Using `flex` layout instead of 3d `transform`

### Links
[//]: # (Related issues, references)
ENYO-5691
ENYO-3473
https://stackoverflow.com/questions/31109299/css-transform-translate-50-50-makes-texts-blurry
