### PR TITLE
ENYO-5718: Add line-height rule for non-latin fonts

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Fixed
+
+- `moonstone` non-latin fonts to display in correct line-height
+
 ### Added
 
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` property `childProps` to support additional props included in the object passed to the `itemsRenderer` callback

--- a/packages/moonstone/styles/text.less
+++ b/packages/moonstone/styles/text.less
@@ -15,6 +15,7 @@
 	.moon-font({
 		font-weight: @moon-non-latin-font-weight;
 		font-size: @moon-non-latin-sub-header-font-size;
+		line-height: @moon-non-latin-line-height;
 	}, @target);
 	font-weight: bold;
 	font-size: @font-size;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -67,6 +67,7 @@
 @moon-non-latin-font-weight-bold: 500;
 @moon-non-latin-font-weight-light: 300;
 @moon-non-latin-body-font-weight: @moon-non-latin-font-weight-light;
+@moon-non-latin-line-height: 1.5em;
 
 @moon-header-font-family: @moon-alt-font-family;
 @moon-header-font-weight: normal;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
LG Display font, which is used for non-latin characters, has a line-height value of `1` which truncates tall glyphs in unstyled components. (e.g. `Marquee`, `<div>`, etc.)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add line-height rule for non-latin fonts. The value is set to `1.5 em` to accommodate the tall glyphs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This problem may have been hidden all along until we made a change in #2007 to use correct rules for the non-latin locale. 

CAUTION: IT may cause a **layout change** and thorough tests are required for the existing apps.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
