### PR TITLE
ENYO-5700: Fix scrolling by voice commands in RTL locales

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via supporting additional scroll type in voice control
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrolling by voice commands in RTL locales
 
 ## [2.2.3] - 2018-10-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via supporting additional scroll type
+
 ## [2.2.3] - 2018-10-22
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via supporting additional scroll type
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll properly via supporting additional scroll type in voice control
 
 ## [2.2.3] - 2018-10-22
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -687,12 +687,24 @@ class ScrollableBase extends Component {
 
 	onVoice = (e) => {
 		const
-			scroll = e && e.detail && e.detail.scroll,
+			type = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl,
 			{scrollTop, scrollLeft} = this.uiRef,
 			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
-			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'];
+			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'],
+			movement = ['previous', 'next', 'first', 'last'];
+
+		let scroll, index;
+		if (verticalDirection.includes(type) || horizontalDirection.includes(type)) {
+			scroll = type;
+		} else if ((index = movement.indexOf(type)) > -1) {
+			if (this.props.direction === 'horizontal') {
+				scroll = isRtl ? horizontalDirection[index % 2 ? index - 1 : index + 1] : horizontalDirection[index];
+			} else {
+				scroll = verticalDirection[index];
+			}
+		}
 
 		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -687,23 +687,20 @@ class ScrollableBase extends Component {
 
 	onVoice = (e) => {
 		const
-			type = e && e.detail && e.detail.scroll,
+			isHorizontal = this.props.direction === 'horizontal',
 			isRtl = this.uiRef.state.rtl,
 			{scrollTop, scrollLeft} = this.uiRef,
 			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
-			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'],
+			horizontalDirection = isRtl ? ['right', 'left', 'rightmost', 'leftmost'] : ['left', 'right', 'leftmost', 'rightmost'],
 			movement = ['previous', 'next', 'first', 'last'];
 
-		let scroll, index;
-		if (verticalDirection.includes(type) || horizontalDirection.includes(type)) {
-			scroll = type;
-		} else if ((index = movement.indexOf(type)) > -1) {
-			if (this.props.direction === 'horizontal') {
-				scroll = isRtl ? horizontalDirection[index % 2 ? index - 1 : index + 1] : horizontalDirection[index];
-			} else {
-				scroll = verticalDirection[index];
-			}
+		let
+			scroll = e && e.detail && e.detail.scroll,
+			index = movement.indexOf(scroll);
+
+		if (index > -1) {
+			scroll = isHorizontal ? horizontalDirection[index] : verticalDirection[index];
 		}
 
 		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -761,23 +761,20 @@ class ScrollableBaseNative extends Component {
 
 	onVoice = (e) => {
 		const
-			type = e && e.detail && e.detail.scroll,
+			isHorizontal = this.props.direction === 'horizontal',
 			isRtl = this.uiRef.state.rtl,
 			{scrollTop, scrollLeft} = this.uiRef,
 			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
-			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'],
+			horizontalDirection = isRtl ? ['right', 'left', 'rightmost', 'leftmost'] : ['left', 'right', 'leftmost', 'rightmost'],
 			movement = ['previous', 'next', 'first', 'last'];
 
-		let scroll, index;
-		if (verticalDirection.includes(type) || horizontalDirection.includes(type)) {
-			scroll = type;
-		} else if ((index = movement.indexOf(type)) > -1) {
-			if (this.props.direction === 'horizontal') {
-				scroll = isRtl ? horizontalDirection[index % 2 ? index - 1 : index + 1] : horizontalDirection[index];
-			} else {
-				scroll = verticalDirection[index];
-			}
+		let
+			scroll = e && e.detail && e.detail.scroll,
+			index = movement.indexOf(scroll);
+
+		if (index > -1) {
+			scroll = isHorizontal ? horizontalDirection[index] : verticalDirection[index];
 		}
 
 		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -761,12 +761,24 @@ class ScrollableBaseNative extends Component {
 
 	onVoice = (e) => {
 		const
-			scroll = e && e.detail && e.detail.scroll,
+			type = e && e.detail && e.detail.scroll,
 			isRtl = this.uiRef.state.rtl,
 			{scrollTop, scrollLeft} = this.uiRef,
 			{maxLeft, maxTop} = this.uiRef.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
-			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'];
+			horizontalDirection = ['left', 'right', 'leftmost', 'rightmost'],
+			movement = ['previous', 'next', 'first', 'last'];
+
+		let scroll, index;
+		if (verticalDirection.includes(type) || horizontalDirection.includes(type)) {
+			scroll = type;
+		} else if ((index = movement.indexOf(type)) > -1) {
+			if (this.props.direction === 'horizontal') {
+				scroll = isRtl ? horizontalDirection[index % 2 ? index - 1 : index + 1] : horizontalDirection[index];
+			} else {
+				scroll = verticalDirection[index];
+			}
+		}
 
 		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
 


### PR DESCRIPTION
Add type for prevent scroll move to reverse direction in RTL

Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In current status, NLP server provide only direction type(ex. left, leftmost, right, rightmost, up, down, top, bottom) scroll info.
For this reason, scroll can be move reverse direction in RTL.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add additional type(previous, next, first, last) for scroll movement

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5700

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee changgi.lee@lge.com