### PR TITLE
Spottable: Fix multiple click event when keyboard accessible node is …

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 - `spotlight` to improve prioritization of the contents of spotlight containers within overflow containers
 - `spotlight/Spottable` and `spotlight/SpotlightContainerDecorator` to prevent focus when `spotlightDisabled` is set
+- `spotlight/Spottable` to prevent emitting multiple click events when certain node types are selected via 5-way enter
 
 ## [2.2.9] - 2019-01-11
 

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -262,6 +262,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			const {currentTarget, repeat, type, which} = ev;
 			const {selectionKeys} = this.state;
+			const keyboardAccessible = isKeyboardAccessible(currentTarget);
 
 			const keyCode = selectionKeys.find((value) => (
 				// emulate mouse events for any remote okay button event
@@ -270,13 +271,15 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 				// control
 				(
 					which === value &&
-					(type !== 'keypress' || !isKeyboardAccessible(currentTarget))
+					(type !== 'keypress' || !keyboardAccessible)
 				)
 			));
 
 			if (getDirection(keyCode)) {
 				preventDefault(ev);
 				stop(ev);
+			} else if (keyboardAccessible) {
+				preventDefault(ev);
 			}
 
 			return keyCode && !repeat;


### PR DESCRIPTION
…selected via 5way enter

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Spottable` was not preventing the native generated click event when using 5way enter to select a keyboard accessible node (ex: `<button>`). This was resulting in 2 click events being emitted per enter press.

### Resolution
We needed to check if the selection key that is pressed is a directional key - if it is not, then we verify its `isKeyboardAccesible` value and can prevent the default behavior.

