### PR TITLE
ENYO-5784 - Qa-Sampler: Marquee - with short content: Cannot read property 'scrollWidth' of undefined

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 ### Changed
 
 - `moonstone/ExpandableInput` and `moonstone/Input` knob to select input type
+- `moonstone/Marquee` switched qa-sample to use `querySelector` instead of `ref`
 
 ## [2.2.9] - 2019-01-11
 

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 ### Changed
 
 - `moonstone/ExpandableInput` and `moonstone/Input` knob to select input type
-- `moonstone/Marquee` switched qa-sample to use `querySelector` instead of `ref`
 
 ## [2.2.9] - 2019-01-11
 

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -75,6 +75,7 @@ class MarqueeWithShortContent extends React.Component {
 	}
 
 	componentDidMount () {
+		// This is hacky. Will break if classes change
 		this.node = document.querySelector('[class^="Panel-module__body"] [class^="Marquee-module__marquee"]');
 		this.updateSizeInfo();
 	}

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -53,7 +53,7 @@ const MarqueeI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale
 const CustomItemBase = ({children, ...rest}) => (
 	<div {...rest} style={{display: 'flex', width: 300, alignItems: 'center'}}>
 		<Icon>flag</Icon>
-		<Marquee style={{flex: 1, overflow: 'hidden'}}>{children}</Marquee>
+		<Marquee id="marqueeText" style={{flex: 1, overflow: 'hidden'}}>{children}</Marquee>
 		<Icon>trash</Icon>
 	</div>
 );
@@ -75,8 +75,7 @@ class MarqueeWithShortContent extends React.Component {
 	}
 
 	componentDidMount () {
-		// This is hacky. Will break if classes change
-		this.node = document.querySelector('[class^="Panel-module__body"] [class^="Marquee-module__marquee"]');
+		this.node = document.querySelector('#marqueeText');
 		this.updateSizeInfo();
 	}
 

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -34,7 +34,7 @@ const RTL = [
 
 const disabledDisclaimer = (disabled) => (disabled ? <p style={{fontSize: '70%', fontStyle: 'italic'}}><sup>*</sup>Marquee does not visually respond to <code>disabled</code> state.</p> : <p />);
 
-const MarqueI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale'}, kind({
+const MarqueeI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale'}, kind({
 	name: 'I18nPanel',
 
 	handlers: {
@@ -50,10 +50,10 @@ const MarqueI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale'
 }));
 
 // eslint-disable-next-line enact/prop-types
-const CustomItemBase = ({children, marqueeRef, ...rest}) => (
+const CustomItemBase = ({children, ...rest}) => (
 	<div {...rest} style={{display: 'flex', width: 300, alignItems: 'center'}}>
 		<Icon>flag</Icon>
-		<Marquee ref={marqueeRef} style={{flex: 1, overflow: 'hidden'}}>{children}</Marquee>
+		<Marquee style={{flex: 1, overflow: 'hidden'}}>{children}</Marquee>
 		<Icon>trash</Icon>
 	</div>
 );
@@ -75,6 +75,7 @@ class MarqueeWithShortContent extends React.Component {
 	}
 
 	componentDidMount () {
+		this.node = document.querySelector('[class^="Panel-module__body"] [class^="Marquee-module__marquee"]');
 		this.updateSizeInfo();
 	}
 
@@ -95,15 +96,11 @@ class MarqueeWithShortContent extends React.Component {
 		this.setState(prevState => ({long: !prevState.long}));
 	}
 
-	getRef = ref => {
-		this.node = ref && ref.node;
-	}
-
 	render () {
 		return (
 			<div>
 				scrollWidth: {this.state.scrollWidth} width: {this.state.width}
-				<CustomItem marqueeRef={this.getRef} onClick={this.handleClick}>{this.state.long ? 'Very very very very very very very very very long text' : 'text'}</CustomItem>
+				<CustomItem onClick={this.handleClick}>{this.state.long ? 'Very very very very very very very very very long text' : 'text'}</CustomItem>
 			</div>
 		);
 	}
@@ -242,7 +239,7 @@ storiesOf('Marquee', module)
 	.add(
 		'I18n',
 		() => (
-			<MarqueI18nSamples />
+			<MarqueeI18nSamples />
 		)
 	)
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Marquee sample broke because of MarqueeDecorator change. Refs no longer work for Marquee, but nobody should be using them in the first place.

### Resolution
Using `querySelector` instead of refs


### Links
ENYO-5784
