### PR TITLE
ENYO-5751: Fixed to focus a list item properly by `scrollTo` API call with the current position

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unrelesed]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly by `scrollTo` API right after scrolling to the same position
+
 ## [2.2.8] - 2018-12-06
 
 ### Fixed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -555,6 +555,7 @@ class ScrollableBase extends Component {
 	scrollTo = (opt) => {
 		this.indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
 		this.nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
+		return !(this.indexToFocus === null && this.nodeToFocus === null);
 	}
 
 	alertThumb = () => {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -918,7 +918,7 @@ class ScrollableBase extends Component {
 
 	scrollStopJob = new Job(this.doScrollStop, scrollStopWaiting);
 
-	start ({targetX, targetY, animate = true, duration = animationDuration, overscrollEffect = false}) {
+	start ({targetX, targetY, animate = true, duration = animationDuration, overscrollEffect = false, force = false}) {
 		const
 			{scrollLeft, scrollTop} = this,
 			bounds = this.getScrollBounds(),
@@ -933,7 +933,7 @@ class ScrollableBase extends Component {
 		};
 
 		// bail early when scrolling to the same position
-		if (this.scrolling && this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+		if (!force && this.scrolling && this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
 			return;
 		}
 
@@ -1111,15 +1111,17 @@ class ScrollableBase extends Component {
 	scrollTo = (opt) => {
 		if (!this.deferScrollTo) {
 			const {left, top} = this.getPositionForScrollTo(opt);
+			let force = false;
 
 			if (this.props.scrollTo) {
-				this.props.scrollTo(opt);
+				force = this.props.scrollTo(opt);
 			}
 			this.scrollToInfo = null;
 			this.start({
 				targetX: (left !== null) ? left : this.scrollLeft,
 				targetY: (top !== null) ? top : this.scrollTop,
-				animate: opt.animate
+				animate: opt.animate,
+				force
 			});
 		} else {
 			this.scrollToInfo = opt;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A list does not perform scrolling if the new position is the same position as the current target position during the list is scrolling.
After #2030 is applied, a list stops its scrolling after a short period of idle time from the last scroll position change to prevent apps from overwhelming events. So, if another scrolling request (from apps by `scrollTo` API) occurs within the short period of idle time above, a list is treated as `scrolling` status and the new request is ignored when the target position is the same position as the current target position.
In normal cases, this behavior is fine regarding the scrolling position only. But, if a list handles another status (`focus` in this issue) beside a position, this behavior blocks a list from proper status updates since it is possible to check only positions and internal scrolling status inside a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed internal logic not to ignore the new request when a `focus` option is set with a valid value.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5751

### Comments
