### PR TITLE
ENYO-5745: Fix unable to navigate into container if first item is disabled

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to find spottable element correctly if first element in container is disabled
+
+
 ## [2.2.8] - 2018-12-06
 
 No significant changes.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -718,7 +718,7 @@ function getContainerNavigableElements (containerId) {
 		// in view
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.find(element => [null, 'false'].includes(element.getAttribute('disabled')) && contains(containerRect, getRect(element)));
+			next = spottables.find(element => !element.hasAttribute('disabled') && contains(containerRect, getRect(element)));
 		}
 
 		// otherwise, return all spottables within the container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -718,7 +718,7 @@ function getContainerNavigableElements (containerId) {
 		// in view
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.find(element => contains(containerRect, getRect(element)));
+			next = spottables.find(element => [null, 'false'].includes(element.getAttribute('disabled')) && contains(containerRect, getRect(element)));
 		}
 
 		// otherwise, return all spottables within the container


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix unable to navigate into spotlight container that has `overflow` configuration if first item is disabled

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Filter element that has `disabled` attribute when finding spottable

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5745
https://stackoverflow.com/a/23701672

### Comments
