### PR TITLE
PLAT-74934: mock support for testing LS2Request

### DIFF
--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -63,6 +63,7 @@ export default class LS2Request {
 	 *	times out.  Used in conjunction with `timeout`.
 	 * @param {Boolean} options.subscribe Subscribe to service methods that support subscription.
 	 * @param {Number} options.timeout The delay in milliseconds to wait for the request to return.
+	 * @param {Object} options.mockData The mock data to return when PalmServiceBridge not found.
 	 * @returns {webos/LS2Request}
 	 * @public
 	 */
@@ -75,7 +76,8 @@ export default class LS2Request {
 		onComplete = null,
 		onTimeout = timeoutHandler,
 		subscribe = false,
-		timeout = 0
+		timeout = 0,
+		mockData = null
 	}) {
 		this.cancelled = false;
 
@@ -84,6 +86,15 @@ export default class LS2Request {
 		}
 
 		if (typeof window !== 'object' || !window.PalmServiceBridge) {
+			if (mockData) {
+				if (mockData.errorCode || mockData.returnValue === false) {
+					onFailure && onFailure(mockData);
+				} else {
+					onSuccess && onSuccess(mockData);
+				}
+				onComplete && onComplete(mockData);
+				return;
+			}
 			/* eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
 			onFailure && onFailure({errorCode: -1, errorText: 'PalmServiceBridge not found.', returnValue: false});
 			onComplete && onComplete({errorCode: -1, errorText: 'PalmServiceBridge not found.', returnValue: false});


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In real applications, we usually use `LS2Request` service to fetch data from webOS TV.
When we run `enact serve` to launch application on PC, `PalmServiceBridge` not found.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
That is why, we can't verify that functions. To avoid from that, we had to add condition `if(!window.PalmSystem)`.
By this condition, we can't test real code related to LS2Request with Jest.
At that time, if we can use mock data, we can show UI with `enact serve` and test that related to `LS2Request`.
Also, many applications already have mock data to test `LS2Request` with Jest.

### Links
[//]: # (Related issues, references)
PLAT-74934