### PR TITLE
ENYO-5793: Restore OPENING state in Popup

### DIFF
--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -404,7 +404,7 @@ class Popup extends React.Component {
 		if (props.open !== state.prevOpen) {
 			if (props.open) {
 				return {
-					popupOpen: props.noAnimation ? OpenState.OPEN : OpenState.CLOSED,
+					popupOpen: props.noAnimation || state.floatLayerOpen ? OpenState.OPEN : OpenState.CLOSED,
 					floatLayerOpen: true,
 					activator: Spotlight.getCurrent(),
 					prevOpen: props.open

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -241,6 +241,12 @@ const checkScrimNone = (props) => {
 		'is not supported. Use a transparent scrim to prevent spotlight focus outside of the popup');
 };
 
+const OpenState = {
+	CLOSED: 0,
+	OPENING: 1,
+	OPEN: 2
+};
+
 /**
  * A stateful component that renders a popup in a
  * [FloatingLayer]{@link ui/FloatingLayer.FloatingLayer}.
@@ -383,9 +389,11 @@ class Popup extends React.Component {
 	constructor (props) {
 		super(props);
 		this.paused = new Pause('Popup');
+		const animateOpen = this.props.noAnimation ? OpenState.OPEN : OpenState.OPENING;
 		this.state = {
 			floatLayerOpen: this.props.open,
-			popupOpen: this.props.open,
+			popupOpen: this.props.open ? animateOpen : OpenState.CLOSED,
+			prevOpen: this.props.open,
 			containerId: Spotlight.add(),
 			activator: null
 		};
@@ -393,14 +401,22 @@ class Popup extends React.Component {
 	}
 
 	static getDerivedStateFromProps (props, state) {
-		if (props.open && !state.floatLayerOpen) {
-			return {
-				floatLayerOpen: true
-			};
-		} else if (!props.open && state.popupOpen) {
-			return {
-				popupOpen: false
-			};
+		if (props.open !== state.prevOpen) {
+			if (props.open) {
+				return {
+					popupOpen: props.noAnimation ? OpenState.OPEN : OpenState.CLOSED,
+					floatLayerOpen: true,
+					activator: Spotlight.getCurrent(),
+					prevOpen: props.open
+				};
+			} else {
+				return {
+					popupOpen: OpenState.CLOSED,
+					floatLayerOpen: state.popupOpen === OpenState.OPEN ? !props.noAnimation : false,
+					activator: props.noAnimation ? null : state.activator,
+					prevOpen: props.open
+				};
+			}
 		}
 		return null;
 	}
@@ -412,10 +428,19 @@ class Popup extends React.Component {
 		}
 	}
 
-	componentDidUpdate (prevProps) {
-		if (!this.props.noAnimation && (this.props.open !== prevProps.open)) {
-			this.paused.pause();
+	componentDidUpdate (prevProps, prevState) {
+		if (this.props.open !== prevProps.open) {
+			if (!this.props.noAnimation) {
+				this.paused.pause();
+			} else if (this.props.open) {
+				forwardShow({}, this.props);
+				this.spotPopupContent();
+			} else if (prevProps.open) {
+				forwardHide({}, this.props);
+				this.spotActivator(prevState.activator);
+			}
 		}
+
 		checkScrimNone(this.props);
 	}
 
@@ -427,15 +452,12 @@ class Popup extends React.Component {
 	}
 
 	handleFloatingLayerOpen = () => {
-		const current = Spotlight.getCurrent();
-
-		this.setState(() => ({
-			activator: current,
-			popupOpen: true
-		}));
-
-		if (current) {
-			current.blur();
+		if (!this.props.noAnimation) {
+			this.setState({
+				popupOpen: OpenState.OPENING
+			});
+		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
+			this.spotPopupContent();
 		}
 	}
 
@@ -476,7 +498,7 @@ class Popup extends React.Component {
 			activator: null
 		});
 
-		if (this.props.noAnimation || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
+		if (ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 			this.paused.resume();
 
 			if (!this.props.open) {
@@ -488,7 +510,11 @@ class Popup extends React.Component {
 	handlePopupShow = (ev) => {
 		forwardShow(ev, this.props);
 
-		if (this.props.noAnimation || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
+		this.setState({
+			popupOpen: OpenState.OPEN
+		});
+
+		if (ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 			this.paused.resume();
 
 			if (this.props.open) {
@@ -549,7 +575,7 @@ class Popup extends React.Component {
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
 					onShow={this.handlePopupShow}
-					open={this.state.popupOpen}
+					open={this.state.popupOpen >= OpenState.OPENING}
 					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
 				/>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In an attempt to simplify Popup's open logic in #2068, we removed mid-`OPENING` state of the transition container. However, since `ui/Transition` relies on `onTransitionEnd` event to notify whether it is opened or not, changing the `visible` state in the midst of transition makes states to go out of sync.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Restored `OPENING` state in Popup. We can revisit later on cleaning up Popup's code, but I think this is okay FWIW.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
