### PR TITLE
ENYO-5395: Improve documentation of moonstone/ToggleIcon

### DIFF
--- a/packages/moonstone/Checkbox/Checkbox.js
+++ b/packages/moonstone/Checkbox/Checkbox.js
@@ -21,7 +21,7 @@ import css from './Checkbox.less';
 /**
  * A checkbox component, ready to use in Moonstone applications.
  *
- * `Checkbox` may be used independently to represent a togglable state but is more commonly used as
+ * `Checkbox` may be used independently to represent a toggleable state but is more commonly used as
  * part of [CheckboxItem]{@link moonstone/CheckboxItem}.
  *
  * Usage:

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
@@ -1,5 +1,5 @@
 /**
- * Provides Moonstone styled form item component and interactive togglable checkbox.
+ * Provides Moonstone styled form item component and interactive toggleable checkbox.
  *
  * @example
  * <FormCheckboxItem>A Checkbox for a form</FormCheckboxItem>

--- a/packages/moonstone/RadioItem/RadioItem.js
+++ b/packages/moonstone/RadioItem/RadioItem.js
@@ -1,5 +1,5 @@
 /**
- * Provides a Moonstone-themed Item component and interactive togglable radio icon.
+ * Provides a Moonstone-themed Item component and interactive toggleable radio icon.
  *
  * @example
  * <RadioItem>Item</RadioItem>

--- a/packages/moonstone/SelectableItem/SelectableIcon.js
+++ b/packages/moonstone/SelectableItem/SelectableIcon.js
@@ -1,6 +1,6 @@
 // Not actually an exported module
 /*
- * Provides Moonstone-themed circle component and interactive togglable capabilities.
+ * Provides Moonstone-themed circle component and interactive toggleable capabilities.
  *
  * @module moonstone/SelectableIcon
  * @exports SelectableIcon

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -1,5 +1,5 @@
 /**
- * Provides Moonstone-themed item component and interactive togglable switch.
+ * Provides Moonstone-themed item component and interactive toggleable switch.
  *
  * @example
  * <SwitchItem>

--- a/packages/moonstone/ToggleIcon/ToggleIcon.js
+++ b/packages/moonstone/ToggleIcon/ToggleIcon.js
@@ -1,7 +1,10 @@
 /**
- * Provides Moonstone-themed Icon component with interactive togglable capabilities.
+ * Provides Moonstone-themed Icon component with interactive toggleable capabilities. It's intended
+ * as a fully do-it-yourself sort of component, as in initially, there is no visual change when a
+ * user interacts with the control; you the developer must add and extend the mechanics by adding
+ * visuals.
  *
- * Moonstone components that uses `ToggleIcon`:
+ * The following Moonstone components use `ToggleIcon`, and make good examples of various usages.
  *
  * * [Checkbox]{@link moonstone/Checkbox.Checkbox},
  * * [FormCheckbox]{@link moonstone/FormCheckbox.FormCheckbox},
@@ -9,12 +12,18 @@
  * * [RadioItem]{@link moonstone/RadioItem.RadioItem}, and
  * * [SelectableItem]{@link moonstone/SelectableItem.SelectableItem}.
  *
- * @module moonstone/ToggleIcon
+ * In the most common use-case, an [Icon]{@link moonstone/Icon.Icon} is necessary to be sent in as
+ * `children`, however, not mandatory. The component, and styling classes, continue function
+ * normally even without an icon. This quality allows you to do highly customizable styling by
+ * attaching to the pseudo-elements `::before` and `::after` and save a DOM node, by adding styles
+ * to the CSS exclucively.
+ *
  * @example
- * <ToggleIcon
- * 	onToggle={(props)=> console.log(props.selected)}>
- * 	check
+ * <ToggleIcon onToggle={(props)=> console.log(props.selected)}>
+ *   check
  * </ToggleIcon>
+ *
+ * @module moonstone/ToggleIcon
  * @exports ToggleIcon
  * @exports ToggleIconBase
  * @exports ToggleIconDecorator

--- a/packages/moonstone/ToggleIcon/ToggleIcon.js
+++ b/packages/moonstone/ToggleIcon/ToggleIcon.js
@@ -1,8 +1,14 @@
 /**
- * Provides Moonstone-themed Icon component with interactive toggleable capabilities. It's intended
- * as a fully do-it-yourself sort of component, as in initially, there is no visual change when a
- * user interacts with the control; you the developer must add and extend the mechanics by adding
- * visuals.
+ * Provides Moonstone-themed Icon component with interactive toggleable capabilities.
+ *
+ * `ToggleIcon` does not implement a visual change when a user interacts with the control and must
+ * be customized by the consumer using [css className
+ * overrides]{@link ui/ToggleIcon.ToggleIconBase.css}.
+ *
+ * Often, an [Icon value]{@link moonstone/Icon.Icon} is passed as `children` to represent the
+ * selected state but is not required. Omitting `children` allows the consumer to implement more
+ * advanced approaches such as styling the `::before` and `::after` pseudo-elements to save a DOM
+ * node.
  *
  * The following Moonstone components use `ToggleIcon`, and make good examples of various usages.
  *
@@ -11,12 +17,6 @@
  * * [Switch]{@link moonstone/Switch.Switch},
  * * [RadioItem]{@link moonstone/RadioItem.RadioItem}, and
  * * [SelectableItem]{@link moonstone/SelectableItem.SelectableItem}.
- *
- * In the most common use-case, an [Icon]{@link moonstone/Icon.Icon} is necessary to be sent in as
- * `children`, however, not mandatory. The component, and styling classes, continue function
- * normally even without an icon. This quality allows you to do highly customizable styling by
- * attaching to the pseudo-elements `::before` and `::after` and save a DOM node, by adding styles
- * to the CSS exclucively.
  *
  * @example
  * <ToggleIcon onToggle={(props)=> console.log(props.selected)}>


### PR DESCRIPTION
Also fixed spelling of "toggleable"

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
ToggleIcon docs are confusing and the intent of the component isn't conveyed.


### Resolution
Added docs to describe what the component is for, why one would use it, and what some of the possibilities for using it are.


### Additional Considerations
Also fixed spelling of "toggleable" globally.