### PR TITLE
ENYO-5842: Switch ui/ProgressBar to unitless proportions from percents

### DIFF
--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -18,7 +18,7 @@ import {validateRange} from '../internal/validators';
 
 import componentCss from './ProgressBar.module.less';
 
-const progressToPercent = (value) => (clamp(0, 1, value) * 100) + '%';
+const progressToPercent = (value) => (clamp(0, 1, value) * 100);
 const calcBarStyle = (prop, anchor, value = anchor, startProp, endProp) => {
 	let start = Math.min(anchor, value);
 	let end = Math.max(anchor, value) - start;
@@ -94,7 +94,7 @@ const ProgressBar = kind({
 		 * @default 'horizontal'
 		 * @public
 		 */
-		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+		orientation: PropTypes.string,
 
 		/**
 		 * The proportion of the filled portion of the progress bar.

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -18,7 +18,7 @@ import {validateRange} from '../internal/validators';
 
 import componentCss from './ProgressBar.module.less';
 
-const progressToPercent = (value) => (clamp(0, 1, value) * 100);
+const progressToProportion = (value) => clamp(0, 1, value);
 const calcBarStyle = (prop, anchor, value = anchor, startProp, endProp) => {
 	let start = Math.min(anchor, value);
 	let end = Math.max(anchor, value) - start;
@@ -29,8 +29,8 @@ const calcBarStyle = (prop, anchor, value = anchor, startProp, endProp) => {
 	}
 
 	return {
-		[startProp]: progressToPercent(start),
-		[endProp]: progressToPercent(end)
+		[startProp]: progressToProportion(start),
+		[endProp]: progressToProportion(end)
 	};
 };
 

--- a/packages/ui/ProgressBar/ProgressBar.module.less
+++ b/packages/ui/ProgressBar/ProgressBar.module.less
@@ -25,13 +25,13 @@
 		}
 
 		.fill {
-			bottom: ~"calc(var(--ui-progressbar-proportion-start) * 1%)";
-			height: ~"calc(var(--ui-progressbar-proportion-end) * 1%)";
+			bottom: ~"calc(var(--ui-progressbar-proportion-start) * 100%)";
+			height: ~"calc(var(--ui-progressbar-proportion-end) * 100%)";
 		}
 
 		.load {
-			bottom: ~"calc(var(--ui-progressbar-proportion-start-background) * 1%)";
-			height: ~"calc(var(--ui-progressbar-proportion-end-background) * 1%)";
+			bottom: ~"calc(var(--ui-progressbar-proportion-start-background) * 100%)";
+			height: ~"calc(var(--ui-progressbar-proportion-end-background) * 100%)";
 		}
 	}
 
@@ -42,13 +42,13 @@
 		}
 
 		.fill {
-			left: ~"calc(var(--ui-progressbar-proportion-start) * 1%)";
-			width: ~"calc(var(--ui-progressbar-proportion-end) * 1%)";
+			left: ~"calc(var(--ui-progressbar-proportion-start) * 100%)";
+			width: ~"calc(var(--ui-progressbar-proportion-end) * 100%)";
 		}
 
 		.load {
-			left: ~"calc(var(--ui-progressbar-proportion-start-background) * 1%)";
-			width: ~"calc(var(--ui-progressbar-proportion-end-background) * 1%)";
+			left: ~"calc(var(--ui-progressbar-proportion-start-background) * 100%)";
+			width: ~"calc(var(--ui-progressbar-proportion-end-background) * 100%)";
 		}
 	}
 }

--- a/packages/ui/ProgressBar/ProgressBar.module.less
+++ b/packages/ui/ProgressBar/ProgressBar.module.less
@@ -1,17 +1,16 @@
 // ProgressBar.module.less
 //
 .progressBar {
-	--ui-progressbar-proportion-start: 0%;
-	--ui-progressbar-proportion-start-background: 0%;
-	--ui-progressbar-proportion-end: 0%;
-	--ui-progressbar-proportion-end-background: 0%;
+	--ui-progressbar-proportion-start: 0;
+	--ui-progressbar-proportion-start-background: 0;
+	--ui-progressbar-proportion-end: 0;
+	--ui-progressbar-proportion-end-background: 0;
 
 	position: relative;
 	direction: ltr;
 
 	.fill,
 	.load {
-		height: 100%;
 		position: absolute;
 	}
 
@@ -20,30 +19,36 @@
 
 		.fill,
 		.load {
+			height: 100%;
 			width: 100%;
 			bottom: 0;
 		}
 
 		.fill {
-			bottom: var(--ui-progressbar-proportion-start);
-			height: var(--ui-progressbar-proportion-end);
+			bottom: ~"calc(var(--ui-progressbar-proportion-start) * 1%)";
+			height: ~"calc(var(--ui-progressbar-proportion-end) * 1%)";
 		}
 
 		.load {
-			bottom: var(--ui-progressbar-proportion-start-background);
-			height: var(--ui-progressbar-proportion-end-background);
+			bottom: ~"calc(var(--ui-progressbar-proportion-start-background) * 1%)";
+			height: ~"calc(var(--ui-progressbar-proportion-end-background) * 1%)";
 		}
 	}
 
 	&.horizontal {
+		.fill,
+		.load {
+			height: 100%;
+		}
+
 		.fill {
-			left: var(--ui-progressbar-proportion-start);
-			width: var(--ui-progressbar-proportion-end);
+			left: ~"calc(var(--ui-progressbar-proportion-start) * 1%)";
+			width: ~"calc(var(--ui-progressbar-proportion-end) * 1%)";
 		}
 
 		.load {
-			left: var(--ui-progressbar-proportion-start-background);
-			width: var(--ui-progressbar-proportion-end-background);
+			left: ~"calc(var(--ui-progressbar-proportion-start-background) * 1%)";
+			width: ~"calc(var(--ui-progressbar-proportion-end-background) * 1%)";
 		}
 	}
 }

--- a/packages/ui/ProgressBar/tests/ProgressBar-specs.js
+++ b/packages/ui/ProgressBar/tests/ProgressBar-specs.js
@@ -4,7 +4,7 @@ import ProgressBar from '../ProgressBar';
 import css from '../ProgressBar.module.less';
 
 describe('ProgressBar Specs', () => {
-	test('should have width of 50%', () => {
+	test('should have width of 0.5', () => {
 		const progressBar = mount(
 			<ProgressBar
 				progress={0.5}
@@ -13,13 +13,13 @@ describe('ProgressBar Specs', () => {
 
 		const style = progressBar.find(`.${css.progressBar}`).prop('style');
 
-		const expected = '50%';
+		const expected = 0.5;
 		const actual = style['--ui-progressbar-proportion-end'];
 
 		expect(actual).toBe(expected);
 	});
 
-	test('should have background width of 75%', () => {
+	test('should have background width of 0.75', () => {
 		const progressBar = mount(
 			<ProgressBar
 				backgroundProgress={0.75}
@@ -28,13 +28,13 @@ describe('ProgressBar Specs', () => {
 
 		const style = progressBar.find(`.${css.progressBar}`).prop('style');
 
-		const expected = '75%';
+		const expected = 0.75;
 		const actual = style['--ui-progressbar-proportion-end-background'];
 
 		expect(actual).toBe(expected);
 	});
 
-	test('should have height of 50%', () => {
+	test('should have height of 0.5', () => {
 		const progressBar = mount(
 			<ProgressBar
 				progress={0.5}
@@ -44,13 +44,13 @@ describe('ProgressBar Specs', () => {
 
 		const style = progressBar.find(`.${css.progressBar}`).prop('style');
 
-		const expected = '50%';
+		const expected = 0.5;
 		const actual = style['--ui-progressbar-proportion-end'];
 
 		expect(actual).toBe(expected);
 	});
 
-	test('should have background height of 50%', () => {
+	test('should have background height of 0.75', () => {
 		const progressBar = mount(
 			<ProgressBar
 				progress={0.5}
@@ -61,7 +61,7 @@ describe('ProgressBar Specs', () => {
 
 		const style = progressBar.find(`.${css.progressBar}`).prop('style');
 
-		const expected = '75%';
+		const expected = 0.75;
 		const actual = style['--ui-progressbar-proportion-end-background'];
 
 		expect(actual).toBe(expected);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Mandating a unit in the proportion CSS values not only doesn't make sense (it's a numeric proportion, not a percentage), but it also makes division and subtraction impossible in the CSS `calc` function.
One is also not free to use `ui/ProgressBar` to its fullest potential in unique themes because `orientation` is "locked" to two finite values.

### Resolution
Switch ui/ProgressBar to unitless proportions from percents.
Also allow any string in the `orientation` prop, since we can't make assumptions about what orientations a theme may want to implement.
