### PR TITLE
PLAT-72727: Remove componentWillMount blocks

### DIFF
--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -149,7 +149,7 @@ const SpinnerBase = kind({
  * @ui
  * @private
  */
-const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'SpinnerSpotlightDecorator';
 
@@ -167,14 +167,11 @@ const SpinnerSpotlightDecorator = hoc((config, Wrapped) => {	// eslint-disable-l
 			blockClickOn: PropTypes.oneOf(['screen', 'container', null])
 		}
 
-		constructor () {
-			super();
+		constructor (props) {
+			super(props);
 
 			this.paused = new Pause('Spinner');
-		}
-
-		UNSAFE_componentWillMount () {
-			const {blockClickOn} = this.props;
+			const {blockClickOn} = props;
 			const current = Spotlight.getCurrent();
 
 			if (blockClickOn === 'screen') {

--- a/packages/moonstone/Spinner/tests/Spinner-specs.js
+++ b/packages/moonstone/Spinner/tests/Spinner-specs.js
@@ -5,7 +5,7 @@ import css from '../Spinner.less';
 
 describe('Spinner Specs', () => {
 	test(
-		'should have not have client node when Spinner has no children',
+		'should not have client node when Spinner has no children',
 		() => {
 			const spinner = mount(
 				<Spinner />
@@ -49,7 +49,7 @@ describe('Spinner Specs', () => {
 		() => {
 			const spinner = mount(
 				<Spinner transparent>
-                    Loading...
+					Loading...
 				</Spinner>
 			);
 

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -54,7 +54,9 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'SpotlightRootDecorator';
 
-		UNSAFE_componentWillMount () {
+		constructor (props) {
+			super(props);
+
 			if (typeof window === 'object') {
 				Spotlight.initialize({
 					selector: '.' + spottableClass,


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Remove `componentWillMount` block. Both `Spinner` and `SpotlightRootDecorator`. Spotlight initialization and pause can be pushed up to `constructor`.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>