### PR TITLE
ENYO-5752: Fix scrolling to boundary for short scrollers

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,11 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` property `childProps` to support additional props included in the object passed to the `itemsRenderer` callback
+
+### Fixed
+
+- `moonstone/Scroller` scrolling to boundary behavior for short scrollers
+
 ## [2.2.8] - 2018-12-06
 
 ### Fixed

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -165,8 +165,11 @@ class ScrollerBase extends Component {
 
 			return st;
 		};
-		const isItemBeforeView = (ib, sb, d) => ib.top + d < sb.top;
-		const isItemAfterView = (ib, sb, d) => ib.top + d + ib.height > sb.top + sb.height;
+		// adding threshold into these determinations ensures that items that are within that are
+		// near the bounds of the scroller cause the edge to be scrolled into view even when the
+		// itme itself is in view (e.g. due to margins)
+		const isItemBeforeView = (ib, sb, d) => ib.top + d - threshold < sb.top;
+		const isItemAfterView = (ib, sb, d) => ib.top + d + ib.height + threshold > sb.top + sb.height;
 		const canItemFit = (ib, sb) => ib.height <= sb.height;
 		const calcItemAtStart = (ib, sb, st, d) => ib.top + st + d - sb.top;
 		const calcItemAtEnd = (ib, sb, st, d) => ib.top + ib.height + st + d - (sb.top + sb.height);
@@ -176,7 +179,6 @@ class ScrollerBase extends Component {
 			} else if (isItemAfterView(ib, sb, d)) {
 				return roundToEnd(sb, calcItemAtEnd(ib, sb, st, d), sh);
 			}
-
 			return st;
 		};
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -152,12 +152,14 @@ class ScrollerBase extends Component {
 	 * @private
 	 */
 	calculateScrollTop = (item) => {
-		const roundToBoundary = (sb, st, sh) => {
-			const threshold = ri.scale(24);
-
+		const threshold = ri.scale(24);
+		const roundToStart = (sb, st) => {
 			// round to start
 			if (st < threshold) return 0;
 
+			return st;
+		};
+		const roundToEnd = (sb, st, sh) => {
 			// round to end
 			if (sh - (st + sb.height) < threshold) return sh - sb.height;
 
@@ -170,9 +172,9 @@ class ScrollerBase extends Component {
 		const calcItemAtEnd = (ib, sb, st, d) => ib.top + ib.height + st + d - (sb.top + sb.height);
 		const calcItemInView = (ib, sb, st, sh, d) => {
 			if (isItemBeforeView(ib, sb, d)) {
-				return roundToBoundary(sb, calcItemAtStart(ib, sb, st, d), sh, d);
+				return roundToStart(sb, calcItemAtStart(ib, sb, st, d));
 			} else if (isItemAfterView(ib, sb, d)) {
-				return roundToBoundary(sb, calcItemAtEnd(ib, sb, st, d), sh, d);
+				return roundToEnd(sb, calcItemAtEnd(ib, sb, st, d), sh);
 			}
 
 			return st;

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
-import {boolean, select} from '../../src/enact-knobs';
+import {boolean, select, number} from '../../src/enact-knobs';
 
 Scroller.displayName = 'Scroller';
 
@@ -263,4 +263,17 @@ storiesOf('Scroller', module)
 		() => (
 			<ScrollerWithTwoExpandableList />
 		)
+	)
+	.add(
+		'Test scrolling to boundary with small overflow',
+		() => {
+			const size = number('Spacer size', {min: 0, max: 300}, 100);
+			return (
+				<Scroller style={{height: 200}}>
+					<Item>1</Item>
+					<div style={{height: size}}>{size}px Spacer</div>
+					<Item style={{marginBottom: '18px'}}>3</Item>
+				</Scroller>
+			);
+		}
 	);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A single function, `roundToBoundary` was used for scrolling to the boundary when the target was either above or below the bounds of the scroller. As a result, when the scroller's contents were larger than the scroller but less so than the value of `threshold`, the function would always round to 0 even trying to scroll to an item below the viewport.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Refactor the method into two methods -- one for `roundToStart` and one for `roundToEnd` and use each based on the position of the target item.
