### PR TITLE
ENYO-5746: Fix Spotlight prioritization within overflow containers

### DIFF
--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -138,7 +138,7 @@ class ScrollerWithLargeContainer extends React.Component {
 
 	render () {
 		return (
-			<Scroller focusableScrollbar spotlightId='scroller' style={{height: 200}}>
+			<Scroller focusableScrollbar spotlightId="scroller" style={{height: 200}}>
 				<Container>
 					<Item>Hello</Item>
 					<Item>Hello</Item>

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -5,6 +5,8 @@ import Item from '@enact/moonstone/Item';
 import Divider from '@enact/moonstone/Divider';
 import ri from '@enact/ui/resolution';
 import Group from '@enact/ui/Group';
+import Spotlight from '@enact/spotlight';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
@@ -121,6 +123,34 @@ class ScrollerWithTwoExpandableList extends React.Component {
 					</ExpandableList>
 				</Scroller>
 			</div>
+		);
+	}
+}
+
+const Container = SpotlightContainerDecorator('div');
+
+class ScrollerWithLargeContainer extends React.Component {
+	componentDidMount () {
+		setTimeout(() => {
+			Spotlight.focus('scroller');
+		}, 50);
+	}
+
+	render () {
+		return (
+			<Scroller focusableScrollbar spotlightId='scroller' style={{height: 200}}>
+				<Container>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+					<Item>Hello</Item>
+				</Container>
+			</Scroller>
 		);
 	}
 }
@@ -262,5 +292,11 @@ storiesOf('Scroller', module)
 		'With Two Expandable List',
 		() => (
 			<ScrollerWithTwoExpandableList />
+		)
+	)
+	.add(
+		'With Large Container',
+		() => (
+			<ScrollerWithLargeContainer />
 		)
 	);

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to improve prioritizing large containers within overflow containers
+
 ## [2.2.8] - 2018-12-06
 
 ### Fixed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` to improve prioritizing large containers within overflow containers
+- `spotlight` to improve prioritization of the contents of spotlight containers within overflow containers
 
 ## [2.2.8] - 2018-12-06
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -717,7 +717,14 @@ function getContainerNavigableElements (containerId) {
 		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.filter(element => contains(containerRect, getRect(element)));
+			next = spottables.filter(element => {
+				const elementRect = getRect(element);
+				if (isContainer(element)) {
+					return intersects(containerRect, elementRect);
+				}
+
+				return contains(containerRect, getRect(element));
+			});
 		}
 
 		// otherwise, return all spottables within the container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -11,7 +11,7 @@ import {coerceArray} from '@enact/core/util';
 import intersection from 'ramda/src/intersection';
 import last from 'ramda/src/last';
 
-import {contains, matchSelector, getContainerRect, getRect} from './utils';
+import {contains, matchSelector, getContainerRect, getRect, intersects} from './utils';
 
 const containerAttribute = 'data-spotlight-id';
 const containerConfigs   = new Map();
@@ -717,7 +717,14 @@ function getContainerNavigableElements (containerId) {
 		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.filter(element => contains(containerRect, getRect(element)));
+			next = spottables.filter(element => {
+				const elementRect = getRect(element);
+				if (isContainerNode(element)) {
+					return intersects(containerRect, elementRect);
+				}
+
+				return contains(containerRect, elementRect);
+			});
 		}
 
 		// otherwise, return all spottables within the container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -712,7 +712,11 @@ function getContainerNavigableElements (containerId) {
 	}
 
 	if (!next) {
-		const spottables = getDeepSpottableDescendants(containerId);
+		let spottables = overflow ?
+			// overflow requires deep recursion to handle selecting the children of unrestricted
+			// containers or restricted containers larger than the container
+			getDeepSpottableDescendants(containerId) :
+			getSpottableDescendants(containerId);
 
 		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -712,19 +712,12 @@ function getContainerNavigableElements (containerId) {
 	}
 
 	if (!next) {
-		const spottables = getSpottableDescendants(containerId);
+		const spottables = getDeepSpottableDescendants(containerId);
 
 		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.filter(element => {
-				const elementRect = getRect(element);
-				if (isContainerNode(element)) {
-					return intersects(containerRect, elementRect);
-				}
-
-				return contains(containerRect, elementRect);
-			});
+			next = spottables.filter(element => contains(containerRect, getRect(element)));
 		}
 
 		// otherwise, return all spottables within the container


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a spotlight container configured for overflow (e.g. a `moonstone/Scroller`) contains a container larger than its viewport, that container could be ignored as a focus target.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Use `getDeepSpottableDescendants` to check contents of unrestricted containers
* Use `intersects` to prioritize large restricted containers

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I avoided `getDeepSpottableDescendants` in #2037 to minimize change. Upon reviewing the code for this change, I realized that the affected code path is only run when explicitly focusing a container via `Spotlight.focus()` so the exposure is minimal for the improvement in usability.

Targeting against `develop` under the assumption it'll land with 2.3.0. We can retarget or cherry-pick into a 2.2.x branch if needed.