### PR TITLE
PLAT-72740: MarqueeDecorator lifecycle update

### DIFF
--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -326,33 +326,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			on('keydown', this.handlePointerHide);
 		}
 
-		UNSAFE_componentWillReceiveProps (next) {
-			const {forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpeed, rtl} = this.props;
-			if (
-				locale !== next.locale ||
-				rtl !== next.rtl ||
-				!shallowEqual(this.props.children, next.children) ||
-				(invalidateProps && didPropChange(invalidateProps, this.props, next))
-			) {
-				// restart marqueeOn="render" marquees or synced marquees that were animating
-				this.forceRestartMarquee = next.marqueeOn === 'render' || (
-					this.sync && (this.state.animating || this.timerState > TimerState.CLEAR)
-				);
-
-				this.invalidateMetrics();
-				this.cancelAnimation();
-			} else if (
-				next.marqueeOn !== marqueeOn ||
-				next.marqueeDisabled !== marqueeDisabled ||
-				next.marqueeSpeed !== marqueeSpeed ||
-				next.forceDirection !== forceDirection
-			) {
-				this.cancelAnimation();
-			} else if (next.disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
-				this.context.enter(this);
-			}
-		}
-
 		shouldComponentUpdate (nextProps, nextState) {
 			return (
 				!shallowEqual(this.state, nextState) ||
@@ -360,7 +333,33 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			);
 		}
 
-		componentDidUpdate () {
+		componentDidUpdate (prevProps) {
+			const {children, disabled, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpeed, rtl} = this.props;
+
+			if (
+				prevProps.locale !== locale ||
+				prevProps.rtl !== rtl ||
+				!shallowEqual(prevProps.children, children) ||
+				(invalidateProps && didPropChange(invalidateProps, prevProps, this.props))
+			) {
+				// restart marqueeOn="render" marquees or synced marquees that were animating
+				this.forceRestartMarquee = marqueeOn === 'render' || (
+					this.sync && (this.state.animating || this.timerState > TimerState.CLEAR)
+				);
+
+				this.invalidateMetrics();
+				this.cancelAnimation();
+			} else if (
+				prevProps.marqueeOn !== marqueeOn ||
+				prevProps.marqueeDisabled !== marqueeDisabled ||
+				prevProps.marqueeSpeed !== marqueeSpeed ||
+				prevProps.forceDirection !== forceDirection
+			) {
+				this.cancelAnimation();
+			} else if (disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
+				this.context.enter(this);
+			}
+
 			this.validateTextDirection();
 			if (this.shouldStartMarquee()) {
 				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -303,7 +303,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				rtl: determineTextDirection(null, props.rtl, props.forceDirection)
 			};
 			this.sync = false;
-			this.forceRestartMarquee = false;
 			this.timerState = TimerState.CLEAR;
 			this.distance = null;
 			this.contentFits = false;
@@ -336,6 +335,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		componentDidUpdate (prevProps) {
 			const {children, disabled, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpeed, rtl} = this.props;
 
+			let forceRestartMarquee = false;
+
 			if (
 				prevProps.locale !== locale ||
 				prevProps.rtl !== rtl ||
@@ -343,7 +344,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				(invalidateProps && didPropChange(invalidateProps, prevProps, this.props))
 			) {
 				// restart marqueeOn="render" marquees or synced marquees that were animating
-				this.forceRestartMarquee = marqueeOn === 'render' || (
+				forceRestartMarquee = marqueeOn === 'render' || (
 					this.sync && (this.state.animating || this.timerState > TimerState.CLEAR)
 				);
 
@@ -361,10 +362,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
-			if (this.shouldStartMarquee()) {
+			if (forceRestartMarquee || this.shouldStartMarquee()) {
 				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
 			}
-			this.forceRestartMarquee = false;
 		}
 
 		componentWillUnmount () {
@@ -442,7 +442,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {disabled, marqueeDisabled, marqueeOn} = this.props;
 			return !marqueeDisabled && (
 				marqueeOn === 'render' ||
-				this.forceRestartMarquee ||
 				!this.sync && (
 					(this.isFocused && marqueeOn === 'focus' && !disabled) ||
 					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus' && disabled))


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Removed the `UNSAFE_componentWillReceiveProps ` life cycle in `MarqueeDecorator`.

### Resolution
The `UNSAFE_componentWillReceiveProps` life cycle was being used in more of a procedural manner rather than state management - mostly to invalidate metrics (`this.invalidateMetrics()`) and cancel animations (`this.cancelAnimation()`) - even though each ultimately updated a piece of state. The combination of that and the amount of new state we would have to manage in order to add a `getDerivedStateFromProps` (to update those minor state changes) leads me to believe that the least impactful solution is to handle things in `componentDidUpdate`.

### Considerations
`componentDidUpdate` already includes code that will cause an additional `setState` re-render (`this.validateTextDirection()`), which is guarded against happening when not necessary. I believe the added state-updating code is also guarded properly, but would love another pair of discerning :eyes: to verify.
