### PR TITLE
PLAT-73547: Update ViewManager internal lifecycle methods

### DIFF
--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -219,13 +219,15 @@ class TransitionGroup extends React.Component {
 	}
 
 	reconcileChildren (prevChildMapping, nextChildMapping) {
+		const {size} = this.props;
+
 		// remove any "dropped" children from the list of transitioning children
 		prevChildMapping.filter(child => !hasChild(child, nextChildMapping)).forEach(child => {
 			delete this.currentlyTransitioningKeys[child.key];
 		});
 
 		// mark any new child as entering
-		nextChildMapping.forEach(child => {
+		nextChildMapping.forEach((child, index) => {
 			const key = child.key;
 			const hasPrev = hasChild(key, prevChildMapping);
 
@@ -233,8 +235,10 @@ class TransitionGroup extends React.Component {
 			// re-entering (is currently transitioning)
 			if (!hasPrev || this.currentlyTransitioningKeys[key]) {
 				this.keysToEnter.push(key);
-			} else {
+			} else if (index < size - 1) {
 				this.keysToStay.push(key);
+			} else {
+				this.keysToLeave.push(key);
 			}
 		});
 

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -221,6 +221,13 @@ class TransitionGroup extends React.Component {
 	reconcileChildren (prevChildMapping, nextChildMapping) {
 		const {size} = this.props;
 
+		// if children haven't changed, there's nothing to reconcile
+		if (prevChildMapping.length === nextChildMapping.length && prevChildMapping.filter(pc => {
+			return !nextChildMapping.find(nc => nc.key === pc.key);
+		}).length === 0) {
+			return;
+		}
+
 		// remove any "dropped" children from the list of transitioning children
 		prevChildMapping.filter(child => !hasChild(child, nextChildMapping)).forEach(child => {
 			delete this.currentlyTransitioningKeys[child.key];
@@ -231,13 +238,15 @@ class TransitionGroup extends React.Component {
 			const key = child.key;
 			const hasPrev = hasChild(key, prevChildMapping);
 
-			// flag a view to enter if it's new (!hasPrev), or if it's not new (hasPrev) but is
-			// re-entering (is currently transitioning)
 			if (!hasPrev || this.currentlyTransitioningKeys[key]) {
+				// flag a view to enter if it's new (!hasPrev), or if it's not new (hasPrev) but is
+				// re-entering (is currently transitioning)
 				this.keysToEnter.push(key);
 			} else if (index < size - 1) {
+				// keep views that are less than size minus the "transition out" buffer
 				this.keysToStay.push(key);
 			} else {
+				// everything else is leaving
 				this.keysToLeave.push(key);
 			}
 		});

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -196,12 +196,14 @@ class TransitionGroup extends React.Component {
 
 		if (state.firstRender) {
 			return {
-				firstRender: false,
-				children
+				activeChildren: children,
+				children,
+				firstRender: false
 			};
 		}
 
 		return {
+			activeChildren: children,
 			children: mergeChildren(children, state.children).slice(0, props.size)
 		};
 	}
@@ -215,7 +217,7 @@ class TransitionGroup extends React.Component {
 	}
 
 	componentDidUpdate (prevProps, prevState) {
-		this.reconcileChildren(prevState.children, this.state.children);
+		this.reconcileChildren(prevState.children, this.state.activeChildren);
 	}
 
 	reconcileChildren (prevChildMapping, nextChildMapping) {

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -7,54 +7,17 @@
 
 import compose from 'ramda/src/compose';
 import eqBy from 'ramda/src/eqBy';
-import equals from 'ramda/src/equals';
 import findIndex from 'ramda/src/findIndex';
 import {forward} from '@enact/core/handle';
 import identity from 'ramda/src/identity';
 import lte from 'ramda/src/lte';
-import map from 'ramda/src/map';
 import prop from 'ramda/src/prop';
 import propEq from 'ramda/src/propEq';
 import React from 'react';
 import PropTypes from 'prop-types';
 import remove from 'ramda/src/remove';
-import sort from 'ramda/src/sort';
 import unionWith from 'ramda/src/unionWith';
 import useWith from 'ramda/src/useWith';
-import when from 'ramda/src/when';
-
-const orderedKeys = map(when(React.isValidElement, prop('key')));
-const unorderedKeys = compose(sort((a, b) => a - b), orderedKeys);
-const unorderedEquals = useWith(equals, [unorderedKeys, unorderedKeys]);
-const orderedEquals = useWith(equals, [orderedKeys, orderedKeys]);
-
-/*
- * Compares the keys of two sets of children and returns `true` if they are equal.
- *
- * @method
- * @param  {Node[]}		prev		Array of children
- * @param  {Node[]}		next		Array of children
- * @param  {Boolean}	[ordered]	`true` to require the same order
- *
- * @returns {Boolean}				`true` if the children are the same
- */
-const childrenEquals = (prev, next, ordered = false) => {
-	const prevChildren = React.Children.toArray(prev);
-	const nextChildren = React.Children.toArray(next);
-
-	if (prevChildren.length !== nextChildren.length) {
-		return false;
-	} else if (prevChildren.length === 1 && nextChildren.length === 1) {
-		const c1 = prevChildren[0];
-		const c2 = nextChildren[0];
-
-		return equals(c1, c2);
-	} else if (ordered) {
-		return orderedEquals(prevChildren, nextChildren);
-	} else {
-		return unorderedEquals(prevChildren, nextChildren);
-	}
-};
 
 /**
  * Returns the index of a child in an array found by `key` matching
@@ -216,7 +179,8 @@ class TransitionGroup extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			children: mapChildren(this.props.children)
+			firstRender: true,
+			children: []
 		};
 
 		this.hasMounted = false;
@@ -227,6 +191,21 @@ class TransitionGroup extends React.Component {
 		this.groupRefs = {};
 	}
 
+	static getDerivedStateFromProps (props, state) {
+		const children = mapChildren(props.children).slice(0, props.size);
+
+		if (state.firstRender) {
+			return {
+				firstRender: false,
+				children
+			};
+		}
+
+		return {
+			children: mergeChildren(children, state.children).slice(0, props.size)
+		};
+	}
+
 	componentDidMount () {
 		this.hasMounted = true;
 
@@ -235,38 +214,31 @@ class TransitionGroup extends React.Component {
 		this.state.children.forEach(child => this.performAppear(child.key));
 	}
 
-	UNSAFE_componentWillReceiveProps (nextProps) {
-		// Avoid an unnecessary setState and reconcileChildren if the children haven't changed
-		if (!childrenEquals(this.props.children, nextProps.children)) {
-			const nextChildMapping = mapChildren(nextProps.children);
-			const prevChildMapping = this.state.children;
-			let children = mergeChildren(nextChildMapping, prevChildMapping);
-
-			// drop children exceeding allowed size
-			const dropped = children.length > nextProps.size ? children.splice(nextProps.size) : null;
-
-			this.setState({
-				children
-			}, () => {
-				this.reconcileChildren(dropped, prevChildMapping, nextChildMapping);
-			});
-		}
+	componentDidUpdate (prevProps, prevState) {
+		this.reconcileChildren(prevState.children, this.state.children);
 	}
 
-	reconcileChildren (dropped, prevChildMapping, nextChildMapping) {
+	reconcileChildren (prevChildMapping, nextChildMapping) {
+		const {size} = this.props;
+
+		// remove any "dropped" children from the list of transitioning children
+		prevChildMapping.filter(child => !hasChild(child, nextChildMapping)).forEach(child => {
+			delete this.currentlyTransitioningKeys[child.key];
+		});
+
 		// mark any new child as entering
-		nextChildMapping.forEach(child => {
+		nextChildMapping.forEach((child, index) => {
 			const key = child.key;
 			const hasPrev = hasChild(key, prevChildMapping);
-			const isDropped = dropped && hasChild(key, dropped);
-			// flag a view to enter if it isn't being dropped, if it's new (!hasPrev), or if it's
-			// not new (hasPrev) but is re-entering (is currently transitioning)
-			if (!isDropped) {
-				if (!hasPrev || this.currentlyTransitioningKeys[key]) {
-					this.keysToEnter.push(key);
-				} else {
-					this.keysToStay.push(key);
-				}
+
+			// flag a view to enter if it's new (!hasPrev), or if it's not new (hasPrev) but is
+			// re-entering (is currently transitioning)
+			if (!hasPrev || this.currentlyTransitioningKeys[key]) {
+				this.keysToEnter.push(key);
+			} else if (index < size - 1) {
+				this.keysToStay.push(key);
+			} else {
+				this.keysToLeave.push(key);
 			}
 		});
 
@@ -274,20 +246,12 @@ class TransitionGroup extends React.Component {
 		prevChildMapping.forEach(child => {
 			const key = child.key;
 			const hasNext = hasChild(key, nextChildMapping);
-			const isDropped = dropped && hasChild(key, dropped);
-			// flag a view to leave if it isn't being dropped and it isn't in the new set (!hasNext)
-			if (!isDropped && !hasNext) {
+			const isRendered = Boolean(this.groupRefs[key]);
+			// flag a view to leave if it isn't in the new set (!hasNext) and it exists (isRendered)
+			if (!hasNext && isRendered) {
 				this.keysToLeave.push(key);
 			}
 		});
-
-		// if any views were dropped because they exceeded `size`, the can no longer be
-		// transitioning so indicate as such
-		if (dropped) {
-			dropped.forEach(child => {
-				delete this.currentlyTransitioningKeys[child.key];
-			});
-		}
 
 		if (this.keysToEnter.length || this.keysToLeave.length) {
 			forwardOnWillTransition(null, this.props);

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -219,15 +219,13 @@ class TransitionGroup extends React.Component {
 	}
 
 	reconcileChildren (prevChildMapping, nextChildMapping) {
-		const {size} = this.props;
-
 		// remove any "dropped" children from the list of transitioning children
 		prevChildMapping.filter(child => !hasChild(child, nextChildMapping)).forEach(child => {
 			delete this.currentlyTransitioningKeys[child.key];
 		});
 
 		// mark any new child as entering
-		nextChildMapping.forEach((child, index) => {
+		nextChildMapping.forEach(child => {
 			const key = child.key;
 			const hasPrev = hasChild(key, prevChildMapping);
 
@@ -235,10 +233,8 @@ class TransitionGroup extends React.Component {
 			// re-entering (is currently transitioning)
 			if (!hasPrev || this.currentlyTransitioningKeys[key]) {
 				this.keysToEnter.push(key);
-			} else if (index < size - 1) {
-				this.keysToStay.push(key);
 			} else {
-				this.keysToLeave.push(key);
+				this.keysToStay.push(key);
 			}
 		});
 

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -237,7 +237,9 @@ class ViewManager extends React.Component {
 			childProps
 		});
 
+		delete rest.end;
 		delete rest.reverseTransition;
+		delete rest.start;
 
 		return (
 			<TransitionGroup {...rest} childFactory={childFactory} size={size} currentIndex={index}>

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -221,7 +221,6 @@ class ViewManager extends React.Component {
 		if (index > end) end = index;
 		if (index < start) start = index;
 
-		// const currentIndex = index - start;
 		const childCount = end - start + 1;
 		const size = (noAnimation || !arranger) ? childCount : childCount + 1;
 

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -213,15 +213,19 @@ class ViewManager extends React.Component {
 	}
 
 	render () {
-		const {arranger, childProps, children, duration, end, index, noAnimation, start, enteringDelay, enteringProp, ...rest} = this.props;
+		const {arranger, childProps, children, duration, index, noAnimation, enteringDelay, enteringProp, ...rest} = this.props;
+		let {end = index, start = index} = this.props;
 		const {prevIndex: previousIndex, reverseTransition} = this.state;
 		const childrenList = React.Children.toArray(children);
 
-		const from = (start || start === 0) ? start : index;
-		const to = (end || end === 0) && end >= index ? end : index;
-		const size = to - from + ((noAnimation || !arranger) ? 0 : 1);
+		if (index > end) end = index;
+		if (index < start) start = index;
 
-		const views = childrenList.slice(from, to + 1);
+		// const currentIndex = index - start;
+		const childCount = end - start + 1;
+		const size = (noAnimation || !arranger) ? childCount : childCount + 1;
+
+		const views = childrenList.slice(start, start + childCount);
 		const childFactory = wrapWithView({
 			arranger,
 			duration,
@@ -237,7 +241,7 @@ class ViewManager extends React.Component {
 		delete rest.reverseTransition;
 
 		return (
-			<TransitionGroup {...rest} childFactory={childFactory} size={size + 1} currentIndex={index}>
+			<TransitionGroup {...rest} childFactory={childFactory} size={size} currentIndex={index}>
 				{views}
 			</TransitionGroup>
 		);

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -251,7 +251,7 @@ describe('ViewManager', () => {
 		expect(actual).toBeFalsy();
 	});
 
-	test('should updated the view when children are reordered', () => {
+	test('should update the view when children are reordered', () => {
 		const subject = mount(
 			<ViewManager index={1}>
 				<div key="view1">View 1</div>
@@ -269,7 +269,7 @@ describe('ViewManager', () => {
 		expect(subject.find('View div').prop('children')).toBe('View 1');
 	});
 
-	test('should updated the view when children are replaced', () => {
+	test('should update the view when children are replaced', () => {
 		const subject = mount(
 			<ViewManager index={0}>
 				<div key="view1">View 1</div>
@@ -285,7 +285,7 @@ describe('ViewManager', () => {
 		expect(subject.find('View div').prop('children')).toBe('View 2');
 	});
 
-	test('should keep update the number of views when {start} updates', () => {
+	test('should update the number of views when {start} updates', () => {
 		const subject = mount(
 			<ViewManager index={3} start={2} end={3}>
 				<div key="view1">View 1</div>

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -186,7 +186,7 @@ describe('ViewManager', () => {
 		}
 	);
 
-	test('should have size of 1 on TransitionGroup', done => {
+	test('should have size of 1 on TransitionGroup', () => {
 		const subject = mount(
 			<ViewManager noAnimation index={0} duration={0}>
 				<div className="view">View 1</div>
@@ -200,10 +200,9 @@ describe('ViewManager', () => {
 		const expected = 1;
 		const actual = subject.find('TransitionGroup').prop('size');
 		expect(actual).toBe(expected);
-		done();
 	});
 
-	test('should update the View reverseTransition prop.', done => {
+	test('should update the View reverseTransition prop.', () => {
 		const subject = mount(
 			<ViewManager noAnimation index={0} duration={0}>
 				<div className="view">View 1</div>
@@ -218,10 +217,9 @@ describe('ViewManager', () => {
 		const actual = subject.find('View').props().reverseTransition;
 
 		expect(actual).toBeTruthy();
-		done();
 	});
 
-	test('should update the View reverseTransition prop to true if it is updated with a smaller index prop.', done => {
+	test('should update the View reverseTransition prop to true if it is updated with a smaller index prop.', () => {
 		const subject = mount(
 			<ViewManager index={2} duration={0} arranger={SlideLeftArranger}>
 				<div>View 1</div>
@@ -236,10 +234,9 @@ describe('ViewManager', () => {
 		const actual = subject.find('View').at(0).props().reverseTransition;
 
 		expect(actual).toBeTruthy();
-		done();
 	});
 
-	test('should update the View reverseTransition prop to false even though it is updated with a smaller index prop.', done => {
+	test('should update the View reverseTransition prop to false even though it is updated with a smaller index prop.', () => {
 		const subject = mount(
 			<ViewManager index={2} duration={0} arranger={SlideLeftArranger}>
 				<div>View 1</div>
@@ -252,6 +249,39 @@ describe('ViewManager', () => {
 		const actual = subject.find('View').at(0).props().reverseTransition;
 
 		expect(actual).toBeFalsy();
-		done();
+	});
+
+	test('should updated the view when children are reordered', () => {
+		const subject = mount(
+			<ViewManager index={1}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View div').prop('children')).toBe('View 2');
+
+		subject.setProps({children: [
+			<div key="view2">View 2</div>,
+			<div key="view1">View 1</div>
+		]});
+
+		expect(subject.find('View div').prop('children')).toBe('View 1');
+	});
+
+	test('should updated the view when children are replaced with start and end bounds', () => {
+		const subject = mount(
+			<ViewManager index={3} start={0} end={1}>
+				<div key="view4">View 4</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View div').prop('children')).toBe('View 4');
+
+		subject.setProps({index: 2, children: [
+			<div key="view3">View 3</div>
+		]});
+
+		expect(subject.find('View div').prop('children')).toBe('View 3');
 	});
 });

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -269,19 +269,83 @@ describe('ViewManager', () => {
 		expect(subject.find('View div').prop('children')).toBe('View 1');
 	});
 
-	test('should updated the view when children are replaced with start and end bounds', () => {
+	test('should updated the view when children are replaced', () => {
 		const subject = mount(
-			<ViewManager index={3} start={0} end={1}>
+			<ViewManager index={0}>
+				<div key="view1">View 1</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View div').prop('children')).toBe('View 1');
+
+		subject.setProps({children: [
+			<div key="view2">View 2</div>
+		]});
+
+		expect(subject.find('View div').prop('children')).toBe('View 2');
+	});
+
+	test('should keep update the number of views when {start} updates', () => {
+		const subject = mount(
+			<ViewManager index={3} start={2} end={3}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+				<div key="view3">View 3</div>
 				<div key="view4">View 4</div>
 			</ViewManager>
 		);
 
+		expect(subject.find('View')).toHaveLength(2);
+		expect(subject.find('View div').at(0).prop('children')).toBe('View 3');
+
+		subject.setProps({start: 1});
+
+		expect(subject.find('View')).toHaveLength(3);
+		expect(subject.find('View div').at(0).prop('children')).toBe('View 2');
+	});
+
+	test('should update the active view when {start}, {end}, and {index} update', () => {
+		const subject = mount(
+			<ViewManager index={3} start={3} end={3}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+				<div key="view3">View 3</div>
+				<div key="view4">View 4</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View')).toHaveLength(1);
 		expect(subject.find('View div').prop('children')).toBe('View 4');
 
-		subject.setProps({index: 2, children: [
-			<div key="view3">View 3</div>
-		]});
+		subject.setProps({start: 2, end: 2, index: 2});
 
+		expect(subject.find('View')).toHaveLength(1);
 		expect(subject.find('View div').prop('children')).toBe('View 3');
+	});
+
+	test('should extend the view range when {index} is less than {start}', () => {
+		const subject = mount(
+			<ViewManager index={1} start={2} end={3}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+				<div key="view3">View 3</div>
+				<div key="view4">View 4</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View')).toHaveLength(3);
+	});
+
+	test('should extend the view range when {index} is greater than {end}', () => {
+		const subject = mount(
+			<ViewManager index={3} start={1} end={2}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+				<div key="view3">View 3</div>
+				<div key="view4">View 4</div>
+			</ViewManager>
+		);
+
+		expect(subject.find('View')).toHaveLength(3);
 	});
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `TransitionGroup` to use `getDerivedStateFromProps`
