### PR TITLE
PLAT-73546: ui/Changeable & ui/Toggleable: Add warning if both [defaultProp] and [prop] are declared

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Changeable` and `ui/Toggleable` to warn when both `[defaultProp]` and `[prop]` are provided
+
 ## [2.3.0] - 2019-02-11
 
 ### Added

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -133,6 +133,11 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 				value: null,
 				controlled: prop in props
 			};
+
+			warning(
+				!(prop in props && defaultPropKey in props),
+				`Do not specify both '${prop}' and '${defaultPropKey}' for Changeable instances. '${defaultPropKey}' will be ignored.`
+			);
 		}
 
 		static getDerivedStateFromProps (props, state) {

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -136,7 +136,8 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 
 			warning(
 				!(prop in props && defaultPropKey in props),
-				`Do not specify both '${prop}' and '${defaultPropKey}' for Changeable instances. '${defaultPropKey}' will be ignored.`
+				`Do not specify both '${prop}' and '${defaultPropKey}' for Changeable instances. '${defaultPropKey}' will be ignored.
+				'${defaultPropKey}' will be ignored unless '${prop}' is 'null' or 'undefined'.`
 			);
 		}
 

--- a/packages/ui/Changeable/tests/Changeable-specs.js
+++ b/packages/ui/Changeable/tests/Changeable-specs.js
@@ -81,7 +81,21 @@ describe('Changeable', () => {
 			expect(actual).toBe(expected);
 		});
 
+		test('should warn when \'defaultValue\' and \'value\' props are provided', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+			const Component = Changeable(DivComponent);
+			const subject = shallow(
+				<Component defaultValue={10} value={5} />
+			);
+
+			const expected = 1;
+			const actual = spy.mock.calls.length;
+
+			expect(actual).toBe(expected);
+		});
+
 		test('should use defaultValue prop when value prop is null', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Changeable(DivComponent);
 			const subject = shallow(
 				<Component defaultValue={1} value={null} />
@@ -91,11 +105,13 @@ describe('Changeable', () => {
 			const actual = subject.find(DivComponent).prop('value');
 
 			expect(actual).toBe(expected);
+			expect(spy).toHaveBeenCalled();
 		});
 
 		test(
 			'should use value prop when value changed from truthy to null',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Changeable(DivComponent);
 				const subject = shallow(
 					<Component defaultValue={1} value={2} />
@@ -107,10 +123,12 @@ describe('Changeable', () => {
 				const actual = subject.find(DivComponent).prop('value');
 
 				expect(actual).toBe(expected);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 
 		test('should use defaultValue prop when value prop is undefined', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Changeable(DivComponent);
 			const subject = shallow(
 				// eslint-disable-next-line no-undefined
@@ -121,11 +139,13 @@ describe('Changeable', () => {
 			const actual = subject.find(DivComponent).prop('value');
 
 			expect(actual).toBe(expected);
+			expect(spy).toHaveBeenCalled();
 		});
 
 		test(
 			'should use value prop when value changed from truthy to undefined',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Changeable(DivComponent);
 				const subject = shallow(
 					<Component defaultValue={1} value={2} />
@@ -138,10 +158,12 @@ describe('Changeable', () => {
 				const actual = subject.find(DivComponent).prop('value');
 
 				expect(actual).toBe(expected);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 
 		test('should use value prop when defined but falsy', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Changeable(DivComponent);
 			const subject = shallow(
 				<Component defaultValue={1} value={0} />
@@ -151,11 +173,13 @@ describe('Changeable', () => {
 			const actual = subject.find(DivComponent).prop('value');
 
 			expect(actual).toBe(expected);
+			expect(spy).toHaveBeenCalled();
 		});
 
 		test(
 			'should use value prop when both value and defaultValue are defined',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Changeable(DivComponent);
 				const subject = shallow(
 					<Component defaultValue={1} value={2} />
@@ -165,6 +189,7 @@ describe('Changeable', () => {
 				const actual = subject.find(DivComponent).prop('value');
 
 				expect(actual).toBe(expected);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 	});

--- a/packages/ui/Changeable/tests/Changeable-specs.js
+++ b/packages/ui/Changeable/tests/Changeable-specs.js
@@ -84,7 +84,7 @@ describe('Changeable', () => {
 		test('should warn when \'defaultValue\' and \'value\' props are provided', () => {
 			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Changeable(DivComponent);
-			const subject = shallow(
+			shallow(
 				<Component defaultValue={10} value={5} />
 			);
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -173,6 +173,11 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 				active: null,
 				controlled: prop in props
 			};
+
+			warning(
+				!(prop in props && defaultPropKey in props),
+				`Do not specify both '${prop}' and '${defaultPropKey}' for Toggleable instances. '${defaultPropKey}' will be ignored.`
+			);
 		}
 
 		static getDerivedStateFromProps (props, state) {

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -176,7 +176,8 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 
 			warning(
 				!(prop in props && defaultPropKey in props),
-				`Do not specify both '${prop}' and '${defaultPropKey}' for Toggleable instances. '${defaultPropKey}' will be ignored.`
+				`Do not specify both '${prop}' and '${defaultPropKey}' for Toggleable instances.
+				'${defaultPropKey}' will be ignored unless '${prop}' is 'null' or 'undefined'.`
 			);
 		}
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -161,7 +161,6 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static defaultProps = {
-			[defaultPropKey]: false,
 			disabled: false
 		}
 

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -87,7 +87,7 @@ describe('Toggleable', () => {
 		test('should warn when \'defaultSelected\' and \'selected\' props are provided', () => {
 			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Toggleable(DivComponent);
-			const subject = shallow(
+			shallow(
 				<Component defaultSelected selected />
 			);
 

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -84,7 +84,21 @@ describe('Toggleable', () => {
 			}
 		);
 
+		test('should warn when \'defaultSelected\' and \'selected\' props are provided', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+			const Component = Toggleable(DivComponent);
+			const subject = shallow(
+				<Component defaultSelected selected />
+			);
+
+			const expected = 1;
+			const actual = spy.mock.calls.length;
+
+			expect(actual).toBe(expected);
+		});
+
 		test('should use defaultSelected prop when selected prop is null', () => {
+			const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 			const Component = Toggleable(DivComponent);
 			const subject = shallow(
 				<Component defaultSelected selected={null} />
@@ -94,11 +108,13 @@ describe('Toggleable', () => {
 			const actual = subject.find(DivComponent).props();
 
 			expect(actual).toHaveProperty(expected, true);
+			expect(spy).toHaveBeenCalled();
 		});
 
 		test(
 			'should use selected prop when selected changed from truthy to null',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Toggleable(DivComponent);
 				const subject = shallow(
 					<Component defaultSelected selected />
@@ -110,12 +126,14 @@ describe('Toggleable', () => {
 				const actual = subject.find(DivComponent).props();
 
 				expect(actual).toHaveProperty(expected, false);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 
 		test(
 			'should use defaultSelected prop when selected prop is undefined',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Toggleable(DivComponent);
 				const subject = shallow(
 					// eslint-disable-next-line no-undefined
@@ -126,12 +144,14 @@ describe('Toggleable', () => {
 				const actual = subject.find(DivComponent).props();
 
 				expect(actual).toHaveProperty(expected, true);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 
 		test(
 			'should use selected prop when selected changed from truthy to undefined',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Toggleable(DivComponent);
 				const subject = shallow(
 					<Component defaultSelected selected />
@@ -143,12 +163,14 @@ describe('Toggleable', () => {
 				const actual = subject.find(DivComponent).props();
 
 				expect(actual).toHaveProperty(expected, false);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 
 		test(
 			'should use selected prop when both selected and defaultSelected are defined',
 			() => {
+				const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 				const Component = Toggleable(DivComponent);
 				const subject = shallow(
 					<Component defaultSelected selected={false} />
@@ -158,6 +180,7 @@ describe('Toggleable', () => {
 				const actual = subject.find(DivComponent).props();
 
 				expect(actual).toHaveProperty(expected, false);
+				expect(spy).toHaveBeenCalled();
 			}
 		);
 	});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Developers should not assign both `[defaultProp]` and `[prop]` at the same time so we add a console warning if that is the case.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Components and apps that have used the pattern will start seeing warnings in the console
- Existing tests for `ui/Changeable` and `ui/Toggleable` have been updated to expect warnings
- There are some tests in `ui/Toggleable` that still warn even when both props are not present


### Links
[//]: # (Related issues, references)
PLAT-73546