### PR TITLE
ENYO-5756: Fix closing Popup's floating layer when closed without animation

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList` to focus an item properly by `scrollTo` API immediately after a prior call to the same position
+- `moonstone/Popup` to close floating layer when the popup closes without animation
 
 ## [2.2.8] - 2018-12-06
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -239,6 +239,12 @@ const checkScrimNone = (props) => {
 		'is not supported. Use a transparent scrim to prevent spotlight focus outside of the popup');
 };
 
+const OpenState = {
+	CLOSED: 0,
+	OPENING: 1,
+	OPEN: 2
+};
+
 /**
  * A stateful component that renders a popup in a
  * [FloatingLayer]{@link ui/FloatingLayer.FloatingLayer}.
@@ -381,9 +387,10 @@ class Popup extends React.Component {
 	constructor (props) {
 		super(props);
 		this.paused = new Pause('Popup');
+		const animateOpen = this.props.noAnimation ? OpenState.OPEN : OpenState.OPENING;
 		this.state = {
 			floatLayerOpen: this.props.open,
-			popupOpen: this.props.noAnimation,
+			popupOpen: this.props.open ? animateOpen : OpenState.CLOSED,
 			containerId: Spotlight.add(),
 			activator: null
 		};
@@ -398,25 +405,20 @@ class Popup extends React.Component {
 	}
 
 	componentWillReceiveProps (nextProps) {
-		// while transitioning, we set `popupOpen` with the given `open` prop value
-		if (!this.props.noAnimation && this.state.floatLayerOpen) {
+		if (!this.props.open && nextProps.open) {
 			this.setState({
-				popupOpen: nextProps.open
-			});
-		} else if (!this.props.open && nextProps.open) {
-			this.setState({
-				popupOpen: nextProps.noAnimation,
+				popupOpen: nextProps.noAnimation ? OpenState.OPEN : OpenState.CLOSED,
 				floatLayerOpen: true,
 				activator: Spotlight.getCurrent()
 			});
 		} else if (this.props.open && !nextProps.open) {
 			const activator = this.state.activator;
 
-			this.setState({
-				popupOpen: nextProps.noAnimation,
-				floatLayerOpen: !nextProps.noAnimation,
+			this.setState(state => ({
+				popupOpen: OpenState.CLOSED,
+				floatLayerOpen: state.popupOpen === OpenState.OPEN ? !nextProps.noAnimation : false,
 				activator: nextProps.noAnimation ? null : activator
-			});
+			}));
 		}
 		checkScrimNone(nextProps);
 	}
@@ -445,9 +447,9 @@ class Popup extends React.Component {
 	handleFloatingLayerOpen = () => {
 		if (!this.props.noAnimation) {
 			this.setState({
-				popupOpen: true
+				popupOpen: OpenState.OPENING
 			});
-		} else if (this.state.popupOpen && this.props.open) {
+		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
 			this.spotPopupContent();
 		}
 	}
@@ -500,6 +502,10 @@ class Popup extends React.Component {
 
 	handlePopupShow = (ev) => {
 		forwardShow(ev, this.props);
+
+		this.setState({
+			popupOpen: OpenState.OPEN
+		});
 
 		if (ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 			this.paused.resume();
@@ -562,7 +568,7 @@ class Popup extends React.Component {
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
 					onShow={this.handlePopupShow}
-					open={this.state.popupOpen}
+					open={this.state.popupOpen >= OpenState.OPENING}
 					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
 				/>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When opening and closing a popup quickly (particularly on low-powered hardware), `Transition`'s `onShow`/`onHide` events aren't fired because the CSS transition is added and removed in the same frame. As a result, Popup isn't notified that opening or closing completes and is unable to clean up its internal state to hide the floating layer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Expanded `popupOpen` to support three modes: closed, opening, and open.
* Updated usage of `popupOpen` to test for the new states rather than a boolean
* Fixed the condition in `componentWillReceiveProps` to close the floating layer when the popup is opening but not yet open to handle this case.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Reverts the changes from #1803 but appear to be correctly handled by this new approach - cc: @viodragon2 
