### PR TITLE
ENYO-5724: Fix marquee is not animating

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to calculate distance precisely
+
 ## [2.2.5] - 2018-11-05
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -477,7 +477,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{Number}			Distance to travel in pixels
 		 */
 		calculateDistance (node) {
-			const distance = Math.ceil(node.scrollWidth - node.clientWidth);
+			const distance = Math.ceil(node.scrollWidth - node.getBoundingClientRect().width);
 			return distance;
 		}
 


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix marquee is not animating if component has floating number width and scrolling width is same with ceiled width

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `node.getBoundingClientRect().width` instead of `node.clientWidth` since `node.clientWidth` doesn't support float number

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I'm not sure about `node.scrollWidth`

### Links
[//]: # (Related issues, references)
https://bugs.chromium.org/p/chromium/issues/detail?id=360889
ENYO-5724

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com