### PR TITLE
ENYO-5734: Resume Spotlight when ExpandableInput closes

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` property `childProps` to support additional props included in the object passed to the `itemsRenderer` callback
+
+### Fixed
+
+- `moonstone/ExpandableInput` to focus labeled item on close
+
 ## [2.2.7] - 2018-11-21
 
 ### Fixed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Added
-
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` property `childProps` to support additional props included in the object passed to the `itemsRenderer` callback
-
 ### Fixed
 
 - `moonstone/ExpandableInput` to focus labeled item on close
@@ -26,7 +22,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to disable pointer mode when hiding media controls via 5-way
 - `moonstone/VirtualList` and `moonstone/Scroller` to not to animate with 5-way navigation by default
 
-### Fixerd
+### Fixed
 
 - `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ExpandableInput` to focus labeled item on close
+- `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
 
 ## [2.2.7] - 2018-11-21
 
@@ -21,10 +22,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` to blur slider when hiding media controls
 - `moonstone/VideoPlayer` to disable pointer mode when hiding media controls via 5-way
 - `moonstone/VirtualList` and `moonstone/Scroller` to not to animate with 5-way navigation by default
-
-### Fixed
-
-- `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
 
 ## [2.2.5] - 2018-11-05
 

--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -210,6 +210,7 @@ class ExpandableInputBase extends React.Component {
 		if (!this.props.open && nextProps.open) {
 			initialValue = nextProps.value;
 		} else if (this.props.open && !nextProps.open) {
+			this.paused.resume();
 			initialValue = null;
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There is a Spotlight issue that causes `<input>` to retain focus when closing `ExpandableInput` right when `<input>` receives focus while `Expandable` is opening. 

In `ExpandableInput`, there are multiple components pausing `Spotlight` so when `Expandable` closes, the following line doesn't highlight `LabeledItem` because `Spotlight` is still paused by `ExpandableInput`
```
//ExpandableSpotlightDecorator.js L179-L182

        handleHide = () => {
            this.resume();
            this.highlight(this.highlightLabeledItem);
        }
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Call `resume()` in `ExpandableInput` when its `open` prop changes to false. This will allow `ExpandableSpotlightDecorator` to resume its instance of Spotlight and then highlight `LabeledItem` which will blur `<input>`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5734

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com