### PR TITLE
PLAT-72250: Fix i18n loader to fail gracefully when paths are not injected

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 ### Fixed
 
 - `i18n` resource loader to use intelligent defaults when the path variables are not injected
+
 ## [2.2.9] - 2019-01-11
 
 No significant changes.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -9,6 +9,11 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 - `i18n/I18nDecorator` HOC config prop `sync` to support asynchronous retrieval of i18n resource files
 - `i18n/I18nDecorator` HOC config props `latinLanguageOverrides` and `nonLatinLanguageOverrides` to allow consumers to configure some locales to be treated as Latin or non-Latin for the purposes of applying the `enact-locale-non-latin` global class name.
 - `i18n/Text` component to provide asynchronous text translations
+
+### Fixed
+
+- `i18n` resource loader to use intelligent defaults when the global path variables are not set.
+
 ## [2.2.8] - 2018-12-06
 
 No significant changes.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 
 ### Fixed
 
-- `i18n` resource loader to use intelligent defaults when the global path variables are not set.
+- `i18n` resource loader to use intelligent defaults when the path variables are not injected
 
 ## [2.2.8] - 2018-12-06
 

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -1,4 +1,4 @@
-/* global XMLHttpRequest, ILIB_BASE_PATH, ILIB_RESOURCES_PATH, ILIB_CACHE_ID */
+/* global XMLHttpRequest */
 
 import {memoize} from '@enact/core/util';
 import xhr from 'xhr';
@@ -19,7 +19,14 @@ const getImpl = (url, callback, sync) => {
 				body = req.response;
 				error = false;
 			}
-			const json = error ? null : JSON.parse(body);
+
+			let json = null;
+			try {
+				json = error ? null : JSON.parse(body);
+			} catch (e) {
+				error = 'Failed to parse ILIB JSON data';
+			}
+
 			callback(json, error);
 		});
 	} else {
@@ -39,11 +46,14 @@ const get = memoize((url) => new Promise((resolve, reject) => {
 	}, false);
 }));
 
-const iLibBase = ILIB_BASE_PATH;
-const iLibResources = ILIB_RESOURCES_PATH;
+// safely access global variables that may be set by the user or a plugin
+const safeGlobal = (key, value) => typeof global[key] === 'undefined' ? value : global[key];
+
+const iLibBase = safeGlobal('ILIB_BASE_PATH', '/ilib');
+const iLibResources = safeGlobal('ILIB_RESOURCES_PATH', '/locale');
 const cachePrefix = 'ENACT-ILIB-';
 const cacheKey = cachePrefix + 'CACHE-ID';
-const cacheID = ILIB_CACHE_ID;
+const cacheID = safeGlobal('ILIB_CACHE_ID', '$ILIB');
 
 function EnyoLoader () {
 	this.base = iLibBase;

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -1,4 +1,4 @@
-/* global XMLHttpRequest */
+/* global XMLHttpRequest, ILIB_BASE_PATH, ILIB_RESOURCES_PATH, ILIB_CACHE_ID */
 
 import {memoize} from '@enact/core/util';
 import xhr from 'xhr';
@@ -46,14 +46,11 @@ const get = memoize((url) => new Promise((resolve, reject) => {
 	}, false);
 }));
 
-// safely access global variables that may be set by the user or a plugin
-const safeGlobal = (key, value) => typeof global[key] === 'undefined' ? value : global[key];
-
-const iLibBase = safeGlobal('ILIB_BASE_PATH', '/ilib');
-const iLibResources = safeGlobal('ILIB_RESOURCES_PATH', '/locale');
+const iLibBase = typeof ILIB_BASE_PATH === 'undefined' ? '/ilib' : ILIB_BASE_PATH;
+const iLibResources = typeof ILIB_RESOURCES_PATH === 'undefined' ? '/locale' : ILIB_RESOURCES_PATH;
 const cachePrefix = 'ENACT-ILIB-';
 const cacheKey = cachePrefix + 'CACHE-ID';
-const cacheID = safeGlobal('ILIB_CACHE_ID', '$ILIB');
+const cacheID = typeof ILIB_CACHE_ID === 'undefined' ? '$ILIB' : ILIB_CACHE_ID;
 
 function EnyoLoader () {
 	this.base = iLibBase;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Including `@enact/i18n` without the ilib plugin causing a runtime error because the `ILIB_` "globals" are not injected by the plugin.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add existence checks to avoid run time errors.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This does not cause ilib to "work" without the plugin but does allow an app with moonstone to still run without the ilib resources.
