### PR TITLE
ENYO-5461: Sampler: ExpandableInput, Input: Change 'type' knob to a dropdown list

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/ExpandableInput` and `moonstone/Input` samples to allow selecting the input type
+
 ## [2.2.8] - 2018-12-06
 
 No significant changes.

--- a/packages/sampler/stories/default/ExpandableInput.js
+++ b/packages/sampler/stories/default/ExpandableInput.js
@@ -13,6 +13,11 @@ const iconNames = ['', ...Object.keys(icons)];
 const Config = mergeComponentMetadata('ExpandableInput', ExpandableInputBase, ExpandableInput);
 ExpandableInput.displayName = 'ExpandableInput';
 
+// Set up some defaults for info and knobs
+const prop = {
+	type: ['text', 'number', 'password']
+};
+
 storiesOf('Moonstone', module)
 	.add(
 		'ExpandableInput',
@@ -29,7 +34,7 @@ storiesOf('Moonstone', module)
 				onOpen={action('onOpen')}
 				title={text('title', Config, 'title')}
 				placeholder={text('placeholder', Config, 'placeholder')}
-				type={text('type', Config, 'text')}
+				type={select('type', prop.type, Config, prop.type[0])}
 			/>
 		))
 	);

--- a/packages/sampler/stories/default/Input.js
+++ b/packages/sampler/stories/default/Input.js
@@ -13,6 +13,11 @@ const iconNames = ['', ...icons];
 const Config = mergeComponentMetadata('Input', InputBase, Input);
 Input.displayName = 'Input';
 
+// Set up some defaults for info and knobs
+const prop = {
+	type: ['text', 'number', 'password']
+};
+
 storiesOf('Moonstone', module)
 	.add(
 		'Input',
@@ -29,7 +34,7 @@ storiesOf('Moonstone', module)
 				invalidMessage={text('invalidMessage', Config)}
 				placeholder={text('placeholder', Config)}
 				small={boolean('small', Config)}
-				type={text('type', Config)}
+				type={select('type', prop.type, Config, prop.type[0])}
 			/>
 		))
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- Changed ExpandableInput, Input components 'type' knob to a dropdown list.


### Resolution
- Change to selectable list instead of text input
- Pass input types and default value to type prop

### Links
ENYO-5461