### PR TITLE
ENYO-5791: Fix timing of popup content spotlight to onOpen

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
 - `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
+- `moonstone/ContextualPopupDecorator` to correctly focus on popup content when opened
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -285,7 +285,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.props.open && !prevProps.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
-				this.spotPopupContent();
 			} else if (!this.props.open && prevProps.open) {
 				off('keydown', this.handleKeyDown);
 				off('keyup', this.handleKeyUp);
@@ -490,6 +489,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.setState({
 				activator: current
 			});
+			this.spotPopupContent();
 		}
 
 		handleClose = () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ContextualPopup` does not focus on popup content when the popup is first opened. This is due to the popup node not being available at the time when `spotPopupContent()` is called.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move popup content spotlight timing to `onOpen` to ensure the popup node is rendered.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
