### PR TITLE
PLAT-72376: Add typescript so linked Enact works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Typescript definitions (auto generated)
+*.d.ts

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "extends": "enact/strict"
   },
   "dependencies": {
+    "@types/react": "^16.7.18",
     "classnames": "^2.2.5",
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@enact/core": "^2.2.9",
+    "@types/react": "^16.7.18",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
     "react": "^16.3.2",

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -32,6 +32,7 @@
     "@enact/i18n": "^2.2.9",
     "@enact/spotlight": "^2.2.9",
     "@enact/ui": "^2.2.9",
+    "@types/react": "^16.7.18",
     "classnames": "^2.2.5",
     "eases": "^1.0.8",
     "invariant": "^2.2.2",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@enact/core": "^2.2.9",
+    "@types/react": "^16.7.18",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
     "react": "^16.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@enact/core": "^2.2.9",
+    "@types/react": "^16.7.18",
     "classnames": "^2.2.5",
     "direction": "^1.0.1",
     "invariant": "^2.2.2",

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@enact/core": "^2.2.9",
+    "@types/react": "^16.7.18",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Adds `@types/react` so that you can work with linked Enact.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Also, ignore any `.d.ts` files in the enact directory so it doesn't show lots of untracked files

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-72376

### Comments
