### PR TITLE
PLAT-72738: Update lifecycle method in SpotlightContainerDecorator

### DIFF
--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -204,6 +204,8 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		static getDerivedStateFromProps (props, state) {
 			const {spotlightId: id, spotlightRestrict} = props;
 			const {id: prevId, spotlightRestrict: prevSpotlightRestrict} = state;
+			// prevId will only be undefined the first render so this prevents releasing the
+			// container after initially creating it
 			const isIdChanged = prevId && id && prevId !== id;
 
 			if (isIdChanged) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
This PR updates the lifecycle in `SpotlightContainerDecorator`.

This update exposed an issue in how `SpotlightContainerDecorator` currently sets spotlight container configs when there is no `spotlightId` prop provided - it will not respect the `spotlightRetrict` prop. This happens when attempting to add or update the specified container by calling `Spotlight.add(spotlightId, options)` when `spotlightId` is `undefined`. In order to update the lifecycle, I also addressed this issue, since we need the correct data in `getDerivedStateFromProps`.