### PR TITLE
ENYO-5725: Fix VideoPlayer to blur slider when hiding media controls

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/VideoPlayer` to blur slider when hiding media controls
 - `moonstone/VideoPlayer` to disable pointer mode when hiding media controls via 5-way
 - `moonstone/VirtualList` and `moonstone/Scroller` to not to animate with 5-way navigation by default
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -631,7 +631,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.selectPlaybackRates('fastForward');
 		this.sliderKnobProportion = 0;
 		this.mediaControlsSpotlightId = props.spotlightId + '_mediaControls';
-		this.mediaSliderSpotlightId = this.mediaSliderSpotlightId + '_mediaSlider';
 		this.moreButtonSpotlightId = this.mediaControlsSpotlightId + '_moreButton';
 
 		this.initI18n();
@@ -722,7 +721,6 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (this.props.spotlightId !== prevProps.spotlightId) {
 			this.mediaControlsSpotlightId = this.props.spotlightId + '_mediaControls';
-			this.mediaSliderSpotlightId = this.mediaSliderSpotlightId + '_mediaSlider';
 			this.moreButtonSpotlightId = this.mediaControlsSpotlightId + '_moreButton';
 		}
 
@@ -731,13 +729,11 @@ const VideoPlayerBase = class extends React.Component {
 			this.stopAutoCloseTimeout();
 
 			if (!this.props.spotlightDisabled) {
-				// If last focused item were in a user specified components (e.g. leftComponents,
-				// rightComponents, children, etc.), we need to explicitly blur the element when
-				// MediaControls hide. See ENYO-5454
+				// If last focused item were in the media controls or slider, we need to explicitly
+				// blur the element when MediaControls hide. See ENYO-5648
 				const current = Spotlight.getCurrent();
-				const mediaControls = document.querySelector(`[data-spotlight-id="${this.mediaControlsSpotlightId}"]`);
-				const mediaSlider = document.querySelector(`[data-spotlight-id="${this.mediaSliderSpotlightId}"]`);
-				if (current && (mediaSlider && mediaSlider.contains(current) || mediaControls && mediaControls.contains(current))) {
+				const bottomControls = document.querySelector(`.${css.bottom}`);
+				if (current && bottomControls && bottomControls.contains(current)) {
 					current.blur();
 				}
 
@@ -1897,7 +1893,6 @@ const VideoPlayerBase = class extends React.Component {
 								onSpotlightUp={this.handleSpotlightUpFromSlider}
 								selection={proportionSelection}
 								spotlightDisabled={spotlightDisabled || !this.state.mediaControlsVisible}
-								spotlightId={this.mediaSliderSpotlightId}
 								value={this.state.proportionPlayed}
 								visible={this.state.mediaSliderVisible}
 							>

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -631,6 +631,7 @@ const VideoPlayerBase = class extends React.Component {
 		this.selectPlaybackRates('fastForward');
 		this.sliderKnobProportion = 0;
 		this.mediaControlsSpotlightId = props.spotlightId + '_mediaControls';
+		this.mediaSliderSpotlightId = this.mediaSliderSpotlightId + '_mediaSlider';
 		this.moreButtonSpotlightId = this.mediaControlsSpotlightId + '_moreButton';
 
 		this.initI18n();
@@ -721,6 +722,7 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (this.props.spotlightId !== prevProps.spotlightId) {
 			this.mediaControlsSpotlightId = this.props.spotlightId + '_mediaControls';
+			this.mediaSliderSpotlightId = this.mediaSliderSpotlightId + '_mediaSlider';
 			this.moreButtonSpotlightId = this.mediaControlsSpotlightId + '_moreButton';
 		}
 
@@ -734,7 +736,8 @@ const VideoPlayerBase = class extends React.Component {
 				// MediaControls hide. See ENYO-5454
 				const current = Spotlight.getCurrent();
 				const mediaControls = document.querySelector(`[data-spotlight-id="${this.mediaControlsSpotlightId}"]`);
-				if (current && mediaControls && mediaControls.contains(current)) {
+				const mediaSlider = document.querySelector(`[data-spotlight-id="${this.mediaSliderSpotlightId}"]`);
+				if (current && (mediaSlider && mediaSlider.contains(current) || mediaControls && mediaControls.contains(current))) {
 					current.blur();
 				}
 
@@ -1894,6 +1897,7 @@ const VideoPlayerBase = class extends React.Component {
 								onSpotlightUp={this.handleSpotlightUpFromSlider}
 								selection={proportionSelection}
 								spotlightDisabled={spotlightDisabled || !this.state.mediaControlsVisible}
+								spotlightId={this.mediaSliderSpotlightId}
 								value={this.state.proportionPlayed}
 								visible={this.state.mediaSliderVisible}
 							>

--- a/packages/sampler/stories/default/VideoPlayer.js
+++ b/packages/sampler/stories/default/VideoPlayer.js
@@ -158,7 +158,7 @@ storiesOf('Moonstone', module)
 							playPauseButtonDisabled={boolean('playPauseButtonDisabled', MediaControlsConfig)}
 							rateButtonsDisabled={boolean('rateButtonsDisabled', MediaControlsConfig)}
 						>
-							<leftComponents><IconButton backgroundOpacity="translucent" onClick={() => alert('!!')}>fullscreen</IconButton></leftComponents>
+							<leftComponents><IconButton backgroundOpacity="translucent">fullscreen</IconButton></leftComponents>
 							<rightComponents><IconButton backgroundOpacity="translucent">flag</IconButton></rightComponents>
 							<Button backgroundOpacity="translucent">Add To Favorites</Button>
 							<IconButton backgroundOpacity="translucent">star</IconButton>

--- a/packages/sampler/stories/default/VideoPlayer.js
+++ b/packages/sampler/stories/default/VideoPlayer.js
@@ -158,7 +158,7 @@ storiesOf('Moonstone', module)
 							playPauseButtonDisabled={boolean('playPauseButtonDisabled', MediaControlsConfig)}
 							rateButtonsDisabled={boolean('rateButtonsDisabled', MediaControlsConfig)}
 						>
-							<leftComponents><IconButton backgroundOpacity="translucent">fullscreen</IconButton></leftComponents>
+							<leftComponents><IconButton backgroundOpacity="translucent" onClick={() => alert('!!')}>fullscreen</IconButton></leftComponents>
 							<rightComponents><IconButton backgroundOpacity="translucent">flag</IconButton></rightComponents>
 							<Button backgroundOpacity="translucent">Add To Favorites</Button>
 							<IconButton backgroundOpacity="translucent">star</IconButton>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
If `mediaControls` disappear when `mediaSlider` has focus and pointer mode is `true`,
focus stays in `mediaSlider`.

### Resolution
Blur focus when hiding `mediaControls`

### Additional Considerations


### Links
Related issues : https://github.com/enactjs/enact/pull/1952


### Comments
