### PR TITLE
ENYO-5721: Fix VideoPlayer to disable pointer mode when hiding media controls

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` to disable pointer mode when hiding media controls via 5-way
+
 ## [2.2.5] - 2018-11-05
 
 ### Fixed

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1682,6 +1682,7 @@ const VideoPlayerBase = class extends React.Component {
 				this.activityDetected();
 			}
 		} else if (is('up', keyCode)) {
+			Spotlight.setPointerMode(false);
 			preventDefault(ev);
 			stopImmediate(ev);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`focusElement` call return `false` because of pointer mode.
The reason the pointer mode is false, `preventDefault` and `stopImmediate` is called in `handleSliderKeyDown` handler

### Resolution
call `Spotlight.setPointerMode(false)`


### Additional Considerations


### Links

### Comments
