### PR TITLE
ENYO-5867: Switched Spinner away from pseudo-elements for animation fidelity

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Spinner` animation synchronization after a rerender
 - `moonstone/VideoPlayer` to continue to show thumbnail when playback control keys are pressed
 
 ## [2.4.0] - 2019-03-04

--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -62,6 +62,8 @@ const SpinnerCore = kind({
 				<div className={css.decorator}>
 					<div className={css.fan1} />
 					<div className={css.fan2} />
+					<div className={css.fan3} />
+					<div className={css.fan4} />
 					<div className={css.cap} />
 				</div>
 			</div>

--- a/packages/moonstone/Spinner/Spinner.module.less
+++ b/packages/moonstone/Spinner/Spinner.module.less
@@ -55,10 +55,10 @@
 		animation-name: spin;
 		animation-play-state: paused;
 
-		.fan1::before,
-		.fan1::after,
-		.fan2::before,
-		.fan2::after {
+		.fan1,
+		.fan2,
+		.fan3,
+		.fan4 {
 			content: "";
 			top: 0;
 			right: 50%;
@@ -67,10 +67,10 @@
 			clip-path: polygon(100% 0, 0 3%, 100% 100%); // Cut each segment into a 1/8th wedge, with a little overhang to avoid a subpixel gap from rounding error
 			transform-origin: bottom right;
 		}
-		.fan1::before,
-		.fan1::after,
-		.fan2::before,
-		.fan2::after,
+		.fan1,
+		.fan2,
+		.fan3,
+		.fan4,
 		.cap {
 			position: absolute;
 			animation: none @moon-spinner-time linear infinite;
@@ -78,13 +78,13 @@
 			animation-play-state: paused;
 			animation-fill-mode: both;
 		}
-		.fan1::after {
+		.fan2 {
 			animation-name: rotate2;
 		}
-		.fan2::before {
+		.fan3 {
 			animation-name: rotate3;
 		}
-		.fan2::after,
+		.fan4,
 		.cap {
 			animation-name: rotate4;
 		}
@@ -112,10 +112,10 @@
 	&.running .decorator {
 		// Apply the following rules to the above selector and all of these children
 		&,
-		.fan1::before,
-		.fan1::after,
-		.fan2::before,
-		.fan2::after,
+		.fan1,
+		.fan2,
+		.fan3,
+		.fan4,
 		.cap {
 			-webkit-animation-play-state: running;
 			animation-play-state: running;
@@ -137,10 +137,10 @@
 				radial-gradient(circle at 0% 0%, @moon-spinner-color 20%, @moon-spinner-empty-color 40%), // Visible gradient
 				radial-gradient(circle at 35% 8%, @moon-spinner-color 15%, transparent 15%); // Filler between the closest fan and center of gradient
 
-			.fan1::before,
-			.fan1::after,
-			.fan2::before,
-			.fan2::after {
+			.fan1,
+			.fan2,
+			.fan3,
+			.fan4 {
 				background-color: @moon-spinner-color;
 			}
 			.cap {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
On some devices, the spinner animation can get out-of-sync after props changes

### Resolution
Due to the way DOM nodes are laid out in react, `::before` and `::after` pseudo-elements get rendered slightly later on some hardware. Being tardy-to-the-party means that their animations aren't perfectly in sync. The `Spinner` is (was) using 3 DOM nodes, the first 2 of which had 2 pseudo-elements each (for a total of 4), which compose the "fan" part of the `Spinner`. The ball was its own DOM node, so it never got out of sync with where it should have been; the DOM node and the pseudo-elements were rendering at different times, causing the effect.

By switching the pseudo-elements to real DOM nodes, they all get rendered at the same time, allowing them to stay in sync when props change on the component.