### PR TITLE
PLAT-72655: Fix ApiDecorator to be compatible with StrictMode

### DIFF
--- a/packages/core/internal/ApiDecorator/ApiDecorator.js
+++ b/packages/core/internal/ApiDecorator/ApiDecorator.js
@@ -10,30 +10,19 @@ import React from 'react';
 
 import hoc from '../../hoc';
 
-// Invokes `name` on `provider` with `args`
-const invoke = (provider, name, args) => {
-	if (provider) {
-		const fn = provider[name];
-		if (typeof fn === 'function') {
-			return provider[name](...args);
-		}
-	}
-};
-
 // Gets a property from `provider`
-const get = (provider, name) => {
+const get = (provider, name) => () => {
 	if (provider) {
 		return provider[name];
 	}
 };
 
 // Sets a property on `provider`
-const set = (provider, name, value) => {
-	if (provider) {
+const set = (provider, name) => (value) => {
+	if (provider && typeof provider[name] !== 'function') {
 		return (provider[name] = value);
 	}
 };
-
 
 /**
  * Default config for {@link core/internal/ApiDecorator.ApiDecorator}.
@@ -87,19 +76,12 @@ const ApiDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		setProvider = (provider) => {
 			api.forEach(key => {
-				if (this[key]) {
-					throw new Error(`API endpoint, ${key}, already exists`);
-				}
-
-				if (typeof provider[key] === 'function') {
-					this[key] = (...args) => invoke(provider, key, args);
-				} else {
-					Object.defineProperty(this, key, {
-						get: () => get(provider, key),
-						set: (v) => set(provider, key, v),
-						enumerable: true
-					});
-				}
+				Object.defineProperty(this, key, {
+					get: get(provider, key),
+					set: set(provider, key),
+					enumerable: true,
+					configurable: true
+				});
 			});
 		}
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In StrictMode, certain lifecycle methods are invoked twice to surface unintended side-effects. `ApiDecorator` was implemented too defensively and was throwing errors when attempting to redefine an API endpoint on a second call to `setApiProvider` which is often called in the constructor of the consumer of the HOC.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The proposed fix makes the properties defined by ApiDecorator configurable. Originally, I was trying to build in some "security" by preventing changes to the props but that isn't protecting against any real threats and instead prevents real use cases for consumers updating the API endpoint if the situation arose.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Also did some related clean up to remove the `invoke` helper method which isn't meaningful for this use case since the `get` handler will return both functions and non-functions and provide native error handling if a consumer attempted to invoke a non-function whereas `invoke` silently failed.
