### PR TITLE
ENYO-5796: Fix large text knob value assignment

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -158,7 +158,7 @@ const StorybookDecorator = (story, config) => {
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
 			locale={selectV2('locale', locales, 'en-US', globalGroup)}
-			textSize={boolean('large text', Config, (getPropFromURL('large text') === 'true')) ? 'large' : 'normal'}
+			textSize={boolean('large text', Config, getPropFromURL('large text') === 'true') ? 'large' : 'normal'}
 			highContrast={boolean('high contrast', Config, (getPropFromURL('high contrast') === 'true'))}
 			style={backgroundLabelMap[select('background', backgroundLabels, Config, getPropFromURL('background'))]}
 			skin={select('skin', skins, Config, getPropFromURL('skin'))}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The knob assignment logic was incorrectly assigning a string to a boolean knob

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move the ternary outside the knob to pass the string to the prop rather than the knob
