### PR TITLE
ENYO-5853: Remove trailing semicolon from AccessibilityDecorator

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/AccessibilityDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/AccessibilityDecorator.js
@@ -75,7 +75,7 @@ const AccessibilityDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 
 			return (
 				<ResizeContext.Provider value={this.resizeRegistry.register}>
-					<Wrapped className={combinedClassName} skinVariants={variants} {...props} />;
+					<Wrapped className={combinedClassName} skinVariants={variants} {...props} />
 				</ResizeContext.Provider>
 			);
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Extra semicolon was lingering in the JSX

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed it!
