### PR TITLE
ENYO-5839: Fix Storybook story workspace positioning

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {Column, Cell} from '@enact/ui/Layout';
 import BodyText from '@enact/moonstone/BodyText';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {Panels, Panel, Header} from '@enact/moonstone/Panels';
@@ -36,10 +37,12 @@ const PanelsBase = kind({
 		<Panels {...rest} onApplicationClose={reloadPage}>
 			<Panel className={css.panel}>
 				<Header type="compact" title={title} casing="preserve" />
-				{description ? (
-					<BodyText className={css.description}>{description}</BodyText>
-				) : null}
-				{children}
+				<Column>
+					{description ? (
+						<Cell shrink component={BodyText} className={css.description}>{description}</Cell>
+					) : null}
+					<Cell className={css.storyCell}>{children}</Cell>
+				</Column>
 			</Panel>
 		</Panels>
 	)

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
@@ -35,6 +35,12 @@
 		}
 	}
 
+	.storyCell > div:not([class]):not([style]):first-child {
+		position: relative;
+		width: 100%;
+		height: 100%;
+	}
+
 	// Hack into the Info - Don't try this at home, kids
 	main > article > section > :nth-child(2) > :nth-child(3) {
 		.enact-selectable();

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
@@ -35,6 +35,12 @@
 		}
 	}
 
+	// Here, we target the storybook rendering canvas div. It's inserted as a child of our Panel,
+	// but it applies position:relative, which doesn't help us when we have stories that should fill
+	// the entire panel body. This targets that inaccessible node using Panel's structure and
+	// storybook's structure to update that goofy rule to a rational one.
+	// The :not() bit targets only non-enact elements, so if a story doesn't use withInfo, and a
+	// `div` isn't added, the components aren't being told to be a different size/position.
 	.storyCell > div:not([class]):not([style]):first-child {
 		position: relative;
 		width: 100%;

--- a/packages/sampler/src/enact-knobs/select.js
+++ b/packages/sampler/src/enact-knobs/select.js
@@ -19,12 +19,12 @@ import nullify from '../utils/nullify.js';
 
 const defaultString = ' (Default)';
 
-const select = (name, items, Config, selecetdValue) => {
+const select = (name, items, Config, selectedValue) => {
 	const labels = {};
 
 	if (typeof Config === 'string' || Config == null) {
 		// Config wasn't set, or was omitted, causing the selectedValue to be the last value. Reassignment dipsy-doodle.
-		selecetdValue = Config;
+		selectedValue = Config;
 		Config = {};
 	}
 
@@ -33,7 +33,7 @@ const select = (name, items, Config, selecetdValue) => {
 		Config.defaultProps = {};
 	}
 
-	const defaultValue = selecetdValue || Config.defaultProps[name];
+	const defaultValue = selectedValue || Config.defaultProps[name];
 
 	const defaultAppender = (key, label = key) => {
 		return key + (Config.defaultProps[name] === label ? defaultString : '');

--- a/packages/sampler/src/utils/propTables.js
+++ b/packages/sampler/src/utils/propTables.js
@@ -5,6 +5,7 @@ const merge = (components, field) => {
 const mergeComponentMetadata = (displayName, ...components) => {
 	const fn = function () {};
 	fn.displayName = displayName;
+	fn.groupId = displayName;
 	fn.propTypes = merge(components, 'propTypes');
 	fn.defaultProps = merge(components, 'defaultProps');
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Storybook addons don't adhere to our idealized styling policy, and as such, some addons simply inject unstylable DOM nodes into the hierarchy. This causes layout problems when a child component expects to have a container which doesn't auto-shrink to minimum size.

There is a typo in an enact-knob code.

And some knobs do not properly group themselves when the page is reloaded even though they do properly group when switching stories.

### Resolution
Added better layout support (by using Layout) to the story workspace area, and restored the positioning rules for the unstylable foreign DIV.

Fixed said typo

Added a `groupId` key to the Config object so the component name isn't discovered after several of the knobs are rendered (into the wrong tab-group category). May not be the *best* place to put it, but it seems logical and should cover all of our cases.