### PR TITLE
ENYO-5695: Fix spotlight target selection of clipped elements

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` selection of elements clipped by an overflow container
+
 ## [2.2.2] - 2018-10-15
 
 No significant changes.

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -132,12 +132,12 @@ function filterRects (elementRects, boundingRect) {
 			if (rightUpdate) updated.right = boundingRect.right;
 
 			if (leftUpdate || rightUpdate) {
-				const centerX = (updated.right - updated.left) / 2;
+				const centerX = updated.left + (updated.right - updated.left) / 2;
 				updated.center.x = updated.center.left = updated.center.right = centerX;
 			}
 
 			if (topUpdate || bottomUpdate) {
-				const centerY = (updated.bottom - updated.top) / 2;
+				const centerY = updated.top + (updated.bottom - updated.top) / 2;
 				updated.center.y = updated.center.top = updated.center.bottom = centerY;
 			}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The center calculation was incorrect when an element was partially visible in an overflow container causing them to "appear" to be closer to spotlight in certain circumstances.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix the calculation to offset the center from the the left/top position
