### PR TITLE
Workaround syntax fix for Babel bug involving `let` edge case usage.

### DIFF
--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -684,8 +684,8 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			let
-				{primaryPosition, secondaryPosition} = this.getGridPosition(updateFrom),
-				width, height;
+				width, height,
+				{primaryPosition, secondaryPosition} = this.getGridPosition(updateFrom);
 
 			width = (isPrimaryDirectionVertical ? secondary.itemSize : primary.itemSize) + 'px';
 			height = (isPrimaryDirectionVertical ? primary.itemSize : secondary.itemSize) + 'px';


### PR DESCRIPTION
Fix taken from https://github.com/enactjs/enact/pull/2108

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Edgecase syntax error in latest Babel release regarding complex `let` usage caused Babel parsing to fail. A fix has been pushed upstream and will be integrated in CLI appropriately. However in the meantime, a basic reordering of syntax can provide a fix for our 2.3.0 release and linting.

### Resolution
* Re-arrange `let` declaration structure, such that the destructuring operation is last.
* Solution originally from https://github.com/enactjs/enact/pull/2108

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>