### PR TITLE
PLAT-72723: Update ui/VirtualList lifecycle method

### DIFF
--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -281,11 +281,11 @@ const VirtualListBaseFactory = (type) => {
 				!equals(prevProps.itemSize, this.props.itemSize)
 			) {
 				this.calculateMetrics(this.props);
-				// eslint-disable-next-line react/no-did-mount-set-state
+				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (this.hasDataSizeChanged) {
-				// eslint-disable-next-line react/no-did-mount-set-state
+				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -805,12 +805,10 @@ const VirtualListBaseFactory = (type) => {
 				this.positionItems();
 			}
 
-			const {cc} = this;
-
 			return (
 				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} ref={this.initContainerRef} style={style}>
 					<div {...rest} ref={this.initContentRef}>
-						{itemsRenderer({cc, initItemContainerRef, primary})}
+						{itemsRenderer({cc: this.cc, initItemContainerRef, primary})}
 					</div>
 				</div>
 			);

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -696,8 +696,8 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			let
-				{primaryPosition, secondaryPosition} = this.getGridPosition(updateFrom),
-				width, height;
+				width, height,
+				{primaryPosition, secondaryPosition} = this.getGridPosition(updateFrom);
 
 			width = (isPrimaryDirectionVertical ? secondary.itemSize : primary.itemSize) + 'px';
 			height = (isPrimaryDirectionVertical ? primary.itemSize : secondary.itemSize) + 'px';

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -229,7 +229,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (props.clientSize) {
 				this.calculateMetrics(props);
-				nextState = this.getStatesAndUpdateBounds(this.props);
+				nextState = this.getStatesAndUpdateBounds(props);
 			}
 
 			this.state = {
@@ -272,6 +272,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		componentDidUpdate (prevProps) {
+			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
 			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
 
 			if (
@@ -285,8 +286,9 @@ const VirtualListBaseFactory = (type) => {
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (this.hasDataSizeChanged) {
+				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
 				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(this.getStatesAndUpdateBounds(this.props));
+				this.setState(newState);
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
 				const {x, y} = this.getXY(this.scrollPosition, 0);
@@ -432,10 +434,9 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		getStatesAndUpdateBounds = (props) => {
+		getStatesAndUpdateBounds = (props, firstIndex = 0) => {
 			const
 				{dataSize, overhang, updateStatesAndBounds} = props,
-				firstIndex = this.hasDataSizeChanged ? this.state.firstIndex : 0,
 				{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 				numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
 				wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
@@ -456,7 +457,7 @@ const VirtualListBaseFactory = (type) => {
 				dataSize,
 				moreInfo
 			}))) {
-				newFirstIndex = this.calculateFirstIndex(props, wasFirstIndexMax, dataSizeDiff);
+				newFirstIndex = this.calculateFirstIndex(props, wasFirstIndexMax, dataSizeDiff, firstIndex);
 			}
 
 			return {
@@ -465,10 +466,9 @@ const VirtualListBaseFactory = (type) => {
 			};
 		}
 
-		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff) {
+		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff, firstIndex) {
 			const
 				{overhang} = props,
-				{firstIndex} = this.state || {firstIndex: 0},
 				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, primary, scrollBounds, scrollPosition, threshold} = this,
 				{gridSize} = primary;
 			let newFirstIndex = firstIndex;
@@ -748,7 +748,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (clientWidth !== scrollBounds.clientWidth || clientHeight !== scrollBounds.clientHeight) {
 				this.calculateMetrics(props);
-				this.setState(this.getStatesAndUpdateBounds(this.props));
+				this.setState(this.getStatesAndUpdateBounds(props));
 				this.setContainerSize();
 				return true;
 			}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -245,13 +245,13 @@ const VirtualListBaseFactory = (type) => {
 
 		static getDerivedStateFromProps (props, state) {
 			const
-				isNeedToInvalidate = (
+				shouldInvalidate = (
 					state.prevFirstIndex === state.firstIndex ||
-					(state.prevChildProps || props.childProps) && state.prevChildProps !== props.childProps
+					state.prevChildProps !== props.childProps
 				),
 				diff = state.firstIndex - state.prevFirstIndex,
-				updateTo = (-state.numOfItems >= diff || diff > 0 || isNeedToInvalidate) ? state.firstIndex + state.numOfItems : state.prevFirstIndex,
-				updateFrom = (0 >= diff || diff >= state.numOfItems || isNeedToInvalidate) ? state.firstIndex : state.prevFirstIndex + state.numOfItems,
+				updateTo = (-state.numOfItems >= diff || diff > 0 || shouldInvalidate) ? state.firstIndex + state.numOfItems : state.prevFirstIndex,
+				updateFrom = (0 >= diff || diff >= state.numOfItems || shouldInvalidate) ? state.firstIndex : state.prevFirstIndex + state.numOfItems,
 				nextUpdateFromAndTo = (state.updateFrom !== updateFrom || state.updateTo !== updateTo) ? {updateFrom, updateTo} : null;
 
 			return {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -229,7 +229,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (props.clientSize) {
 				this.calculateMetrics(props);
-				nextState = this.getStatesAndUpdateBounds(this.props, true);
+				nextState = this.getStatesAndUpdateBounds(this.props);
 			}
 
 			this.state = {
@@ -265,6 +265,7 @@ const VirtualListBaseFactory = (type) => {
 		componentDidMount () {
 			if (!this.props.clientSize) {
 				this.calculateMetrics(this.props);
+				// eslint-disable-next-line react/no-did-mount-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 			}
 			this.setContainerSize();
@@ -279,10 +280,12 @@ const VirtualListBaseFactory = (type) => {
 				prevProps.spacing !== this.props.spacing ||
 				!equals(prevProps.itemSize, this.props.itemSize)
 			) {
-				this.calculateMetrics(props);
+				this.calculateMetrics(this.props);
+				// eslint-disable-next-line react/no-did-mount-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (this.hasDataSizeChanged) {
+				// eslint-disable-next-line react/no-did-mount-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
@@ -429,7 +432,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		getStatesAndUpdateBounds = (props, slient = false) => {
+		getStatesAndUpdateBounds = (props) => {
 			const
 				{dataSize, overhang, updateStatesAndBounds} = props,
 				firstIndex = this.hasDataSizeChanged ? this.state.firstIndex : 0,


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

`UNSAFE_componentWillMount()`, `UNSAFE_componentWillReceiveProps()`, and `UNSAFE_componentWillUpdate()` will be deprecated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Move the code in `UNSAFE_componentWillMount()` to `constructor`.
But `updateStatesAndBounds` was renamed as `getStatesAndUpdateBounds` to get a new state instead of calling `setState` in the `updateStatesAndBounds`.

- Move the code in `UNSAFE_componentWillReceiveProps()` to `componentDidUpdate`.
But we still need the `this.hasDataSizeChanged` variable used in `moonstone/VirtualList`.
In addition, `this.cc = []` for RTL was removed.

- Move the code in `UNSAFE_componentWillUpdate()` and the part of the `positionItems` in render phase to `getDerivedStateFromProps` so that the previous first index and the previous `childProps` are only referenced in the `getDerivedStateFromProps`.

### Links
[//]: # (Related issues, references)

PLAT-72723