### PR TITLE
PLAT-61824: Add QA sample to test disabling spottable-marqueeable button

### DIFF
--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -123,6 +123,38 @@ class DisappearTest extends React.Component {
 	}
 }
 
+class DisableOnClick extends React.Component {
+	constructor (props) {
+		super(props);
+
+		this.state = {
+			disabled: false
+		};
+	}
+
+	handleButtonDisable = () => {
+		this.setState({disabled: true});
+	}
+
+	handleButtonEnable = () => {
+		this.setState({disabled: false});
+	}
+
+	render () {
+		return (
+			<div>
+				<p>Pressing the marqueeable button will disable it. The marquee should continue and restart while the button is focused and disabled.</p>
+				<Button disabled={this.state.disabled} onClick={this.handleButtonDisable}>
+					Marqueeable Button
+				</Button>
+				<Button onClick={this.handleButtonEnable}>
+					Enable
+				</Button>
+			</div>
+		);
+	}
+}
+
 class DisableTest extends React.Component {
 	constructor (props) {
 		super(props);
@@ -376,6 +408,12 @@ storiesOf('Spotlight', module)
 		'Disappearing Spottable',
 		() => (
 			<DisappearTest />
+		)
+	)
+	.add(
+		'Disabled on Click',
+		() => (
+			<DisableOnClick />
 		)
 	)
 	.add(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Adding a QA sample to test a case where `Spottable` becomes disabled while focused and sets state that is needed by `Marquee` to allow marquee behavior to restart.