### PR TITLE
PLAT-72730: Update ContextualPopupDecorator life cycle methods

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -268,7 +268,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 						// is on the activator and we want to re-spot it so a11y read out can occur
 						current === prevState.activator ||
 						// is within the popup
-						this.containerNode.contains(Spotlight.getCurrent())
+						this.containerNode.contains(current)
 					)
 				};
 			}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -482,21 +482,21 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			forward('onClose')
 		)
 
-		handleOpen = () => {
-			forward('onOpen', this.props);
+		handleOpen = (ev) => {
+			forward('onOpen', ev, this.props);
 			this.positionContextualPopup();
 			const current = Spotlight.getCurrent();
 			this.updateLeaveFor(current);
-			this.setState(() => ({
+			this.setState({
 				activator: current
-			}));
+			});
 		}
 
 		handleClose = () => {
 			this.updateLeaveFor(null);
-			this.setState(() => ({
+			this.setState({
 				activator: null
-			}));
+			});
 		}
 
 		handleDirectionalKey (ev) {

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -236,8 +236,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				arrowPosition: {top: 0, left: 0},
 				containerPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				activator: null,
-				shouldSpotActivator: true
+				activator: null
 			};
 
 			this.overflow = {};
@@ -259,38 +258,30 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		UNSAFE_componentWillReceiveProps (nextProps) {
-			const current = Spotlight.getCurrent();
-
-			if (this.props.direction !== nextProps.direction) {
-				this.adjustedDirection = nextProps.direction;
-				this.positionContextualPopup();
-			}
-
-			if (!this.props.open && nextProps.open) {
-				this.updateLeaveFor(current);
-				this.setState({
-					activator: current
-				});
-			} else if (this.props.open && !nextProps.open) {
-
-				this.updateLeaveFor(null);
-				this.setState(state => ({
-					activator: null,
-					// only spot the activator on close if spotlight ...
+		getSnapshotBeforeUpdate (prevProps, prevState) {
+			if (prevProps.open && !this.props.open) {
+				const current = Spotlight.getCurrent();
+				return {
 					shouldSpotActivator: (
 						// isn't set
 						!current ||
 						// is on the activator and we want to re-spot it so a11y read out can occur
-						current === state.activator ||
+						current === prevState.activator ||
 						// is within the popup
-						this.containerNode.contains(current)
+						this.containerNode.contains(Spotlight.getCurrent())
 					)
-				}));
+				};
 			}
+			return null;
 		}
 
-		componentDidUpdate (prevProps, prevState) {
+		componentDidUpdate (prevProps, prevState, snapshot) {
+			if (prevProps.direction !== this.props.direction) {
+				this.adjustedDirection = this.props.direction;
+				// NOTE: `setState` is called and will cause re-render
+				this.positionContextualPopup();
+			}
+
 			if (this.props.open && !prevProps.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
@@ -298,8 +289,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (!this.props.open && prevProps.open) {
 				off('keydown', this.handleKeyDown);
 				off('keyup', this.handleKeyUp);
-
-				if (this.state.shouldSpotActivator) {
+				if (snapshot && snapshot.shouldSpotActivator) {
 					this.spotActivator(prevState.activator);
 				}
 			}
@@ -476,9 +466,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getContainerNode = (node) => {
 			this.containerNode = node;
-			if (node) {
-				this.positionContextualPopup();
-			}
 		}
 
 		getClientNode = (node) => {
@@ -494,6 +481,23 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			stop,
 			forward('onClose')
 		)
+
+		handleOpen = () => {
+			forward('onOpen', this.props);
+			this.positionContextualPopup();
+			const current = Spotlight.getCurrent();
+			this.updateLeaveFor(current);
+			this.setState(() => ({
+				activator: current
+			}));
+		}
+
+		handleClose = () => {
+			this.updateLeaveFor(null);
+			this.setState(() => ({
+				activator: null
+			}));
+		}
 
 		handleDirectionalKey (ev) {
 			// prevent default page scrolling
@@ -566,7 +570,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		render () {
-			const {'data-webos-voice-exclusive': voiceExclusive, showCloseButton, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, onClose, onOpen, popupProps, skin, spotlightRestrict, ...rest} = this.props;
+			const {'data-webos-voice-exclusive': voiceExclusive, showCloseButton, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, onClose, popupProps, skin, spotlightRestrict, ...rest} = this.props;
 			const scrimType = spotlightRestrict === 'self-only' ? 'transparent' : 'none';
 			const popupPropsRef = Object.assign({}, popupProps);
 			const ariaProps = extractAriaProps(popupPropsRef);
@@ -575,6 +579,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				rest.skin = skin;
 			}
 
+			delete rest.onOpen;
 			delete rest.popupSpotlightId;
 			delete rest.rtl;
 			delete rest.setApiProvider;
@@ -583,7 +588,14 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			return (
 				<div className={css.contextualPopupDecorator}>
-					<FloatingLayer open={open} scrimType={scrimType} noAutoDismiss={noAutoDismiss} onDismiss={onClose} onOpen={onOpen}>
+					<FloatingLayer
+						noAutoDismiss={noAutoDismiss}
+						onClose={this.handleClose}
+						onDismiss={onClose}
+						onOpen={this.handleOpen}
+						open={open}
+						scrimType={scrimType}
+					>
 						<ContextualPopupContainer
 							{...ariaProps}
 							className={popupClassName}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `ContextualPopupDecorator` life cycle methods

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove `componentWillReceiveProps`
- Instead of positioning the popup container in ref callback function, it positions when `FloatingLayer`'s `onOpen` is invoked. This guarantees that both `this.clientNode` and `this.containerNode` are present
- `onOpen` essentially can replace the `open` condition in `componentWillReceiveProps`. Spotlight caching can be moved here.
- Similarly, `onClose` event can be used for the `close` condition in `componentWillReceiveProps`. Resets Spotlight activator and leavefor
- `shouldSpotActivator` requires to check whether the spotlight was in container node on close condition. This can't be done in either `static getDerivedStateFromProps` or `onClose` handler, because `this.containerNode` is inaccessible or null.
- `getSnapshotBeforeUpdate` allows us to access the `this.containerNode` before `onClose` on closing condition. Therefore` shouldSpotActivator` state is removed and passed down as the snapshot.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Previously, `ContextualPopopDecorator` only rendered once on closing, but with this change, it will render twice. Once per `open` prop change and then subsequent render caused by `setState` in `onClose` handler.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>