### PR TITLE
PLAT-68796: Add more aria property values to verify visually (for debug aria feature)

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -146,21 +146,25 @@ const StorybookDecorator = (story, config) => {
 	const DevelopmentConfig = {
 		defaultProps: {
 			'debug aria': false,
+			'debug aria type': '',
 			'debug layout': false,
 			'debug spotlight': false
 		},
 		groupId: 'Development'
 	};
 
-	const debugAriaType = select('debug aria type', debugAriaTypes, DevelopmentConfig, getPropFromURL('debugAriaType'));
+	const
+		aria = boolean('debug aria', DevelopmentConfig, (getPropFromURL('debug aria') === 'true')),
+		ariaDebugType = select('debug aria type', debugAriaTypes, DevelopmentConfig, getPropFromURL('debug aria type')),
+		layout = boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
+		spotlight = boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'));
 
-	let classes = {
-		aria: boolean('debug aria', DevelopmentConfig, (getPropFromURL('debug aria') === 'true')),
-		layout: boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
-		spotlight: boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'))
+	const classes = {
+		aria: aria,
+		[ariaDebugType]: aria,
+		layout: layout,
+		spotlight: spotlight
 	};
-
-	classes = Object.assign({[debugAriaType]: classes.aria}, classes);
 
 	if (Object.keys(classes).length > 0) {
 		classes.debug = true;

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -102,8 +102,8 @@ const skins = {
 	'Light': 'light'
 };
 
-const debugAriaTypes = {
-	'': '',
+const debugAria = {
+	'Disable': '',
 	'All': 'all',
 	'Live region attributes': 'live',
 	'Relationship attributes': 'relationship',
@@ -145,29 +145,25 @@ const StorybookDecorator = (story, config) => {
 
 	const DevelopmentConfig = {
 		defaultProps: {
-			'debug aria': false,
-			'debug aria type': '',
+			'debug aria': '',
 			'debug layout': false,
 			'debug spotlight': false
 		},
 		groupId: 'Development'
 	};
 
-	const
-		aria = boolean('debug aria', DevelopmentConfig, (getPropFromURL('debug aria') === 'true')),
-		ariaDebugType = select('debug aria type', debugAriaTypes, DevelopmentConfig, getPropFromURL('debug aria type')),
-		layout = boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
-		spotlight = boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'));
+	const debugAriaType = select('debug aria', debugAria, DevelopmentConfig, getPropFromURL('debug aria'));
 
 	const classes = {
-		aria: aria,
-		[ariaDebugType]: aria,
-		layout: layout,
-		spotlight: spotlight
+		[`aria ${debugAriaType}`]: debugAriaType && true,
+		layout: boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
+		spotlight: boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'))
 	};
 
-	if (Object.keys(classes).length > 0) {
-		classes.debug = true;
+	for (const key in classes) {
+		if (typeof classes[key] !== 'undefined') {
+			classes.debug = true;
+		}
 	}
 
 	return (

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -154,13 +154,13 @@ const StorybookDecorator = (story, config) => {
 	const debugAriaOption = select('debug aria', debugAriaOptions, DevelopmentConfig, getPropFromURL('debug aria'));
 
 	const classes = {
-		[`aria ${debugAriaOption}`]: debugAriaOption && true,
+		[`aria ${debugAriaOption}`]: !!debugAriaOption,
 		layout: boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
 		spotlight: boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'))
 	};
 
 	for (const key in classes) {
-		if (typeof classes[key] !== 'undefined') {
+		if (classes[key]) {
 			classes.debug = true;
 		}
 	}

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -102,8 +102,8 @@ const skins = {
 	'Light': 'light'
 };
 
-const debugAria = {
-	'Disable': '',
+const debugAriaOptions = {
+	'Disable (Default)': '',
 	'All': 'all',
 	'Live region attributes': 'live',
 	'Relationship attributes': 'relationship',
@@ -145,17 +145,16 @@ const StorybookDecorator = (story, config) => {
 
 	const DevelopmentConfig = {
 		defaultProps: {
-			'debug aria': '',
 			'debug layout': false,
 			'debug spotlight': false
 		},
 		groupId: 'Development'
 	};
 
-	const debugAriaType = select('debug aria', debugAria, DevelopmentConfig, getPropFromURL('debug aria'));
+	const debugAriaOption = select('debug aria', debugAriaOptions, DevelopmentConfig, getPropFromURL('debug aria'));
 
 	const classes = {
-		[`aria ${debugAriaType}`]: debugAriaType && true,
+		[`aria ${debugAriaOption}`]: debugAriaOption && true,
 		layout: boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
 		spotlight: boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'))
 	};

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -102,6 +102,15 @@ const skins = {
 	'Light': 'light'
 };
 
+const debugAriaTypes = {
+	'': '',
+	'All': 'all',
+	'Live region attributes': 'live',
+	'Relationship attributes': 'relationship',
+	'Role': 'role',
+	'Widget attributes': 'widget'
+};
+
 // NOTE: Knobs cannot set locale in fullscreen mode. This allows any knob to be taken from the URL.
 const getPropFromURL = (propName, fallbackValue) => {
 	propName = encodeURI(propName);
@@ -143,11 +152,16 @@ const StorybookDecorator = (story, config) => {
 		groupId: 'Development'
 	};
 
-	const classes = {
+	const debugAriaType = select('debug aria type', debugAriaTypes, DevelopmentConfig, getPropFromURL('debugAriaType'));
+
+	let classes = {
 		aria: boolean('debug aria', DevelopmentConfig, (getPropFromURL('debug aria') === 'true')),
 		layout: boolean('debug layout', DevelopmentConfig, (getPropFromURL('debug layout') === 'true')),
 		spotlight: boolean('debug spotlight', DevelopmentConfig, (getPropFromURL('debug spotlight') === 'true'))
 	};
+
+	classes = Object.assign({[debugAriaType]: classes.aria}, classes);
+
 	if (Object.keys(classes).length > 0) {
 		classes.debug = true;
 	}

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -93,9 +93,10 @@
 			}
 
 			&.live {
-				[aria-live]::after {
+				[aria-live]::after,
+				[role]::after {
 					.field();
-					content: "Live(" attr(aria-live) ")";
+					content: "Live(" attr(aria-live) "), Role(" attr(role) ")";
 				}
 			}
 

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -57,8 +57,7 @@
 	.debug {
 		// `.debug.aria` Add in an Aria overlay to visualize what is assigned to the aria attributes
 		&.aria {
-			[aria-label]::after,
-			[aria-valuetext]::after {
+			.field() {
 				position: absolute;
 				font-size: small;
 				font-weight: 100;
@@ -76,16 +75,56 @@
 				pointer-events: none;
 			}
 
-			[aria-label]::after {
-				content: "Aria Label:\0020" attr(aria-label);
+			&.all {
+				[role]::after,
+				[aria-checked]::after,
+				[aria-controls]::after,
+				[aria-disabled]::after,
+				[aria-hidden]::after,
+				[aria-label]::after,
+				[aria-labelledby]::after,
+				[aria-live]::after,
+				[aria-owns]::after,
+				[aria-pressed]::after,
+				[aria-valuetext]::after {
+					.field();
+					content: "Role:(" attr(role) "), Checked:(" attr(aria-checked) "), Controls:(" attr(aria-controls) "), Disabled:(" attr(aria-disabled) "), Hidden:(" attr(aria-hidden) "), Label(" attr(aria-label) "), Labelledby:(" attr(aria-labelledby) "), Live:(" attr(aria-live) "), Owns:(" attr(aria-owns) "), Pressed:(" attr(aria-pressed) "), Valuetext:(" attr(aria-valuetext) ")";
+				}
 			}
 
-			[aria-valuetext]::after {
-				content: "Aria Value:\0020" attr(aria-valuetext);
+			&.live {
+				[aria-live]::after {
+					.field();
+					content: "Live(" attr(aria-live) ")";
+				}
 			}
 
-			[aria-label][aria-valuetext]::after {
-				content: "Aria Label:\0020'" attr(aria-label) "'; Aria Value:\0020'" attr(aria-valuetext) "';";
+			&.relationship {
+				[aria-controls]::after,
+				[aria-labelledby]::after,
+				[aria-owns]::after {
+					.field();
+					content: "Controls:(" attr(aria-controls) "), Labelledby:(" attr(aria-labelledby) "), Owns:(" attr(aria-owns) ")";
+				}
+			}
+
+			&.role {
+				[role]::after {
+					.field();
+					content: "Role(" attr(role) ")";
+				}
+			}
+
+			&.widget {
+				[aria-checked]::after,
+				[aria-disabled]::after,
+				[aria-hidden]::after,
+				[aria-label]::after,
+				[aria-pressed]::after,
+				[aria-valuetext]::after {
+					.field();
+					content: "Checked(" attr(aria-checked) "), Disabled(" attr(aria-disabled) "), Hidden(" attr(aria-hidden) "), Label(" attr(aria-label) "), Pressed(" attr(aria-pressed) "), Valuetext(" attr(aria-valuetext) ")";
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Currently, only aria-label and aria-valuetext display when 'debug aria' is enabled.
It would be helpful if adding more aria properties to verify aria features visually.
This PR will cause more debug aria properties to be displayed on the screen.

### Resolution
Support the following property categories in `debug aria` feature except for few semantical aria properties (ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#States_and_properties)
- Role (role)
- Widget attributes (aria-checked, aria-disabled, aria-hidden, aria-label, aria-pressed, aria-valuetext)
- Live region attributes (aria-live, role)
- Relationship attributes (aria-controls, aria-labelledby, aria-owns)
- All (All of the above-mentioned attributes)
(sampler: 
![image](https://user-images.githubusercontent.com/15621154/50465184-e325c500-09d8-11e9-92e0-bb7bc2ce90ff.png)
)

If you want to enable debug aria in your app, the aria property of the category is displayed on the screen by putting the names of the above categories after the `debug aria` class.
(e.g.)
- `debug aria role`
- `debug aria widget`
- `debug aria live`
- `debug aria relationship`
- `debug aria all`


### Additional Considerations
- Fixed issue where debug features was not enabled but `debug` class was included in the sampler

<img width="977" alt="issue" src="https://user-images.githubusercontent.com/15621154/50462705-6986da80-09ca-11e9-9c24-72605c6ad7ed.png">

AS-IS
```
Line: 151~153
if (Object.keys(classes).length > 0) {	 
	classes.debug = true;
}
```
TO-BE
```
Line: 162~165
for (const key in classes) {
	if (typeof classes[key] !== 'undefined') {
		classes.debug = true;
	}
}
```