### PR TITLE
PLAT-72726: Update VideoPlayer life cycle methods

### DIFF
--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -669,6 +669,15 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			}
 		}
 
+		static getDerivedStateFromProps (props) {
+			if (!props.visible) {
+				return {
+					showMoreComponents: false
+				};
+			}
+			return null;
+		}
+
 		componentDidMount () {
 			this.calculateMaxComponentCount(
 				countReactChildren(this.props.leftComponents),

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -679,11 +679,11 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			on('keyup', this.handleKeyUp);
 		}
 
-		UNSAFE_componentWillReceiveProps (nextProps) {
+		componentDidUpdate (prevProps, prevState) {
 			// Detect if the number of components has changed
-			const leftCount = countReactChildren(nextProps.leftComponents),
-				rightCount = countReactChildren(nextProps.rightComponents),
-				childrenCount = countReactChildren(nextProps.children);
+			const leftCount = countReactChildren(prevProps.leftComponents),
+				rightCount = countReactChildren(prevProps.rightComponents),
+				childrenCount = countReactChildren(prevProps.children);
 
 			if (
 				countReactChildren(this.props.leftComponents) !== leftCount ||
@@ -693,16 +693,6 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 				this.calculateMaxComponentCount(leftCount, rightCount, childrenCount);
 			}
 
-			if (this.props.visible && !nextProps.visible) {
-				this.setState(() => {
-					return {
-						showMoreComponents: false
-					};
-				});
-			}
-		}
-
-		componentDidUpdate (prevProps, prevState) {
 			if (this.state.showMoreComponents !== prevState.showMoreComponents) {
 				forwardToggleMore({showMoreComponents: this.state.showMoreComponents}, this.props);
 			}

--- a/packages/moonstone/VideoPlayer/MediaTitle.js
+++ b/packages/moonstone/VideoPlayer/MediaTitle.js
@@ -1,3 +1,4 @@
+import ForwardRef from '@enact/ui/ForwardRef';
 import kind from '@enact/core/kind';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import React from 'react';
@@ -37,6 +38,14 @@ const MediaTitleBase = kind({
 		 * @public
 		 */
 		children: PropTypes.node,
+
+		/**
+		 * Forwards a reference to the MediaTitle component.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		forwardRef: PropTypes.func,
 
 		/**
 		 * Control whether the children (infoComponents) are displayed.
@@ -94,12 +103,12 @@ const MediaTitleBase = kind({
 		})
 	},
 
-	render: ({children, childrenClassName, id, title, titleClassName, ...rest}) => {
+	render: ({children, childrenClassName, id, forwardRef, title, titleClassName, ...rest}) => {
 		delete rest.infoVisible;
 		delete rest.visible;
 
 		return (
-			<div {...rest} id={id}>
+			<div {...rest} id={id} ref={forwardRef}>
 				<Marquee id={id + '_title'} className={titleClassName} marqueeOn="render">
 					{title}
 				</Marquee>
@@ -111,7 +120,11 @@ const MediaTitleBase = kind({
 	}
 });
 
-const MediaTitle = onlyUpdateForKeys(['children', 'title', 'infoVisible', 'visible'])(MediaTitleBase);
+const MediaTitle = ForwardRef(
+	onlyUpdateForKeys(['children', 'title', 'infoVisible', 'visible'])(
+		MediaTitleBase
+	)
+);
 
 export default MediaTitle;
 export {

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -703,8 +703,8 @@ const VideoPlayerBase = class extends React.Component {
 
 	componentDidUpdate (prevProps, prevState) {
 		if (this.titleRef && this.state.infoVisible &&
-			(!prevState.infoVisible ||
-			!equals(this.props.infoComponents, prevProps.infoComponents))) {
+			(!prevState.infoVisible || !equals(this.props.infoComponents, prevProps.infoComponents))
+		) {
 			this.titleRef.style.setProperty('--infoComponentsOffset', `${this.getHeightForElement('infoComponents')}px`);
 		}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1112,7 +1112,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			this.showMiniFeedback = true;
 			this.jump(jumpBy);
-			this.announceJob.startAfter(500, secondsToTime(this.video.currentTime, this.durfmt, {includeHour: true}));
+			this.announceJob.startAfter(500, secondsToTime(this.video.currentTime, this.getDurFmt(this.props.locale), {includeHour: true}));
 		}
 	}
 
@@ -1608,7 +1608,7 @@ const VideoPlayerBase = class extends React.Component {
 
 			if (!isNaN(seconds)) {
 				this.sliderTooltipTimeJob.throttle(seconds);
-				const knobTime = secondsToTime(seconds, this.durfmt, {includeHour: true});
+				const knobTime = secondsToTime(seconds, this.getDurFmt(this.props.locale), {includeHour: true});
 
 				forward('onScrub', {...ev, seconds}, this.props);
 
@@ -1629,7 +1629,7 @@ const VideoPlayerBase = class extends React.Component {
 
 		if (!isNaN(seconds)) {
 			this.sliderTooltipTimeJob.throttle(seconds);
-			const knobTime = secondsToTime(seconds, this.durfmt, {includeHour: true});
+			const knobTime = secondsToTime(seconds, this.getDurFmt(this.props.locale), {includeHour: true});
 
 			forward('onScrub', {
 				detached: this.sliderScrubbing,
@@ -1813,7 +1813,7 @@ const VideoPlayerBase = class extends React.Component {
 			proportionSelection = selection.map(t => t / this.state.duration);
 		}
 
-		this.durfmt = this.getDurFmt(locale);
+		const durFmt = this.getDurFmt(locale);
 
 		return (
 			<RootContainer
@@ -1851,7 +1851,7 @@ const VideoPlayerBase = class extends React.Component {
 							playbackState={this.pulsedPlaybackState || this.prevCommand}
 							visible={this.state.miniFeedbackVisible && !noMiniFeedback}
 						>
-							{secondsToTime(this.state.sliderTooltipTime, this.durfmt)}
+							{secondsToTime(this.state.sliderTooltipTime, durFmt)}
 						</FeedbackContent>
 						<ControlsContainer
 							className={css.bottom + (this.state.mediaControlsVisible ? '' : ' ' + css.hidden)}
@@ -1873,7 +1873,7 @@ const VideoPlayerBase = class extends React.Component {
 									>
 										{infoComponents}
 									</MediaTitle>
-									<Times current={this.state.currentTime} total={this.state.duration} formatter={this.durfmt} />
+									<Times current={this.state.currentTime} total={this.state.duration} formatter={durFmt} />
 								</div> :
 								null
 							}
@@ -1896,7 +1896,7 @@ const VideoPlayerBase = class extends React.Component {
 								<FeedbackTooltip
 									action={this.state.feedbackAction}
 									duration={this.state.duration}
-									formatter={this.durfmt}
+									formatter={durFmt}
 									hidden={!this.state.feedbackVisible || this.state.sourceUnavailable}
 									playbackRate={this.selectPlaybackRate(this.speedIndex)}
 									playbackState={this.prevCommand}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1698,8 +1698,6 @@ const VideoPlayerBase = class extends React.Component {
 	)
 
 	handleToggleMore = ({showMoreComponents}) => {
-		console.log('handleToggleMore');
-		
 		if (!showMoreComponents) {
 			this.startAutoCloseTimeout();	// Restore the timer since we are leaving "more.
 			// Restore the title-hide now that we're finished with "more".


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update VideoPlayer life cycle methods. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
**General**
_style_ updates to components are moved to `componentDidUpdate` life cycle
- Remove `style` attribute from JSX
- Remove any _state_ keeping track of the DOM values as managing DOM values via _state_ can result in different values depending on which life cycle it's accessed from

**MediaControls**
- Counting the left/right components and resetting width of the controls is moved from `componentWillReceiveProps` to `componentDidUpdate`
- Setting `showMoreComponents` on `visible` prop change is unnecessary as it is set in associated event handlers

**VideoPlayer**
- Add `I18nContextDecorator` to handle `locale` change via prop
- Change `durfmt` to *state* as it depends on locale change
- Set title offset height in `componentDidUpdate`

**MediaTitle**
- Forwards `ref` for VideoPlayer to access the DOM

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- It is possible to measure `MediaTitle` height in `getSnapshotBeforeUpdate`, but we're interested in the value of height after it's been rendered in this case. Therefore `componentDidUpdate` is more suitable.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
