### PR TITLE
PLAT-73358: Fix to perform `scrollTo` callback during the list is updated by prop changes

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Changeable` and `ui/Toggleable` to warn when both `[defaultProp]` and `[prop]` are provided
 
+### Fixed
+
+- `ui/VirtualList` to scroll properly by `scrollTo` callback during the list is updated by prop changes
+
 ## [2.3.0] - 2019-02-11
 
 ### Added

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -980,20 +980,14 @@ class ScrollableBase extends Component {
 	}
 
 	scroll = (left, top) => {
-		let
-			dirX = 0,
-			dirY = 0;
-
 		if (left !== this.scrollLeft) {
-			dirX = Math.sign(left - this.scrollLeft);
 			this.setScrollLeft(left);
 		}
 		if (top !== this.scrollTop) {
-			dirY = Math.sign(top - this.scrollTop);
 			this.setScrollTop(top);
 		}
 
-		this.childRef.setScrollPosition(this.scrollLeft, this.scrollTop, dirX, dirY);
+		this.childRef.setScrollPosition(this.scrollLeft, this.scrollTop);
 		this.forwardScrollEvent('onScroll');
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -425,8 +425,6 @@ class ScrollableBase extends Component {
 			}
 		}
 
-		this.deferScrollTo = true;
-
 		this.clampScrollPosition();
 
 		this.addEventListeners();
@@ -1320,6 +1318,8 @@ class ScrollableBase extends Component {
 		delete rest.scrollTo;
 		delete rest.stop;
 		delete rest.verticalScrollbar;
+
+		this.deferScrollTo = true;
 
 		return (
 			<ResizeContext.Provider value={this.resizeRegistry.register}>

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -412,8 +412,6 @@ class ScrollableBaseNative extends Component {
 			}
 		}
 
-		this.deferScrollTo = true;
-
 		this.addEventListeners();
 		if (
 			hasDataSizeChanged === false &&
@@ -1330,6 +1328,8 @@ class ScrollableBaseNative extends Component {
 		delete rest.scrollTo;
 		delete rest.start;
 		delete rest.verticalScrollbar;
+
+		this.deferScrollTo = true;
 
 		return (
 			<ResizeContext.Provider value={this.resizeRegistry.register}>

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -296,7 +296,7 @@ const VirtualListBaseFactory = (type) => {
 				if (type === Native) {
 					this.scrollToPosition(x, y, this.props.rtl);
 				} else {
-					this.setScrollPosition(x, y, nextProps.rtl);
+					this.setScrollPosition(x, y, this.props.rtl);
 				}
 			}
 		}
@@ -324,7 +324,6 @@ const VirtualListBaseFactory = (type) => {
 		dimensionToExtent = 0
 		threshold = 0
 		maxFirstIndex = 0
-		lastPositionedFirstIndex = 0
 		curDataSize = 0
 		hasDataSizeChanged = false
 		cc = []
@@ -472,7 +471,7 @@ const VirtualListBaseFactory = (type) => {
 				{overhang} = props,
 				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, primary, scrollBounds, scrollPosition, threshold} = this,
 				{gridSize} = primary;
-			let newFirstIndex;
+			let newFirstIndex = firstIndex;
 
 			if (wasFirstIndexMax && dataSizeDiff > 0) { // If dataSize increased from bottom, we need adjust firstIndex
 				// If this is a gridlist and dataSizeDiff is smaller than 1 line, we are adjusting firstIndex without threshold change.
@@ -496,7 +495,7 @@ const VirtualListBaseFactory = (type) => {
 					threshold.min = Math.min(maxOfMin, threshold.max - gridSize);
 				}
 			} else { // Other cases, we can keep the min value between firstIndex and maxFirstIndex. No need to change threshold
-				newFirstIndex = Math.min(this.lastPositionedFirstIndex, maxFirstIndex);
+				newFirstIndex = Math.min(firstIndex, maxFirstIndex);
 			}
 
 			return newFirstIndex;
@@ -624,7 +623,6 @@ const VirtualListBaseFactory = (type) => {
 			this.updateMoreInfo(dataSize, pos);
 
 			if (firstIndex !== newFirstIndex) {
-				this.lastPositionedFirstIndex = newFirstIndex;
 				this.setState({firstIndex: newFirstIndex});
 			}
 		}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -306,6 +306,7 @@ const VirtualListBaseFactory = (type) => {
 		threshold = 0
 		maxFirstIndex = 0
 		prevFirstIndex = 0
+		lastPositionedFirstIndex = 0
 		curDataSize = 0
 		hasDataSizeChanged = false
 		cc = []
@@ -454,10 +455,9 @@ const VirtualListBaseFactory = (type) => {
 		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff) {
 			const
 				{overhang} = props,
-				{firstIndex} = this.state,
 				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, primary, scrollBounds, scrollPosition, threshold} = this,
 				{gridSize} = primary;
-			let newFirstIndex = firstIndex;
+			let newFirstIndex;
 
 			if (wasFirstIndexMax && dataSizeDiff > 0) { // If dataSize increased from bottom, we need adjust firstIndex
 				// If this is a gridlist and dataSizeDiff is smaller than 1 line, we are adjusting firstIndex without threshold change.
@@ -481,7 +481,7 @@ const VirtualListBaseFactory = (type) => {
 					threshold.min = Math.min(maxOfMin, threshold.max - gridSize);
 				}
 			} else { // Other cases, we can keep the min value between firstIndex and maxFirstIndex. No need to change threshold
-				newFirstIndex = Math.min(firstIndex, maxFirstIndex);
+				newFirstIndex = Math.min(this.lastPositionedFirstIndex, maxFirstIndex);
 			}
 
 			return newFirstIndex;
@@ -609,6 +609,7 @@ const VirtualListBaseFactory = (type) => {
 			this.updateMoreInfo(dataSize, pos);
 
 			if (firstIndex !== newFirstIndex) {
+				this.lastPositionedFirstIndex = newFirstIndex;
 				this.setState({firstIndex: newFirstIndex});
 			}
 		}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -271,7 +271,7 @@ const VirtualListBaseFactory = (type) => {
 				if (type === Native) {
 					this.scrollToPosition(x, y, nextProps.rtl);
 				} else {
-					this.setScrollPosition(x, y, 0, 0, nextProps.rtl);
+					this.setScrollPosition(x, y, nextProps.rtl);
 				}
 			}
 		}
@@ -563,51 +563,45 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		// JS only
-		setScrollPosition (x, y, dirX, dirY, rtl = this.props.rtl) {
+		setScrollPosition (x, y, rtl = this.props.rtl) {
 			if (this.contentRef) {
 				this.contentRef.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
-				this.didScroll(x, y, dirX, dirY);
+				this.didScroll(x, y);
 			}
 		}
 
-		didScroll (x, y, dirX, dirY) {
+		didScroll (x, y) {
 			const
 				{dataSize} = this.props,
 				{firstIndex} = this.state,
 				{isPrimaryDirectionVertical, threshold, dimensionToExtent, maxFirstIndex, scrollBounds} = this,
 				{gridSize} = this.primary,
-				maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft,
-				minOfMax = threshold.base,
-				maxOfMin = maxPos - threshold.base;
-			let delta, numOfGridLines, newFirstIndex = firstIndex, pos, dir = 0;
+				maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft;
+			let newFirstIndex = firstIndex, pos;
 
 			if (isPrimaryDirectionVertical) {
 				pos = y;
-				dir = dirY;
 			} else {
 				pos = x;
-				dir = dirX;
 			}
 
-			if (dir === 1 && pos > threshold.max) {
-				delta = pos - threshold.max;
-				numOfGridLines = Math.ceil(delta / gridSize); // how many lines should we add
-				threshold.max = Math.min(maxPos, threshold.max + numOfGridLines * gridSize);
-				threshold.min = Math.min(maxOfMin, threshold.max - gridSize);
-				newFirstIndex += numOfGridLines * dimensionToExtent;
-			} else if (dir === -1 && pos < threshold.min) {
-				delta = threshold.min - pos;
-				numOfGridLines = Math.ceil(delta / gridSize);
-				threshold.max = Math.max(minOfMax, threshold.min - (numOfGridLines * gridSize - gridSize));
-				threshold.min = (threshold.max > minOfMax) ? threshold.max - gridSize : -Infinity;
-				newFirstIndex -= numOfGridLines * dimensionToExtent;
-			}
+			if (pos > threshold.max || pos < threshold.min) {
+				const
+					overhangBefore = Math.floor(this.props.overhang / 2),
+					firstExtent = Math.max(
+						0,
+						Math.min(
+							Math.floor(maxFirstIndex / dimensionToExtent),
+							Math.floor((pos - gridSize * overhangBefore) / gridSize)
+						)
+					);
+				let newThresholdMin, newThresholdMax;
 
-			if (threshold.min === -Infinity) {
-				newFirstIndex = 0;
-			} else {
-				newFirstIndex = Math.min(maxFirstIndex, newFirstIndex);
-				newFirstIndex = Math.max(0, newFirstIndex);
+				newFirstIndex = firstExtent * dimensionToExtent;
+				newThresholdMin = (firstExtent + overhangBefore) * gridSize;
+				newThresholdMax = newThresholdMin + gridSize;
+				threshold.min = newFirstIndex === 0 ? -Infinity : newThresholdMin;
+				threshold.max = newFirstIndex === maxFirstIndex ? Infinity : newThresholdMax;
 			}
 
 			this.syncThreshold(maxPos);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After migration to React 16.7, items are not displayed properly if an app calls `scrollTo` during VirtualList is being updated by prop changes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When props are changed, a list should be reset by data change or bounds change. And if the scroll area is expanded or shrunk by scrollbar visibility, a list needs at least two rendering cycles due to measuring. So we had a logic to defer a `scrollTo` request until internal updating is finished.
Note that the first index to render is managed through `state` and it is very tightly coupled with the scroll position of a list which is _updated by browser outside of React lifecycles_.
Here are changes in this PR;
- After migration to React 16.7, timing to defer is changed, so I moved the code from `componentDidUpdate` to `render`.
- Due to async execution of `setState`, the first index value and the scroll position are not matched if a list is updated by props change. So changed to use intentional last first index.
- Also, the legacy code to pick the first index on scroll is assuming that the previous first index and thresholds are matched to the scroll position. But, it's not true now, so I changed calculation logic to be independent from the assumption.

### Links
[//]: # (Related issues, references)
PLAT-73358
