### PR TITLE
ENYO-5726: Reduced onScrollStart and onScrollStop calls on key down

### DIFF
--- a/packages/moonstone/VirtualList/tests/VirtualList-specs.js
+++ b/packages/moonstone/VirtualList/tests/VirtualList-specs.js
@@ -40,10 +40,13 @@ describe('VirtualList', () => {
 		handlerOnScrollStart = () => {
 			onScrollStartCount++;
 		};
-		handlerOnScrollStop = (e) => {
+		handlerOnScrollStop = (done, testCase) => (e) => {
 			onScrollStopCount++;
 			resultScrollLeft = e.scrollLeft;
 			resultScrollTop = e.scrollTop;
+
+			testCase();
+			done();
 		};
 		renderItem = ({index, ...rest}) => { // eslint-disable-line enact/display-name, enact/prop-types
 			return (
@@ -125,7 +128,14 @@ describe('VirtualList', () => {
 	});
 
 	describe('ScrollTo', () => {
-		it('should scroll to the specific item of a given index with scrollTo', () => {
+		it('should scroll to the specific item of a given index with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 300;
+				const actual = resultScrollTop;
+
+				expect(actual).to.equal(expected);
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -133,19 +143,21 @@ describe('VirtualList', () => {
 					dataSize={dataSize}
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({index: 10, animate: false});
-
-			const expected = 300;
-			const actual = resultScrollTop;
-
-			expect(actual).to.equal(expected);
 		});
 
-		it('should scroll to the given \'x\' position with scrollTo', () => {
+		it('should scroll to the given \'x\' position with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 100;
+				const actual = resultScrollLeft;
+
+				expect(actual).to.equal(expected);
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -154,19 +166,21 @@ describe('VirtualList', () => {
 					direction="horizontal"
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({position: {x: 100}, animate: false});
-
-			const expected = 100;
-			const actual = resultScrollLeft;
-
-			expect(actual).to.equal(expected);
 		});
 
-		it('should scroll to the given \'y\' position with scrollTo', () => {
+		it('should scroll to the given \'y\' position with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 100;
+				const actual = resultScrollTop;
+
+				expect(actual).to.equal(expected);
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -174,16 +188,11 @@ describe('VirtualList', () => {
 					dataSize={dataSize}
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({position: {y: 100}, animate: false});
-
-			const expected = 100;
-			const actual = resultScrollTop;
-
-			expect(actual).to.equal(expected);
 		});
 
 		describe('scroll events', () => {
@@ -227,7 +236,14 @@ describe('VirtualList', () => {
 				expect(actual).to.equal(expected);
 			});
 
-			it('should call onScrollStop once', () => {
+			it('should call onScrollStop once', (done) => {
+				const onScrollStop = handlerOnScrollStop(done, () => {
+					const expected = 1;
+					const actual = onScrollStopCount;
+
+					expect(actual).to.equal(expected);
+				});
+
 				mount(
 					<VirtualList
 						cbScrollTo={getScrollTo}
@@ -235,16 +251,11 @@ describe('VirtualList', () => {
 						dataSize={dataSize}
 						itemRenderer={renderItem}
 						itemSize={30}
-						onScrollStop={handlerOnScrollStop}
+						onScrollStop={onScrollStop}
 					/>
 				);
 
 				myScrollTo({position: {y: 100}, animate: false});
-
-				const expected = 1;
-				const actual = onScrollStopCount;
-
-				expect(actual).to.equal(expected);
 			});
 		});
 	});

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,8 +4,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
-### Changed
-- `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` components not to call `onScrollStop` too frequently during scroll
+### Fixed
+- `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` to debounce `onScrollStop` events for non-animated scrolls
 
 ## [2.2.7] - 2018-11-21
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+- `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` components not to call `onScrollStop` too frequently during scroll
+
 ## [2.2.7] - 2018-11-21
 
 ### Fixed

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1026,9 +1026,7 @@ class ScrollableBase extends Component {
 		}
 
 		this.childRef.setScrollPosition(this.scrollLeft, this.scrollTop, dirX, dirY);
-		if (this.scrolling) {
-			this.forwardScrollEvent('onScroll');
-		}
+		this.forwardScrollEvent('onScroll');
 	}
 
 	stop () {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -944,7 +944,7 @@ class ScrollableBase extends Component {
 			this.scrolling = true;
 			this.forwardScrollEvent('onScrollStart');
 		}
-		this.scrollStopJob.start();
+		this.scrollStopJob.stop();
 
 		if (Math.abs(maxLeft - targetX) < epsilon) {
 			targetX = maxLeft;
@@ -1028,7 +1028,6 @@ class ScrollableBase extends Component {
 		this.childRef.setScrollPosition(this.scrollLeft, this.scrollTop, dirX, dirY);
 		if (this.scrolling) {
 			this.forwardScrollEvent('onScroll');
-			this.scrollStopJob.start();
 		}
 	}
 
@@ -1042,6 +1041,9 @@ class ScrollableBase extends Component {
 		}
 		if (this.props.stop) {
 			this.props.stop();
+		}
+		if (this.scrolling) {
+			this.scrollStopJob.start();
 		}
 	}
 

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -39,7 +39,6 @@ describe('VirtualList', () => {
 		};
 		handlerOnScrollStop = (done, testCase) => (e) => {
 			onScrollStopCount++;
-			resultScrollLeft = e.scrollLeft;
 			resultScrollTop = e.scrollTop;
 
 			testCase();
@@ -71,7 +70,6 @@ describe('VirtualList', () => {
 		onScrollStartCount = null;
 		onScrollStopCount = null;
 		renderItem = null;
-		resultScrollLeft = null;
 		resultScrollTop = null;
 	});
 

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -39,10 +39,13 @@ describe('VirtualList', () => {
 		handlerOnScrollStart = () => {
 			onScrollStartCount++;
 		};
-		handlerOnScrollStop = (e) => {
+		handlerOnScrollStop = (done, testCase) => (e) => {
 			onScrollStopCount++;
 			resultScrollLeft = e.scrollLeft;
 			resultScrollTop = e.scrollTop;
+
+			testCase();
+			done();
 		};
 		renderItem = ({index, ...rest}) => {	// eslint-disable-line enact/display-name, enact/prop-types
 			return (
@@ -107,7 +110,15 @@ describe('VirtualList', () => {
 	});
 
 	describe('ScrollTo', () => {
-		it('should scroll to the specific item of a given index with scrollTo', () => {
+		it('should scroll to the specific item of a given index with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 300;
+				const actual = resultScrollTop;
+
+				expect(actual).to.equal(expected);
+
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -115,19 +126,21 @@ describe('VirtualList', () => {
 					dataSize={dataSize}
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({index: 10, animate: false});
-
-			const expected = 300;
-			const actual = resultScrollTop;
-
-			expect(actual).to.equal(expected);
 		});
 
-		it('should scroll to the given \'x\' position with scrollTo', () => {
+		it('should scroll to the given \'x\' position with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 1;
+				const actual = onScrollStopCount;
+
+				expect(actual).to.equal(expected);
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -136,19 +149,21 @@ describe('VirtualList', () => {
 					direction="horizontal"
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({position: {x: 100}, animate: false});
-
-			const expected = 100;
-			const actual = resultScrollLeft;
-
-			expect(actual).to.equal(expected);
 		});
 
-		it('should scroll to the given \'y\' position with scrollTo', () => {
+		it('should scroll to the given \'y\' position with scrollTo', (done) => {
+			const onScrollStop = handlerOnScrollStop(done, () => {
+				const expected = 100;
+				const actual = resultScrollTop;
+
+				expect(actual).to.equal(expected);
+			});
+
 			mount(
 				<VirtualList
 					cbScrollTo={getScrollTo}
@@ -156,16 +171,11 @@ describe('VirtualList', () => {
 					dataSize={dataSize}
 					itemRenderer={renderItem}
 					itemSize={30}
-					onScrollStop={handlerOnScrollStop}
+					onScrollStop={onScrollStop}
 				/>
 			);
 
 			myScrollTo({position: {y: 100}, animate: false});
-
-			const expected = 100;
-			const actual = resultScrollTop;
-
-			expect(actual).to.equal(expected);
 		});
 
 		describe('scroll events', () => {
@@ -209,7 +219,14 @@ describe('VirtualList', () => {
 				expect(actual).to.equal(expected);
 			});
 
-			it('should call onScrollStop once', () => {
+			it('should call onScrollStop once', (done) => {
+				const onScrollStop = handlerOnScrollStop(done, () => {
+					const expected = 1;
+					const actual = onScrollStopCount;
+
+					expect(actual).to.equal(expected);
+				});
+
 				mount(
 					<VirtualList
 						cbScrollTo={getScrollTo}
@@ -217,16 +234,11 @@ describe('VirtualList', () => {
 						dataSize={dataSize}
 						itemRenderer={renderItem}
 						itemSize={30}
-						onScrollStop={handlerOnScrollStop}
+						onScrollStop={onScrollStop}
 					/>
 				);
 
 				myScrollTo({position: {y: 100}, animate: false});
-
-				const expected = 1;
-				const actual = onScrollStopCount;
-
-				expect(actual).to.equal(expected);
 			});
 		});
 	});

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -17,7 +17,6 @@ describe('VirtualList', () => {
 		onScrollStartCount,
 		onScrollStopCount,
 		renderItem,
-		resultScrollLeft,
 		resultScrollTop;
 
 	beforeEach(() => {
@@ -27,7 +26,6 @@ describe('VirtualList', () => {
 		onScrollCount = 0;
 		onScrollStartCount = 0;
 		onScrollStopCount = 0;
-		resultScrollLeft = 0;
 		resultScrollTop = 0;
 
 		getScrollTo = (scrollTo) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After removing animations during scroll by arrow key down,
onScrollStart and onScrollStop are called back on every focus movement.
If an app sets at least one of those callbacks, this behavior may affect the performance.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To reduce unnecessary callbacks,
this PR changes lists to fire onScrollStop after waiting a certain period of time
from the last update of the scroll position.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5726

### Comments
