### PR TITLE
PLAT-69081: Fix I18nDecorator to defer locale change until window focus

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/I18nDecorator` to defer updating the locale until window is focused
+
 ## [2.4.0] - 2019-03-04
 
 No significant changes.

--- a/packages/i18n/I18nDecorator/I18nDecorator.js
+++ b/packages/i18n/I18nDecorator/I18nDecorator.js
@@ -18,6 +18,7 @@ import {createResBundle, setResBundle} from '../src/resBundle';
 import wrapIlibCallback from '../src/wrapIlibCallback';
 
 import getI18nClasses from './getI18nClasses';
+import {onWindowFocus} from './windowFocus';
 
 const join = (a, b) => a && b ? a + ' ' + b : (a || b || '');
 
@@ -254,7 +255,7 @@ const I18nDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleLocaleChange = () => {
-			this.updateLocale();
+			onWindowFocus(this.updateLocale);
 		}
 
 		/**

--- a/packages/i18n/I18nDecorator/tests/windowFocus-specs.js
+++ b/packages/i18n/I18nDecorator/tests/windowFocus-specs.js
@@ -1,0 +1,82 @@
+/* eslint-disable react/jsx-no-bind */
+
+import {onWindowFocus} from '../windowFocus';
+
+describe('windowFocus', () => {
+	const dispatchFocus = () => window.dispatchEvent(new window.FocusEvent('focus'));
+	const dispatchBlur = () => window.dispatchEvent(new window.FocusEvent('blur'));
+
+	describe('at launch', () => {
+		test('should invoke fn immediately', () => {
+			const fn = jest.fn();
+			onWindowFocus(fn);
+
+			const expected = 1;
+			const actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
+	});
+
+	describe('when window focused', () => {
+		beforeEach(dispatchFocus);
+		afterEach(dispatchBlur);
+
+		test('should invoke fn immediately', () => {
+			const fn = jest.fn();
+			onWindowFocus(fn);
+
+			const expected = 1;
+			const actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
+	});
+
+	describe('when window blurred', () => {
+		beforeEach(dispatchBlur);
+		afterEach(dispatchFocus);
+
+		test('should not invoke fn', () => {
+			const fn = jest.fn();
+			onWindowFocus(fn);
+
+			const expected = 0;
+			const actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
+
+		test('should invoke fn after focus', () => {
+			const fn = jest.fn();
+			onWindowFocus(fn);
+
+			let expected = 0;
+			let actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+
+			dispatchFocus();
+
+			expected = 1;
+			actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
+
+		test('should invoke fn only once after focus when queued multiple times', () => {
+			const fn = jest.fn();
+			onWindowFocus(fn);
+			onWindowFocus(fn);
+			onWindowFocus(fn);
+			onWindowFocus(fn);
+
+			dispatchFocus();
+
+			const expected = 1;
+			const actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
+	});
+});

--- a/packages/i18n/I18nDecorator/tests/windowFocus-specs.js
+++ b/packages/i18n/I18nDecorator/tests/windowFocus-specs.js
@@ -78,5 +78,22 @@ describe('windowFocus', () => {
 
 			expect(actual).toEqual(expected);
 		});
+
+		test('should continue if a handler throws', () => {
+			const fails = () => {
+				throw new Error('Failed');
+			};
+			const fn = jest.fn();
+
+			onWindowFocus(fails);
+			onWindowFocus(fn);
+
+			dispatchFocus();
+
+			const expected = 1;
+			const actual = fn.mock.calls.length;
+
+			expect(actual).toEqual(expected);
+		});
 	});
 });

--- a/packages/i18n/I18nDecorator/windowFocus.js
+++ b/packages/i18n/I18nDecorator/windowFocus.js
@@ -1,0 +1,32 @@
+import {on} from '@enact/core/dispatcher';
+import {onWindowReady} from '@enact/core/snapshot';
+
+let focused = true;
+const queue = new Set();
+
+const flush = () => {
+	queue.forEach(fn => fn());
+};
+
+const onWindowFocus = (handler) => {
+	if (focused) {
+		handler();
+	} else {
+		queue.add(handler);
+	}
+};
+
+onWindowReady(() => {
+	on('focus', () => {
+		focused = true;
+		flush();
+	}, window);
+
+	on('blur', () => {
+		focused = false;
+	}, window);
+});
+
+export {
+	onWindowFocus
+};

--- a/packages/i18n/I18nDecorator/windowFocus.js
+++ b/packages/i18n/I18nDecorator/windowFocus.js
@@ -4,9 +4,15 @@ import {onWindowReady} from '@enact/core/snapshot';
 let focused = true;
 const queue = new Set();
 
-const flush = () => {
-	queue.forEach(fn => fn());
+const invoke = (fn) => {
+	try {
+		fn();
+	} catch (e) {
+		// failing silently
+	}
 };
+
+const flush = () => queue.forEach(invoke);
 
 const onWindowFocus = (handler) => {
 	if (focused) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On webOS, when the app is in the background, the system still dispatches the {{languagechange}} event but XHR requests are disabled causing I18nDecorator to fail to update the locale.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Enqueue the update locale logic until the window regains focus.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I generalized the window focus monitoring logic into another file to separate the logic and ease testability. For now, it's private to `I18nDecorator` but it could be moved elsewhere for reuse if the need arises.