### PR TITLE
ENYO-5780: Apply throttle to onmousemove event

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -456,6 +456,26 @@ const Spotlight = (function () {
 		}
 	}
 
+	let throttleTimer = null;
+	let throttleClientX, throttleClientY;
+
+	function throttleMouseMove (e) {
+		throttleClientX = e.clientX;
+		throttleClientY = e.clientY;
+
+		if (!throttleTimer) {
+			throttleTimer = setTimeout( () => {
+				const evt = Object.assign({}, e, {
+					clientX: throttleClientX,
+					clientY: throttleClientY,
+					target: document.elementFromPoint(throttleClientX, throttleClientY)
+				});
+				onMouseMove(evt);
+				throttleTimer = null;
+			}, 100);
+		}
+	}
+
 	function onMouseMove ({target, clientX, clientY}) {
 		if (shouldPreventNavigation()) {
 			notifyPointerMove(null, target, clientX, clientY);


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
CPU usage is increase rapidly during cursor navigation in enact app.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In current status, spotlight use onmousemove event and handler function called many times during cursor move. For resolve this issue, I try to test using throttle.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-5780

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>