### PR TITLE
PLAT-72731: DaySelectorDecorator life cycle methods updates

### DIFF
--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -22,7 +22,7 @@ function adjustWeekends (firstDayOfWeek, day) {
 	return ((day - firstDayOfWeek + 7) % 7);
 }
 
-const memoLocaleState = memoize((key, dayNameLength, locale) => {
+const memoLocaleState = memoize((key, dayNameLength) => {
 	const df = new DateFmt({length: 'full'});
 	const sdf = new DateFmt({length: dayNameLength});
 	const li = new LocaleInfo(ilib.getLocale());
@@ -31,10 +31,11 @@ const memoLocaleState = memoize((key, dayNameLength, locale) => {
 	const firstDayOfWeek = li.getFirstDayOfWeek();
 
 	const state = {
-		locale,
-		fullDayNames: [],
 		abbreviatedDayNames: [],
-		firstDayOfWeek
+		firstDayOfWeek: 0,
+		fullDayNames: [],
+		weekendEnd: 0,
+		weekendStart: 6
 	};
 
 	if (li.getWeekEndStart) {
@@ -57,15 +58,15 @@ const memoLocaleState = memoize((key, dayNameLength, locale) => {
 function getLocaleState (dayNameLength, locale) {
 	if (typeof window === 'undefined') {
 		return {
-			firstDayOfWeek: 0,
-			weekendStart: 6,
-			weekendEnd: 0,
-			fullDayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
 			abbreviatedDayNames: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+			firstDayOfWeek: 0,
+			fullDayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+			weekendEnd: 0,
+			weekendStart: 6
 		};
 	}
 
-	return memoLocaleState(dayNameLength + locale, dayNameLength, locale);
+	return memoLocaleState(dayNameLength + locale, dayNameLength);
 }
 
 /**

--- a/packages/moonstone/DaySelector/tests/DaySelector-specs.js
+++ b/packages/moonstone/DaySelector/tests/DaySelector-specs.js
@@ -135,4 +135,24 @@ describe('DaySelector', () => {
 			expect(actual).toBe(expected);
 		}
 	);
+
+	test(
+		'should render updated day name length.',
+		() => {
+			const handleSelect = jest.fn();
+			const subject = mount(
+				<DaySelector dayNameLength={'full'} />
+			);
+
+			subject.setProps({
+				dayNameLength: 'short'
+			});
+			subject.update();
+
+			const expected = '✓S✓M✓T✓W✓T✓F✓S';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
 });

--- a/packages/moonstone/DaySelector/tests/DaySelector-specs.js
+++ b/packages/moonstone/DaySelector/tests/DaySelector-specs.js
@@ -139,7 +139,6 @@ describe('DaySelector', () => {
 	test(
 		'should render updated day name length.',
 		() => {
-			const handleSelect = jest.fn();
 			const subject = mount(
 				<DaySelector dayNameLength={'full'} />
 			);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Update `DaySelectorDecorator` life cycle methods


### Resolution
Used `getDerivedStateFromProps` to set states with new props, and divided getLocaleStates into two parts so that these can be called independently.


Enact-DCO-1.0-Signed-off-by: Hailey Ryu hangyeol.ryu@lge.com
