### PR TITLE
ENYO-5745: Fix ExpandableItem and Scroller handling of disabled containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Fixed
 
 - `moonstone/ExpandableInput` to focus labeled item on close
+- `moonstone/ExpandableItem` to disable its spotlight container when the component is disabled
 - `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
 - `ui/Marquee` to display an ellipsis when changing to text that no longer fits within its bounds
 - `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` to debounce `onScrollStop` events for non-animated scrolls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ## [2.2.7] - 2018-11-21
 
-## Fixed
+### Fixed
 
 - `moonstone/Picker`, `moonstone/ExpandablePicker`, `moonstone/ExpandableList`, `moonstone/IncrementSlider` to support disabling voice control
 - `ui/Marquee` to avoid very small animations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/ExpandableInput` to focus labeled item on close
 - `moonstone/ExpandableItem` to disable its spotlight container when the component is disabled
 - `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
+- `spotlight` to focus correctly within an overflow container in which the first element is another container without spottable children
 - `ui/Marquee` to display an ellipsis when changing to text that no longer fits within its bounds
 - `ui/VirtualList`, `ui/VirtualGridList`, and `ui/Scroller` to debounce `onScrollStop` events for non-animated scrolls
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ExpandableInput` to focus labeled item on close
+- `moonstone/ExpandableItem` to disable its spotlight container when the component is disabled
 - `moonstone/Scroller` to correctly handle scrolling focused elements and containers into view
 
 ## [2.2.7] - 2018-11-21

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -387,6 +387,7 @@ const ExpandableItemBase = kind({
 				aria-disabled={disabled}
 				disabled={disabled}
 				ref={setContainerNode}
+				spotlightDisabled={spotlightDisabled || disabled}
 			>
 				<LabeledItem
 					{...ariaProps}

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -403,6 +403,28 @@ storiesOf('Spotlight', module)
 		)
 	)
 	.add(
+		'Navigating into overflow containers',
+		() => (
+			<div>
+				<Item>Before last-focused Container + Scroller</Item>
+				<Container style={{outline: '1px dotted #ffffff80'}}>
+					<Scroller>
+						<ExpandableItem disabled title="Expandable Item">
+							<Button>Hiding!</Button>
+						</ExpandableItem>
+						<Item>Item A</Item>
+						<Item disabled>Item B</Item>
+						<Item>Item C</Item>
+						<ExpandableItem disabled title="Expandable Item">
+							<Button>Hiding!</Button>
+						</ExpandableItem>
+					</Scroller>
+				</Container>
+				<Item>After last-focused Container + Scroller</Item>
+			</div>
+		)
+	)
+	.add(
 		'Kitchen Sink',
 		() => (
 			<div>

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,6 +4,8 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [2.2.8] - 2018-12-06
 
+### Fixed
+
 - `spotlight` to focus correctly within an overflow container in which the first element is another container without spottable children
 
 ## [2.2.7] - 2018-11-21

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [2.2.8] - 2018-12-06
 
-No significant changes.
+- `spotlight` to focus correctly within an overflow container in which the first element is another container without spottable children
 
 ## [2.2.7] - 2018-11-21
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -714,11 +714,10 @@ function getContainerNavigableElements (containerId) {
 	if (!next) {
 		const spottables = getSpottableDescendants(containerId);
 
-		// if there isn't a preferred entry on an overflow container, try to find the first element
-		// in view
+		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.find(element => contains(containerRect, getRect(element)));
+			next = spottables.filter(element => contains(containerRect, getRect(element)));
 		}
 
 		// otherwise, return all spottables within the container


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/ExpandableItem` (and related components) did not disable its spotlight container when the component was disable. As a result, it was still treated as a spotlight candidate even though it isn't navigable. When placed first inside a Scroller which itself is inside a restricted container (`enterTo: 'last-focused'`), it causes spotlight to abandon target detection for the scroller prematurely.

#### Longer Description ...

1. Spotlight retrieves the spottable descendants for the scroller which includes the `ExpandableItem`
2. The scroller is an overflow container (meaning it may have spottable descendants which are out of view) so the candidate list is pruned down to the visible elements and the first visible element is returned.
3. This element is the `ExpandableItem` (which isn't in fact spottable) which spotlight determines it can't focus so it assumes that the scroller has no spottable contents and continues on to the next candidate (the item after the scroller).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Update `ExpandableItem` to set `spotlightDisabled` when disabled
* Use `filter` instead of `find` for overflow containers to handle other possible situations in which a container reports as available when it lacks any spottable children.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I tested the proposed fix against ENYO-5656 (#1964) as well which introduced the logic I've changed,.

### Links
[//]: # (Related issues, references)


### Comments
