### PR TITLE
ENYO-5710: Fix Scroller to better handle scrolling due to focus

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to disable pointer mode when hiding media controls via 5-way
 - `moonstone/VirtualList` and `moonstone/Scroller` to not to animate with 5-way navigation by default
 
+### Fixerd
+
+- `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
+
 ## [2.2.5] - 2018-11-05
 
 ### Fixed

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -16,19 +16,18 @@
  * @exports ScrollerBase
  */
 
+import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
+import {Spotlight} from '@enact/spotlight';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {Spotlight} from '@enact/spotlight';
 
-import ri from '@enact/ui/resolution';
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
 
 const
 	dataContainerDisabledAttribute = 'data-spotlight-container-disabled',
-	epsilon = 1,
 	reverseDirections = {
 		left: 'right',
 		right: 'left'
@@ -152,98 +151,69 @@ class ScrollerBase extends Component {
 	 * @returns {Number} Calculated `scrollTop`
 	 * @private
 	 */
-	calculateScrollTop = (focusedItem, itemTop, itemHeight, scrollInfo, scrollPosition) => {
-		const
-			heightThreshold = ri.scale(24),
-			{clientHeight, scrollHeight} = this.uiRef.scrollBounds,
-			{top: containerTop} = this.uiRef.containerRef.getBoundingClientRect(),
-			currentScrollTop = (scrollPosition ? scrollPosition : this.uiRef.scrollPos.top),
-			// calculation based on client position
-			newItemTop = this.uiRef.containerRef.scrollTop + (itemTop - containerTop),
-			itemBottom = newItemTop + itemHeight,
-			scrollBottom = clientHeight + currentScrollTop;
-		let
-			newScrollTop = this.uiRef.scrollPos.top,
-			scrollHeightChange = 0;
+	calculateScrollTop = (item) => {
+		const roundToBoundary = (sb, st, sh) => {
+			const threshold = ri.scale(24);
 
-		// Calculations for when scrollHeight decrease.
-		if (scrollInfo) {
-			const
-				{scrollTop, previousScrollHeight} = scrollInfo;
+			// round to start
+			if (st < threshold) return 0;
 
-			scrollHeightChange = previousScrollHeight - scrollHeight;
-			if (scrollHeightChange > 0) {
-				newScrollTop = scrollTop;
+			// round to end
+			if (sh - (st + sb.height) < threshold) return sh - sb.height;
 
-				const
-					itemBounds = focusedItem.getBoundingClientRect(),
-					newItemBottom = newScrollTop + itemBounds.top + itemBounds.height - containerTop;
-
-				if (newItemBottom < scrollBottom && scrollHeightChange + newItemBottom > scrollBottom) {
-					// When `focusedItem` is not at the very bottom of the `Scroller` and
-					// `scrollHeightChange` caused a scroll.
-					const
-						distanceFromBottom = scrollBottom - newItemBottom,
-						bottomOffset = scrollHeightChange - distanceFromBottom;
-					if (bottomOffset < newScrollTop) {
-						// guard against negative `scrollTop`
-						newScrollTop -= bottomOffset;
-					}
-				} else if (newItemBottom === scrollBottom) {
-					// when `focusedItem` is at the very bottom of the `Scroller`
-					if (scrollHeightChange < newScrollTop) {
-						// guard against negative `scrollTop`
-						newScrollTop -= scrollHeightChange;
-					}
-				}
+			return st;
+		};
+		const isItemBeforeView = (ib, sb, d) => ib.top + d < sb.top;
+		const isItemAfterView = (ib, sb, d) => ib.top + d + ib.height > sb.top + sb.height;
+		const canItemFit = (ib, sb) => ib.height <= sb.height;
+		const calcItemAtStart = (ib, sb, st, d) => ib.top + st + d - sb.top;
+		const calcItemAtEnd = (ib, sb, st, d) => ib.top + ib.height + st + d - (sb.top + sb.height);
+		const calcItemInView = (ib, sb, st, sh, d) => {
+			if (isItemBeforeView(ib, sb, d)) {
+				return roundToBoundary(sb, calcItemAtStart(ib, sb, st, d), sh, d);
+			} else if (isItemAfterView(ib, sb, d)) {
+				return roundToBoundary(sb, calcItemAtEnd(ib, sb, st, d), sh, d);
 			}
+
+			return st;
+		};
+
+		const container = this.getSpotlightContainerForNode(item);
+		const scrollerBounds = this.uiRef.containerRef.getBoundingClientRect();
+		let {scrollHeight, scrollTop} = this.uiRef.containerRef;
+		let scrollTopDelta = 0;
+
+		const adjustScrollTop = (v) => {
+			scrollTopDelta = scrollTop - v;
+			scrollTop = v;
+		};
+
+		if (container) {
+			const containerBounds = container.getBoundingClientRect();
+
+			// if the entire container fits in the scroller, scroll it into view
+			if (canItemFit(containerBounds, scrollerBounds)) {
+				return calcItemInView(containerBounds, scrollerBounds, scrollTop, scrollHeight, scrollTopDelta);
+			}
+
+			// if the container doesn't fit, adjust the scroll top ...
+			if (containerBounds.top > scrollerBounds.top) {
+				// ... to the top of the container if the top is below the top of the scroller
+				adjustScrollTop(calcItemAtStart(containerBounds, scrollerBounds, scrollTop, scrollTopDelta));
+			} else if (containerBounds.top + containerBounds.height < scrollerBounds.top + scrollerBounds.height) {
+				// ... to the bottom of the container if the bottom is above the bottom of the
+				// scroller
+				adjustScrollTop(calcItemAtEnd(containerBounds, scrollerBounds, scrollTop, scrollTopDelta));
+			}
+
+			// N.B. if the container covers the scrollable area (its top is above the top of the
+			// scroller and its bottom is below the bottom of the scroller), we need not adjust the
+			// scroller to ensure the container is wholly in view.
 		}
 
-		if (itemHeight > clientHeight) {
-			// Calculations for `containerHeight` that are bigger than `clientHeight`
-			const
-				{top, height: nestedItemHeight} = focusedItem.getBoundingClientRect(),
-				nestedItemTop = this.uiRef.containerRef.scrollTop + (top - containerTop),
-				nestedItemBottom = nestedItemTop + nestedItemHeight;
+		const itemBounds = item.getBoundingClientRect();
 
-			if (nestedItemBottom - scrollBottom > epsilon) {
-				// Calculate when 5-way focus down past the bottom.
-				newScrollTop += nestedItemBottom - scrollBottom;
-			} else if (nestedItemTop - currentScrollTop < epsilon) {
-				// Calculate when 5-way focus up past the top.
-				if (newItemTop > newScrollTop) {
-					// Ensure that the adjusted scrollTop would at least scroll the container to the top of
-					// the viewport (e.g. because the container is at the bottom of the scroller and the
-					// nested item is at the top of the container)
-					newScrollTop = newItemTop;
-				} else {
-					newScrollTop += nestedItemTop - currentScrollTop;
-				}
-			} else if (newItemTop - nestedItemHeight - currentScrollTop > epsilon) {
-				// set scroll position so that the top of the container is at least on the top as a fallback.
-				newScrollTop = newItemTop - nestedItemHeight;
-			}
-		} else if (itemBottom - scrollBottom > epsilon) {
-			// Calculate when 5-way focus down past the bottom.
-
-			// if the last item is focused and have an invisible area, scroll all the way to the bottom
-			if (scrollHeight - itemBottom < heightThreshold) {
-				newScrollTop += scrollHeight - scrollBottom;
-			} else {
-				newScrollTop += itemBottom - scrollBottom;
-			}
-		} else if (newItemTop - currentScrollTop < epsilon && scrollHeightChange <= 0) {
-			// Calculate when 5-way focus up past the top.
-
-			// if the first item is focused and have an invisible area, scroll all the way to the top
-			if (newItemTop < heightThreshold) {
-				newScrollTop = 0;
-			} else {
-				newScrollTop += newItemTop - currentScrollTop;
-			}
-		}
-
-		return newScrollTop;
+		return calcItemInView(itemBounds, scrollerBounds, scrollTop, scrollHeight, scrollTopDelta);
 	}
 
 	/**
@@ -262,16 +232,14 @@ class ScrollerBase extends Component {
 			return;
 		}
 
-		const {
-			top: itemTop,
-			left: itemLeft,
-			height: itemHeight,
-			width: itemWidth
-		} = this.getFocusedItemBounds(item);
-
 		if (this.uiRef.isVertical()) {
-			this.uiRef.scrollPos.top = this.calculateScrollTop(item, itemTop, itemHeight, scrollInfo, scrollPosition);
+			this.uiRef.scrollPos.top = this.calculateScrollTop(item, scrollInfo, scrollPosition);
 		} else if (this.uiRef.isHorizontal()) {
+			const {
+				left: itemLeft,
+				width: itemWidth
+			} = this.getFocusedItemBounds(item);
+
 			const
 				{rtl} = this.props,
 				{clientWidth} = this.uiRef.scrollBounds,

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -200,11 +200,13 @@ class ScrollerBase extends Component {
 			if (containerBounds.top > scrollerBounds.top) {
 				// ... to the top of the container if the top is below the top of the scroller
 				adjustScrollTop(calcItemAtStart(containerBounds, scrollerBounds, scrollTop, scrollTopDelta));
-			} else if (containerBounds.top + containerBounds.height < scrollerBounds.top + scrollerBounds.height) {
-				// ... to the bottom of the container if the bottom is above the bottom of the
-				// scroller
-				adjustScrollTop(calcItemAtEnd(containerBounds, scrollerBounds, scrollTop, scrollTopDelta));
 			}
+			// removing support for "snap to bottom" for 2.2.8
+			// } else if (containerBounds.top + containerBounds.height < scrollerBounds.top + scrollerBounds.height) {
+			// 	// ... to the bottom of the container if the bottom is above the bottom of the
+			// 	// scroller
+			// 	adjustScrollTop(calcItemAtEnd(containerBounds, scrollerBounds, scrollTop, scrollTopDelta));
+			// }
 
 			// N.B. if the container covers the scrollable area (its top is above the top of the
 			// scroller and its bottom is below the bottom of the scroller), we need not adjust the

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -227,13 +227,13 @@ class ScrollerBase extends Component {
 	 * @returns {Object} with keys {top, left} containing calculated top and left positions for scroll.
 	 * @private
 	 */
-	calculatePositionOnFocus = ({item, scrollInfo, scrollPosition}) => {
+	calculatePositionOnFocus = ({item, scrollPosition}) => {
 		if (!this.uiRef.isVertical() && !this.uiRef.isHorizontal() || !item || !this.uiRef.containerRef.contains(item)) {
 			return;
 		}
 
 		if (this.uiRef.isVertical()) {
-			this.uiRef.scrollPos.top = this.calculateScrollTop(item, scrollInfo, scrollPosition);
+			this.uiRef.scrollPos.top = this.calculateScrollTop(item);
 		} else if (this.uiRef.isHorizontal()) {
 			const {
 				left: itemLeft,

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -118,7 +118,7 @@ class ScrollerBase extends Component {
 	 */
 	getSpotlightContainerForNode = (node) => {
 		do {
-			if (node.dataset.spotlightId && node.dataset.spotlightContainer) {
+			if (node.dataset.spotlightId && node.dataset.spotlightContainer && !node.dataset.expandableContainer) {
 				return node;
 			}
 		} while ((node = node.parentNode) && node !== this.uiRef.containerRef);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changing the size of a container within a Scroller causing some unpredictable scrolling behavior.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The logic for scrolling on focus had become overly complex due to changing requirements over time. I've restated the requirements and reimplemented the method in light of those requirements.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
My goal for this PR was to standardize behaviors so there may be scenarios that behave differently than before. If we decide on specific deviations to the current behavior, we can add those here as well.