### PR TITLE
ENYO-5852: Enact-ui-tests: DatePicker and TimePicker - running same test on different builds gives different result

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Slider` to prevent gaining focus when clicked when disabled
 - `moonstone/Slider` to prevent default browser scroll behavior when 5-way directional key is pressed on an active knob
+- `moonstone/DatePicker` and `moonstone/TimePicker` to close with back/ESC
+- `moonstone/DatePicker` and `moonstone/TimePicker` value handling when open on mount
 
 ## [2.3.0] - 2019-02-11
 

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -109,22 +109,16 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 		static getDerivedStateFromProps (props, state) {
 			const propValue = toTime(props.value);
-			if (state.derived) {
-				if (state.value !== propValue) {
-					return {
-						value: propValue
-					};
-				}
+			if (state.derived && state.value !== propValue) {
+				return {
+					value: propValue
+				};
+			} else if (!state.derived) {
+				return {
+					derived: true
+				};
 			}
-			return {
-				derived: true
-			};
-			// if (propValue && !props.open && state.value !== propValue) {
-			// 	return {
-			// 		value: propValue
-			// 	};
-			// }
-			// return null;
+			return null;
 		}
 
 		/**

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -5,7 +5,7 @@
  * @private
  */
 
-import {forward} from '@enact/core/handle';
+import handle, {call, forKey, forProp, forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {memoize} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
@@ -91,12 +91,9 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
-			const initialValue = toTime(props.value);
-			const value = props.open && !initialValue ? Date.now() : initialValue;
 			this.state = {
-				derived: false,
-				initialValue,
-				value
+				initialValue: null,
+				value: null
 			};
 
 			this.handlers = {};
@@ -108,16 +105,23 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			const propValue = toTime(props.value);
-			if (state.derived && state.value !== propValue) {
+			let value = toTime(props.value);
+
+			if (props.open && !props.disabled && state.initialValue == null && state.value == null) {
+				// when the expandable opens, we cache the prop value so it can be restored on
+				// cancel and set value to be the current time if unset in order to initialize the
+				// pickers
 				return {
-					value: propValue
+					initialValue: value,
+					value: value || Date.now()
 				};
-			} else if (!state.derived) {
+			} else if (state.value !== value) {
+				// always respect a value change from props
 				return {
-					derived: true
+					value
 				};
 			}
+
 			return null;
 		}
 
@@ -204,19 +208,24 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 		handleCancel = () => {
 			const {initialValue, value} = this.state;
 
-			if (this.props.open) {
-				// if we're cancelling, reset our state and emit an onChange with the initial value
-				this.setState({
-					value: initialValue,
-					initialValue: null,
-					pickerValue: value
-				});
+			// if we're cancelling, reset our state and emit an onChange with the initial value
+			this.setState({
+				value: null,
+				initialValue: null,
+				pickerValue: value
+			});
 
-				if (initialValue !== value) {
-					this.emitChange(this.toIDate(initialValue));
-				}
+			if (initialValue !== value) {
+				this.emitChange(this.toIDate(initialValue));
 			}
 		}
+
+		handleKeyDown = handle(
+			forward('onKeyDown'),
+			forProp('open', true),
+			forKey('cancel'),
+			call('handleCancel')
+		).bindAs(this, 'handleKeyDown')
 
 		render () {
 			const value = this.toIDate(this.state.value);
@@ -243,10 +252,11 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 					{...props}
 					{...this.handlers}
 					label={label}
+					onKeyDown={this.handleKeyDown}
+					onClose={this.handleClose}
+					onOpen={this.handleOpen}
 					order={order}
 					value={value}
-					onOpen={this.handleOpen}
-					onClose={this.handleClose}
 				/>
 			);
 		}

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -105,7 +105,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 		static getDerivedStateFromProps (props, state) {
 			const propValue = toTime(props.value);
-			if (state.value !== propValue) {
+			if (propValue && !props.open && state.value !== propValue) {
 				return {
 					value: propValue
 				};

--- a/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
+++ b/packages/moonstone/internal/DateTimeDecorator/DateTimeDecorator.js
@@ -93,7 +93,11 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 			const initialValue = toTime(props.value);
 			const value = props.open && !initialValue ? Date.now() : initialValue;
-			this.state = {initialValue, value};
+			this.state = {
+				derived: false,
+				initialValue,
+				value
+			};
 
 			this.handlers = {};
 			if (handlers) {
@@ -105,12 +109,22 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 
 		static getDerivedStateFromProps (props, state) {
 			const propValue = toTime(props.value);
-			if (propValue && !props.open && state.value !== propValue) {
-				return {
-					value: propValue
-				};
+			if (state.derived) {
+				if (state.value !== propValue) {
+					return {
+						value: propValue
+					};
+				}
 			}
-			return null;
+			return {
+				derived: true
+			};
+			// if (propValue && !props.open && state.value !== propValue) {
+			// 	return {
+			// 		value: propValue
+			// 	};
+			// }
+			// return null;
 		}
 
 		/**

--- a/packages/sampler/stories/default/DatePicker.js
+++ b/packages/sampler/stories/default/DatePicker.js
@@ -21,6 +21,7 @@ storiesOf('Moonstone', module)
 			<DatePicker
 				dayAriaLabel={text('dayAriaLabel', Config)}
 				dayLabel={text('dayLabel', Config)}
+				disabled={boolean('disabled', Config)}
 				monthAriaLabel={text('monthAriaLabel', Config)}
 				monthLabel={text('monthLabel', Config)}
 				noLabels={boolean('noLabels', Config)}

--- a/packages/sampler/stories/default/TimePicker.js
+++ b/packages/sampler/stories/default/TimePicker.js
@@ -17,6 +17,7 @@ storiesOf('Moonstone', module)
 			text: 'The basic TimePicker'
 		})(() => (
 			<TimePicker
+				disabled={boolean('disabled', Config)}
 				hourAriaLabel={text('hourAriaLabel', Config, '')}
 				hourLabel={text('hourLabel', Config, '')}
 				meridiemAriaLabel={text('meridiemAriaLabel', Config, '')}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In certain cases, most notably in `TimePicker`, an `undefined` value is incorrectly overriding a supplied `defaultValue` on render.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I opted to use a state value (`derived`), initially `false`, that is checked in `getDerivedStateFromProps` and prevents updating in the case where a decorated component is rendered `open`.  Once the props have been derived the first time, the state is updated and the component will update properly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Component and UI tests seem to work fine with this change, but there might be a better way to handle this?

### Links
[//]: # (Related issues, references)
ENYO-5852