### PR TITLE
PLAT-72734: Update DateTimeDecorator life cycle methods

### DIFF
--- a/packages/moonstone/DatePicker/tests/DatePicker-specs.js
+++ b/packages/moonstone/DatePicker/tests/DatePicker-specs.js
@@ -23,10 +23,11 @@ describe('DatePicker', () => {
 		() => {
 			const handleChange = jest.fn();
 			const subject = mount(
-				<DatePicker onChange={handleChange} open title="Date" value={new Date(2000, 6, 15)} />
+				<DatePicker onChange={handleChange} open title="Date" value={new Date(2000, 6, 15)} locale="en-US" />
 			);
 
 			const base = subject.find('DateComponentRangePicker').first();
+
 			base.prop('onChange')({value: 0});
 
 			const expected = 1;
@@ -60,7 +61,7 @@ describe('DatePicker', () => {
 
 	test('should accept a JavaScript Date for its value prop', () => {
 		const subject = mount(
-			<DatePicker open title="Date" value={new Date(2000, 0, 1)} />
+			<DatePicker open title="Date" value={new Date(2000, 0, 1)} locale="en-US" />
 		);
 
 		const yearPicker = subject.find(`DateComponentRangePicker.${css.year}`);
@@ -75,7 +76,7 @@ describe('DatePicker', () => {
 		'should accept an updated JavaScript Date for its value prop',
 		() => {
 			const subject = mount(
-				<DatePicker open title="Date" value={new Date(2000, 0, 1)} />
+				<DatePicker open title="Date" value={new Date(2000, 0, 1)} locale="en-US" />
 			);
 
 			subject.setProps({

--- a/packages/moonstone/TimePicker/tests/TimePicker-specs.js
+++ b/packages/moonstone/TimePicker/tests/TimePicker-specs.js
@@ -23,7 +23,7 @@ describe('TimePicker', () => {
 		() => {
 			const handleChange = jest.fn();
 			const subject = mount(
-				<TimePicker onChange={handleChange} open title="Time" value={new Date(2000, 6, 15, 3, 30)} />
+				<TimePicker onChange={handleChange} open title="Time" value={new Date(2000, 6, 15, 3, 30)} locale="en-US" />
 			);
 
 			const base = subject.find('DateComponentRangePicker').first();
@@ -60,7 +60,7 @@ describe('TimePicker', () => {
 
 	test('should accept a JavaScript Date for its value prop', () => {
 		const subject = mount(
-			<TimePicker open title="Date" value={new Date(2000, 0, 1, 12, 30)} />
+			<TimePicker open title="Date" value={new Date(2000, 0, 1, 12, 30)} locale="en-US" />
 		);
 
 		const minutePicker = subject.find(`.${css.minutesComponents}`).at(0);
@@ -75,7 +75,7 @@ describe('TimePicker', () => {
 		'should accept an updated JavaScript Date for its value prop',
 		() => {
 			const subject = mount(
-				<TimePicker open title="Date" value={new Date(2000, 0, 1, 12, 30)} />
+				<TimePicker open title="Date" value={new Date(2000, 0, 1, 12, 30)} locale="en-US" />
 			);
 
 			subject.setProps({

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -16,6 +16,18 @@ import React from 'react';
 
 import {Expandable} from '../../ExpandableItem';
 
+
+/**
+ * Converts a JavaScript Date to unix time
+ *
+ * @param	{Date}	date	A Date to convert
+ *
+ * @returns	{undefined}
+ */
+const toTime = (date) => {
+	return date && date.getTime();
+};
+
 /**
  * {@link moonstone/internal/DateTimeDecorator.DateTimeDecorator} provides common behavior for
  * {@link moonstone/DatePicker.DatePicker} and {@link moonstone/TimePicker.TimePicker}.
@@ -63,7 +75,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
-			const initialValue = this.toTime(props.value);
+			const initialValue = toTime(props.value);
 			const value = props.open && !initialValue ? Date.now() : initialValue;
 			this.state = {initialValue, value};
 
@@ -73,6 +85,16 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 					this.handlers[name] = this.handlePickerChange.bind(this, handlers[name]);
 				});
 			}
+		}
+
+		static getDerivedStateFromProps (props, state) {
+			const propValue = toTime(props.value);
+			if (state.value !== propValue) {
+				return {
+					value: propValue
+				};
+			}
+			return null;
 		}
 
 		initI18n () {
@@ -98,17 +120,6 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 					timezone: 'local'
 				});
 			}
-		}
-
-		/**
-		 * Converts a JavaScript Date to unix time
-		 *
-		 * @param	{Date}	date	A Date to convert
-		 *
-		 * @returns	{undefined}
-		 */
-		toTime (date) {
-			return date && date.getTime();
 		}
 
 		/**
@@ -145,7 +156,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		handleOpen = (ev) => {
 			forward('onOpen', ev, this.props);
 
-			const newValue = this.toTime(this.props.value);
+			const newValue = toTime(this.props.value);
 			const value = newValue || Date.now();
 
 			// if we're opening, store the current value as the initial value for cancellation
@@ -163,7 +174,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 		handleClose = (ev) => {
 			forward('onClose', ev, this.props);
-			const newValue = this.toTime(this.props.value);
+			const newValue = toTime(this.props.value);
 			this.setState({
 				value: newValue
 			});

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -139,12 +139,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		}
 
 		emitChange = (date) => {
-			const {onChange} = this.props;
-			if (onChange) {
-				onChange({
-					value: date ? date.getJSDate() : null
-				});
-			}
+			forward('onChange', {value: date ? date.getJSDate() : null}, this.props);
 		}
 
 		handleOpen = (ev) => {

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -190,7 +190,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 		handlePickerChange = (handler, ev) => {
 			const value = this.toIDate(this.state.value);
-			handler(ev, value, i18n());
+			handler(ev, value, memoizedI18nConfig(this.props.locale));
 			this.updateValue(value);
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `moonstone/internal/DateTimeDecorator` life cycle methods

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- `date` prop converts from JS `Date()` to unix time and stored as `state.date`. `static getDerivedStateFromProps` handles the job for conversion.
- Since `setState` calls were invoked only when `open` props changed, we can achieve the same effect by handling it in `onOpen` and `onClose` handlers.
- `initI18n` is moved to `render` and added `I18nContextDecorator` to handle `locale` change through props.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Wonder if `memoize` is necessary for `toTime` function.
- We could use `static getDerivedStateFromProps` to handle `open` state and pass down a new state down the life cycle, but the timing of `emitChange` will then have to happen in `componentDidUpdate`. This isn't wrong by any sense as it happens in the same update life cycle, but `onChange` could fire before the `render` is complete if we handle it in `onOpen`.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
