### PR TITLE
ENYO-5812: Updated all sampler image references from HTTPS to HTTP

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact Sampler, newest changes 
 
 - `moonstone/ExpandableInput` and `moonstone/Input` knob to select input type
 
+### Fixed
+
+- `MoonstoneEnvironment` now loads sampler background images from HTTP sources, rather than HTTPS
+
 ## [2.2.9] - 2019-01-11
 
 No significant changes.

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -87,14 +87,14 @@ const backgroundLabels = {
 // Values of `backgroundLabels` must be kept in sync with keys of `backgroundLabelMap`.
 const backgroundLabelMap = {
 	'': {},
-	'backgroundColorful1': {background: '#bb3352 url("https://picsum.photos/1280/720?image=1080") no-repeat center/cover'},
-	'backgroundColorful2': {background: '#4e6a40 url("https://picsum.photos/1280/720?image=1063") no-repeat center/cover'},
-	'backgroundColorful3': {background: '#5985a8 url("https://picsum.photos/1280/720?image=930") no-repeat center/cover'},
-	'backgroundColorful4': {background: '#71736d url("https://picsum.photos/1280/720?image=1044") no-repeat center/cover'},
-	'backgroundColorful5': {background: '#547460 url("https://picsum.photos/1280/720?image=1053") no-repeat center/cover'},
-	'backgroundColorful6': {background: '#7c4590 url("https://picsum.photos/1280/720?image=967") no-repeat center/cover'},
-	'backgroundColorful7': {background: '#5d6542 url("https://picsum.photos/1280/720?image=1025") no-repeat center/cover'},
-	'backgroundColorful8': {background: '#555 url("https://picsum.photos/1280/720") no-repeat center/cover'}
+	'backgroundColorful1': {background: '#bb3352 url("http://picsum.photos/1280/720?image=1080") no-repeat center/cover'},
+	'backgroundColorful2': {background: '#4e6a40 url("http://picsum.photos/1280/720?image=1063") no-repeat center/cover'},
+	'backgroundColorful3': {background: '#5985a8 url("http://picsum.photos/1280/720?image=930") no-repeat center/cover'},
+	'backgroundColorful4': {background: '#71736d url("http://picsum.photos/1280/720?image=1044") no-repeat center/cover'},
+	'backgroundColorful5': {background: '#547460 url("http://picsum.photos/1280/720?image=1053") no-repeat center/cover'},
+	'backgroundColorful6': {background: '#7c4590 url("http://picsum.photos/1280/720?image=967") no-repeat center/cover'},
+	'backgroundColorful7': {background: '#5d6542 url("http://picsum.photos/1280/720?image=1025") no-repeat center/cover'},
+	'backgroundColorful8': {background: '#555 url("http://picsum.photos/1280/720") no-repeat center/cover'}
 };
 
 const skins = {

--- a/packages/sampler/stories/default/MediaOverlay.js
+++ b/packages/sampler/stories/default/MediaOverlay.js
@@ -29,9 +29,9 @@ const prop = {
 	],
 	images: {
 		'None': '',
-		'Strawberries': 'https://picsum.photos/1280/720?image=1080',
-		'Tunnel': 'https://picsum.photos/1280/720?image=1063',
-		'Mountains': 'https://picsum.photos/1280/720?image=930',
+		'Strawberries': 'http://picsum.photos/1280/720?image=1080',
+		'Tunnel': 'http://picsum.photos/1280/720?image=1063',
+		'Mountains': 'http://picsum.photos/1280/720?image=930',
 		'Bad Image Source': 'imagenotfound.png'
 	},
 	text: [


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
It appears that images loaded over HTTPS do not complete when requested from a blink#68 build.

### Resolution
Simply convert all Sampler image references from HTTPS to HTTP.

### Additional Considerations
This actually isn't ideal, since connections _should_ be using HTTPS, however, if a fix in the short term is critical for testing, this PR will resolve the issue.