### PR TITLE
ENYO-5703: Fix Marquee component to render font based on locale correctly

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Marquee` to render correct font based on locales
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrolling by voice commands in RTL locales
 
 ## [2.2.3] - 2018-10-22

--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -40,6 +40,7 @@
 
 // Generic Non-Latin Font Rule generator
 .moon-locale-non-latin(@nlrules) when (isruleset(@nlrules)) {
+	:global(.enact-locale-non-latin)&,
 	:global(.enact-locale-non-latin) & {
 		@nlrules();
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix `.moon-locale-non-latin()` to be working if current element has {{.enact-locale-non-latin}} class.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add selector on `.moon-locale-non-latin()` to cover current element scope.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5703

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com