### PR TITLE
PLAT-72618: [qa-sampler] Add `max`, `min`, and `value` knobs to IncrementSlider sample

### DIFF
--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -143,7 +143,7 @@ storiesOf('IncrementSlider', module)
 		'with max, min, and value',
 		() => (
 			<div>
-				Test the IncrementSlider by changing the values of min and value knobs.
+				Test the IncrementSlider by changing the values of max, min, and value knobs.
 				<IncrementSliderWithMinValue />
 			</div>
 		)

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -1,14 +1,18 @@
 import Button from '@enact/moonstone/Button';
 import ContextualPopupDecorator from '@enact/moonstone/ContextualPopupDecorator';
 import IconButton from '@enact/moonstone/IconButton';
-import IncrementSlider from '@enact/moonstone/IncrementSlider';
+import IncrementSlider, {IncrementSliderBase} from '@enact/moonstone/IncrementSlider';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
+import {mergeComponentMetadata} from '../../src/utils';
+import {number} from '../../src/enact-knobs';
+
 import IncrementSliderDelayValue from './components/IncrementSliderDelayValue';
 
 const ContextualPopupButton = ContextualPopupDecorator(IconButton);
+const IncrementSliderConfig = mergeComponentMetadata('IncrementSlider', IncrementSliderBase, IncrementSlider);
 
 class IncrementSliderView extends React.Component {
 
@@ -83,6 +87,28 @@ class IncrementSliderWithContextualPopup extends React.Component {
 	}
 }
 
+class IncrementSliderWithMinValue extends React.Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			value: 0
+		};
+	}
+
+	handleChange = ({value}) => this.setState({value})
+
+	render () {
+		return (
+			<div>
+				<IncrementSlider
+					min={number('min', IncrementSliderConfig)}
+					onChange={this.handleChange}
+					value={number('value', this.state.value)}
+				/>
+			</div>
+		);
+	}
+}
 
 storiesOf('IncrementSlider', module)
 	.add(
@@ -109,6 +135,15 @@ storiesOf('IncrementSlider', module)
 			<div>
 				Slider knob changes value with 5-way Interaction between ContextualPopup and Slider.
 				<IncrementSliderWithContextualPopup />
+			</div>
+		)
+	)
+	.add(
+		'with min and value',
+		() => (
+			<div>
+				Test the IncrementSlider by changing the values of min and value knobs.
+				<IncrementSliderWithMinValue />
 			</div>
 		)
 	);

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -101,6 +101,7 @@ class IncrementSliderWithMinValue extends React.Component {
 		return (
 			<div>
 				<IncrementSlider
+					max={number('max', IncrementSliderConfig)}
 					min={number('min', IncrementSliderConfig)}
 					onChange={this.handleChange}
 					value={number('value', this.state.value)}
@@ -139,7 +140,7 @@ storiesOf('IncrementSlider', module)
 		)
 	)
 	.add(
-		'with min and value',
+		'with max, min, and value',
 		() => (
 			<div>
 				Test the IncrementSlider by changing the values of min and value knobs.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The qa-sampler did not have a sample to test max, min, and value knobs of IncrementSlider

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Implemented using number function so that max, min, and value are passed to the IncrementSlider sample.