### PR TITLE
ENYO-5795: SliderBehaviorDecorator - prevent setting focus when disabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Slider` to not gain focus when clicked
+
 ## [2.3.0] - 2019-02-11
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Slider` to not gain focus when clicked
+- `moonstone/Slider` to prevent gaining focus when clicked when disabled
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -49,7 +49,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static propTypes = {
 			'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-			disabled: PropTypes.boolean,
+			disabled: PropTypes.bool,
 			max: PropTypes.number,
 			min: PropTypes.number,
 			orientation: PropTypes.string,

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -49,6 +49,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static propTypes = {
 			'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+			disabled: PropTypes.boolean,
 			max: PropTypes.number,
 			min: PropTypes.number,
 			orientation: PropTypes.string,
@@ -136,8 +137,10 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleFocus (ev) {
-			forward('onFocus', ev, this.props);
-			this.setState({focused: true});
+			if (!this.props.disabled) {
+				forward('onFocus', ev, this.props);
+				this.setState({focused: true});
+			}
 		}
 
 		handleSpotlightEvents (ev) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`SliderBehaviorDecorator` can be focused when it is disabled, which can result in unintended actions - such as a `Slider` displaying a tooltip when a click action occurs on the slider bar.


### Resolution
Preventing forwarding the focus event and setting an internal focused state when the component is `disabled` fixes the issue.
