### PR TITLE
ENYO-5731: Fix marquee shaking issue

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to not to marquee when its width is not an integer number
+
 ## [2.2.6] - 2018-11-15
 
 ### Fixed

--- a/packages/ui/Marquee/Marquee.less
+++ b/packages/ui/Marquee/Marquee.less
@@ -19,7 +19,8 @@
 		pointer-events: none;
 		text-overflow: ellipsis;
 		overflow: hidden;
-		width: 100%;
+		width: fit-content;
+		max-width: 100%;
 		white-space: pre !important;
 		transition-property: left, right;
 		transition-timing-function: linear;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Marquee always starts animation although content is shorter than its width in case of it has non-integer number width.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Don't fill available space when text is not that long to make `scrollWidth` trustful.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5731

### Comments
Enact-DCO-1.0-Signed-off-by: Yeram Choi yeram.choi@lge.com