### PR TITLE
Prevent focused functions until window ready

### DIFF
--- a/packages/i18n/I18nDecorator/windowFocus.js
+++ b/packages/i18n/I18nDecorator/windowFocus.js
@@ -1,7 +1,7 @@
 import {on} from '@enact/core/dispatcher';
 import {onWindowReady} from '@enact/core/snapshot';
 
-let focused = true;
+let focused = false;
 const queue = new Set();
 
 const invoke = (fn) => {
@@ -23,6 +23,7 @@ const onWindowFocus = (handler) => {
 };
 
 onWindowReady(() => {
+	focused = true;	// Treat window as initially focused once ready
 	on('focus', () => {
 		focused = true;
 		flush();

--- a/packages/i18n/I18nDecorator/windowFocus.js
+++ b/packages/i18n/I18nDecorator/windowFocus.js
@@ -24,6 +24,7 @@ const onWindowFocus = (handler) => {
 
 onWindowReady(() => {
 	focused = true;	// Treat window as initially focused once ready
+	flush();
 	on('focus', () => {
 		focused = true;
 		flush();


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `onWindowFocus` was called without a window or before the window was ready then the callback function could be executed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Only set `focused` once the window is ready

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Current usage guards against a problem but things could easily change.

### Links
[//]: # (Related issues, references)
ENYO-5881

### Comments
