### PR TITLE
PLAT-67660: Pass childProps through VirtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` property `childProps` to support additional props included in the object passed to the `itemsRenderer` callback
+
 ## [2.2.4] - 2018-10-29
 
 ### Fixed

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -159,7 +159,7 @@ const VirtualListBaseFactory = (type) => {
 			getComponentProps: PropTypes.func,
 
 			/**
-			 * It is the object which is passed as arguments of `itemsRenderer` prop function.
+			 * Additional props included in the object passed to the `itemsRenderer` callback.
 			 *
 			 * @type {Object}
 			 * @private

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -116,6 +116,14 @@ const VirtualListBaseFactory = (type) => {
 			cbScrollTo: PropTypes.func,
 
 			/**
+			 * Additional props included in the object passed to the `itemsRenderer` callback.
+			 *
+			 * @type {Object}
+			 * @public
+			 */
+			childProps: PropTypes.object,
+
+			/**
 			 * Client size of the list; valid values are an object that has `clientWidth` and `clientHeight`.
 			 *
 			 * @type {Object}
@@ -157,14 +165,6 @@ const VirtualListBaseFactory = (type) => {
 			 * @private
 			 */
 			getComponentProps: PropTypes.func,
-
-			/**
-			 * Additional props included in the object passed to the `itemsRenderer` callback.
-			 *
-			 * @type {Object}
-			 * @private
-			 */
-			itemProps: PropTypes.object,
 
 			/**
 			 * Number of spare DOM node.
@@ -277,7 +277,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		componentWillUpdate (nextProps, nextState) {
-			if (this.state.firstIndex === nextState.firstIndex || this.props.itemProps && this.props.itemProps !== nextProps.itemProps) {
+			if (this.state.firstIndex === nextState.firstIndex || this.props.childProps && this.props.childProps !== nextProps.childProps) {
 				this.prevFirstIndex = -1; // force to re-render items
 			}
 		}
@@ -647,7 +647,7 @@ const VirtualListBaseFactory = (type) => {
 				{itemRenderer, getComponentProps} = this.props,
 				key = index % this.state.numOfItems,
 				itemElement = itemRenderer({
-					...this.props.itemProps,
+					...this.props.childProps,
 					key,
 					index
 				}),
@@ -782,11 +782,12 @@ const VirtualListBaseFactory = (type) => {
 				containerClasses = this.mergeClasses(className);
 
 			delete rest.cbScrollTo;
+			delete rest.childProps;
 			delete rest.clientSize;
 			delete rest.dataSize;
 			delete rest.direction;
 			delete rest.getComponentProps;
-			delete rest.itemProps;
+			delete rest.isVerticalScrollbarVisible;
 			delete rest.itemRenderer;
 			delete rest.itemSize;
 			delete rest.onUpdate;
@@ -795,7 +796,6 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.rtl;
 			delete rest.spacing;
 			delete rest.updateStatesAndBounds;
-			delete rest.isVerticalScrollbarVisible;
 
 			if (primary) {
 				this.positionItems();

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -27,8 +27,6 @@ const gridListItemSizeShape = PropTypes.shape({
 	minWidth: PropTypes.number.isRequired
 });
 
-const ListContext = React.createContext();
-
 /**
  * The base version of the virtual list component.
  *
@@ -275,6 +273,12 @@ const VirtualListBaseFactory = (type) => {
 				} else {
 					this.setScrollPosition(x, y, 0, 0, nextProps.rtl);
 				}
+			}
+		}
+
+		componentWillUpdate (nextProps, nextState) {
+			if (this.state.firstIndex === nextState.firstIndex || this.props.itemProps && this.props.itemProps !== nextProps.itemProps) {
+				this.prevFirstIndex = -1; // force to re-render items
 			}
 		}
 
@@ -642,26 +646,18 @@ const VirtualListBaseFactory = (type) => {
 			const
 				{itemRenderer, getComponentProps} = this.props,
 				key = index % this.state.numOfItems,
+				itemElement = itemRenderer({
+					...this.props.itemProps,
+					key,
+					index
+				}),
 				componentProps = getComponentProps && getComponentProps(index) || {};
 
-			this.cc[key] = (
-				<ListContext.Consumer key={key}>
-					{(context) => {
-						const itemElement = itemRenderer({
-							...context,
-							index
-						});
-
-						return (
-							React.cloneElement(itemElement, {
-								...componentProps,
-								className: classNames(css.listItem, itemElement.props.className),
-								style: {...itemElement.props.style, ...(this.composeStyle(...rest))}
-							})
-						);
-					}}
-				</ListContext.Consumer>
-			);
+			this.cc[key] = React.cloneElement(itemElement, {
+				...componentProps,
+				className: classNames(css.listItem, itemElement.props.className),
+				style: {...itemElement.props.style, ...(this.composeStyle(...rest))}
+			});
 		}
 
 		applyStyleToHideNode = (index) => {
@@ -675,10 +671,10 @@ const VirtualListBaseFactory = (type) => {
 				{firstIndex, numOfItems} = this.state,
 				{isPrimaryDirectionVertical, dimensionToExtent, primary, secondary, cc} = this,
 				diff = firstIndex - this.prevFirstIndex,
-				updateFrom = (cc.length === 0 || 0 >= diff || diff >= numOfItems) ? firstIndex : this.prevFirstIndex + numOfItems;
+				updateFrom = (cc.length === 0 || 0 >= diff || diff >= numOfItems || this.prevFirstIndex === -1) ? firstIndex : this.prevFirstIndex + numOfItems;
 			let
 				hideTo = 0,
-				updateTo = (cc.length === 0 || -numOfItems >= diff || diff > 0) ? firstIndex + numOfItems : this.prevFirstIndex;
+				updateTo = (cc.length === 0 || -numOfItems >= diff || diff > 0 || this.prevFirstIndex === -1) ? firstIndex + numOfItems : this.prevFirstIndex;
 
 			if (updateFrom >= updateTo) {
 				return;
@@ -781,7 +777,7 @@ const VirtualListBaseFactory = (type) => {
 
 		render () {
 			const
-				{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, itemProps, itemsRenderer, style, ...rest} = this.props,
+				{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, itemsRenderer, style, ...rest} = this.props,
 				{cc, initItemContainerRef, primary} = this,
 				containerClasses = this.mergeClasses(className);
 
@@ -790,6 +786,7 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.dataSize;
 			delete rest.direction;
 			delete rest.getComponentProps;
+			delete rest.itemProps;
 			delete rest.itemRenderer;
 			delete rest.itemSize;
 			delete rest.onUpdate;
@@ -807,9 +804,7 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} ref={this.initContainerRef} style={style}>
 					<div {...rest} ref={this.initContentRef}>
-						<ListContext.Provider value={itemProps}>
-							{itemsRenderer({cc, initItemContainerRef, primary})}
-						</ListContext.Provider>
+						{itemsRenderer({cc, initItemContainerRef, primary})}
 					</div>
 				</div>
 			);

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -29,30 +29,6 @@ const gridListItemSizeShape = PropTypes.shape({
 
 const ListContext = React.createContext();
 
-class ListProvider extends Component {
-	static propTypes = /** @lends ui/VirtualList.ListProvider.prototype */ {
-		/**
-		 * It is the object which is passed to items.
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		itemProps: PropTypes.object
-	}
-
-	static defaultProps = {
-		itemProps: {}
-	}
-
-	render () {
-		return (
-			<ListContext.Provider value={this.props.itemProps}>
-				{this.props.children}
-			</ListContext.Provider>
-		);
-	}
-}
-
 /**
  * The base version of the virtual list component.
  *
@@ -831,9 +807,9 @@ const VirtualListBaseFactory = (type) => {
 			return (
 				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} ref={this.initContainerRef} style={style}>
 					<div {...rest} ref={this.initContentRef}>
-						<ListProvider itemProps={itemProps}>
+						<ListContext.Provider value={itemProps}>
 							{itemsRenderer({cc, initItemContainerRef, primary})}
-						</ListProvider>
+						</ListContext.Provider>
 					</div>
 				</div>
 			);

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -159,10 +159,10 @@ const VirtualListBaseFactory = (type) => {
 			getComponentProps: PropTypes.func,
 
 			/**
-			 * It is the object which is passed to items.
+			 * It is the object which is passed as arguments of `itemsRenderer` prop function.
 			 *
 			 * @type {Object}
-			 * @public
+			 * @private
 			 */
 			itemProps: PropTypes.object,
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is no way to pass custom parameters from app to VirtualList's itemRenderer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Define `childProps` prop in VirtualList and spread it as arguments of the `itemRenderer`.

### Links
[//]: # (Related issues, references)

PLAT-67660

### Comments
