### PR TITLE
ENYO-5724: Fix marquee handling of very small marquees

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to handle very small marquees better
+
 ## [2.2.5] - 2018-11-05
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -171,7 +171,7 @@ const MarqueeBase = kind({
 				textOverflow: overflow
 			};
 
-			if (animating) {
+			if (animating && distance > 1) {
 				const duration = distance / speed;
 
 				style[sideProperty] = `${distance}px`;

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -477,7 +477,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{Number}			Distance to travel in pixels
 		 */
 		calculateDistance (node) {
-			const distance = Math.ceil(node.scrollWidth - node.clientWidth);
+			const rect = node.getBoundingClientRect();
+			const distance = Math.abs(node.scrollWidth - rect.width);
 			return distance;
 		}
 

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -186,9 +186,18 @@ describe('MarqueeBase', () => {
 		expect(actual).to.not.have.property('transition');
 	});
 
-	it('should transition when animating is true', function () {
+	it('should not transition when animating is true and distance is less than or equal to 1', function () {
 		const subject = shallow(
-			<MarqueeBase animating />
+			<MarqueeBase animating distance={1} />
+		);
+
+		const actual = subject.childAt(0).prop('style');
+		expect(actual).to.not.have.property('transitionDuration');
+	});
+
+	it('should transition when animating is true and distance is greater than 1', function () {
+		const subject = shallow(
+			<MarqueeBase animating distance={1.1} />
 		);
 
 		const actual = subject.childAt(0).prop('style');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It's possible to have a Marquee instance where the natural width of the text is larger than the allowed width but both round to the same value. As a result, the browser determines it should display an ellipsis for `text-overflow` but `ui/Marquee` believes the distance to be zero (due to rounding of `clientWidth` and `scrollWidth`).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Update `ui/Marquee.MarqueeDecorator` to use `getBoundingClientRect()` to retrieve the sub-pixel measurements
* Update `ui/Marquee.MarqueeBase` to only animate when the distance is greater than 1px

The cumulative result is that the text will still appear with an ellipsis but will then be displayed fully when marquee is triggered even though no animation occurs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I was unable to find a way to definitively determine if the ellipsis should be suppressed altogether so this is a compromise.
