### PR TITLE
ENYO-5703: Fix MoonstoneDecorator to Latin and non-Latin font rules to the root

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/MoonstoneDecorator` to properly globally apply non-Latin rules to the root element. All children inheriting font rules will automatically pick up the expected default font rules for non-Latin.
+- `moonstone/Marquee`, `moonstone/MediaOverlay` to display localed based font
 - `moonstone/DayPicker` separator character used between selected days in the label in fa-IR locale
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrolling by voice commands in RTL locales
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,8 +12,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/MoonstoneDecorator` to properly globally apply non-Latin rules to the root element. All children inheriting font rules will automatically pick up the expected default font rules for non-Latin.
-- `moonstone/Marquee`, `moonstone/MediaOverlay` to display localed based font
+- `moonstone/MoonstoneDecorator` to apply both Latin and non-Latin rules to the root element so all children inherit the correct default font rules.
+- `moonstone/Marquee`, `moonstone/MediaOverlay` to display locale-based font
 - `moonstone/DayPicker` separator character used between selected days in the label in fa-IR locale
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrolling by voice commands in RTL locales
 

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.less
@@ -2,15 +2,15 @@
 //
 
 // Core Rules
-@import '~@enact/ui/styles/core.less';
+@import "~@enact/ui/styles/core.less";
 
 // Moonstone Rules
-@import '../styles/variables.less';
-@import '../styles/text.less';
-@import '../styles/rules.less';
+@import "../styles/variables.less";
+@import "../styles/text.less";
+@import "../styles/rules.less";
 
 .root {
-	.moon-text-base(@moon-sub-header-font-size);
+	.moon-text-base(@moon-sub-header-font-size, self);
 	font-weight: normal;
 	font-style: normal;
 	letter-spacing: normal;

--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -7,7 +7,10 @@
 //
 
 // Text base provides family, weight, and size
-// Accepts 0 or 1 argument
+// Accepts 0, 1 or 2 arguments
+// The first argument allows overriding the font size, defaulting to
+// the default body font size, the 2nd argument is used privately by
+// MoonstoneDecorator to override the target of the rules.
 .moon-text-base(@font-size: @moon-body-font-size; @target: normal) {
 	.moon-font({
 		font-weight: @moon-non-latin-font-weight;

--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -6,13 +6,13 @@
 // Mixin classes for creating the moontone text classes
 //
 
-// Text base provides weight color
+// Text base provides family, weight, and size
 // Accepts 0 or 1 argument
-.moon-text-base(@font-size: @moon-body-font-size) {
+.moon-text-base(@font-size: @moon-body-font-size; @target: normal) {
 	.moon-font({
 		font-weight: @moon-non-latin-font-weight;
 		font-size: @moon-non-latin-sub-header-font-size;
-	});
+	}, @target);
 	font-weight: bold;
 	font-size: @font-size;
 }
@@ -20,26 +20,31 @@
 //
 // Moonstone Font Applicator
 //
-// When only rules are provided.
-.moon-font(@nlrules) when (isruleset(@nlrules)) {
-	.moon-font(@moon-font-family, @moon-non-latin-font-family, @nlrules);
+// When only rules are provided. Default populate the @target argument.
+.moon-font(@nlrules; @target: normal) when (isruleset(@nlrules)) {
+	.moon-font(@moon-font-family, @moon-non-latin-font-family, @nlrules, @target);
 }
-// When 0, 1, or 2 strings (font family names) are provided.
-.moon-font(@family: @moon-font-family; @nlfamily: @moon-non-latin-font-family) when (isstring(@family)) and (isstring(@nlfamily)) {
-	.moon-font(@family; @nlfamily; {})
+// When 0, 1, or 2 strings (font family names) are provided. Default populate the @target argument so the signature stays the same.
+.moon-font(@family: @moon-font-family; @nlfamily: @moon-non-latin-font-family; @target: normal) when (isstring(@family)) and (isstring(@nlfamily)) and (isstring(@target)) {
+	.moon-font(@family, @nlfamily, {}, @target);
 }
-// When exactly 3 args are provided. Types are assumed because they went through the trouble to provide all 3 args.
-.moon-font(@family; @nlfamily; @nlrules) {
+// When exactly 3 or 4 args are provided. Types are assumed because they went through the trouble to provide all 3 required args.
+.moon-font(@family; @nlfamily; @nlrules; @target: normal) {
 	font-family: @family;
 
 	.moon-locale-non-latin({
 		font-family: @nlfamily;
 		@nlrules();
-	});
+	}, @target);
 }
 
 // Generic Non-Latin Font Rule generator
-.moon-locale-non-latin(@nlrules) when (isruleset(@nlrules)) {
+.moon-locale-non-latin(@nlrules; @target) when (isruleset(@nlrules)) and (@target = self) {
+	&:global(.enact-locale-non-latin) {
+		@nlrules();
+	}
+}
+.moon-locale-non-latin(@nlrules; @target: normal) when (isruleset(@nlrules)) {
 	:global(.enact-locale-non-latin) & {
 		@nlrules();
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
MoonstoneDecorator is not receiving any non-latin rules, but it **is** receiving latin rules. This discrepancy causes unexpected behavior in components that inherit rules.


### Resolution
Added a new argument to several mixins which dictate **where** to apply the non-latin set of rules. In this case, MoonstoneDecorator now leverages this by instructing the mixin thusly:
```
.moon-text-base(@moon-sub-header-font-size, self);
```
`self` instructs the mixin collection to apply the non-latin rules to itself rather than expecting that the rules will be on some ancestor.

Several mixins have been updated with this functionality due to the relationships necessary in the affected mixins. A->B->C->D so each A, B, C, and D must have and support the feature. They all work though now, so we get a more complete API as a result.