### PR TITLE
PLAT-67667: Fix DayPicker separator character for fa-IR locale

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/DayPicker` separator character used between selected days in the label in fa-IR locale
 - `moonstone/Scroller` to scroll to the boundary when focusing the first or last element with a minimal margin in 5-way mode
 - `moonstone/VideoPlayer` to position the slider knob correctly when beyond the left or right edge of the slider
 

--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -14,6 +14,7 @@
  */
 
 import kind from '@enact/core/kind';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
@@ -120,6 +121,7 @@ const DayPickerDecorator = compose(
 	Pure,
 	Expandable,
 	Changeable({change: 'onSelect', prop: 'selected'}),
+	I18nContextDecorator({localeProp: 'locale'}),
 	DaySelectorDecorator
 );
 

--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -3,7 +3,6 @@ import hoc from '@enact/core/hoc';
 import {coerceArray} from '@enact/core/util';
 import ilib from '@enact/i18n';
 import DateFmt from '@enact/i18n/ilib/lib/DateFmt';
-import ListFmt from '@enact/i18n/ilib/lib/ListFmt';
 import LocaleInfo from '@enact/i18n/ilib/lib/LocaleInfo';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -242,12 +241,9 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 
 			const type = this.calcSelectedDayType(selected);
 			const format = (list) => {
-				if (this.props.locale === 'fa-IR') {
-					const listFmt = new ListFmt({length: 'medium', style:'unit'});
-					return listFmt.format(list);
-				}
+				let separator = this.props.locale === 'fa-IR' ? '، ' : ', ';
 
-				return list.join(', ');
+				return list.join(separator);
 			};
 
 			switch (type) {

--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -3,6 +3,7 @@ import hoc from '@enact/core/hoc';
 import {coerceArray} from '@enact/core/util';
 import ilib from '@enact/i18n';
 import DateFmt from '@enact/i18n/ilib/lib/DateFmt';
+import ListFmt from '@enact/i18n/ilib/lib/ListFmt';
 import LocaleInfo from '@enact/i18n/ilib/lib/LocaleInfo';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -240,6 +241,14 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 			}
 
 			const type = this.calcSelectedDayType(selected);
+			const format = (list) => {
+				if (this.props.locale === 'fa-IR') {
+					const listFmt = new ListFmt({length: 'medium', style:'unit'});
+					return listFmt.format(list);
+				}
+
+				return list.join(', ');
+			};
 
 			switch (type) {
 				case SELECTED_DAY_TYPES.EVERY_DAY :
@@ -249,7 +258,7 @@ const DaySelectorDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 				case SELECTED_DAY_TYPES.EVERY_WEEKDAY :
 					return everyWeekdayText;
 				case SELECTED_DAY_TYPES.SELECTED_DAYS :
-					return selected.sort().map((dayIndex) => selectDayStrings[dayIndex]).join(', ');
+					return format(selected.sort().map((dayIndex) => selectDayStrings[dayIndex]));
 				case SELECTED_DAY_TYPES.SELECTED_NONE :
 					return '';
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
fa-IR locale uses `u+060c` as a list separator but `DayPicker` used `,` for all locales.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Patch `DayPicker` to use the correct character in `fa-IR`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Longer term, we'll want to adopt `ilib/ListFmt` for all locales for both `DayPicker` and `ExpandableList`