### PR TITLE
ENYO-5666: Cache client size, scroll size, and scroll thumb size ratio in VirtualList and Scroller

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -159,17 +159,17 @@ class ScrollButtons extends Component {
 			shouldDisableNextButton = maxPos - currentPos <= 1,
 			updatePrevButton = (prevButtonDisabled !== shouldDisablePrevButton),
 			updateNextButton = (nextButtonDisabled !== shouldDisableNextButton);
-		let nextState = null;
-
-		if (updatePrevButton && updateNextButton) {
-			nextState = {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};
-		} else if (updatePrevButton) {
-			nextState = {prevButtonDisabled: shouldDisablePrevButton};
-		} else if (updateNextButton) {
-			nextState = {nextButtonDisabled: shouldDisableNextButton};
-		}
 
 		if (updatePrevButton || updateNextButton) {
+			let nextState = {};
+
+			if (updatePrevButton) {
+				nextState.prevButtonDisabled = shouldDisablePrevButton;
+			}
+			if (updateNextButton) {
+				nextState.nextButtonDisabled = shouldDisableNextButton;
+			}
+
 			this.setState(nextState);
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -157,19 +157,22 @@ class ScrollButtons extends Component {
 			   browsers's max scroll position could be smaller than maxPos by 1 pixel.*/
 			shouldDisableNextButton = maxPos - currentPos <= 1;
 
-		this.setState((prevState) => {
-			const
-				updatePrevButton = (prevState.prevButtonDisabled !== shouldDisablePrevButton),
-				updateNextButton = (prevState.nextButtonDisabled !== shouldDisableNextButton);
+		let nextState = null;
+		const
+			updatePrevButton = (this.state.prevButtonDisabled !== shouldDisablePrevButton),
+			updateNextButton = (this.state.nextButtonDisabled !== shouldDisableNextButton);
 
-			if (updatePrevButton && updateNextButton) {
-				return {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};
-			} else if (updatePrevButton) {
-				return {prevButtonDisabled: shouldDisablePrevButton};
-			} else if (updateNextButton) {
-				return {nextButtonDisabled: shouldDisableNextButton};
-			}
-		});
+		if (updatePrevButton && updateNextButton) {
+			nextState = {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};
+		} else if (updatePrevButton) {
+			nextState = {prevButtonDisabled: shouldDisablePrevButton};
+		} else if (updateNextButton) {
+			nextState = {nextButtonDisabled: shouldDisableNextButton};
+		}
+
+		if (updatePrevButton || updateNextButton) {
+			this.setState(nextState);
+		}
 	}
 
 	isOneOfScrollButtonsFocused = () => {

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -150,17 +150,16 @@ class ScrollButtons extends Component {
 	updateButtons = (bounds) => {
 		const
 			{vertical} = this.props,
+			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			currentPos = vertical ? bounds.scrollTop : bounds.scrollLeft,
 			maxPos = vertical ? bounds.maxTop : bounds.maxLeft,
 			shouldDisablePrevButton = currentPos <= 0,
 			/* If a scroll size or a client size is not integer,
 			   browsers's max scroll position could be smaller than maxPos by 1 pixel.*/
-			shouldDisableNextButton = maxPos - currentPos <= 1;
-
+			shouldDisableNextButton = maxPos - currentPos <= 1,
+			updatePrevButton = (prevButtonDisabled !== shouldDisablePrevButton),
+			updateNextButton = (nextButtonDisabled !== shouldDisableNextButton);
 		let nextState = null;
-		const
-			updatePrevButton = (this.state.prevButtonDisabled !== shouldDisablePrevButton),
-			updateNextButton = (this.state.nextButtonDisabled !== shouldDisableNextButton);
 
 		if (updatePrevButton && updateNextButton) {
 			nextState = {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -783,6 +783,7 @@ class ScrollableBase extends Component {
 					rtl,
 					scrollTo,
 					style,
+					syncScrollBounds,
 					verticalScrollbarProps
 				}) => (
 					<div
@@ -805,7 +806,8 @@ class ScrollableBase extends Component {
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
 									rtl,
-									spotlightId
+									spotlightId,
+									syncScrollBounds
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -857,6 +857,7 @@ class ScrollableBaseNative extends Component {
 					rtl,
 					scrollTo,
 					style,
+					syncScrollBounds,
 					verticalScrollbarProps
 				}) => (
 					<div
@@ -878,7 +879,8 @@ class ScrollableBaseNative extends Component {
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.initChildRef,
 									rtl,
-									spotlightId
+									spotlightId,
+									syncScrollBounds
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -82,12 +82,13 @@ class ScrollbarBase extends Component {
 
 	initScrollbarRef = (ref) => {
 		if (ref) {
-			const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = ref;
+			const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate, updateBounds: uiUpdateBounds} = ref;
 
 			this.getContainerRef = getContainerRef;
 			this.showThumb = showThumb;
 			this.startHidingThumb = startHidingThumb;
 			this.uiUpdate = uiUpdate;
+			this.updateBounds = uiUpdateBounds;
 		}
 	}
 
@@ -146,7 +147,8 @@ const Scrollbar = ApiDecorator(
 		'isOneOfScrollButtonsFocused',
 		'showThumb',
 		'startHidingThumb',
-		'update'
+		'update',
+		'updateBounds'
 	]}, ScrollbarBase
 );
 Scrollbar.displayName = 'Scrollbar';

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1207,6 +1207,16 @@ class ScrollableBase extends Component {
 		}
 	}
 
+	syncScrollBounds = (bounds) => {
+		if (this.horizontalScrollbarRef) {
+			this.horizontalScrollbarRef.updateBounds(bounds);
+		}
+
+		if (this.verticalScrollbarRef) {
+			this.verticalScrollbarRef.updateBounds(bounds);
+		}
+	}
+
 	getMoreInfo () {
 		if (typeof this.childRef.getMoreInfo === 'function') {
 			return this.childRef.getMoreInfo();
@@ -1339,6 +1349,7 @@ class ScrollableBase extends Component {
 			rtl,
 			scrollTo: this.scrollTo,
 			style,
+			syncScrollBounds: this.syncScrollBounds,
 			verticalScrollbarProps: this.verticalScrollbarProps
 		});
 	}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1281,6 +1281,16 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
+	syncScrollBounds = (bounds) => {
+		if (this.horizontalScrollbarRef) {
+			this.horizontalScrollbarRef.updateBounds(bounds);
+		}
+
+		if (this.verticalScrollbarRef) {
+			this.verticalScrollbarRef.updateBounds(bounds);
+		}
+	}
+
 	getMoreInfo () {
 		if (typeof this.childRef.getMoreInfo === 'function') {
 			return this.childRef.getMoreInfo();
@@ -1403,6 +1413,7 @@ class ScrollableBaseNative extends Component {
 			rtl,
 			scrollTo: this.scrollTo,
 			style,
+			syncScrollBounds: this.syncScrollBounds,
 			verticalScrollbarProps: this.verticalScrollbarProps
 		});
 	}

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -117,7 +117,7 @@ class ScrollbarBase extends PureComponent {
 			this.updateBounds(bounds);
 		}
 
-		const scrollThumbPositionRatio = (scrollOrigin / (this.scrollSize - this.clientSize));
+		const scrollThumbPositionRatio = scrollOrigin / (this.scrollSize - this.clientSize);
 
 		setCSSVariable(this.thumbRef, '--scrollbar-size-ratio', this.scrollThumbSizeRatio);
 		setCSSVariable(this.thumbRef, '--scrollbar-progress-ratio', scrollThumbPositionRatio);

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -103,20 +103,34 @@ class ScrollbarBase extends PureComponent {
 	containerRef = null
 	thumbRef = null
 
+	clientSize = null
+	scrollSize = null
+	scrollThumbSizeRatio = null
+
 	update = (bounds) => {
 		const
 			{vertical} = this.props,
-			{clientWidth, clientHeight, scrollWidth, scrollHeight, scrollLeft, scrollTop} = bounds,
-			clientSize = vertical ? clientHeight : clientWidth,
-			scrollSize = vertical ? scrollHeight : scrollWidth,
-			scrollOrigin = vertical ? scrollTop : scrollLeft,
+			{scrollLeft, scrollTop} = bounds,
+			scrollOrigin = vertical ? scrollTop : scrollLeft;
 
-			thumbSizeRatioBase = (clientSize / scrollSize),
-			scrollThumbPositionRatio = (scrollOrigin / (scrollSize - clientSize)),
-			scrollThumbSizeRatio = Math.max(this.minThumbSizeRatio, Math.min(1, thumbSizeRatioBase));
+		if (this.clientSize === null && this.scrollSize === null) {
+			this.updateBounds(bounds);
+		}
 
-		setCSSVariable(this.thumbRef, '--scrollbar-size-ratio', scrollThumbSizeRatio);
+		const scrollThumbPositionRatio = (scrollOrigin / (this.scrollSize - this.clientSize));
+
+		setCSSVariable(this.thumbRef, '--scrollbar-size-ratio', this.scrollThumbSizeRatio);
 		setCSSVariable(this.thumbRef, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
+	}
+
+	updateBounds = (bounds) => {
+		const
+			{vertical} = this.props,
+			{clientWidth, clientHeight, scrollWidth, scrollHeight} = bounds;
+
+		this.clientSize = vertical ? clientHeight : clientWidth;
+		this.scrollSize = vertical ? scrollHeight : scrollWidth;
+		this.scrollThumbSizeRatio = Math.max(this.minThumbSizeRatio, Math.min(1, this.clientSize / this.scrollSize));
 	}
 
 	showThumb = () => {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -69,7 +69,15 @@ class ScrollerBase extends Component {
 		 * @type {Boolean}
 		 * @private
 		 */
-		rtl: PropTypes.bool
+		rtl: PropTypes.bool,
+
+		/**
+		 * Called to update scroll bounds.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		syncScrollBounds: PropTypes.func
 	}
 
 	static defaultProps = {
@@ -156,6 +164,7 @@ class ScrollerBase extends Component {
 
 	calculateMetrics () {
 		const
+			{syncScrollBounds} = this.props,
 			{scrollBounds} = this,
 			{scrollWidth, scrollHeight, clientWidth, clientHeight} = this.containerRef;
 		scrollBounds.scrollWidth = scrollWidth;
@@ -164,6 +173,10 @@ class ScrollerBase extends Component {
 		scrollBounds.clientHeight = clientHeight;
 		scrollBounds.maxLeft = Math.max(0, scrollWidth - clientWidth);
 		scrollBounds.maxTop = Math.max(0, scrollHeight - clientHeight);
+
+		if (syncScrollBounds) {
+			syncScrollBounds(scrollBounds);
+		}
 	}
 
 	initContainerRef = (ref) => {
@@ -182,8 +195,9 @@ class ScrollerBase extends Component {
 
 		delete rest.cbScrollTo;
 		delete rest.direction;
-		delete rest.rtl;
 		delete rest.isVerticalScrollbarVisible;
+		delete rest.rtl;
+		delete rest.syncScrollBounds;
 
 		return (
 			<div

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -789,6 +789,7 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.dataSize;
 			delete rest.direction;
 			delete rest.getComponentProps;
+			delete rest.isVerticalScrollbarVisible;
 			delete rest.itemRenderer;
 			delete rest.itemSize;
 			delete rest.onUpdate;
@@ -798,7 +799,6 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.spacing;
 			delete rest.syncScrollBounds;
 			delete rest.updateStatesAndBounds;
-			delete rest.isVerticalScrollbarVisible;
 
 			if (primary) {
 				this.positionItems();

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -196,6 +196,14 @@ const VirtualListBaseFactory = (type) => {
 			spacing: PropTypes.number,
 
 			/**
+			 * Called to update scroll bounds.
+			 *
+			 * @type {Function}
+			 * @private
+			 */
+			syncScrollBounds: PropTypes.func,
+
+			/**
 			 * Called to execute additional logic in a themed component when updating states and bounds.
 			 *
 			 * @type {Function}
@@ -481,7 +489,7 @@ const VirtualListBaseFactory = (type) => {
 
 		calculateScrollBounds (props) {
 			const
-				{clientSize} = props,
+				{clientSize, syncScrollBounds} = props,
 				node = this.containerRef;
 
 			if (!clientSize && !node) {
@@ -507,6 +515,10 @@ const VirtualListBaseFactory = (type) => {
 
 			if (this.scrollPosition > maxPos) {
 				this.props.cbScrollTo({position: (isPrimaryDirectionVertical) ? {y: maxPos} : {x: maxPos}, animate: false});
+			}
+
+			if (syncScrollBounds) {
+				syncScrollBounds(scrollBounds);
 			}
 		}
 
@@ -784,6 +796,7 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.pageScroll;
 			delete rest.rtl;
 			delete rest.spacing;
+			delete rest.syncScrollBounds;
 			delete rest.updateStatesAndBounds;
 			delete rest.isVerticalScrollbarVisible;
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When moving scroll thumb, `client size`, `scroll size`, and `scroll thumb size ratio` were recalculated even thought they did not change.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Cache `client size`, `scroll size`, and `scroll thumb size ratio` values.
- Recalculate them when updated.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

The scroll button disabled state was changed by `setState` which enforces react to rerender. This was a costly operation. @viodragon2 fixed this issue by calling `setState` when the IconButton status changed instead of calling it every time when updating scroll thumb position.

### Links
[//]: # (Related issues, references)

ENYO-5666

### Comments
