### PR TITLE
PLAT-72716: Picker and Scrollable - Update lifecycle method

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -419,18 +419,6 @@ const PickerBase = class extends React.Component {
 		}
 	}
 
-	UNSAFE_componentWillReceiveProps (nextProps) {
-		const first = nextProps.min;
-		const last = nextProps.max;
-		const nextValue = nextProps.value;
-
-		if (__DEV__) {
-			validateRange(nextValue, first, last, PickerBase.displayName);
-			validateStepped(nextValue, first, nextProps.step, PickerBase.displayName);
-			validateStepped(last, first, nextProps.step, PickerBase.displayName, '"max"');
-		}
-	}
-
 	componentDidUpdate (prevProps) {
 		if (this.props.joined && !prevProps.joined) {
 			this.containerRef.addEventListener('wheel', this.handleWheel);
@@ -805,14 +793,23 @@ const PickerBase = class extends React.Component {
 			id,
 			index,
 			joined,
+			max,
+			min,
 			onSpotlightDisappear,
 			orientation,
 			reverse,
 			spotlightDisabled,
 			step,
+			value,
 			width,
 			...rest
 		} = this.props;
+
+		if (__DEV__) {
+			validateRange(value, min, max, PickerBase.displayName);
+			validateStepped(value, min, step, PickerBase.displayName);
+			validateStepped(max, min, step, PickerBase.displayName, '"max"');
+		}
 
 		delete rest['aria-label'];
 		delete rest.accessibilityHint;
@@ -820,14 +817,11 @@ const PickerBase = class extends React.Component {
 		delete rest.decrementIcon;
 		delete rest.incrementAriaLabel;
 		delete rest.incrementIcon;
-		delete rest.max;
-		delete rest.min;
 		delete rest.onChange;
 		delete rest.onSpotlightDown;
 		delete rest.onSpotlightLeft;
 		delete rest.onSpotlightRight;
 		delete rest.onSpotlightUp;
-		delete rest.value;
 		delete rest.wrap;
 
 		const incrementIcon = selectIncIcon(this.props);

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -415,10 +415,6 @@ class ScrollableBase extends Component {
 		this.updateScrollbars();
 	}
 
-	UNSAFE_componentWillUpdate () {
-		this.deferScrollTo = true;
-	}
-
 	componentDidUpdate (prevProps, prevState) {
 		const
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
@@ -432,6 +428,8 @@ class ScrollableBase extends Component {
 				this.setScrollTop(0);
 			}
 		}
+
+		this.deferScrollTo = true;
 
 		this.clampScrollPosition();
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -402,10 +402,6 @@ class ScrollableBaseNative extends Component {
 		this.updateScrollbars();
 	}
 
-	UNSAFE_componentWillUpdate () {
-		this.deferScrollTo = true;
-	}
-
 	componentDidUpdate (prevProps, prevState) {
 		const
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
@@ -419,6 +415,8 @@ class ScrollableBaseNative extends Component {
 				this.setScrollTop(0);
 			}
 		}
+
+		this.deferScrollTo = true;
 
 		this.addEventListeners();
 		if (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Remove _componentWillReceiveProps_ from Picker and _componentWillUpdate_ from Scrollable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Validation code of Picker is moved to _render_ function to validate values both for mounting and updating cases.
Code for _scrollTo_ method of Scrollable is moved to _componentDidUpdate_.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
If we don't need to validate values of Picker for mounting, we can move the code into _getDerivedStateFromProps_ from _componentWillReceiveProps_ instead.

For Scrollable, the behavior of before and after this PR is identical, but I found that the code does not work as intention in some cases due to the changed behavior of React life cycle. We need to take a look at this issue separately.

### Links
[//]: # (Related issues, references)
PLAT-72716

### Comments
