### PR TITLE
ENYO-5703: Fix Marquee component to render font based on locale correctly

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Marquee`, `moonstone/MediaOverlay` to display localed based font
 - `moonstone/DayPicker` separator character used between selected days in the label in fa-IR locale
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrolling by voice commands in RTL locales
 

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -23,7 +23,7 @@ import Spottable from '@enact/spotlight/Spottable';
 
 import Icon from '../Icon';
 import {ImageBase as Image} from '../Image';
-import {Marquee, MarqueeController} from '../Marquee';
+import {MarqueeDecorator, MarqueeController} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './GridListImageItem.less';
@@ -34,6 +34,7 @@ const
 	'9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHN0cm9rZT0iIzU1NSIgZmlsbD0iI2FhYSIg' +
 	'ZmlsbC1vcGFjaXR5PSIwLjIiIHN0cm9rZS1vcGFjaXR5PSIwLjgiIHN0cm9rZS13aWR0aD0iNiIgLz48L3N2Zz' +
 	'4NCg==',
+	Marquee = MarqueeDecorator('div'),
 	captionComponent = (props) => (
 		<Marquee alignment="center" marqueeOn="hover" {...props} />
 	);

--- a/packages/moonstone/LabeledItem/LabeledItem.js
+++ b/packages/moonstone/LabeledItem/LabeledItem.js
@@ -18,9 +18,10 @@ import Spottable from '@enact/spotlight/Spottable';
 
 import Icon from '../Icon';
 import {ItemBase} from '../Item';
-import {Marquee, MarqueeController} from '../Marquee';
+import {MarqueeDecorator, MarqueeController} from '../Marquee';
 import Skinnable from '../Skinnable';
 
+const Marquee = MarqueeDecorator('div');
 const Controller = MarqueeController(
 	{marqueeOnFocus: true},
 	Touchable(

--- a/packages/moonstone/Marquee/Marquee.js
+++ b/packages/moonstone/Marquee/Marquee.js
@@ -12,7 +12,6 @@
  * @exports MarqueeDecorator
  */
 
-import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
 import {isRtlText} from '@enact/i18n/util';
 import {
@@ -20,38 +19,14 @@ import {
 	MarqueeController,
 	MarqueeDecorator as UiMarqueeDecorator
 } from '@enact/ui/Marquee';
-import React from 'react';
 
 import css from './Marquee.less';
-
-/**
- * A Moonstone styled div without any behavior.
- *
- * @class MoonMarqueeBase
- * @memberof moonstone/Marquee
- * @ui
- * @private
- */
-const MoonMarqueeBase = kind({
-	name: 'MarqueeBase',
-
-	styles: {
-		css: css,
-		className: 'marquee'
-	},
-
-	render: (props) => (
-		<div
-			{...props}
-		/>
-	)
-});
 
 const MarqueeDecorator = hoc({
 	marqueeDirection: (str) => isRtlText(str) ? 'rtl' : 'ltr'
 }, UiMarqueeDecorator);
 
-const Marquee = MarqueeDecorator(MoonMarqueeBase);
+const Marquee = MarqueeDecorator({className: css.marquee}, 'div');
 
 export default Marquee;
 export {

--- a/packages/moonstone/Marquee/Marquee.js
+++ b/packages/moonstone/Marquee/Marquee.js
@@ -12,6 +12,7 @@
  * @exports MarqueeDecorator
  */
 
+import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
 import {isRtlText} from '@enact/i18n/util';
 import {
@@ -19,12 +20,38 @@ import {
 	MarqueeController,
 	MarqueeDecorator as UiMarqueeDecorator
 } from '@enact/ui/Marquee';
+import React from 'react';
+
+import css from './Marquee.less';
+
+/**
+ * A Moonstone styled div without any behavior.
+ *
+ * @class MoonMarqueeBase
+ * @memberof moonstone/Marquee
+ * @ui
+ * @private
+ */
+const MoonMarqueeBase = kind({
+	name: 'MarqueeBase',
+
+	styles: {
+		css: css,
+		className: 'marquee'
+	},
+
+	render: (props) => (
+		<div
+			{...props}
+		/>
+	)
+});
 
 const MarqueeDecorator = hoc({
 	marqueeDirection: (str) => isRtlText(str) ? 'rtl' : 'ltr'
 }, UiMarqueeDecorator);
 
-const Marquee = MarqueeDecorator('div');
+const Marquee = MarqueeDecorator(MoonMarqueeBase);
 
 export default Marquee;
 export {

--- a/packages/moonstone/Marquee/Marquee.less
+++ b/packages/moonstone/Marquee/Marquee.less
@@ -1,0 +1,7 @@
+// Marquee.less
+//
+@import "../styles/text.less";
+
+.marquee {
+	.moon-font();
+}

--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -22,10 +22,12 @@ import UiSpinnerBase from '@enact/ui/Spinner';
 import Spotlight from '@enact/spotlight';
 
 import $L from '../internal/$L';
-import Marquee from '../Marquee';
+import {MarqueeDecorator} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './Spinner.less';
+
+const Marquee = MarqueeDecorator('div');
 
 /**
  * A component that shows spinning balls, with optional text as children.

--- a/packages/moonstone/VideoPlayer/MediaTitle.js
+++ b/packages/moonstone/VideoPlayer/MediaTitle.js
@@ -3,9 +3,11 @@ import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Marquee from '../Marquee';
+import {MarqueeDecorator} from '../Marquee';
 
 import css from './VideoPlayer.less';
+
+const Marquee = MarqueeDecorator('div');
 
 /**
  * MediaTitle {@link moonstone/VideoPlayer}.

--- a/packages/moonstone/internal/Picker/PickerItem.js
+++ b/packages/moonstone/internal/Picker/PickerItem.js
@@ -1,8 +1,10 @@
 import kind from '@enact/core/kind';
 import React from 'react';
 
-import Marquee from '../../Marquee';
+import {MarqueeDecorator} from '../../Marquee';
 import css from './Picker.less';
+
+const Marquee = MarqueeDecorator('div');
 
 const PickerItemBase = kind({
 	name: 'PickerItem',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Make `Marquee` as a styled component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix `Marquee` to use `moon-font()` mixin.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Some of moonstone components are using `Marquee` and handling font styling by themselves.
To minimize impact of change, I modified them to use `MarqueeDecorator('div')` instead of `Marquee`.

Here is the list of those components
- `moonstone/GridListImageItem`
- `moonstone/LabeledItem`
- `moonstone/Spinner`
- `moonstone/VideoPlayer/MediaTitle`
- `moonstone/internal/Picker/PickerItem`

Also note that `moonstone/MediaOverlay`  is using `Marquee` but has no font styling for it.
I leave it as-is to be fixed by styled `Marquee`.

### Links
[//]: # (Related issues, references)
ENYO-5703

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com