### PR TITLE
ENYO-5791: Adjust focus timing of ContextualPoup

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
+- `moonstone/ContextualPopupDecorator` to focus on the inner content when the ContextualPopup first opens
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,8 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
-- `moonstone/ContextualPopupDecorator` to focus on the inner content when the ContextualPopup first opens
 - `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
+- `moonstone/ContextualPopupDecorator` to focus on the inner content when the ContextualPopup first opens
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
 - `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
-- `moonstone/ContextualPopupDecorator` to focus on the popup content when the ContextualPopup is first time open
+- `moonstone/ContextualPopupDecorator` to focus on a popup content when the ContextualPopup is first opened
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
 - `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
-- `moonstone/ContextualPopupDecorator` to focus on the inner content when the ContextualPopup first opens
+- `moonstone/ContextualPopupDecorator` to focus on the popup content when the ContextualPopup is first time open
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -233,10 +233,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
+				activator: null,
 				arrowPosition: {top: 0, left: 0},
-				containerPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				activator: null
+				containerPosition: {top: 0, left: 0},
+				prevOpen: false
 			};
 
 			this.overflow = {};
@@ -262,6 +263,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (prevProps.open && !this.props.open) {
 				const current = Spotlight.getCurrent();
 				return {
+					prevOpen: this.props.open,
 					shouldSpotActivator: (
 						// isn't set
 						!current ||
@@ -271,6 +273,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 						this.containerNode.contains(current)
 					)
 				};
+			} else if (prevProps.open && this.props.open) {
+				return {
+					prevOpen: this.props.open
+				}
 			}
 			return null;
 		}
@@ -282,8 +288,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (prevProps.open && this.state.activator) {
-				if (this.props.open) {
+			if (prevProps.open) {
+				if (this.props.open && !this.state.prevOpen) {
 					on('keydown', this.handleKeyDown);
 					on('keyup', this.handleKeyUp);
 					this.spotPopupContent();

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -282,15 +282,17 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.props.open && prevProps.open) {
-				on('keydown', this.handleKeyDown);
-				on('keyup', this.handleKeyUp);
-				this.spotPopupContent();
-			} else if (!this.props.open && prevProps.open) {
-				off('keydown', this.handleKeyDown);
-				off('keyup', this.handleKeyUp);
-				if (snapshot && snapshot.shouldSpotActivator) {
-					this.spotActivator(prevState.activator);
+			if (prevProps.open && this.state.activator) {
+				if (this.props.open) {
+					on('keydown', this.handleKeyDown);
+					on('keyup', this.handleKeyUp);
+					this.spotPopupContent();
+				} else if (!this.props.open) {
+					off('keydown', this.handleKeyDown);
+					off('keyup', this.handleKeyUp);
+					if (snapshot && snapshot.shouldSpotActivator) {
+						this.spotActivator(prevState.activator);
+					}
 				}
 			}
 		}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -233,10 +233,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
+				activator: null,
 				arrowPosition: {top: 0, left: 0},
-				containerPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				activator: null
+				containerPosition: {top: 0, left: 0},
+				renderedContent: false
 			};
 
 			this.overflow = {};
@@ -282,7 +283,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.props.open && this.state.activator && !prevState.activator) {
+			if (this.props.open && this.state.renderedContent && !prevState.renderedContent) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
 				this.spotPopupContent();
@@ -488,14 +489,16 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			const current = Spotlight.getCurrent();
 			this.updateLeaveFor(current);
 			this.setState({
-				activator: current
+				activator: current,
+				renderedContent: true
 			});
 		}
 
 		handleClose = () => {
 			this.updateLeaveFor(null);
 			this.setState({
-				activator: null
+				activator: null,
+				renderedContent: false
 			});
 		}
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -233,11 +233,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
-				activator: null,
 				arrowPosition: {top: 0, left: 0},
-				containerId: Spotlight.add(this.props.popupSpotlightId),
 				containerPosition: {top: 0, left: 0},
-				prevOpen: false
+				containerId: Spotlight.add(this.props.popupSpotlightId),
+				activator: null
 			};
 
 			this.overflow = {};
@@ -263,7 +262,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (prevProps.open && !this.props.open) {
 				const current = Spotlight.getCurrent();
 				return {
-					prevOpen: this.props.open,
 					shouldSpotActivator: (
 						// isn't set
 						!current ||
@@ -273,10 +271,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 						this.containerNode.contains(current)
 					)
 				};
-			} else if (prevProps.open && this.props.open) {
-				return {
-					prevOpen: this.props.open
-				}
 			}
 			return null;
 		}
@@ -288,17 +282,15 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (prevProps.open) {
-				if (this.props.open && !this.state.prevOpen) {
-					on('keydown', this.handleKeyDown);
-					on('keyup', this.handleKeyUp);
-					this.spotPopupContent();
-				} else if (!this.props.open) {
-					off('keydown', this.handleKeyDown);
-					off('keyup', this.handleKeyUp);
-					if (snapshot && snapshot.shouldSpotActivator) {
-						this.spotActivator(prevState.activator);
-					}
+			if (this.props.open && this.state.activator && !prevState.activator) {
+				on('keydown', this.handleKeyDown);
+				on('keyup', this.handleKeyUp);
+				this.spotPopupContent();
+			} else if (!this.props.open && prevProps.open) {
+				off('keydown', this.handleKeyDown);
+				off('keyup', this.handleKeyUp);
+				if (snapshot && snapshot.shouldSpotActivator) {
+					this.spotActivator(prevState.activator);
 				}
 			}
 		}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -283,7 +283,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.props.open && this.state.renderedContent && !prevState.renderedContent) {
+			if (this.state.renderedContent && !prevState.renderedContent) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
 				this.spotPopupContent();

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -236,8 +236,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				activator: null,
 				arrowPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				containerPosition: {top: 0, left: 0},
-				contentRendered: false
+				containerPosition: {top: 0, left: 0}
 			};
 
 			this.overflow = {};
@@ -283,10 +282,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.state.contentRendered && !prevState.contentRendered) {
+			if (this.props.open && !prevProps.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
-				this.spotPopupContent();
 			} else if (!this.props.open && prevProps.open) {
 				off('keydown', this.handleKeyDown);
 				off('keyup', this.handleKeyUp);
@@ -489,16 +487,15 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			const current = Spotlight.getCurrent();
 			this.updateLeaveFor(current);
 			this.setState({
-				activator: current,
-				contentRendered: true
+				activator: current
 			});
+			this.spotPopupContent();
 		}
 
 		handleClose = () => {
 			this.updateLeaveFor(null);
 			this.setState({
-				activator: null,
-				contentRendered: false
+				activator: null
 			});
 		}
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -237,7 +237,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				arrowPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
 				containerPosition: {top: 0, left: 0},
-				renderedContent: false
+				contentRendered: false
 			};
 
 			this.overflow = {};
@@ -283,7 +283,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.state.renderedContent && !prevState.renderedContent) {
+			if (this.state.contentRendered && !prevState.contentRendered) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
 				this.spotPopupContent();
@@ -490,7 +490,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.updateLeaveFor(current);
 			this.setState({
 				activator: current,
-				renderedContent: true
+				contentRendered: true
 			});
 		}
 
@@ -498,7 +498,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.updateLeaveFor(null);
 			this.setState({
 				activator: null,
-				renderedContent: false
+				contentRendered: false
 			});
 		}
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -282,7 +282,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.positionContextualPopup();
 			}
 
-			if (this.props.open && !prevProps.open) {
+			if (this.props.open && prevProps.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
 				this.spotPopupContent();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
ContextualPopup does not focus on popup content when the popup is first opened.

### Resolution
The inner content was not yet rendered at the timing to focus it. so I fixed the timing to focus after it is rendered.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)