### PR TITLE
ENYO-5843: Added a component prop to Repeater to allow customization

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Added
+
+- `ui/Repeater` prop `component` to allow customization of its base element
+
 ### Changed
 
 - `ui/Changeable` and `ui/Toggleable` to warn when both `[defaultProp]` and `[prop]` are provided

--- a/packages/ui/Repeater/Repeater.js
+++ b/packages/ui/Repeater/Repeater.js
@@ -65,6 +65,17 @@ const RepeaterBase = kind({
 		childProp: PropTypes.string,
 
 		/**
+		 * Component type to wrap around all of the repeated elements.
+		 *
+		 * This can be a string describing a DOM node or React component (e.g. `'div'` or `Layout`).
+		 *
+		 * @type {Component}
+		 * @default 'span'
+		 * @public
+		 */
+		component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+		/**
 		 * The property on each `childComponent` that receives the index of the item in the `Repeater`.
 		 *
 		 * @type {String}
@@ -83,8 +94,9 @@ const RepeaterBase = kind({
 	},
 
 	defaultProps: {
-		indexProp: 'data-index',
-		childProp: 'children'
+		childProp: 'children',
+		component: 'span',
+		indexProp: 'data-index'
 	},
 
 	computed: {
@@ -103,13 +115,13 @@ const RepeaterBase = kind({
 		}
 	},
 
-	render: (props) => {
-		delete props.childComponent;
-		delete props.childProp;
-		delete props.indexProp;
-		delete props.itemProps;
+	render: ({component: Component, ...rest}) => {
+		delete rest.childComponent;
+		delete rest.childProp;
+		delete rest.indexProp;
+		delete rest.itemProps;
 
-		return <span role="list" {...props} />;
+		return <Component role="list" {...rest} />;
 	}
 });
 

--- a/packages/ui/Repeater/tests/Repeater-specs.js
+++ b/packages/ui/Repeater/tests/Repeater-specs.js
@@ -8,6 +8,7 @@ describe('Repeater Specs', () => {
 	const stringItems = ['One', 'Two', 'Three'];
 	const objItems = stringItems.map((content, key) => ({key, content}));
 
+	const CustomRootType = (props) => <div {...props} />;
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	const CustomType = (props) => <div>{props.content}</div>;
 
@@ -17,6 +18,28 @@ describe('Repeater Specs', () => {
 		);
 
 		const expected = 'span';
+		const actual = subject.first().name();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should accept a nodeName as root element', () => {
+		const subject = shallow(
+			<Repeater component="div" childComponent="div">{stringItems}</Repeater>
+		);
+
+		const expected = 'div';
+		const actual = subject.first().name();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should accept a function as root element', () => {
+		const subject = shallow(
+			<Repeater component={CustomRootType} childComponent="div">{stringItems}</Repeater>
+		);
+
+		const expected = 'CustomRootType';
 		const actual = subject.first().name();
 
 		expect(actual).toBe(expected);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`ui/Repeater` always renders a `<span>` tag. It's often useful to be able to change this.

### Resolution
Added a `component` prop to `ui/Repeater` to allow customization of its base level element. This logically makes sense because the child component can already be customized (via `childComponet`) and fits in line with the way other components' base elements are customized (via the `component` prop).

This simple change greatly improves the flexibility and utility of this component.