### PR TITLE
PLAT-73583: Consolidated Picker's largeText rules into one section

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
@@ -30,12 +30,16 @@
 
 		&.reserveClose {
 			.padding-start-end(@moon-contextual-popup-padding, @moon-icon-button-small-size + @moon-spotlight-outset);
-
-			.moon-custom-text({
-				.padding-start-end(@moon-contextual-popup-padding, @moon-icon-button-small-size-large + @moon-spotlight-outset, parent);
-			});
 		}
 	}
+
+	.moon-custom-text({
+		.container {
+			&.reserveClose {
+				.padding-start-end(@moon-contextual-popup-padding, @moon-icon-button-small-size-large + @moon-spotlight-outset, parent);
+			}
+		}
+	});
 
 	.arrow {
 		position: absolute;

--- a/packages/moonstone/ExpandableList/ExpandableList.js
+++ b/packages/moonstone/ExpandableList/ExpandableList.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
 import CheckboxItem from '../CheckboxItem';
 import {Expandable, ExpandableItemBase} from '../ExpandableItem';
 import RadioItem from '../RadioItem';
+import Skinnable from '../Skinnable';
 
 import css from './ExpandableList.module.less';
 
@@ -415,7 +416,9 @@ const ExpandableList = Pure(
 					return selectedNode;
 				}
 			},
-			ExpandableListBase
+			Skinnable(
+				ExpandableListBase
+			)
 		)
 	)
 );

--- a/packages/moonstone/ExpandableList/ExpandableList.module.less
+++ b/packages/moonstone/ExpandableList/ExpandableList.module.less
@@ -1,11 +1,15 @@
-@import '../styles/variables.less';
-@import '../styles/mixins.less';
+@import "../styles/variables.less";
+@import "../styles/mixins.less";
 
 .expandableList {
 	.listItem {
 		font-weight: @moon-expandable-value-font-weight;
 		font-size: @moon-expandable-client-item-font-size;
-
-		.moon-custom-text-size(@moon-expandable-client-item-font-size-large);
 	}
+
+	.moon-custom-text({
+		.listItem {
+			font-size: @moon-expandable-client-item-font-size-large;
+		}
+	});
 }

--- a/packages/moonstone/LabeledItem/LabeledItem.module.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.module.less
@@ -48,8 +48,6 @@
 		// Force the label to fill the next line in the flexbox container
 		width: 100%;
 
-		.moon-custom-text-size(@moon-expandable-value-font-size-large);
-
 		:global(.enact-locale-right-to-left) & {
 			padding-left: 0;
 		}
@@ -60,6 +58,13 @@
 			padding-bottom: 3px;
 		}
 	}
+
+	// Large-text mode
+	.moon-custom-text({
+		.label {
+			font-size: @moon-expandable-value-font-size-large;
+		}
+	});
 
 	// Skin colors
 	.applySkins({

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -38,14 +38,16 @@
 			box-sizing: border-box;
 			will-change: transform;
 			transition: transform ease-out 100ms;
-
-			.moon-custom-text({
-				height: @moon-slider-knob-height-large;
-				width: @moon-slider-knob-width-large;
-				border-radius: (@moon-slider-knob-height-large / 2);
-			});
 		}
 	}
+
+	.moon-custom-text({
+		.knob::before {
+			height: @moon-slider-knob-height-large;
+			width: @moon-slider-knob-width-large;
+			border-radius: (@moon-slider-knob-height-large / 2);
+		}
+	});
 
 	.tooltip {
 		display: none;

--- a/packages/moonstone/internal/Picker/Picker.module.less
+++ b/packages/moonstone/internal/Picker/Picker.module.less
@@ -1,8 +1,8 @@
 // Picker.module.less
 //
-@import '../../styles/variables.less';
-@import '../../styles/mixins.less';
-@import '../../styles/skin.less';
+@import "../../styles/variables.less";
+@import "../../styles/mixins.less";
+@import "../../styles/skin.less";
 
 .picker {
 	display: inline-block;
@@ -13,19 +13,11 @@
 	margin-left: @moon-spotlight-outset;
 	margin-right: @moon-spotlight-outset;
 
-	.moon-custom-text({
-		border-radius: @moon-button-small-height-large;
-	});
-
 	.sizingPlaceholder,
 	.valueWrapper {
 		.moon-text-base();
 		.moon-locale-non-latin({line-height: @moon-button-small-height;});
 		max-width: 300px;
-
-		.moon-custom-text({
-			font-size: @moon-item-font-size-large;
-		});
 	}
 
 	.sizingPlaceholder {
@@ -38,14 +30,8 @@
 		margin-left: auto;
 		margin-right: auto;
 		vertical-align: bottom;
-
 		line-height: @moon-button-small-height;
 		height: @moon-button-small-height;
-
-		.moon-custom-text({
-			line-height: @moon-button-small-height-large;
-			height: @moon-button-small-height-large;
-		});
 	}
 
 	.incrementer,
@@ -126,11 +112,6 @@
 		});
 
 		&.horizontal {
-			.moon-custom-text({
-				font-size: @moon-item-font-size-large;
-				height: @moon-button-small-height-large;
-				line-height: @moon-button-small-height-large;
-			});
 			&.incrementing::before {
 				border-right-width: @moon-integer-picker-shadow-width;
 			}
@@ -143,16 +124,6 @@
 				height: @moon-button-small-height;
 				line-height: @moon-button-small-height;
 			}
-			.moon-custom-text({
-				.incrementer,
-				.decrementer {
-					&,
-					.icon {
-						height: @moon-button-small-height-large;
-						line-height: @moon-button-small-height-large;
-					}
-				}
-			});
 		}
 
 		&.vertical {
@@ -190,34 +161,15 @@
 				.position(0);
 			}
 		}
-
-		&.vertical {
-			.valueWrapper {
-				.sizingPlaceholder,
-				.item {
-					.moon-custom-text({
-						margin: 0 @moon-spotlight-outset;
-					});
-				}
-			}
-		}
 	}
 
 	&.vertical .valueWrapper {
 		display: block;
 		position: relative;
 
-		.moon-custom-text({
-			padding: 0 @moon-spotlight-outset;
-		});
-
 		.sizingPlaceholder,
 		.item {
 			margin: 0 @moon-spotlight-outset;
-
-			.moon-custom-text({
-				margin: 0;
-			});
 		}
 
 		.item {
@@ -249,6 +201,61 @@
 				background-color: @moon-spotlight-border-color;
 				color: @moon-spotlight-text-color;
 			});
+		}
+	});
+
+	// Large-text mode rules
+	.moon-custom-text({
+		border-radius: @moon-button-small-height-large;
+
+		.sizingPlaceholder,
+		.valueWrapper {
+			font-size: @moon-item-font-size-large;
+		}
+		.valueWrapper {
+			line-height: @moon-button-small-height-large;
+			height: @moon-button-small-height-large;
+		}
+
+		&.joined {
+			&.horizontal {
+				font-size: @moon-item-font-size-large;
+				height: @moon-button-small-height-large;
+				line-height: @moon-button-small-height-large;
+
+				.incrementer,
+				.decrementer {
+					&,
+					.icon {
+						height: @moon-button-small-height-large;
+						line-height: @moon-button-small-height-large;
+					}
+				}
+			}
+		}
+
+		&.small,
+		&.medium,
+		&.large {
+			&.vertical {
+				.valueWrapper {
+					.sizingPlaceholder,
+					.item {
+						margin: 0 @moon-spotlight-outset;
+					}
+				}
+			}
+		}
+
+		&.vertical {
+			.valueWrapper {
+				padding: 0 @moon-spotlight-outset;
+
+				.sizingPlaceholder,
+				.item {
+					margin: 0;
+				}
+			}
 		}
 	});
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
With the changes to the CSS structure of supporting largeText as a skin variant, Picker is generating selectors that don't match the reality of the DOM structure any longer.

### Resolution
Rearrange the `.moon-custom-text` mixin rules in the Picker LESS file to apply the correct classes only to the base element. Secondarily, the rules have been consolidated into a single mixin, replicating the selector structure for better readability.

Includes updates to `ContextualPopup`, `LabeledItem`, and `Slider` as well.