### PR TITLE
ENYO-5798: Update QA Sampler to add marqueeOnRenderDelay knob for Marquee > LTR sample or create new sample

### DIFF
--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -120,7 +120,7 @@ storiesOf('Marquee', module)
 						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
 						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
-						marqueeOnRenderDelay={1000}
+						marqueeOnRenderDelay={number('marqueeOnRenderDelay', Marquee, 1000)}
 						marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
 						marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 					>
@@ -145,7 +145,7 @@ storiesOf('Marquee', module)
 						marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 						marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
 						marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
-						marqueeOnRenderDelay={1000}
+						marqueeOnRenderDelay={number('marqueeOnRenderDelay', Marquee, 1000)}
 						marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
 						marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 					>
@@ -171,7 +171,7 @@ storiesOf('Marquee', module)
 							marqueeDelay={number('marqueeDelay', Marquee, 1000)}
 							marqueeDisabled={boolean('marqueeDisabled', Marquee, false)}
 							marqueeOn={select('marqueeOn', ['hover', 'render'], Marquee, 'render')}
-							marqueeOnRenderDelay={5000}
+							marqueeOnRenderDelay={number('marqueeOnRenderDelay', Marquee, 5000)}
 							marqueeResetDelay={number('marqueeResetDelay', Marquee, 1000)}
 							marqueeSpeed={number('marqueeSpeed', Marquee, 60)}
 						>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This patch adds a knob for `marqueeOnRenderDelay` for `Marquee` qa stories.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
At least one of the stories has multiple `Marquee`s but currently offer no knobs at all, so they have been left out of this patch as well.

### Links
[//]: # (Related issues, references)
ENYO-5798

### Comments
