### PR TITLE
ENYO-5708: Transition to support children changing after initial render

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Transition` to support changing children dimensions after an initial render with no children
+
 ## [2.2.4] - 2018-10-29
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Transition` to support changing children dimensions after an initial render with no children
+- `ui/Transition` to better support layout after changing children
 
 ## [2.2.4] - 2018-10-29
 

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -463,7 +463,7 @@ class Transition extends React.Component {
 		if ((visible === prevProps.visible &&
 			initialHeight === prevState.initialHeight &&
 			renderState !== TRANSITION_STATE.INIT) ||
-			(initialHeight == null && visible)) {
+			(!initialHeight && visible)) {
 			this.measureInner();
 		}
 

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -436,8 +436,10 @@ class Transition extends React.Component {
 	}
 
 	componentWillReceiveProps (nextProps) {
-		if (nextProps.visible && this.state.renderState === TRANSITION_STATE.INIT) {
+		if (!this.props.visible && nextProps.visible) {
 			this.setState({
+				initialHeight: null,
+				innerWidth: null,
 				renderState: TRANSITION_STATE.MEASURE
 			});
 		}
@@ -463,7 +465,7 @@ class Transition extends React.Component {
 		if ((visible === prevProps.visible &&
 			initialHeight === prevState.initialHeight &&
 			renderState !== TRANSITION_STATE.INIT) ||
-			(!initialHeight && visible)) {
+			(initialHeight == null && visible)) {
 			this.measureInner();
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`ExpandableList` that initially render with no children, fools the system to think that no measurements are ever necessary, and once children are added, that fact is ignored because it assumes the fact that it measured 0 the first time is still the correct value.


### Resolution
`Transition` now treats `null`, `undefined` and `0` as cases where a measurement should be taken again.