### PR TITLE
ENYO-5731: Fix Marquee to avoid very small animations

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to avoid very small animations
+
 ## [2.2.6] - 2018-11-15
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -332,13 +332,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		shouldComponentUpdate (nextProps, nextState) {
-			const {overflow, ...rest} = this.state;
-			const {overflow: nextOverflow, ...nextRest} = nextState;
-
 			return (
-				!shallowEqual(rest, nextRest) ||
-				!shallowEqual(this.props, nextProps) ||
-				(overflow !== 'ellipsis' && nextOverflow !== 'clip')
+				!shallowEqual(this.state, nextState) ||
+				!shallowEqual(this.props, nextProps)
 			);
 		}
 
@@ -462,11 +458,10 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.distance = this.calculateDistance(node);
 				this.contentFits = !this.shouldAnimate(this.distance);
 
-				// TODO: Replace with functional setState with React 16
 				const overflow = this.calculateTextOverflow(this.distance);
-				if (!(this.contentFits && overflow === 'clip' && this.state.overflow === 'ellipsis')) {
-					this.setState({overflow});
-				}
+				this.setState(state => {
+					return state.overflow === overflow ? null : {overflow};
+				});
 			}
 		}
 
@@ -495,7 +490,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{String}				text-overflow value
 		 */
 		calculateTextOverflow (distance) {
-			return distance === 0 ? 'clip' : 'ellipsis';
+			return distance < 1 ? 'clip' : 'ellipsis';
 		}
 
 		/*
@@ -505,7 +500,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{Boolean}				`true` if it should animated
 		 */
 		shouldAnimate (distance) {
-			return distance > 0;
+			return distance >= 1;
 		}
 
 		/*


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The change in #2019 introduced a regression that would allow text that fits in its container to marquee if the subpixel size of the text container were smaller than the rounded `scrollWidth`.

This should resolve both the issues from ENYO-5731 and ENYO-5724:
1. text that is long enough to cause an ellipsis but not enough to cause marquee (the text length using `getBoundingClientRect()` is a subpixel value [e.g. `165.5px`] and would round up) causing it to never fully be visible to the user
2. text that fits in its container but its size is a subpixel value that would round up (e.g. `165.5px`) causing it to marquee just a little

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add a 1px threshold before triggering animation
* Update state logic to ensure `overflow: clip` is applied after measuring and determining that animation isn't required.
