### PR TITLE
ENYO-5808: Slider knob > prevent default browser scroll behavior when using 5way

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
+- `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/Slider/utils.js
+++ b/packages/moonstone/Slider/utils.js
@@ -1,5 +1,5 @@
 import clamp from 'ramda/src/clamp';
-import {adaptEvent, forKey, forProp, forward, handle, oneOf, stop} from '@enact/core/handle';
+import {adaptEvent, forKey, forProp, forward, handle, oneOf, preventDefault, stop} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import {calcProportion} from '@enact/ui/Slider/utils';
 
@@ -53,6 +53,7 @@ const isActive = (ev, props) => {
 const handleIncrement = handle(
 	isActive,
 	isIncrement,
+	preventDefault,
 	stop,
 	isNotMax,
 	emitChange(1)
@@ -61,6 +62,7 @@ const handleIncrement = handle(
 const handleDecrement = handle(
 	isActive,
 	isDecrement,
+	preventDefault,
 	stop,
 	isNotMin,
 	emitChange(-1)


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixed an issue where using 5way directional keys on an active `Slider` knob resulted in default browser scroll behavior.

### Resolution
We simply need to call `preventDefault` on the `keydown` event used to increment/decrement the slider. It turns out that we have the necessary guards in place to only call this behavior when needed.
