### PR TITLE
ENYO-5735: Fix Marquee to show ellipsis when children change

### DIFF
--- a/packages/sampler/stories/qa/Header.js
+++ b/packages/sampler/stories/qa/Header.js
@@ -146,7 +146,7 @@ storiesOf('Header', module)
 			const input = boolean('Input Mode', Config, true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', Config, true)} /> : null;
 			return (
 				<Header
-					title={text('title', Config, ' ิ้  ไั  ஒ  த')}
+					title={text('title', Config, 'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  த')}
 					headerInput={input}
 					titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 					subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}

--- a/packages/sampler/stories/qa/Header.js
+++ b/packages/sampler/stories/qa/Header.js
@@ -146,7 +146,7 @@ storiesOf('Header', module)
 			const input = boolean('Input Mode', Config, true) ? <Input dismissOnEnter={boolean('Input dismissOnEnter', Config, true)} /> : null;
 			return (
 				<Header
-					title={text('title', Config, 'ิ้  ไั  ஒ  து': 'ิ้  ไั  ஒ  த')}
+					title={text('title', Config, ' ิ้  ไั  ஒ  த')}
 					headerInput={input}
 					titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
 					subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Maruqee` to display an ellipsis when changing to text that no longer fits within its bounds
+- `ui/Marquee` to display an ellipsis when changing to text that no longer fits within its bounds
 
 ## [2.2.7] - 2018-11-21
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Maruqee` to display an ellipsis when changing to text that no longer fits within its bounds
+
 ## [2.2.7] - 2018-11-21
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -443,6 +443,10 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.distance = null;
 			// Assume the marquee does not fit until calculations show otherwise
 			this.contentFits = false;
+
+			this.setState(state => {
+				return state.overflow === 'ellipsis' ? null : {overflow: 'ellipsis'};
+			});
 		}
 
 		/*

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -280,8 +280,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.sync = false;
 			this.forceRestartMarquee = false;
 			this.timerState = TimerState.CLEAR;
-
-			this.invalidateMetrics();
+			this.distance = null;
+			this.contentFits = false;
 		}
 
 		componentWillMount () {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I'm a little fuzzy on the specifics of the bug but it relates to some recent changes to Marquee. There are two related issues it seems.

First, when changing from short text to long text, the long text should display an ellipsis until animation starts. If the long text is set after the `marqueeRenderDelay` timeout fires, it won't show an ellipsis but will start animating after the requisite delay.

Second, when the above occurs, the subsequent state change to update `overflow` to `'ellipsis'` causes marquee to attempt to start the animation which prevents resetting when complete because the `timerState` is pending due to the spurious animation start request.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Resetting the `overflow` state when invalidating metrics resolves the first issue and, by extension, prevents the second. Seems like a reasonable change to make regardless since it would correctly mirror invalidating all of the potential changes from `calculateMetrics'.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We may need to investigate the latter issue further. It's possible that we could expand `shouldStartMarquee` to handle this as well but I think the proposed solution is adequate for now.
