### PR TITLE
PLAT-70230: Drop Sinon in favor of using Jest built-ins for mocking/spies

### DIFF
--- a/docs/testing-components/unit-testing/index.md
+++ b/docs/testing-components/unit-testing/index.md
@@ -33,7 +33,6 @@ component or item under test and end with the `"-specs.js"` suffix.
 We use a dizzying number of tools to perform unit testing.  A quick overview of the different tools can be helpful.
 
 *   [Jest](https://jestjs.io/) - A test framework. This tool allows us to setup, assert and run tests. We can also use `jest` as a mocking library.
-*   [Sinon](http://sinonjs.org/) - A mock library.  Useful for adding mocks and spies to components under test.
 *   [Enzyme](http://airbnb.io/enzyme/) - A test library for use with React.  It allows us to shallowly render components and inspect the output.
 *   [jsdom](https://github.com/jsdom/jsdom) - A pure-JavaScript implementation of many web standards, notably the WHATWG DOM and HTML Standards, for use with Node.js.
 

--- a/packages/core/dispatcher/tests/dispatcher-specs.js
+++ b/packages/core/dispatcher/tests/dispatcher-specs.js
@@ -95,7 +95,7 @@ describe('dispatcher', () => {
 
 			// restore console.error and set up enyo-console-spy again so it can complete successfully
 			// eslint-disable-next-line no-console
-			console.error.restore();
+			console.error.mockRestore();
 			watchErrorAndWarnings();
 
 			const expected = true;

--- a/packages/core/dispatcher/tests/dispatcher-specs.js
+++ b/packages/core/dispatcher/tests/dispatcher-specs.js
@@ -1,39 +1,36 @@
-import sinon from 'sinon';
-import {restoreErrorAndWarnings, watchErrorAndWarnings} from 'console-snoop';
-
 import {off, on, once} from '../dispatcher';
 
 describe('dispatcher', () => {
 
 	test('should register handlers on target', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		on('localechange', handler, window);
 
 		const ev = new window.CustomEvent('localechange', {});
 		window.dispatchEvent(ev);
 
-		const expected = true;
-		const actual = handler.calledOnce;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should not register duplicate handlers on target', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		on('localechange', handler, window);
 		on('localechange', handler, window);
 
 		const ev = new window.CustomEvent('localechange', {});
 		window.dispatchEvent(ev);
 
-		const expected = true;
-		const actual = handler.calledOnce;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should unregister handlers on target', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		on('localechange', handler, window);
 
 		const ev = new window.CustomEvent('localechange', {});
@@ -42,36 +39,36 @@ describe('dispatcher', () => {
 		off('localechange', handler, window);
 		window.dispatchEvent(ev);
 
-		const expected = false;
-		const actual = handler.calledTwice;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should only call a "once" handler once', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		once('localechange', handler, window);
 
 		const ev = new window.CustomEvent('localechange', {});
 		window.dispatchEvent(ev);
 		window.dispatchEvent(ev);
 
-		const expected = true;
-		const actual = handler.calledOnce;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should allow unregistering a "once" before it is called', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const onceHandler = once('localechange', handler, window);
 		off('localechange', onceHandler, window);
 
 		const ev = new window.CustomEvent('localechange', {});
 		window.dispatchEvent(ev);
 
-		const expected = false;
-		const actual = handler.calledOnce;
+		const expected = 0;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -79,27 +76,22 @@ describe('dispatcher', () => {
 	test(
 		'should not block subsequent handlers when a handler throws',
 		() => {
-			// clear enyo-console-spy so we can stub it to suppress the console.error
-			restoreErrorAndWarnings();
-			sinon.stub(console, 'error');
+			// Modify the console spy to silence error output with
+			// an empty mock implementation
+			console.error.mockImplementation();
 
 			const throws = function () {
 				throw new Error('Thrown from handler');
 			};
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			on('localechange', throws, window);
 			on('localechange', handler, window);
 
 			const ev = new window.CustomEvent('localechange', {});
 			window.dispatchEvent(ev);
 
-			// restore console.error and set up enyo-console-spy again so it can complete successfully
-			// eslint-disable-next-line no-console
-			console.error.mockRestore();
-			watchErrorAndWarnings();
-
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/core/dispatcher/tests/dispatcher-specs.js
+++ b/packages/core/dispatcher/tests/dispatcher-specs.js
@@ -78,6 +78,7 @@ describe('dispatcher', () => {
 		() => {
 			// Modify the console spy to silence error output with
 			// an empty mock implementation
+			// eslint-disable-next-line no-console
 			console.error.mockImplementation();
 
 			const throws = function () {

--- a/packages/core/handle/tests/handle-specs.js
+++ b/packages/core/handle/tests/handle-specs.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import {
 	handle,
 	adaptEvent,
@@ -17,8 +16,8 @@ import {
 describe('handle', () => {
 
 	const makeEvent = (payload) => ({
-		preventDefault: sinon.spy(),
-		stopPropagation: sinon.spy(),
+		preventDefault: jest.fn(),
+		stopPropagation: jest.fn(),
 		...payload
 	});
 
@@ -26,53 +25,54 @@ describe('handle', () => {
 	const returnsFalse = () => false;
 
 	test('should call only handler', () => {
-		const handler = sinon.spy(returnsTrue);
+		const handler = jest.fn(returnsTrue);
 		const callback = handle(handler);
 
 		callback(makeEvent());
 
-		const expected = true;
-		const actual = handler.calledOnce;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should call multiple handlers', () => {
-		const handler1 = sinon.spy(returnsTrue);
-		const handler2 = sinon.spy(returnsTrue);
+		const handler1 = jest.fn(returnsTrue);
+		const handler2 = jest.fn(returnsTrue);
 
 		const callback = handle(handler1, handler2);
 
 		callback(makeEvent());
 
 		const expected = true;
-		const actual = handler1.calledOnce && handler2.calledOnce;
+		const actual = handler1.mock.calls.length === 1 &&
+				handler2.mock.calls.length === 1;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should skip non-function handlers', () => {
-		const handler = sinon.spy(returnsTrue);
+		const handler = jest.fn(returnsTrue);
 		const callback = handle(null, void 0, 0, 'purple', handler);
 
 		callback(makeEvent());
 
-		const expected = true;
-		const actual = handler.calledOnce;
+		const expected = 1;
+		const actual = handler.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should not call handlers after one that returns false', () => {
-		const handler1 = sinon.spy(returnsTrue);
-		const handler2 = sinon.spy(returnsTrue);
+		const handler1 = jest.fn(returnsTrue);
+		const handler2 = jest.fn(returnsTrue);
 
 		const callback = handle(handler1, returnsFalse, handler2);
 
 		callback(makeEvent());
 
-		const expected = false;
-		const actual = handler2.calledOnce;
+		const expected = 0;
+		const actual = handler2.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -82,8 +82,8 @@ describe('handle', () => {
 		const ev = makeEvent();
 		callback(ev);
 
-		const expected = true;
-		const actual = ev.stopPropagation.calledOnce;
+		const expected = 1;
+		const actual = ev.stopPropagation.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -93,8 +93,8 @@ describe('handle', () => {
 		const ev = makeEvent();
 		callback(ev);
 
-		const expected = true;
-		const actual = ev.preventDefault.calledOnce;
+		const expected = 1;
+		const actual = ev.preventDefault.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -102,66 +102,66 @@ describe('handle', () => {
 	test('should call any method on event', () => {
 		const callback = handle(callOnEvent('customMethod'));
 		const ev = makeEvent({
-			customMethod: sinon.spy()
+			customMethod: jest.fn()
 		});
 		callback(ev);
 
-		const expected = true;
-		const actual = ev.customMethod.calledOnce;
+		const expected = 1;
+		const actual = ev.customMethod.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should only call handler for specified keyCode', () => {
 		const keyCode = 13;
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const callback = handle(forKeyCode(keyCode), handler);
 
 		callback(makeEvent());
-		expect(handler.calledOnce).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
 
 		callback(makeEvent({keyCode}));
-		expect(handler.calledOnce).toBe(true);
+		expect(handler).toHaveBeenCalled();
 	});
 
 	test('should only call handler for specified event prop', () => {
 		const prop = 'index';
 		const value = 0;
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const callback = handle(forEventProp(prop, value), handler);
 
 		// undefined shouldn't pass
 		callback(makeEvent());
-		expect(handler.calledOnce).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
 
 		// == check shouldn't pass
 		callback(makeEvent({
 			[prop]: false
 		}));
-		expect(handler.calledOnce).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
 
 		// === should pass
 		callback(makeEvent({
 			[prop]: value
 		}));
-		expect(handler.calledOnce).toBe(true);
+		expect(handler).toHaveBeenCalled();
 	});
 
 	test('should only call handler for specified prop', () => {
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const callback = handle(forProp('checked', true), handler);
 
 		// undefined shouldn't pass
 		callback({}, {});
-		expect(handler.calledOnce).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
 
 		// == check shouldn't pass
 		callback({}, {checked: 1});
-		expect(handler.calledOnce).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
 
 		// === should pass
 		callback({}, {checked: true});
-		expect(handler.calledOnce).toBe(true);
+		expect(handler).toHaveBeenCalled();
 	});
 
 	test(
@@ -170,7 +170,7 @@ describe('handle', () => {
 			const event = 'onMyClick';
 			const prop = 'index';
 			const propValue = 0;
-			const spy = sinon.spy();
+			const spy = jest.fn();
 
 			const props = {
 				[event]: spy
@@ -182,7 +182,7 @@ describe('handle', () => {
 			handle(forward(event))(payload, props);
 
 			const expected = true;
-			const actual = spy.args[0][0][prop] === propValue;
+			const actual = spy.mock.calls[0][0][prop] === propValue;
 
 			expect(actual).toBe(expected);
 		}
@@ -192,12 +192,12 @@ describe('handle', () => {
 		'should forwardWithPrevent events to function specified in provided props when preventDefault() hasn\'t been called',
 		() => {
 			const event = 'onMyClick';
-			const handler = sinon.spy();
+			const handler = jest.fn();
 
 			const callback = handle(forwardWithPrevent(event), handler);
 
 			callback();
-			expect(handler.calledOnce).toBe(true);
+			expect(handler).toHaveBeenCalledTimes(1);
 		}
 	);
 
@@ -205,7 +205,7 @@ describe('handle', () => {
 		'should not forwardWithPrevent events to function specified in provided props when preventDefault() has been called',
 		() => {
 			const event = 'onMyClick';
-			const handler = sinon.spy();
+			const handler = jest.fn();
 
 			const callback = handle(forwardWithPrevent(event), handler);
 
@@ -213,7 +213,7 @@ describe('handle', () => {
 			callback({}, {
 				'onMyClick': (ev) => ev.preventDefault()
 			});
-			expect(handler.calledOnce).toBe(false);
+			expect(handler).not.toHaveBeenCalled();
 		}
 	);
 
@@ -224,13 +224,13 @@ describe('handle', () => {
 				value: 1
 			}
 		};
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const h = handle.bind(componentInstance);
 		const callback = h(handler);
 		callback();
 
 		const expected = 1;
-		const actual = handler.firstCall.args[1].value;
+		const actual = handler.mock.calls[0][1].value;
 
 		expect(actual).toBe(expected);
 	});
@@ -242,26 +242,26 @@ describe('handle', () => {
 			},
 			props: {}
 		};
-		const handler = sinon.spy();
+		const handler = jest.fn();
 		const h = handle.bind(componentInstance);
 		const callback = h(handler);
 		callback();
 
 		const expected = 1;
-		const actual = handler.firstCall.args[2].value;
+		const actual = handler.mock.calls[0][2].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	describe('finally', () => {
 		test('should call the finally callback when handle returns true', () => {
-			const finallyCallback = sinon.spy();
+			const finallyCallback = jest.fn();
 			const callback = handle(returnsTrue).finally(finallyCallback);
 
 			callback(makeEvent());
 
-			const expected = true;
-			const actual = finallyCallback.calledOnce;
+			const expected = 1;
+			const actual = finallyCallback.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
@@ -269,13 +269,13 @@ describe('handle', () => {
 		test(
 			'should call the finally callback when handle returns false',
 			() => {
-				const finallyCallback = sinon.spy();
+				const finallyCallback = jest.fn();
 				const callback = handle(returnsFalse).finally(finallyCallback);
 
 				callback(makeEvent());
 
-				const expected = true;
-				const actual = finallyCallback.calledOnce;
+				const expected = 1;
+				const actual = finallyCallback.mock.calls.length;
 
 				expect(actual).toBe(expected);
 			}
@@ -284,7 +284,7 @@ describe('handle', () => {
 		test(
 			'should call the finally callback when handle throws an error',
 			() => {
-				const finallyCallback = sinon.spy();
+				const finallyCallback = jest.fn();
 				const callback = handle(() => {
 					throw new Error('Something has gone awry ...');
 				}).finally(finallyCallback);
@@ -295,8 +295,8 @@ describe('handle', () => {
 					// we don't want the error to interrupt the test
 				}
 
-				const expected = true;
-				const actual = finallyCallback.calledOnce;
+				const expected = 1;
+				const actual = finallyCallback.mock.calls.length;
 
 				expect(actual).toBe(expected);
 			}
@@ -305,7 +305,7 @@ describe('handle', () => {
 
 	describe('#oneOf', () => {
 		test('should call each handler until one passes', () => {
-			const handler = sinon.spy(returnsTrue);
+			const handler = jest.fn(returnsTrue);
 			const h1 = [
 				returnsFalse,
 				handler
@@ -318,13 +318,13 @@ describe('handle', () => {
 			callback();
 
 			const expected = 1;
-			const actual = handler.callCount;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should stop if the first handler passes', () => {
-			const handler = sinon.spy(returnsTrue);
+			const handler = jest.fn(returnsTrue);
 			const callback = oneOf(
 				[returnsTrue, handler],
 				[returnsTrue, handler],
@@ -333,13 +333,13 @@ describe('handle', () => {
 			callback();
 
 			const expected = 1;
-			const actual = handler.callCount;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should pass args to condition', () => {
-			const handler = sinon.spy(returnsTrue);
+			const handler = jest.fn(returnsTrue);
 			const callback = oneOf(
 				[handler, returnsTrue]
 			);
@@ -347,13 +347,13 @@ describe('handle', () => {
 			callback(ev);
 
 			const expected = ev;
-			const actual = handler.firstCall.args[0];
+			const actual = handler.mock.calls[0][0];
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should pass args to handlers', () => {
-			const handler = sinon.spy(returnsTrue);
+			const handler = jest.fn(returnsTrue);
 			const callback = oneOf(
 				[returnsTrue, handler]
 			);
@@ -361,7 +361,7 @@ describe('handle', () => {
 			callback(ev);
 
 			const expected = ev;
-			const actual = handler.firstCall.args[0];
+			const actual = handler.mock.calls[0][0];
 
 			expect(actual).toBe(expected);
 		});
@@ -413,7 +413,7 @@ describe('handle', () => {
 					value: 1
 				}
 			};
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const h = handle.bind(componentInstance);
 			const callback = oneOf(
 				[returnsTrue, h(handler)]
@@ -421,7 +421,7 @@ describe('handle', () => {
 			callback();
 
 			const expected = 1;
-			const actual = handler.firstCall.args[2].value;
+			const actual = handler.mock.calls[0][2].value;
 
 			expect(actual).toBe(expected);
 		});
@@ -433,7 +433,7 @@ describe('handle', () => {
 				},
 				context: {}
 			};
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const o = oneOf.bind(componentInstance);
 			const callback = o(
 				[returnsTrue, handler]
@@ -441,7 +441,7 @@ describe('handle', () => {
 			callback();
 
 			const expected = 1;
-			const actual = handler.firstCall.args[1].value;
+			const actual = handler.mock.calls[0][1].value;
 
 			expect(actual).toBe(expected);
 		});
@@ -453,7 +453,7 @@ describe('handle', () => {
 					value: 1
 				}
 			};
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const o = oneOf.bind(componentInstance);
 			const callback = o(
 				[returnsTrue, handler]
@@ -461,13 +461,13 @@ describe('handle', () => {
 			callback();
 
 			const expected = 1;
-			const actual = handler.firstCall.args[2].value;
+			const actual = handler.mock.calls[0][2].value;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should support finally callback', () => {
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const callback = oneOf(
 				[returnsFalse, returnsTrue],
 				[returnsFalse, returnsTrue]
@@ -475,8 +475,8 @@ describe('handle', () => {
 
 			callback();
 
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
@@ -484,7 +484,7 @@ describe('handle', () => {
 
 	describe('#adaptEvent', () => {
 		test('should pass the adapted event payload to the provided handler', () => {
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const onlyValue = ({value}) => ({value});
 			const ev = {
 				value: 1,
@@ -494,18 +494,18 @@ describe('handle', () => {
 			adaptEvent(onlyValue, handler)(ev);
 
 			const expected = {value: 1};
-			const actual = handler.firstCall.args[0];
+			const actual = handler.mock.calls[0][0];
 
 			expect(actual).toEqual(expected);
 		});
 
 		test('should pass additional arguments to the provided handler', () => {
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const returnOne = () => 1;
 			adaptEvent(returnOne, handler)(0, 2, 3);
 
 			const expected = [1, 2, 3];
-			const actual = handler.firstCall.args;
+			const actual = handler.mock.calls[0];
 
 			expect(actual).toEqual(expected);
 		});
@@ -514,20 +514,20 @@ describe('handle', () => {
 			const obj = {
 				adapt: () => 1
 			};
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const fn = adaptEvent(call('adapt'), handler).bind(obj);
 
 			fn(0, 2, 3);
 
 			const expected = [1, 2, 3];
-			const actual = handler.firstCall.args;
+			const actual = handler.mock.calls[0];
 
 			expect(actual).toEqual(expected);
 		});
 
 		test('should support bound handler function', () => {
 			const obj = {
-				handler: sinon.spy()
+				handler: jest.fn()
 			};
 			const returnOne = () => 1;
 			const fn = adaptEvent(returnOne, call('handler')).bind(obj);
@@ -535,7 +535,7 @@ describe('handle', () => {
 			fn(0, 2, 3);
 
 			const expected = [1, 2, 3];
-			const actual = obj.handler.firstCall.args;
+			const actual = obj.handler.mock.calls[0];
 
 			expect(actual).toEqual(expected);
 		});

--- a/packages/core/util/tests/memoize-specs.js
+++ b/packages/core/util/tests/memoize-specs.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import {memoize} from '..';
 
 describe('memoize', () => {
@@ -19,12 +17,12 @@ describe('memoize', () => {
 	});
 
 	test('should forward all args to memoized function', () => {
-		const spy = sinon.spy();
+		const spy = jest.fn();
 		const memoized = memoize(spy);
 		memoized(1, 2);
 
 		const expected = [1, 2];
-		const actual = spy.firstCall.args;
+		const actual = spy.mock.calls[0];
 
 		expect(expected).toEqual(actual);
 	});

--- a/packages/moonstone/Button/tests/Button-specs.js
+++ b/packages/moonstone/Button/tests/Button-specs.js
@@ -54,7 +54,7 @@ describe('Button', () => {
 
 			subject.simulate('click');
 
-			const expected = 1;
+			const expected = 0;
 			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);

--- a/packages/moonstone/Button/tests/Button-specs.js
+++ b/packages/moonstone/Button/tests/Button-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import Button from '../Button';
 
 describe('Button', () => {
@@ -34,29 +33,29 @@ describe('Button', () => {
 
 	describe('events', () => {
 		test('should call onClick when not disabled', () => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const subject = mount(
 				<Button onClick={handleClick}>I am a disabled Button</Button>
 			);
 
 			subject.simulate('click');
 
-			const expected = true;
-			const actual = handleClick.called;
+			const expected = 1;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should not call onClick when disabled', () => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const subject = mount(
 				<Button disabled onClick={handleClick}>I am a disabled Button</Button>
 			);
 
 			subject.simulate('click');
 
-			const expected = false;
-			const actual = handleClick.called;
+			const expected = 1;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});

--- a/packages/moonstone/DatePicker/tests/DatePicker-specs.js
+++ b/packages/moonstone/DatePicker/tests/DatePicker-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import {DatePicker, DatePickerBase} from '../DatePicker';
 import css from '../DatePicker.less';
 
@@ -22,7 +21,7 @@ describe('DatePicker', () => {
 	test(
 		'should emit an onChange event when changing a component picker',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const subject = mount(
 				<DatePicker onChange={handleChange} open title="Date" value={new Date(2000, 6, 15)} />
 			);
@@ -30,8 +29,8 @@ describe('DatePicker', () => {
 			const base = subject.find('DateComponentRangePicker').first();
 			base.prop('onChange')({value: 0});
 
-			const expected = true;
-			const actual = handleChange.calledOnce;
+			const expected = 1;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/DaySelector/tests/DaySelector-specs.js
+++ b/packages/moonstone/DaySelector/tests/DaySelector-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 
 import DaySelector from '../DaySelector';
 
@@ -28,7 +27,7 @@ describe('DaySelector', () => {
 	);
 
 	test('should fire onSelect when a day is selected', () => {
-		const handleSelect = sinon.spy();
+		const handleSelect = jest.fn();
 		const subject = mount(
 			<DaySelector onSelect={handleSelect} />
 		);
@@ -36,8 +35,8 @@ describe('DaySelector', () => {
 		const item = subject.find('DaySelectorItem').first();
 		tap(item);
 
-		const expected = true;
-		const actual = handleSelect.calledOnce;
+		const expected = 1;
+		const actual = handleSelect.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -45,7 +44,7 @@ describe('DaySelector', () => {
 	test(
 		'should fire onSelect with the correct content when a day is selected',
 		() => {
-			const handleSelect = sinon.spy();
+			const handleSelect = jest.fn();
 			const content = 'Sat';
 			const subject = mount(
 				<DaySelector onSelect={handleSelect} />
@@ -55,7 +54,7 @@ describe('DaySelector', () => {
 			tap(item);
 
 			const expected = content;
-			const actual = handleSelect.firstCall.args[0].content;
+			const actual = handleSelect.mock.calls[0][0].content;
 
 			expect(actual).toBe(expected);
 		}
@@ -64,7 +63,7 @@ describe('DaySelector', () => {
 	test(
 		'should use the full string format when dayNameLength is `full`',
 		() => {
-			const handleSelect = sinon.spy();
+			const handleSelect = jest.fn();
 			const content = 'Saturday';
 			const subject = mount(
 				<DaySelector dayNameLength="full" onSelect={handleSelect} />
@@ -74,7 +73,7 @@ describe('DaySelector', () => {
 			tap(item);
 
 			const expected = content;
-			const actual = handleSelect.firstCall.args[0].content;
+			const actual = handleSelect.mock.calls[0][0].content;
 
 			expect(actual).toBe(expected);
 		}
@@ -83,7 +82,7 @@ describe('DaySelector', () => {
 	test(
 		'should set selected content as Every day when every day is selected',
 		() => {
-			const handleSelect = sinon.spy();
+			const handleSelect = jest.fn();
 			const content = 'Every Day';
 			const subject = mount(
 				<DaySelector defaultSelected={[0, 1, 2, 3, 4, 5]} onSelect={handleSelect} />
@@ -93,7 +92,7 @@ describe('DaySelector', () => {
 			tap(item);
 
 			const expected = content;
-			const actual = handleSelect.firstCall.args[0].content;
+			const actual = handleSelect.mock.calls[0][0].content;
 
 			expect(actual).toBe(expected);
 		}
@@ -102,7 +101,7 @@ describe('DaySelector', () => {
 	test(
 		'should set selected content as Every weekday when every weekday is selected',
 		() => {
-			const handleSelect = sinon.spy();
+			const handleSelect = jest.fn();
 			const content = 'Every Weekday';
 			const subject = mount(
 				<DaySelector defaultSelected={[0, 1, 2, 3, 4, 5]} onSelect={handleSelect} />
@@ -112,7 +111,7 @@ describe('DaySelector', () => {
 			tap(item);
 
 			const expected = content;
-			const actual = handleSelect.firstCall.args[0].content;
+			const actual = handleSelect.mock.calls[0][0].content;
 
 			expect(actual).toBe(expected);
 		}
@@ -121,7 +120,7 @@ describe('DaySelector', () => {
 	test(
 		'should set selected content as Every weekend when every weekend is selected',
 		() => {
-			const handleSelect = sinon.spy();
+			const handleSelect = jest.fn();
 			const content = 'Every Weekend';
 			const subject = mount(
 				<DaySelector defaultSelected={[0]} onSelect={handleSelect} />
@@ -131,7 +130,7 @@ describe('DaySelector', () => {
 			tap(item);
 
 			const expected = content;
-			const actual = handleSelect.firstCall.args[0].content;
+			const actual = handleSelect.mock.calls[0][0].content;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/ExpandableInput/tests/ExpandableInput-specs.js
+++ b/packages/moonstone/ExpandableInput/tests/ExpandableInput-specs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
 import {mount, shallow} from 'enzyme';
 import {ExpandableInput, ExpandableInputBase} from '../ExpandableInput';
 
@@ -112,7 +111,7 @@ describe('ExpandableInputBase', () => {
 
 describe('ExpandableInput', () => {
 	test('should pass onChange callback to input', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 'input string';
 		const evt = {target: {value: value}};
 
@@ -123,7 +122,7 @@ describe('ExpandableInput', () => {
 		subject.find('input').simulate('change', evt);
 
 		const expected = value;
-		const actual = handleChange.firstCall.args[0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/moonstone/ExpandablePicker/tests/ExpandablePicker-specs.js
+++ b/packages/moonstone/ExpandablePicker/tests/ExpandablePicker-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import ExpandablePicker, {ExpandablePickerBase} from '../ExpandablePicker';
 
 const tap = (node) => {
@@ -29,7 +28,7 @@ describe('ExpandablePicker Specs', () => {
 
 	test('should include value in onChange when value is specified', () => {
 		const value = 2;
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const expandablePicker = mount(
 			<ExpandablePicker onChange={handleChange} open title="Options" value={value}>
 				{['Option one', 'Option two', 'Option three']}
@@ -40,7 +39,7 @@ describe('ExpandablePicker Specs', () => {
 		tap(checkButton);
 
 		const expected = value;
-		const actual = handleChange.firstCall.args[0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
@@ -49,7 +48,7 @@ describe('ExpandablePicker Specs', () => {
 		'should include default value in onChange when value is not specified',
 		() => {
 			const value = 0;
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const expandablePicker = mount(
 				<ExpandablePickerBase onChange={handleChange} open title="Options">
 					{['Option one', 'Option two', 'Option three']}
@@ -60,7 +59,7 @@ describe('ExpandablePicker Specs', () => {
 			tap(checkButton);
 
 			const expected = value;
-			const actual = handleChange.firstCall.args[0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
+++ b/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
 import {mount} from 'enzyme';
 import IncrementSlider from '../IncrementSlider';
 import css from '../IncrementSlider.less';
@@ -18,19 +17,19 @@ const upKeyDown = keyDown(38);
 const downKeyDown = keyDown(40);
 
 const callCount = spy => {
-	switch (spy.callCount) {
+	switch (spy.mock.calls.length) {
 		case 0:
 			return 'not called';
 		case 1:
 			return 'called once';
 		default:
-			return `called ${spy.callCount} times`;
+			return `called ${spy.mock.calls.length} times`;
 	}
 };
 
 describe('IncrementSlider Specs', () => {
 	test('should decrement value', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 50;
 		const incrementSlider = mount(
 			<IncrementSlider
@@ -42,13 +41,13 @@ describe('IncrementSlider Specs', () => {
 		decrement(incrementSlider);
 
 		const expected = value - 1;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should increment value', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 50;
 		const incrementSlider = mount(
 			<IncrementSlider
@@ -60,13 +59,13 @@ describe('IncrementSlider Specs', () => {
 		increment(incrementSlider);
 
 		const expected = value + 1;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should only call onChange once', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 50;
 		const incrementSlider = mount(
 			<IncrementSlider
@@ -77,14 +76,14 @@ describe('IncrementSlider Specs', () => {
 
 		increment(incrementSlider);
 
-		const expected = true;
-		const actual = handleChange.calledOnce;
+		const expected = 1;
+		const actual = handleChange.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should not call onChange on prop change', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 50;
 		const incrementSlider = mount(
 			<IncrementSlider
@@ -95,8 +94,8 @@ describe('IncrementSlider Specs', () => {
 
 		incrementSlider.setProps({onChange: handleChange, value: value + 1});
 
-		const expected = false;
-		const actual = handleChange.called;
+		const expected = 0;
+		const actual = handleChange.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -244,7 +243,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightLeft from the decrement button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider onSpotlightLeft={handleSpotlight} />
 			);
@@ -261,7 +260,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightLeft from the decrement button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightLeft={handleSpotlight} />
 			);
@@ -278,7 +277,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightLeft from the increment button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightLeft={handleSpotlight} />
 			);
@@ -295,7 +294,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightRight from the increment button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider onSpotlightRight={handleSpotlight} />
 			);
@@ -312,7 +311,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightRight from the increment button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightRight={handleSpotlight} />
 			);
@@ -329,7 +328,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightRight from the decrement button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightRight={handleSpotlight} />
 			);
@@ -346,7 +345,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightUp from the decrement button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider onSpotlightUp={handleSpotlight} />
 			);
@@ -363,7 +362,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightUp from the increment button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider onSpotlightUp={handleSpotlight} />
 			);
@@ -380,7 +379,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightUp from the increment button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightUp={handleSpotlight} />
 			);
@@ -397,7 +396,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightDown from the increment button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider onSpotlightDown={handleSpotlight} />
 			);
@@ -414,7 +413,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightDown from the decrement button of horizontal IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightDown={handleSpotlight} />
 			);
@@ -431,7 +430,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightDown from the decrement button of vertical IncrementSlider',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider orientation="vertical" onSpotlightDown={handleSpotlight} />
 			);
@@ -450,7 +449,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightLeft from slider of horizontal IncrementSlider when value is at min',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider min={0} value={0} onSpotlightLeft={handleSpotlight} />
 			);
@@ -467,7 +466,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightRight from slider of horizontal IncrementSlider when value is at max',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider max={100} value={100} onSpotlightRight={handleSpotlight} />
 			);
@@ -484,7 +483,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightDown from slider of vertical IncrementSlider when value is at min',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider min={0} value={0} orientation="vertical" onSpotlightDown={handleSpotlight} />
 			);
@@ -501,7 +500,7 @@ describe('IncrementSlider Specs', () => {
 	test(
 		'should call onSpotlightUp from slider of horizontal IncrementSlider when value is at max',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const incrementSlider = mount(
 				<IncrementSlider max={100} value={100} orientation="vertical" onSpotlightUp={handleSpotlight} />
 			);

--- a/packages/moonstone/Input/tests/Input-specs.js
+++ b/packages/moonstone/Input/tests/Input-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import Input from '../Input';
 import Spotlight from '@enact/spotlight';
 
@@ -24,7 +23,7 @@ describe('Input Specs', () => {
 	});
 
 	test('should callback onChange when the text changes', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const value = 'blah';
 		const evt = {target: {value: value}};
 		const subject = mount(
@@ -34,14 +33,14 @@ describe('Input Specs', () => {
 		subject.find('input').simulate('change', evt);
 
 		const expected = value;
-		const actual = handleChange.firstCall.args[0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should blur input on enter if dismissOnEnter', () => {
 		const node = document.body.appendChild(document.createElement('div'));
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 
 		const subject = mount(
 			<Input onBlur={handleChange} dismissOnEnter />,
@@ -53,8 +52,8 @@ describe('Input Specs', () => {
 		input.simulate('keyUp', {which: 13, keyCode: 13, code:13});
 		node.remove();
 
-		const expected = true;
-		const actual = handleChange.calledOnce;
+		const expected = 1;
+		const actual = handleChange.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/moonstone/Panels/tests/Breadcrumb-specs.js
+++ b/packages/moonstone/Panels/tests/Breadcrumb-specs.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import Breadcrumb from '../Breadcrumb';
 
 describe('Breadcrumb', () => {
 
 	test('should include {index} in the payload of {onSelect}', () => {
-		const handleSelect = sinon.spy();
+		const handleSelect = jest.fn();
 		const subject = mount(
 			<Breadcrumb index={3} onSelect={handleSelect} />
 		);
@@ -14,7 +13,7 @@ describe('Breadcrumb', () => {
 		subject.simulate('click', {});
 
 		const expected = 3;
-		const actual = handleSelect.firstCall.args[0].index;
+		const actual = handleSelect.mock.calls[0][0].index;
 
 		expect(actual).toBe(expected);
 	});
@@ -22,8 +21,8 @@ describe('Breadcrumb', () => {
 	test(
 		'should include call both the {onClick} and {onSelect} handlers on click',
 		() => {
-			const handleSelect = sinon.spy();
-			const handleClick = sinon.spy();
+			const handleSelect = jest.fn();
+			const handleClick = jest.fn();
 			const subject = mount(
 				<Breadcrumb index={3} onClick={handleClick} onSelect={handleSelect} />
 			);
@@ -31,7 +30,8 @@ describe('Breadcrumb', () => {
 			subject.simulate('click', {});
 
 			const expected = true;
-			const actual = handleSelect.calledOnce && handleClick.calledOnce;
+			const actual = handleSelect.mock.calls.length === 1 &&
+					handleClick.mock.calls.length === 1;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/Panels/tests/IndexedBreadcrumbs-specs.js
+++ b/packages/moonstone/Panels/tests/IndexedBreadcrumbs-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import IndexedBreadcrumbs from '../IndexedBreadcrumbs';
 
 describe('IndexedBreadcrumbs', () => {
@@ -42,7 +41,7 @@ describe('IndexedBreadcrumbs', () => {
 	test(
 		'should call {onBreadcrumbClick} once when breadcrumb is clicked',
 		() => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const subject = mount(
 				<nav>
 					{IndexedBreadcrumbs('id', 1, 1, handleClick)}
@@ -51,8 +50,8 @@ describe('IndexedBreadcrumbs', () => {
 
 			subject.find('Breadcrumb').simulate('click', {});
 
-			const expected = true;
-			const actual = handleClick.calledOnce;
+			const expected = 1;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/Panels/tests/Panels-specs.js
+++ b/packages/moonstone/Panels/tests/Panels-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 
 import {Panels, PanelsBase} from '../Panels';
 
@@ -44,15 +43,15 @@ describe('Panels Specs', () => {
 	test(
 		'should call onApplicationClose when application close button is clicked',
 		() => {
-			const handleAppClose = sinon.spy();
+			const handleAppClose = jest.fn();
 			const subject = mount(
 				<Panels onApplicationClose={handleAppClose} />
 			);
 
 			tap(subject.find('IconButton'));
 
-			const expected = true;
-			const actual = handleAppClose.calledOnce;
+			const expected = 1;
+			const actual = handleAppClose.mock.calls.length;
 
 			expect(expected).toBe(actual);
 		}

--- a/packages/moonstone/Panels/tests/Router-specs.js
+++ b/packages/moonstone/Panels/tests/Router-specs.js
@@ -76,9 +76,9 @@ describe('Router', () => {
 	test(
 		'should render no children if {path} does not exist in {routes}',
 		() => {
-			// Remove Global Spy and replace with a stub instead
-			console.error.mockRestore();
-			jest.spyOn(console, 'error').mockImplementation();
+			// Modify the console spy to silence error output with
+			// an empty mock implementation
+			console.error.mockImplementation();
 
 			const subject = shallow(
 				<Router routes={routes} path="/help" />
@@ -178,9 +178,9 @@ describe('Router', () => {
 	);
 
 	test('should render nothing for an invalid path', () => {
-		// Remove Global Spy and replace with a stub instead
-		console.error.mockRestore();
-		jest.spyOn(console, 'error').mockImplementation();
+		// Modify the console spy to silence error output with
+		// an empty mock implementation
+		console.error.mockImplementation();
 
 		const subject = mount(
 			<Router path="/does/not/exist">
@@ -199,9 +199,9 @@ describe('Router', () => {
 	});
 
 	test('should render nothing for a partially valid path', () => {
-		// Remove Global Spy and replace with a stub instead
-		console.error.mockRestore();
-		jest.spyOn(console, 'error').mockImplementation();
+		// Modify the console spy to silence error output with
+		// an empty mock implementation
+		console.error.mockImplementation();
 
 		const subject = mount(
 			<Router path="/app/home/other">

--- a/packages/moonstone/Panels/tests/Router-specs.js
+++ b/packages/moonstone/Panels/tests/Router-specs.js
@@ -5,7 +5,6 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {Router, Route} from '../Router';
-import sinon from 'sinon';
 
 describe('Router', () => {
 
@@ -78,8 +77,8 @@ describe('Router', () => {
 		'should render no children if {path} does not exist in {routes}',
 		() => {
 			// Remove Global Spy and replace with a stub instead
-			console.error.restore();
-			sinon.stub(console, 'error');
+			console.error.mockRestore();
+			jest.spyOn(console, 'error').mockImplementation();
 
 			const subject = shallow(
 				<Router routes={routes} path="/help" />
@@ -180,8 +179,8 @@ describe('Router', () => {
 
 	test('should render nothing for an invalid path', () => {
 		// Remove Global Spy and replace with a stub instead
-		console.error.restore();
-		sinon.stub(console, 'error');
+		console.error.mockRestore();
+		jest.spyOn(console, 'error').mockImplementation();
 
 		const subject = mount(
 			<Router path="/does/not/exist">
@@ -201,8 +200,8 @@ describe('Router', () => {
 
 	test('should render nothing for a partially valid path', () => {
 		// Remove Global Spy and replace with a stub instead
-		console.error.restore();
-		sinon.stub(console, 'error');
+		console.error.mockRestore();
+		jest.spyOn(console, 'error').mockImplementation();
 
 		const subject = mount(
 			<Router path="/app/home/other">

--- a/packages/moonstone/Scroller/tests/Scroller-specs.js
+++ b/packages/moonstone/Scroller/tests/Scroller-specs.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import {mount, shallow} from 'enzyme';
 import React from 'react';
 
@@ -167,7 +166,7 @@ describe('Scroller', () => {
 
 	describe('ScrollerBase API', () => {
 		test('should call onUpdate when Scroller updates', () => {
-			const handleUpdate = sinon.spy();
+			const handleUpdate = jest.fn();
 			const subject = shallow(
 				<ScrollerBase
 					onUpdate={handleUpdate}
@@ -178,8 +177,8 @@ describe('Scroller', () => {
 
 			subject.setProps({children: ''});
 
-			const expected = true;
-			const actual = handleUpdate.calledOnce;
+			const expected = 1;
+			const actual = handleUpdate.mock.calls.length;
 
 			expect(expected).toBe(actual);
 		});

--- a/packages/moonstone/Slider/tests/Slider-specs.js
+++ b/packages/moonstone/Slider/tests/Slider-specs.js
@@ -1,6 +1,5 @@
 import {mount} from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 
 import Slider from '../Slider';
 import css from '../Slider.less';
@@ -19,13 +18,13 @@ const downKeyDown = keyDown(40);
 
 describe('Slider', () => {
 	const callCount = spy => {
-		switch (spy.callCount) {
+		switch (spy.mock.calls.length) {
 			case 0:
 				return 'not called';
 			case 1:
 				return 'called once';
 			default:
-				return `called ${spy.callCount} times`;
+				return `called ${spy.mock.calls.length} times`;
 		}
 	};
 
@@ -256,7 +255,7 @@ describe('Slider', () => {
 	test(
 		'should not emit onChange when decrementing at the lower bound when value is unset',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const subject = mount(
 				<Slider min={0} max={10} onChange={handleChange} />
 			);
@@ -265,14 +264,14 @@ describe('Slider', () => {
 			leftKeyDown(subject);
 
 			const expected = 'onChange not emitted';
-			const actual = handleChange.called ? 'onChange emitted' : 'onChange not emitted';
+			const actual = handleChange.mock.calls.length > 0 ? 'onChange emitted' : 'onChange not emitted';
 
 			expect(actual).toBe(expected);
 		}
 	);
 
 	test('should increment from the lower bound when value is unset', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const subject = mount(
 			<Slider min={0} max={10} onChange={handleChange} />
 		);
@@ -287,7 +286,7 @@ describe('Slider', () => {
 	});
 
 	test('should call onSpotlightLeft on horizontal slider at min value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={0} onSpotlightLeft={handleSpotlight} />
 		);
@@ -302,7 +301,7 @@ describe('Slider', () => {
 	});
 
 	test('should call onSpotlightLeft on vertical slider at any value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={50} orientation="vertical" onSpotlightLeft={handleSpotlight} />
 		);
@@ -319,7 +318,7 @@ describe('Slider', () => {
 	test(
 		'should not call onSpotlightLeft on horizontal slider at greater than min value',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const subject = mount(
 				<Slider defaultValue={1} onSpotlightLeft={handleSpotlight} />
 			);
@@ -335,7 +334,7 @@ describe('Slider', () => {
 	);
 
 	test('should call onSpotlightDown on vertical slider at min value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={0} orientation="vertical" onSpotlightDown={handleSpotlight} />
 		);
@@ -350,7 +349,7 @@ describe('Slider', () => {
 	});
 
 	test('should call onSpotlightDown on horizontal slider at any value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={50} onSpotlightDown={handleSpotlight} />
 		);
@@ -367,7 +366,7 @@ describe('Slider', () => {
 	test(
 		'should not call onSpotlightDown on vertical slider at greater than min value',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const subject = mount(
 				<Slider defaultValue={1} orientation="vertical" onSpotlightDown={handleSpotlight} />
 			);
@@ -383,7 +382,7 @@ describe('Slider', () => {
 	);
 
 	test('should call onSpotlightRight on horizontal slider at max value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={100} onSpotlightRight={handleSpotlight} />
 		);
@@ -398,7 +397,7 @@ describe('Slider', () => {
 	});
 
 	test('should call onSpotlightRight on vertical slider at any value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={50} orientation="vertical" onSpotlightRight={handleSpotlight} />
 		);
@@ -415,7 +414,7 @@ describe('Slider', () => {
 	test(
 		'should not call onSpotlightRight on horizontal slider at less than max value',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const subject = mount(
 				<Slider defaultValue={99} onSpotlightRight={handleSpotlight} />
 			);
@@ -431,7 +430,7 @@ describe('Slider', () => {
 	);
 
 	test('should call onSpotlightUp on vertical slider at max value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={100} max={100} orientation="vertical" onSpotlightUp={handleSpotlight} />
 		);
@@ -446,7 +445,7 @@ describe('Slider', () => {
 	});
 
 	test('should call onSpotlightUp on horizontal slider at any value', () => {
-		const handleSpotlight = sinon.spy();
+		const handleSpotlight = jest.fn();
 		const subject = mount(
 			<Slider defaultValue={50} onSpotlightUp={handleSpotlight} />
 		);
@@ -463,7 +462,7 @@ describe('Slider', () => {
 	test(
 		'should not call onSpotlightUp on vertical slider at less than max value',
 		() => {
-			const handleSpotlight = sinon.spy();
+			const handleSpotlight = jest.fn();
 			const subject = mount(
 				<Slider defaultValue={99} orientation="vertical" onSpotlightUp={handleSpotlight} />
 			);

--- a/packages/moonstone/TimePicker/tests/TimePicker-specs.js
+++ b/packages/moonstone/TimePicker/tests/TimePicker-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import {TimePicker, TimePickerBase} from '../TimePicker';
 import css from '../TimePicker.less';
 
@@ -22,7 +21,7 @@ describe('TimePicker', () => {
 	test(
 		'should emit an onChange event when changing a component picker',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const subject = mount(
 				<TimePicker onChange={handleChange} open title="Time" value={new Date(2000, 6, 15, 3, 30)} />
 			);
@@ -30,8 +29,8 @@ describe('TimePicker', () => {
 			const base = subject.find('DateComponentRangePicker').first();
 			base.prop('onChange')({value: 0});
 
-			const expected = true;
-			const actual = handleChange.calledOnce;
+			const expected = 1;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/moonstone/internal/Picker/tests/Picker-specs.js
+++ b/packages/moonstone/internal/Picker/tests/Picker-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import Picker from '../Picker';
 import PickerItem from '../PickerItem';
 import css from '../Picker.less';
@@ -28,7 +27,7 @@ describe('Picker Specs', () => {
 	test(
 		'should return an object {value: Number} that represents the next value of the Picker component when pressing the increment <span>',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} max={1} min={-1} onChange={handleChange} value={0} />
 			);
@@ -36,7 +35,7 @@ describe('Picker Specs', () => {
 			increment(picker);
 
 			const expected = 1;
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -45,7 +44,7 @@ describe('Picker Specs', () => {
 	test(
 		'should return an object {value: Number} that represents the next value of the Picker component when pressing the decrement <span>',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} max={1} min={-1} onChange={handleChange} value={0} />
 			);
@@ -53,22 +52,22 @@ describe('Picker Specs', () => {
 			decrement(picker);
 
 			const expected = -1;
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
 	);
 
 	test('should not run the onChange handler when disabled', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const picker = mount(
 			<Picker disabled index={0} max={0} min={0} onChange={handleChange} value={0} />
 		);
 
 		increment(picker);
 
-		const expected = false;
-		const actual = handleChange.called;
+		const expected = 0;
+		const actual = handleChange.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -76,7 +75,7 @@ describe('Picker Specs', () => {
 	test(
 		'should wrap to the beginning of the value range if \'wrap\' is true',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} max={0} min={-1} onChange={handleChange} value={0} wrap />
 			);
@@ -84,7 +83,7 @@ describe('Picker Specs', () => {
 			increment(picker);
 
 			const expected = -1;
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -93,7 +92,7 @@ describe('Picker Specs', () => {
 	test(
 		'should wrap to the end of the value range if \'wrap\' is true',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} max={1} min={0} onChange={handleChange} value={0} wrap />
 			);
@@ -101,14 +100,14 @@ describe('Picker Specs', () => {
 			decrement(picker);
 
 			const expected = 1;
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
 	);
 
 	test('should increment by \'step\' value', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const picker = mount(
 			<Picker index={0} max={6} min={0} onChange={handleChange} step={3} value={0} />
 		);
@@ -116,13 +115,13 @@ describe('Picker Specs', () => {
 		increment(picker);
 
 		const expected = 3;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should decrement by \'step\' value', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const picker = mount(
 			<Picker index={0} max={3} min={0} onChange={handleChange} step={3} value={3} />
 		);
@@ -130,13 +129,13 @@ describe('Picker Specs', () => {
 		decrement(picker);
 
 		const expected = 0;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should increment by \'step\' value and wrap successfully', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const picker = mount(
 			<Picker index={0} max={3} min={0} onChange={handleChange} step={3} value={3} wrap />
 		);
@@ -144,13 +143,13 @@ describe('Picker Specs', () => {
 		increment(picker);
 
 		const expected = 0;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should decrement by \'step\' value and wrap successfully', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const picker = mount(
 			<Picker index={0} max={9} min={0} onChange={handleChange} step={3} value={0} wrap />
 		);
@@ -158,7 +157,7 @@ describe('Picker Specs', () => {
 		decrement(picker);
 
 		const expected = 9;
-		const actual = handleChange.args[0][0].value;
+		const actual = handleChange.mock.calls[0][0].value;
 
 		expect(actual).toBe(expected);
 	});
@@ -237,14 +236,14 @@ describe('Picker Specs', () => {
 	test(
 		'should allow keyboard decrement via left arrow keys when \'joined\' and \'horizontal\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} value={0} />
 			);
 
 			const expected = -1;
 			picker.simulate('keyDown', {keyCode: 37});
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -253,14 +252,14 @@ describe('Picker Specs', () => {
 	test(
 		'should allow keyboard increment via right arrow keys when \'joined\' and \'horizontal\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} value={0} />
 			);
 
 			const expected = 1;
 			picker.simulate('keyDown', {keyCode: 39});
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -269,14 +268,14 @@ describe('Picker Specs', () => {
 	test(
 		'should allow keyboard decrement via down arrow keys when \'joined\' and \'vertical\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="vertical" value={0} />
 			);
 
 			const expected = -1;
 			picker.simulate('keyDown', {keyCode: 40});
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -285,14 +284,14 @@ describe('Picker Specs', () => {
 	test(
 		'should allow keyboard decrement via up arrow keys when \'joined\' and \'vertical\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="vertical" value={0} />
 			);
 
 			const expected = 1;
 			picker.simulate('keyDown', {keyCode: 38});
-			const actual = handleChange.args[0][0].value;
+			const actual = handleChange.mock.calls[0][0].value;
 
 			expect(actual).toBe(expected);
 		}
@@ -301,14 +300,14 @@ describe('Picker Specs', () => {
 	test(
 		'should not allow keyboard decrement via left arrow keys when \'joined\' and \'vertical\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="vertical" value={0} />
 			);
 
-			const expected = false;
+			const expected = 0;
 			picker.simulate('keyDown', {keyCode: 37});
-			const actual = handleChange.called;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -317,14 +316,14 @@ describe('Picker Specs', () => {
 	test(
 		'should not allow keyboard increment via right arrow keys when \'joined\' and \'vertical\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="vertical" value={0} />
 			);
 
-			const expected = false;
+			const expected = 0;
 			picker.simulate('keyDown', {keyCode: 39});
-			const actual = handleChange.called;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -333,14 +332,14 @@ describe('Picker Specs', () => {
 	test(
 		'should not allow keyboard decrement via down arrow keys when \'joined\' and \'horizontal\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="horizontal" value={0}  />
 			);
 
-			const expected = false;
+			const expected = 0;
 			picker.simulate('keyDown', {keyCode: 40});
-			const actual = handleChange.called;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -349,14 +348,14 @@ describe('Picker Specs', () => {
 	test(
 		'should not allow keyboard increment via up arrow keys when \'joined\' and \'horizontal\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const picker = mount(
 				<Picker index={0} joined max={1} min={-1} onChange={handleChange} orientation="horizontal" value={0} />
 			);
 
-			const expected = false;
+			const expected = 0;
 			picker.simulate('keyDown', {keyCode: 38});
-			const actual = handleChange.called;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/ui/Cancelable/tests/Cancelable-specs.js
+++ b/packages/ui/Cancelable/tests/Cancelable-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
-import sinon from 'sinon';
 
 import {addCancelHandler, Cancelable, removeCancelHandler} from '../Cancelable';
 
@@ -18,7 +17,7 @@ describe('Cancelable', () => {
 		return {
 			keyCode,
 			nativeEvent: {
-				stopImmediatePropagation: sinon.spy()
+				stopImmediatePropagation: jest.fn()
 			}
 		};
 	};
@@ -28,7 +27,7 @@ describe('Cancelable', () => {
 	const stop = (ev) => ev.stopPropagation();
 
 	test('should call onCancel from prop for escape key', () => {
-		const handleCancel = sinon.spy(returnsTrue);
+		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: 'onCustomEvent'},
 			Component
@@ -40,14 +39,14 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', makeKeyEvent(27));
 
-		const expected = true;
-		const actual = handleCancel.called;
+		const expected = 1;
+		const actual = handleCancel.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should only call onCancel for escape key by default', () => {
-		const handleCancel = sinon.spy(returnsTrue);
+		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
 			Component
@@ -59,14 +58,14 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', makeKeyEvent(27));
 
-		const expected = true;
-		const actual = handleCancel.calledOnce;
+		const expected = 1;
+		const actual = handleCancel.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should not call onCancel for non-escape key', () => {
-		const handleCancel = sinon.spy(returnsTrue);
+		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
 			Component
@@ -78,14 +77,14 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', makeKeyEvent(42));
 
-		const expected = false;
-		const actual = handleCancel.calledOnce;
+		const expected = 0;
+		const actual = handleCancel.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should stop propagation when handled', () => {
-		const handleCancel = sinon.spy(stop);
+		const handleCancel = jest.fn(stop);
 		const keyEvent = makeKeyEvent(27);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
@@ -98,14 +97,14 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', keyEvent);
 
-		const expected = true;
-		const actual = keyEvent.nativeEvent.stopImmediatePropagation.calledOnce;
+		const expected = 1;
+		const actual = keyEvent.nativeEvent.stopImmediatePropagation.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should not stop propagation for not handled', () => {
-		const handleCancel = sinon.spy(returnsTrue);
+		const handleCancel = jest.fn(returnsTrue);
 		const keyEvent = makeKeyEvent(42);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
@@ -118,14 +117,14 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', keyEvent);
 
-		const expected = false;
-		const actual = keyEvent.nativeEvent.stopImmediatePropagation.calledOnce;
+		const expected = 0;
+		const actual = keyEvent.nativeEvent.stopImmediatePropagation.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should forward to onKeyUp handler for any key', () => {
-		const handleKeyUp = sinon.spy();
+		const handleKeyUp = jest.fn();
 		const keyEvent = makeKeyEvent(42);
 		const Comp = Cancelable(
 			{onCancel: returnsTrue},
@@ -138,8 +137,8 @@ describe('Cancelable', () => {
 
 		subject.simulate('keyup', keyEvent);
 
-		const expected = true;
-		const actual = handleKeyUp.calledOnce;
+		const expected = 1;
+		const actual = handleKeyUp.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -147,7 +146,7 @@ describe('Cancelable', () => {
 	test('should call onCancel when additional cancel handlers pass', () => {
 		const customCancelHandler = (ev) => ev.keyCode === 461;
 		addCancelHandler(customCancelHandler);
-		const handleCancel = sinon.spy(returnsTrue);
+		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
 			Component
@@ -161,8 +160,8 @@ describe('Cancelable', () => {
 
 		removeCancelHandler(customCancelHandler);
 
-		const expected = true;
-		const actual = handleCancel.calledOnce;
+		const expected = 1;
+		const actual = handleCancel.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -170,7 +169,7 @@ describe('Cancelable', () => {
 	test(
 		'should bubble up the component tree when config handler does not call stopPropagation',
 		() => {
-			const handleCancel = sinon.spy(returnsTrue);
+			const handleCancel = jest.fn(returnsTrue);
 			const Comp = Cancelable(
 				{onCancel: handleCancel},
 				Component
@@ -185,7 +184,7 @@ describe('Cancelable', () => {
 			subject.find('Component.second').simulate('keyup', makeKeyEvent(27));
 
 			const expected = 2;
-			const actual = handleCancel.callCount;
+			const actual = handleCancel.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -195,7 +194,7 @@ describe('Cancelable', () => {
 	test(
 		'should not bubble up the component tree when config handler calls stopPropagation',
 		() => {
-			const handleCancel = sinon.spy(stop);
+			const handleCancel = jest.fn(stop);
 			const Comp = Cancelable(
 				{onCancel: handleCancel},
 				Component
@@ -210,7 +209,7 @@ describe('Cancelable', () => {
 			subject.find('Component.second').simulate('keyup', makeKeyEvent(27));
 
 			const expected = 1;
-			const actual = handleCancel.callCount;
+			const actual = handleCancel.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -219,7 +218,7 @@ describe('Cancelable', () => {
 	test(
 		'should bubble up the component tree when prop handler does not call stopPropagation',
 		() => {
-			const handleCancel = sinon.spy();
+			const handleCancel = jest.fn();
 			const Comp = Cancelable(
 				{onCancel: 'onCustomEvent'},
 				Component
@@ -233,8 +232,8 @@ describe('Cancelable', () => {
 
 			subject.find('Component.second').simulate('keyup', makeKeyEvent(27));
 
-			const expected = true;
-			const actual = handleCancel.called;
+			const expected = 1;
+			const actual = handleCancel.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -243,7 +242,7 @@ describe('Cancelable', () => {
 	test(
 		'should not bubble up the component tree when prop handler calls stopPropagation',
 		() => {
-			const handleCancel = sinon.spy();
+			const handleCancel = jest.fn();
 			const Comp = Cancelable(
 				{onCancel: 'onCustomEvent'},
 				Component
@@ -257,8 +256,8 @@ describe('Cancelable', () => {
 
 			subject.find('Component.second').simulate('keyup', makeKeyEvent(27));
 
-			const expected = false;
-			const actual = handleCancel.called;
+			const expected = 0;
+			const actual = handleCancel.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -284,7 +283,7 @@ describe('Cancelable', () => {
 		test(
 			'should invoke handler for cancel events dispatch to the window',
 			() => {
-				const handleCancel = sinon.spy(returnsTrue);
+				const handleCancel = jest.fn(returnsTrue);
 				const Comp = Cancelable(
 					{modal: true, onCancel: handleCancel},
 					Component
@@ -293,8 +292,8 @@ describe('Cancelable', () => {
 				mount(<Comp />);
 				document.dispatchEvent(makeKeyboardEvent(27));
 
-				const expected = true;
-				const actual = handleCancel.called;
+				const expected = 1;
+				const actual = handleCancel.mock.calls.length;
 
 				expect(actual).toBe(expected);
 			}
@@ -330,7 +329,7 @@ describe('Cancelable', () => {
 		test(
 			'should not invoke modal handlers after one calls stopPropagation',
 			() => {
-				const handleCancel = sinon.spy(returnsTrue);
+				const handleCancel = jest.fn(returnsTrue);
 
 				const First = Cancelable(
 					{modal: true, onCancel: handleCancel},
@@ -346,8 +345,8 @@ describe('Cancelable', () => {
 
 				document.dispatchEvent(makeKeyboardEvent(27));
 
-				const expected = false;
-				const actual = handleCancel.called;
+				const expected = 0;
+				const actual = handleCancel.mock.calls.length;
 
 				expect(actual).toBe(expected);
 			}

--- a/packages/ui/Changeable/tests/Changeable-specs.js
+++ b/packages/ui/Changeable/tests/Changeable-specs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
 import {mount, shallow} from 'enzyme';
 import Changeable from '../Changeable';
 
@@ -136,15 +135,15 @@ describe('Changeable', () => {
 	});
 
 	test('should invoke passed \'onChange\' handler', () => {
-		const handleChange = sinon.spy();
+		const handleChange = jest.fn();
 		const Component = Changeable(DivComponent);
 		const subject = shallow(
 			<Component onChange={handleChange} />
 		);
 		subject.simulate('change', {});
 
-		const expected = true;
-		const actual = handleChange.called;
+		const expected = 1;
+		const actual = handleChange.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -152,15 +151,15 @@ describe('Changeable', () => {
 	test(
 		'should not invoke passed \'onChange\' handler when \'disabled\'',
 		() => {
-			const handleChange = sinon.spy();
+			const handleChange = jest.fn();
 			const Component = Changeable(DivComponent);
 			const subject = shallow(
 				<Component onChange={handleChange} disabled />
 			);
 			subject.simulate('change', {});
 
-			const expected = false;
-			const actual = handleChange.called;
+			const expected = 0;
+			const actual = handleChange.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/ui/Group/tests/Group-specs.js
+++ b/packages/ui/Group/tests/Group-specs.js
@@ -1,7 +1,6 @@
 /* globals describe, it, expect */
 
 import React from 'react';
-import sinon from 'sinon';
 import {mount, shallow} from 'enzyme';
 import {GroupBase} from '../Group';
 
@@ -9,7 +8,7 @@ describe('Group', () => {
 	const stringItems = ['One', 'Two', 'Three'];
 
 	test('should call handler with selected on select', () => {
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" onSelect={handleClick}>
 				{stringItems}
@@ -20,13 +19,13 @@ describe('Group', () => {
 		subject.find('div').at(selected).simulate('click', {});
 
 		const expected = selected;
-		const actual = handleClick.firstCall.args[0].selected;
+		const actual = handleClick.mock.calls[0][0].selected;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should call handler with data on select', () => {
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" onSelect={handleClick}>
 				{stringItems}
@@ -37,7 +36,7 @@ describe('Group', () => {
 		subject.find('div').at(selected).simulate('click', {});
 
 		const expected = stringItems[selected];
-		const actual = handleClick.firstCall.args[0].data;
+		const actual = handleClick.mock.calls[0][0].data;
 
 		expect(actual).toBe(expected);
 	});
@@ -45,7 +44,7 @@ describe('Group', () => {
 	test(
 		'should call handler on move when childSelect="onMouseMove"',
 		() => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const subject = mount(
 				<GroupBase childComponent="div" childSelect="onMouseMove" onSelect={handleClick}>
 					{stringItems}
@@ -54,8 +53,8 @@ describe('Group', () => {
 
 			subject.find('div').at(0).simulate('mousemove', {});
 
-			const expected = true;
-			const actual = handleClick.called;
+			const expected = 1;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -63,7 +62,7 @@ describe('Group', () => {
 
 	test('should select the third item with selected=2', () => {
 		const selected = 2;
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" selected={selected} onSelect={handleClick}>
 				{stringItems}
@@ -78,7 +77,7 @@ describe('Group', () => {
 
 	test('should set {data-active} on the first item', () => {
 		const selected = 0;
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" selected={selected} selectedProp="data-active" onSelect={handleClick}>
 				{stringItems}
@@ -93,7 +92,7 @@ describe('Group', () => {
 
 	test('should set {children} to be the item by default', () => {
 		const selected = 0;
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" onSelect={handleClick}>
 				{stringItems}
@@ -108,7 +107,7 @@ describe('Group', () => {
 
 	test('should set {data-child} to be the item', () => {
 		const selected = 0;
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<GroupBase childComponent="div" childProp="data-child" onSelect={handleClick}>
 				{stringItems}

--- a/packages/ui/Item/tests/Item-specs.js
+++ b/packages/ui/Item/tests/Item-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import Item from '../Item';
 
 const tap = (node) => {
@@ -37,29 +36,29 @@ describe('Item', () => {
 
 	describe('events', () => {
 		test('should call onTap when tapped', () => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const item = mount(
 				<Item onTap={handleClick}>I am a normal Item</Item>
 			);
 
 			tap(item);
 
-			const expected = true;
-			const actual = handleClick.called;
+			const expected = 1;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should not call onTap when tapped and disabled', () => {
-			const handleClick = sinon.spy();
+			const handleClick = jest.fn();
 			const item = mount(
 				<Item disabled onTap={handleClick}>I am a disabled Item</Item>
 			);
 
 			tap(item);
 
-			const expected = false;
-			const actual = handleClick.called;
+			const expected = 0;
+			const actual = handleClick.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});

--- a/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
+++ b/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import {RadioControllerDecorator, RadioDecorator} from '../RadioDecorator';
 
 describe('RadioDecorator', () => {
@@ -149,7 +148,7 @@ describe('RadioDecorator', () => {
 
 
 	test('should not call deactivate callback on inactive items', () => {
-		const handleDeactivate = sinon.spy();
+		const handleDeactivate = jest.fn();
 		const Component = RadioDecorator({deactivate: 'onClick', prop: 'active'}, Item);
 
 		// deactivate() is only called when there was a previously active item
@@ -172,8 +171,8 @@ describe('RadioDecorator', () => {
 		});
 
 		// verify that the deactivate handler wasn't called
-		const expected = false;
-		const actual = handleDeactivate.called;
+		const expected = 0;
+		const actual = handleDeactivate.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -121,7 +121,7 @@ describe('Slottable Specs', () => {
 		'should not distribute children with an invalid \'slot\' property',
 		() => {
 			// Remove Global Spy and replace with a stub instead
-			console.error.restore();
+			console.error.mockRestore();
 			sinon.stub(console, 'error');
 
 			const Component = Slottable({slots: ['a', 'b']}, ({a, b, c}) => (

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -5,7 +5,6 @@ import React from 'react';
 import {mount} from 'enzyme';
 import kind from '@enact/core/kind';
 import Slottable from '../Slottable';
-import sinon from 'sinon';
 
 describe('Slottable Specs', () => {
 
@@ -120,9 +119,9 @@ describe('Slottable Specs', () => {
 	test(
 		'should not distribute children with an invalid \'slot\' property',
 		() => {
-			// Remove Global Spy and replace with a stub instead
-			console.error.mockRestore();
-			sinon.stub(console, 'error');
+			// Modify the console spy to silence error output with
+			// an empty mock implementation
+			console.error.mockImplementation();
 
 			const Component = Slottable({slots: ['a', 'b']}, ({a, b, c}) => (
 				<div>
@@ -146,12 +145,12 @@ describe('Slottable Specs', () => {
 			expect(actual).toBe(expected);
 
 			// Check to make sure that we only get the one expected error
-			const actualErrorsLength = console.error.args.length;
+			const actualErrorsLength = console.error.mock.calls.length;
 			const expectedErrorLength = 1;
 
 			expect(actualErrorsLength).toBe(expectedErrorLength);
 
-			const actualError = console.error.args[0][0];
+			const actualError = console.error.mock.calls[0][0];
 			const expectedError = 'Warning: The slot "c" specified on div does not exist';
 
 			expect(actualError).toBe(expectedError);

--- a/packages/ui/ToggleIcon/tests/ToggleIcon-specs.js
+++ b/packages/ui/ToggleIcon/tests/ToggleIcon-specs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 
 import ToggleIcon from '../ToggleIcon';
 
@@ -12,7 +11,7 @@ const tap = (node) => {
 describe('ToggleIcon Specs', () => {
 
 	test('should call onToggle when tapped', () => {
-		const handleToggle = sinon.spy();
+		const handleToggle = jest.fn();
 		const subject = mount(
 			<ToggleIcon onToggle={handleToggle}>
 				star
@@ -21,14 +20,14 @@ describe('ToggleIcon Specs', () => {
 
 		tap(subject);
 
-		const expected = true;
-		const actual = handleToggle.calledOnce;
+		const expected = 1;
+		const actual = handleToggle.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call onClick when clicked', () => {
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<ToggleIcon onClick={handleClick}>
 				star
@@ -37,14 +36,14 @@ describe('ToggleIcon Specs', () => {
 
 		subject.simulate('click');
 
-		const expected = true;
-		const actual = handleClick.calledOnce;
+		const expected = 1;
+		const actual = handleClick.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call onTap when tapped', () => {
-		const handleTap = sinon.spy();
+		const handleTap = jest.fn();
 		const subject = mount(
 			<ToggleIcon onTap={handleTap}>
 				star
@@ -53,14 +52,14 @@ describe('ToggleIcon Specs', () => {
 
 		tap(subject);
 
-		const expected = true;
-		const actual = handleTap.calledOnce;
+		const expected = 1;
+		const actual = handleTap.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call both onToggle and onTap when tapped', () => {
-		const handleBoth = sinon.spy();
+		const handleBoth = jest.fn();
 		const subject = mount(
 			<ToggleIcon onTap={handleBoth} onToggle={handleBoth}>
 				star
@@ -69,8 +68,8 @@ describe('ToggleIcon Specs', () => {
 
 		tap(subject);
 
-		const expected = true;
-		const actual = handleBoth.calledTwice;
+		const expected = 2;
+		const actual = handleBoth.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});

--- a/packages/ui/ToggleItem/tests/ToggleItem-specs.js
+++ b/packages/ui/ToggleItem/tests/ToggleItem-specs.js
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 
 import ToggleItem, {ToggleItemBase} from '../ToggleItem';
 import Icon from '../../Icon';
@@ -20,7 +19,7 @@ const CustomIcon = (props) => <Icon {...props}>star</Icon>;
 describe('ToggleItem Specs', () => {
 
 	test('should call onToggle, onClick, or both when clicked', () => {
-		const handleToggle = sinon.spy();
+		const handleToggle = jest.fn();
 		const subject = mount(
 			<ToggleItem component={SlottedItem} onToggle={handleToggle} iconComponent={CustomIcon}>
 				Toggle Item
@@ -30,13 +29,13 @@ describe('ToggleItem Specs', () => {
 		tap(subject);
 
 		const expected = 1;
-		const actual = handleToggle.callCount;
+		const actual = handleToggle.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call onClick when clicked', () => {
-		const handleClick = sinon.spy();
+		const handleClick = jest.fn();
 		const subject = mount(
 			<ToggleItemBase component={SlottedItem} onClick={handleClick} iconComponent={CustomIcon}>
 				Toggle Item
@@ -46,13 +45,13 @@ describe('ToggleItem Specs', () => {
 		subject.simulate('click');
 
 		const expected = 1;
-		const actual = handleClick.callCount;
+		const actual = handleClick.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call onTap when tapped', () => {
-		const handleTap = sinon.spy();
+		const handleTap = jest.fn();
 		const subject = mount(
 			<ToggleItem component={SlottedItem} onTap={handleTap} iconComponent={CustomIcon}>
 				Toggle Item
@@ -61,13 +60,13 @@ describe('ToggleItem Specs', () => {
 
 		tap(subject);
 		const expected = 1;
-		const actual = handleTap.callCount;
+		const actual = handleTap.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});
 
 	test('should call both onToggle and onTap when tapped', () => {
-		const handleBoth = sinon.spy();
+		const handleBoth = jest.fn();
 		const subject = mount(
 			<ToggleItem component={SlottedItem} onTap={handleBoth} onToggle={handleBoth} iconComponent={CustomIcon}>
 				Toggle Item
@@ -77,7 +76,7 @@ describe('ToggleItem Specs', () => {
 		tap(subject);
 
 		const expected = 2;
-		const actual = handleBoth.callCount;
+		const actual = handleBoth.mock.calls.length;
 
 		expect(expected).toBe(actual);
 	});

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -1,7 +1,6 @@
 /* eslint-disable enact/prop-types */
 import React from 'react';
 import {mount, shallow} from 'enzyme';
-import sinon from 'sinon';
 import Toggleable from '../Toggleable';
 
 describe('Toggleable', () => {
@@ -132,43 +131,43 @@ describe('Toggleable', () => {
 	// test forwarding events
 
 	test('should invoke passed \'onToggle\' handler', () => {
-		const handleToggle = sinon.spy();
+		const handleToggle = jest.fn();
 		const Component = Toggleable(DivComponent);
 		const subject = shallow(
 			<Component onToggle={handleToggle} />
 		);
 		subject.simulate('toggle');
 
-		const expected = true;
-		const actual = handleToggle.called;
+		const expected = 1;
+		const actual = handleToggle.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should invoke passed \'onActivate\' handler', () => {
-		const handleActivate = sinon.spy();
+		const handleActivate = jest.fn();
 		const Component = Toggleable({activate: 'onActivate'}, DivComponent);
 		const subject = shallow(
 			<Component onActivate={handleActivate} />
 		);
 		subject.simulate('activate');
 
-		const expected = true;
-		const actual = handleActivate.called;
+		const expected = 1;
+		const actual = handleActivate.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should invoke passed \'onDeactivate\' handler', () => {
-		const handleDeactivate = sinon.spy();
+		const handleDeactivate = jest.fn();
 		const Component = Toggleable({deactivate: 'onDeactivate'}, DivComponent);
 		const subject = shallow(
 			<Component onDeactivate={handleDeactivate} />
 		);
 		subject.simulate('deactivate');
 
-		const expected = true;
-		const actual = handleDeactivate.called;
+		const expected = 1;
+		const actual = handleDeactivate.mock.calls.length;
 
 		expect(actual).toBe(expected);
 	});
@@ -176,15 +175,15 @@ describe('Toggleable', () => {
 	test(
 		'should not invoke passed \'onToggle\' handler when disabled',
 		() => {
-			const handleToggle = sinon.spy();
+			const handleToggle = jest.fn();
 			const Component = Toggleable(DivComponent);
 			const subject = shallow(
 				<Component onToggle={handleToggle} disabled />
 			);
 			subject.simulate('toggle');
 
-			const expected = false;
-			const actual = handleToggle.called;
+			const expected = 0;
+			const actual = handleToggle.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -193,15 +192,15 @@ describe('Toggleable', () => {
 	test(
 		'should not invoke passed \'onActivate\' handler when disabled',
 		() => {
-			const handleActivate = sinon.spy();
+			const handleActivate = jest.fn();
 			const Component = Toggleable({activate: 'onActivate'}, DivComponent);
 			const subject = shallow(
 				<Component onActivate={handleActivate} disabled />
 			);
 			subject.simulate('activate');
 
-			const expected = false;
-			const actual = handleActivate.called;
+			const expected = 0;
+			const actual = handleActivate.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}
@@ -210,15 +209,15 @@ describe('Toggleable', () => {
 	test(
 		'should not invoke passed \'onDeactivate\' handler when \'disabled\'',
 		() => {
-			const handleDeactivate = sinon.spy();
+			const handleDeactivate = jest.fn();
 			const Component = Toggleable({deactivate: 'onDeactivate'}, DivComponent);
 			const subject = shallow(
 				<Component onDeactivate={handleDeactivate} disabled />
 			);
 			subject.simulate('deactivate');
 
-			const expected = false;
-			const actual = handleDeactivate.called;
+			const expected = 0;
+			const actual = handleDeactivate.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		}

--- a/packages/ui/Touchable/tests/Touchable-specs.js
+++ b/packages/ui/Touchable/tests/Touchable-specs.js
@@ -3,7 +3,6 @@
 
 import React from 'react';
 import {shallow, mount} from 'enzyme';
-import sinon from 'sinon';
 
 import Touchable from '../Touchable';
 import {activate, deactivate} from '../state';
@@ -114,15 +113,15 @@ describe('Touchable', () => {
 	describe('#onDown', () => {
 		test('should invoke onDown handle on mouse down', () => {
 			const Component = Touchable(DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onDown={handler} />
 			);
 
 			subject.simulate('mousedown', {});
 
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
@@ -131,7 +130,7 @@ describe('Touchable', () => {
 	describe('#onUp', () => {
 		test('should invoke onUp handle on mouse up', () => {
 			const Component = Touchable({activeProp: 'pressed'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onUp={handler} />
 			);
@@ -140,8 +139,8 @@ describe('Touchable', () => {
 			subject.simulate('mousedown', ev);
 			subject.simulate('mouseup', ev);
 
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
@@ -150,7 +149,7 @@ describe('Touchable', () => {
 	describe('#onTap', () => {
 		test('should be called on mouse up', () => {
 			const Component = Touchable({activeProp: 'active'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onTap={handler} />
 			);
@@ -159,30 +158,30 @@ describe('Touchable', () => {
 			subject.simulate('mousedown', ev);
 			subject.simulate('mouseup', ev);
 
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should be called on click', () => {
 			const Component = Touchable({activeProp: 'active'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onTap={handler} />
 			);
 
 			subject.simulate('click');
 
-			const expected = true;
-			const actual = handler.calledOnce;
+			const expected = 1;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
 
 		test('should be called before onClick on click', () => {
 			const Component = Touchable({activeProp: 'active'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onTap={handler} onClick={handler} />
 			);
@@ -190,14 +189,14 @@ describe('Touchable', () => {
 			subject.simulate('click');
 
 			const expected = ['onTap', 'click'];
-			const actual = handler.getCalls().map(call => call.args[0].type);
+			const actual = handler.mock.calls.map(call => call[0].type);
 
 			expect(actual).toEqual(expected);
 		});
 
 		test('should be called before onCLick on mouse up', () => {
 			const Component = Touchable({activeProp: 'active'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onTap={handler} onClick={handler} />
 			);
@@ -212,14 +211,14 @@ describe('Touchable', () => {
 			subject.simulate('click', ev);
 
 			const expected = ['onTap', 'click'];
-			const actual = handler.getCalls().map(call => call.args[0].type);
+			const actual = handler.mock.calls.map(call => call[0].type);
 
 			expect(actual).toEqual(expected);
 		});
 
 		test('should be preventable via onUp handler', () => {
 			const Component = Touchable({activeProp: 'active'}, DivComponent);
-			const handler = sinon.spy();
+			const handler = jest.fn();
 			const subject = mount(
 				<Component onTap={handler} onUp={preventDefault} />
 			);
@@ -228,8 +227,8 @@ describe('Touchable', () => {
 			subject.simulate('mousedown', ev);
 			subject.simulate('mouseup', ev);
 
-			const expected = false;
-			const actual = handler.calledOnce;
+			const expected = 0;
+			const actual = handler.mock.calls.length;
 
 			expect(actual).toBe(expected);
 		});
@@ -263,7 +262,7 @@ describe('Touchable', () => {
 				'should update active state on mouse down when activeProp is configured',
 				() => {
 					const Component = Touchable({activeProp: 'active'}, DivComponent);
-					const handler = sinon.spy();
+					const handler = jest.fn();
 					const subject = mount(
 						<Component onDown={handler} />
 					);
@@ -284,7 +283,7 @@ describe('Touchable', () => {
 				'should not update active state on mouse down when disabled',
 				() => {
 					const Component = Touchable({activeProp: 'active'}, DivComponent);
-					const handler = sinon.spy();
+					const handler = jest.fn();
 					const subject = mount(
 						<Component onDown={handler} disabled />
 					);
@@ -344,7 +343,7 @@ describe('Touchable', () => {
 				'should update active state on mouse up when activeProp is configured',
 				() => {
 					const Component = Touchable({activeProp: 'active'}, DivComponent);
-					const handler = sinon.spy();
+					const handler = jest.fn();
 					const subject = mount(
 						<Component onDown={handler} />
 					);
@@ -367,7 +366,7 @@ describe('Touchable', () => {
 				'should not update active state on mouse down when disabled',
 				() => {
 					const Component = Touchable({activeProp: 'active'}, DivComponent);
-					const handler = sinon.spy();
+					const handler = jest.fn();
 					const subject = mount(
 						<Component onDown={handler} disabled />
 					);


### PR DESCRIPTION
Requires: https://github.com/enactjs/cli/pull/157

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Our usage of Sinon spies/stubs was no longer needed now that we've switched to Jest, which includes built-in support for mocking and spies.

### Resolution
* Switch to use Jest built-ins.

### Reference Links
* https://jestjs.io/docs/en/mock-function-api
* https://github.com/maurocarrero/sinon-jest-cheatsheet

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>