### PR TITLE
ENYO-5697: Added .moon-font-size mixin

### DIFF
--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -41,6 +41,22 @@
 	}, @target);
 }
 
+// Convenience method added to simply set the font size. Please don't use this inside the framework
+// as it will generate a significant amount of selectors and rules that might not be minified.
+// The framework offers more direct and more efficient means of assigning multiple rules at once.
+// This is primarily a convenience for external app developers.
+// Usage:
+//    0 args -> default size for latin is applied to both latin and non-latin
+//    1 arg  -> that size is applied to both latin and non-latin
+//    2 args -> first is applied to latin, second to non-latin
+.moon-font-size(@font-size: @moon-body-font-size; @nlfont-size: @font-size) {
+	font-size: @font-size;
+
+	.moon-locale-non-latin({
+		font-size: @nlfont-size;
+	});
+}
+
 // Generic Non-Latin Font Rule generator
 .moon-locale-non-latin(@nlrules; @target) when (isruleset(@nlrules)) and (@target = self) {
 	&:global(.enact-locale-non-latin) {


### PR DESCRIPTION
Added for app convenience, not necessarily for framework use.

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Occasionally app developers have a need to set the font size of *their* components, and it's awkward to set both latin and non-latin manually.


### Resolution
Added a mixin to facilitate this need.


### Note
The changelog was intentionally _not_ updated since this is more of a "special request" rather than a new official API feature.