### PR TITLE
Use latest LTS release of NodeJS for increased stability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "node"
+    - "lts/*"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Currently using latest NodeJS release for Travis. However new/changed APIs and cause breaks in our process. To allow for vetting and update-time, it's safer to lock in to using latest LTS release.

### Resolution
* Use latest LTS release

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>