### PR TITLE
ENYO-5720: Storybook: cannot set local languages

### DIFF
--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -99,7 +99,12 @@ const I18nDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unuse
 
 		componentWillReceiveProps (newProps) {
 			if (newProps.locale) {
-				this.updateLocale(newProps.locale);
+				if (newProps.locale === 'local') {
+					ilib.getLocale();
+					this.updateLocale();
+				} else {
+					this.updateLocale(newProps.locale);
+				}
 			}
 		}
 

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -98,13 +98,8 @@ const I18nDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unuse
 		}
 
 		componentWillReceiveProps (newProps) {
-			if (newProps.locale) {
-				if (newProps.locale === 'local') {
-					ilib.getLocale();
-					this.updateLocale();
-				} else {
-					this.updateLocale(newProps.locale);
-				}
+			if (this.props.locale !== newProps.locale) {
+				this.updateLocale(newProps.locale);
 			}
 		}
 

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -156,7 +156,7 @@ const StorybookDecorator = (story, config) => {
 			className={classnames(classes)}
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
-			locale={select('locale', locales, Config, getPropFromURL('locale'))}
+			locale={select('locale', locales, Config, getPropFromURL('locale') || window.navigator.language)}
 			textSize={boolean('large text', Config, (getPropFromURL('large text') === 'true')) ? 'large' : 'normal'}
 			highContrast={boolean('high contrast', Config, (getPropFromURL('high contrast') === 'true'))}
 			style={backgroundLabelMap[select('background', backgroundLabels, Config, getPropFromURL('background'))]}

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -55,7 +55,7 @@ const MoonstoneFullscreen = MoonstoneDecorator({overlay: false}, FullscreenBase)
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
-	'local':                                                'local',
+	'local':                                                '',
 	'en-US - US English':                                   'en-US',
 	'ko-KR - Korean':                                       'ko-KR',
 	'es-ES - Spanish, with alternate weekends':             'es-ES',
@@ -125,7 +125,7 @@ const StorybookDecorator = (story, config) => {
 	const sample = story();
 	const Config = {
 		defaultProps: {
-			locale: 'en-US',
+			locale: '',
 			'large text': false,
 			'high contrast': false,
 			skin: 'dark'

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -55,7 +55,7 @@ const MoonstoneFullscreen = MoonstoneDecorator({overlay: false}, FullscreenBase)
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
-	'local':                                                '',
+	'local':                                                'local',
 	'en-US - US English':                                   'en-US',
 	'ko-KR - Korean':                                       'ko-KR',
 	'es-ES - Spanish, with alternate weekends':             'es-ES',
@@ -156,7 +156,7 @@ const StorybookDecorator = (story, config) => {
 			className={classnames(classes)}
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
-			locale={select('locale', locales, Config, getPropFromURL('locale') || window.navigator.language)}
+			locale={select('locale', locales, Config, getPropFromURL('locale'))}
 			textSize={boolean('large text', Config, (getPropFromURL('large text') === 'true')) ? 'large' : 'normal'}
 			highContrast={boolean('high contrast', Config, (getPropFromURL('high contrast') === 'true'))}
 			style={backgroundLabelMap[select('background', backgroundLabels, Config, getPropFromURL('background'))]}


### PR DESCRIPTION
Fixed MoonstoneEnvironment.js to use window locale when selected local language.

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We should check on TV that all the text inside Enact framework has been translated. The QE team uses Enact Sampler to check the strings of the input component.
However, after they change the language, they can not see the translated string in the Enact sampler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When `local` is selected, Enact sampler passes locale value to MoonstoneDecorator/I18nDecorator as empty string `''`.But, string is not updated to current locale language.
So, I fixed some codes to use `window.navigator.language` when locale value is `''`.


### Links
[//]: # (Related issues, references)
ENYO-5720
