### PR TITLE
Removed focused state from spotlight

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+### Unreleased
+
+### Fixed 
+- `spotlight/Spottable` to prevent unnecessary updates due to blur changes
+
+
 ## [2.4.0] - 2019-03-04
 
 ### Fixed

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -386,7 +386,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (ev.currentTarget === ev.target) {
 				isFocused = true;
-				// this.setState({focused: true});
 			}
 
 			if (Spotlight.isMuted(ev.target)) {

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -199,7 +199,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			this.shouldPreventBlur = false;
 
 			this.state = {
-				focused: false,
 				focusedWhenDisabled: false
 			};
 		}

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -90,7 +90,7 @@ const defaultConfig = {
  */
 const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 	const {emulateMouse} = config;
-
+	let isFocused = false;
 	return class extends React.Component {
 		static displayName = 'Spottable'
 
@@ -205,7 +205,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		static getDerivedStateFromProps (props, state) {
-			const focusedWhenDisabled = Boolean(state.focused && (props.disabled || props.spotlightDisabled));
+			const focusedWhenDisabled = Boolean(isFocused && (props.disabled || props.spotlightDisabled));
 
 			if (focusedWhenDisabled !== state.focusedWhenDisabled) {
 				return {
@@ -362,9 +362,9 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleBlur = (ev) => {
 			if (this.shouldPreventBlur) return;
-
 			if (ev.currentTarget === ev.target) {
-				this.setState({focused: false, focusedWhenDisabled: false});
+				isFocused = false;
+				this.setState({focusedWhenDisabled: false});
 			}
 
 			if (Spotlight.isMuted(ev.target)) {
@@ -381,9 +381,10 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 				this.shouldPreventBlur = false;
 				return;
 			}
-
+			
 			if (ev.currentTarget === ev.target) {
-				this.setState({focused: true});
+				isFocused = true;
+				// this.setState({focused: true});
 			}
 
 			if (Spotlight.isMuted(ev.target)) {

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -255,7 +255,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			if (this.state.focused) {
+			if (isFocused) {
 				forward('onSpotlightDisappear', null, this.props);
 			}
 			if (lastSelectTarget === this) {

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -364,7 +364,9 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.shouldPreventBlur) return;
 			if (ev.currentTarget === ev.target) {
 				isFocused = false;
-				this.setState({focusedWhenDisabled: false});
+				if (this.state.focusedWhenDisabled) {
+					this.setState({focusedWhenDisabled: false});
+				}
 			}
 
 			if (Spotlight.isMuted(ev.target)) {
@@ -381,7 +383,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 				this.shouldPreventBlur = false;
 				return;
 			}
-			
+
 			if (ev.currentTarget === ev.target) {
 				isFocused = true;
 				// this.setState({focused: true});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Spotlight takes a long time to blur and focus, causing things like Scroller to not animate properly.


### Resolution
Optimizing spottable so it doesn't take a long time during focus and blur



### Links
PLAT-64252
