### PR TITLE
ENYO-5794: Set default value for Slider

### DIFF
--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -254,7 +254,8 @@ const SliderBase = kind({
 			activateOnFocus,
 			active
 		}),
-		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
+		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip,
+		value: ({min, value}) => value || min
 	},
 
 	render: ({css, focused, tooltip, ...rest}) => {

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -255,7 +255,7 @@ const SliderBase = kind({
 			active
 		}),
 		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip,
-		value: ({min, value}) => value || min
+		value: ({min, value = min}) => value
 	},
 
 	render: ({css, focused, tooltip, ...rest}) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
A recent change to `Changeable` expects the config `prop` value to be set on creation. `moonstone/Slider` uses this to manage the `value` prop. This value is not set on creation, rather letting a child component `ui/Slider` set the value (default is `min`). `moonstone/Slider`'s use of `Changeable` cannot access that value, so it looks like we also need to set the default value in `moonstone/Slider`.
