### PR TITLE
ENYO-5755: Add voice control attribute extractor

### DIFF
--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -111,6 +111,28 @@ const extractAriaProps = function (props) {
 };
 
 /**
+ * Removes voice control related props from `props` and returns them in a new object.
+ *
+ * @function
+ * @param   {Object}    props    Props object
+ *
+ * @returns {Object}             voice control related props
+ * @memberof core/util
+ * @public
+ */
+const extractVoiceProps = function (props) {
+	const obj = {};
+	Object.keys(props).forEach(key => {
+		if (key.indexOf('data-webos-voice-') === 0) {
+			obj[key] = props[key];
+			delete props[key];
+		}
+	});
+
+	return obj;
+};
+
+/**
  * Gets the current timestamp of either `window.performance.now` or `Date.now`
  *
  * @function
@@ -204,6 +226,7 @@ export {
 	coerceArray,
 	coerceFunction,
 	extractAriaProps,
+	extractVoiceProps,
 	isRenderable,
 	Job,
 	memoize,

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -22,7 +22,7 @@
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
-import {extractAriaProps} from '@enact/core/util';
+import {extractAriaProps, extractVoiceProps} from '@enact/core/util';
 import Spottable from '@enact/spotlight/Spottable';
 import Changeable from '@enact/ui/Changeable';
 import Slottable from '@enact/ui/Slottable';
@@ -87,24 +87,6 @@ const IncrementSliderBase = kind({
 		 * @public
 		 */
 		'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-		/**
-		 * Disables voice control.
-		 *
-		 * @type {Boolean}
-		 * @memberof moonstone/IncrementSlider.IncrementSliderBase.prototype
-		 * @public
-		 */
-		'data-webos-voice-disabled': PropTypes.bool,
-
-		/**
-		 * The `data-webos-voice-group-label` for the IconButton of IncrementSlider.
-		 *
-		 * @type {String}
-		 * @memberof moonstone/IncrementSlider.IncrementSliderBase.prototype
-		 * @public
-		 */
-		'data-webos-voice-group-label': PropTypes.string,
 
 		/**
 		 * Sets the knob to selected state and allows it to move via 5-way controls.
@@ -473,8 +455,6 @@ const IncrementSliderBase = kind({
 
 	render: ({active,
 		'aria-hidden': ariaHidden,
-		'data-webos-voice-disabled': voiceDisabled,
-		'data-webos-voice-group-label': voiceGroupLabel,
 		backgroundProgress,
 		css,
 		decrementAriaLabel,
@@ -507,6 +487,7 @@ const IncrementSliderBase = kind({
 		...rest
 	}) => {
 		const ariaProps = extractAriaProps(rest);
+		const voiceProps = extractVoiceProps(rest);
 		delete rest.onSpotlightDirection;
 		delete rest.onSpotlightDown;
 		delete rest.onSpotlightLeft;
@@ -516,12 +497,11 @@ const IncrementSliderBase = kind({
 		return (
 			<div {...rest}>
 				<IncrementSliderButton
+					{...voiceProps}
 					aria-controls={!incrementDisabled ? id : null}
 					aria-hidden={ariaHidden}
 					aria-label={decrementAriaLabel}
 					className={css.decrementButton}
-					data-webos-voice-disabled={voiceDisabled}
-					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={decrementDisabled}
 					onTap={onDecrement}
 					onSpotlightDisappear={onDecrementSpotlightDisappear}
@@ -554,12 +534,11 @@ const IncrementSliderBase = kind({
 					value={value}
 				/>
 				<IncrementSliderButton
+					{...voiceProps}
 					aria-controls={!decrementDisabled ? id : null}
 					aria-hidden={ariaHidden}
 					aria-label={incrementAriaLabel}
 					className={css.incrementButton}
-					data-webos-voice-disabled={voiceDisabled}
-					data-webos-voice-group-label={voiceGroupLabel}
 					disabled={incrementDisabled}
 					onTap={onIncrement}
 					onSpotlightDisappear={onIncrementSpotlightDisappear}


### PR DESCRIPTION

### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In current status, propType should be added in each moonstone components when additional voice control attribute need

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add extractor function for pre-check and delegate voiceProps to sub components.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5755

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>