### PR TITLE
ENYO-5720: Use device locale as default in sampler

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/I18nDecorator` to allow changing the locale to a falsey value to use the device locale
+
 ## [2.2.5] - 2018-11-05
 
 No significant changes.

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -98,7 +98,7 @@ const I18nDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unuse
 		}
 
 		componentWillReceiveProps (newProps) {
-			if (newProps.locale) {
+			if (this.props.locale !== newProps.locale) {
 				this.updateLocale(newProps.locale);
 			}
 		}

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- Sampler to allow selecting the device locale
+
 ## [2.2.5] - 2018-11-05
 
 No significant changes.

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {Panels, Panel, Header} from '@enact/moonstone/Panels';
 import {boolean, select} from '../enact-knobs';
+import {selectV2} from '@storybook/addon-knobs';
 
 import css from './MoonstoneEnvironment.less';
 
@@ -56,7 +57,7 @@ const MoonstoneFullscreen = MoonstoneDecorator({overlay: false}, FullscreenBase)
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
 	'local':                                                '',
-	'en-US - US English':                                   'en-US',
+	'en-US - US English (Default)':                         'en-US',
 	'ko-KR - Korean':                                       'ko-KR',
 	'es-ES - Spanish, with alternate weekends':             'es-ES',
 	'am-ET - Amharic, 6 meridiems':                         'am-ET',
@@ -125,7 +126,7 @@ const StorybookDecorator = (story, config) => {
 	const sample = story();
 	const Config = {
 		defaultProps: {
-			locale: '',
+			locale: 'en-US',
 			'large text': false,
 			'high contrast': false,
 			skin: 'dark'
@@ -156,7 +157,7 @@ const StorybookDecorator = (story, config) => {
 			className={classnames(classes)}
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
-			locale={select('locale', locales, Config, getPropFromURL('locale'))}
+			locale={selectV2('locale', locales, 'en-US', globalGroup)}
 			textSize={boolean('large text', Config, (getPropFromURL('large text') === 'true')) ? 'large' : 'normal'}
 			highContrast={boolean('high contrast', Config, (getPropFromURL('high contrast') === 'true'))}
 			style={backgroundLabelMap[select('background', backgroundLabels, Config, getPropFromURL('background'))]}
@@ -173,7 +174,7 @@ const FullscreenStorybookDecorator = (story, config) => {
 		<MoonstoneFullscreen
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
-			locale={select('locale', locales, getPropFromURL('locale', 'en-US'))}
+			locale={selectV2('locale', locales, 'en-US', globalGroup)}
 			textSize={boolean('large text', (getPropFromURL('large text') === 'true')) ? 'large' : 'normal'}
 			highContrast={boolean('high contrast', (getPropFromURL('high contrast') === 'true'))}
 			style={backgroundLabelMap[select('background', backgroundLabels, getPropFromURL('background'))]}

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -125,7 +125,7 @@ const StorybookDecorator = (story, config) => {
 	const sample = story();
 	const Config = {
 		defaultProps: {
-			locale: 'en-US',
+			locale: '',
 			'large text': false,
 			'high contrast': false,
 			skin: 'dark'


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unable to use device language in sampler. Selecting the `'local'` value of `''` resulted in the custom knobs reverting to the default value of `'en-US'`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Update sampler to use the local language as the default to avoid the knob overriding with a non-falsey default
* Update I18nDecorator to allow a prop change of `locale` to a falsey value triggering the existing logic in `updateLocale` to use the device language