### PR TITLE
ENYO-5794: Revert logic for controlled state for Changeable/Toggleable

### DIFF
--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -130,7 +130,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.state = {
 				value: props[prop] != null ? props[prop] : props[defaultPropKey],
-				controlled: typeof props[prop] !== 'undefined'
+				controlled: prop in props
 			};
 		}
 

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -14,8 +14,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
 
-const UNINITIALIZED = Symbol('Unitialized');
-
 /**
  * Default config for {@link ui/Changeable.Changeable}.
  *
@@ -131,14 +129,16 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 			super(props);
 
 			this.state = {
-				value: UNINITIALIZED,
+				rendered: false,
+				value: null,
 				controlled: prop in props
 			};
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.value === UNINITIALIZED) {
+			if (state.rendered === false) {
 				return {
+					rendered: true,
 					value: props[prop] != null ? props[prop] : props[defaultPropKey]
 				};
 			} else if (state.controlled) {

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -14,6 +14,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
 
+const UNINITIALIZED = Symbol('Unitialized');
+
 /**
  * Default config for {@link ui/Changeable.Changeable}.
  *
@@ -129,13 +131,17 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 			super(props);
 
 			this.state = {
-				value: props[prop] != null ? props[prop] : props[defaultPropKey],
+				value: UNINITIALIZED,
 				controlled: prop in props
 			};
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.controlled && typeof props[prop] !== 'undefined') {
+			if (state.value === UNINITIALIZED) {
+				return {
+					value: props[prop] != null ? props[prop] : props[defaultPropKey]
+				};
+			} else if (state.controlled) {
 				return {
 					value: props[prop]
 				};

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -135,7 +135,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.controlled) {
+			if (state.controlled && typeof props[prop] !== 'undefined') {
 				return {
 					value: props[prop]
 				};

--- a/packages/ui/Changeable/tests/Changeable-specs.js
+++ b/packages/ui/Changeable/tests/Changeable-specs.js
@@ -81,13 +81,13 @@ describe('Changeable', () => {
 			expect(actual).toBe(expected);
 		});
 
-		test('should use value prop when value prop is null', () => {
+		test('should use defaultValue prop when value prop is null', () => {
 			const Component = Changeable(DivComponent);
 			const subject = shallow(
 				<Component defaultValue={1} value={null} />
 			);
 
-			const expected = null;
+			const expected = 1;
 			const actual = subject.find(DivComponent).prop('value');
 
 			expect(actual).toBe(expected);

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -99,6 +99,8 @@ const defaultConfig = {
 	toggleProp: null
 };
 
+const UNINITIALIZED = Symbol('Unitialized');
+
 /**
  * A higher-order component that applies a 'toggleable' behavior to its wrapped component.
  *
@@ -169,13 +171,17 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			super(props);
 
 			this.state = {
-				active: Boolean(props[prop] != null ? props[prop] : props[defaultPropKey]),
+				active: UNINITIALIZED,
 				controlled: prop in props
 			};
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.controlled && props[prop] != null) {
+			if (state.active === UNINITIALIZED) {
+				return {
+					active: Boolean(props[prop] != null ? props[prop] : props[defaultPropKey])
+				};
+			} else if (state.controlled) {
 				return {
 					active: Boolean(props[prop])
 				};

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -175,7 +175,7 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.controlled) {
+			if (state.controlled && props[prop] != null) {
 				return {
 					active: Boolean(props[prop])
 				};

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -170,7 +170,7 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.state = {
 				active: Boolean(props[prop] != null ? props[prop] : props[defaultPropKey]),
-				controlled: typeof props[prop] !== 'undefined'
+				controlled: prop in props
 			};
 		}
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -99,8 +99,6 @@ const defaultConfig = {
 	toggleProp: null
 };
 
-const UNINITIALIZED = Symbol('Unitialized');
-
 /**
  * A higher-order component that applies a 'toggleable' behavior to its wrapped component.
  *
@@ -171,14 +169,16 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			super(props);
 
 			this.state = {
-				active: UNINITIALIZED,
+				rendered: false,
+				active: null,
 				controlled: prop in props
 			};
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			if (state.active === UNINITIALIZED) {
+			if (state.rendered === false) {
 				return {
+					rendered: true,
 					active: Boolean(props[prop] != null ? props[prop] : props[defaultPropKey])
 				};
 			} else if (state.controlled) {

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -113,7 +113,7 @@ describe('Toggleable', () => {
 			}
 		);
 
-		test.only(
+		test(
 			'should use defaultSelected prop when selected prop is undefined',
 			() => {
 				const Component = Toggleable(DivComponent);

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -106,7 +106,6 @@ describe('Toggleable', () => {
 
 				subject.setProps({selected: null});
 
-
 				const expected = 'selected';
 				const actual = subject.find(DivComponent).props();
 

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -84,7 +84,7 @@ describe('Toggleable', () => {
 			}
 		);
 
-		test('should use selected prop when selected prop is null', () => {
+		test('should use defaultSelected prop when selected prop is null', () => {
 			const Component = Toggleable(DivComponent);
 			const subject = shallow(
 				<Component defaultSelected selected={null} />
@@ -93,7 +93,7 @@ describe('Toggleable', () => {
 			const expected = 'selected';
 			const actual = subject.find(DivComponent).props();
 
-			expect(actual).toHaveProperty(expected, false);
+			expect(actual).toHaveProperty(expected, true);
 		});
 
 		test(
@@ -105,6 +105,7 @@ describe('Toggleable', () => {
 				);
 
 				subject.setProps({selected: null});
+
 
 				const expected = 'selected';
 				const actual = subject.find(DivComponent).props();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We changed how we determined that an instance of Changeable or Toggleable was controller in #2057 but it has had some unintended side effects in our components and would likely in app usage as well.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reverting that bit of logic in both coomponents

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
May consider revising this in a future (e.g. 3.0) release.