### PR TITLE
PLAT-72723: Fix first index reset on props update

### DIFF
--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -229,7 +229,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (props.clientSize) {
 				this.calculateMetrics(props);
-				nextState = this.getStatesAndUpdateBounds(this.props);
+				nextState = this.getStatesAndUpdateBounds(props);
 			}
 
 			this.state = {
@@ -272,8 +272,6 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
-
 			if (
 				prevProps.direction !== this.props.direction ||
 				prevProps.overhang !== this.props.overhang ||
@@ -284,9 +282,10 @@ const VirtualListBaseFactory = (type) => {
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
-			} else if (this.hasDataSizeChanged) {
+			} else if (prevProps.dataSize !== this.props.dataSize) {
+				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
 				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(this.getStatesAndUpdateBounds(this.props));
+				this.setState(newState);
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
 				const {x, y} = this.getXY(this.scrollPosition, 0);
@@ -323,7 +322,6 @@ const VirtualListBaseFactory = (type) => {
 		threshold = 0
 		maxFirstIndex = 0
 		curDataSize = 0
-		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
 
@@ -432,10 +430,9 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		getStatesAndUpdateBounds = (props) => {
+		getStatesAndUpdateBounds = (props, firstIndex = 0) => {
 			const
 				{dataSize, overhang, updateStatesAndBounds} = props,
-				firstIndex = this.hasDataSizeChanged ? this.state.firstIndex : 0,
 				{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
 				numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
 				wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
@@ -456,7 +453,7 @@ const VirtualListBaseFactory = (type) => {
 				dataSize,
 				moreInfo
 			}))) {
-				newFirstIndex = this.calculateFirstIndex(props, wasFirstIndexMax, dataSizeDiff);
+				newFirstIndex = this.calculateFirstIndex(props, wasFirstIndexMax, dataSizeDiff, firstIndex);
 			}
 
 			return {
@@ -465,10 +462,9 @@ const VirtualListBaseFactory = (type) => {
 			};
 		}
 
-		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff) {
+		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff, firstIndex) {
 			const
 				{overhang} = props,
-				{firstIndex} = this.state || {firstIndex: 0},
 				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, primary, scrollBounds, scrollPosition, threshold} = this,
 				{gridSize} = primary;
 			let newFirstIndex = firstIndex;
@@ -748,7 +744,7 @@ const VirtualListBaseFactory = (type) => {
 
 			if (clientWidth !== scrollBounds.clientWidth || clientHeight !== scrollBounds.clientHeight) {
 				this.calculateMetrics(props);
-				this.setState(this.getStatesAndUpdateBounds(this.props));
+				this.setState(this.getStatesAndUpdateBounds(props));
 				this.setContainerSize();
 				return true;
 			}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -272,6 +272,9 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		componentDidUpdate (prevProps) {
+			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
+			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
+
 			if (
 				prevProps.direction !== this.props.direction ||
 				prevProps.overhang !== this.props.overhang ||
@@ -282,7 +285,7 @@ const VirtualListBaseFactory = (type) => {
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
-			} else if (prevProps.dataSize !== this.props.dataSize) {
+			} else if (this.hasDataSizeChanged) {
 				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(newState);
@@ -322,6 +325,7 @@ const VirtualListBaseFactory = (type) => {
 		threshold = 0
 		maxFirstIndex = 0
 		curDataSize = 0
+		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When metrics props (e.g. `direction`, `spacing`, etc.) update, children are incorrectly positioned. For example, changing `direction` in `VirtualGridList` after scrolling a bit, it will show a blank page.

Prior to lifecycle method update PR (#2108), it used to reset `firstIndex` state directly prior to making an updated `setState` call, but it's been removed as part of the fix. This left us with incorrect value of the "new first index", thus resulting in wrong positioned items.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed references of `this.state` in all related calculation logic and added parameters to each function that accepts "firstIndex" value.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
