### PR TITLE
ENYO-5691: Fix Notification text to be rendered clearly

### DIFF
--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -15,6 +15,7 @@ import Popup from '../Popup';
 
 import componentCss from './Notification.less';
 
+// ENYO-5691: Workaround to fix a text rendering issue by aligning the content to the pixel grid
 const fixTransform = (node) => {
 	if (!node) return;
 
@@ -23,6 +24,7 @@ const fixTransform = (node) => {
 	const deltaY = Math.round(top) - top;
 	const deltaX = Math.round(left) - left;
 	if (deltaY !== 0 || deltaX !== 0) {
+		// on webOS, the layer promotion is necessary to resolve the text rendering issue
 		parent.style.transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
 		parent.style.willChange = 'transform';
 	}

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -15,6 +15,16 @@ import Popup from '../Popup';
 
 import componentCss from './Notification.less';
 
+const fixHeight = (node) => {
+	if (!node) return;
+
+	const {top} = node.getBoundingClientRect();
+	const delta = Math.round(top) - top;
+	if (delta !== 0) {
+		node.style.transform = `translateY(${delta}px)`;
+	}
+};
+
 /**
  * A Moonstone styled notification component.
  *
@@ -139,7 +149,7 @@ const NotificationBase = kind({
 	render: ({buttons, children, css, ...rest}) => {
 		return (
 			<Popup noAnimation {...rest}>
-				<div className={css.body}>
+				<div className={css.body} ref={fixHeight}>
 					{children}
 				</div>
 				{buttons ? <div className={css.buttons}>

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -18,10 +18,12 @@ import componentCss from './Notification.less';
 const fixHeight = (node) => {
 	if (!node) return;
 
-	const {top} = node.getBoundingClientRect();
-	const delta = Math.round(top) - top;
-	if (delta !== 0) {
-		node.style.transform = `translate3d(0, ${delta}px, 0)`;
+	const {left, top} = node.getBoundingClientRect();
+	const deltaY = Math.round(top) - top;
+	const deltaX = Math.round(left) - left;
+	if (deltaY !== 0 || deltaX !== 0) {
+		node.style.transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
+		node.style.willChange = 'transform';
 	}
 };
 

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -15,15 +15,16 @@ import Popup from '../Popup';
 
 import componentCss from './Notification.less';
 
-const fixHeight = (node) => {
+const fixTransform = (node) => {
 	if (!node) return;
 
-	const {left, top} = node.getBoundingClientRect();
+	const parent = node.parentNode;
+	const {left, top} = parent.getBoundingClientRect();
 	const deltaY = Math.round(top) - top;
 	const deltaX = Math.round(left) - left;
 	if (deltaY !== 0 || deltaX !== 0) {
-		node.style.transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
-		node.style.willChange = 'transform';
+		parent.style.transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
+		parent.style.willChange = 'transform';
 	}
 };
 
@@ -151,7 +152,7 @@ const NotificationBase = kind({
 	render: ({buttons, children, css, ...rest}) => {
 		return (
 			<Popup noAnimation {...rest}>
-				<div className={css.body} ref={fixHeight}>
+				<div className={css.body} ref={fixTransform}>
 					{children}
 				</div>
 				{buttons ? <div className={css.buttons}>

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -21,7 +21,7 @@ const fixHeight = (node) => {
 	const {top} = node.getBoundingClientRect();
 	const delta = Math.round(top) - top;
 	if (delta !== 0) {
-		node.style.transform = `translateY(${delta}px)`;
+		node.style.transform = `translate3d(0, ${delta}px, 0)`;
 	}
 };
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `Notification` has an odd-numbered height/width, the CSS centering logic cause it to be rendered on subpixels resulting in blurry text.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The proposed fix is a workaround until a more significant refactor can take place to use flexbox instead of CSS transforms to position the notification.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This workaround will only resolve the rendering issue on mount and may not be effective if the content of the notification changes. While it's common to update the content in many cases, this seems rare for Notification but should be noted in case we get additional bug reports later.
