### PR TITLE
ENYO-5881: Fix TooltipDecorator in iso builds

### DIFF
--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -167,6 +167,15 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.TOOLTIP_HEIGHT = ri.scale(18); // distance between client and tooltip's label
 
+			this.state = {
+				showing: false,
+				tooltipDirection: null,
+				arrowAnchor: null,
+				position: {top: 0, left: 0}
+			};
+		}
+
+		componentDidMount () {
 			if (window.MutationObserver) {
 				this.mutationObserver = new MutationObserver(this.setTooltipLayoutJob.start);
 			}
@@ -174,13 +183,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (window.ResizeObserver) {
 				this.resizeObserver = new ResizeObserver(this.setTooltipLayoutJob.start);
 			}
-
-			this.state = {
-				showing: false,
-				tooltipDirection: null,
-				arrowAnchor: null,
-				position: {top: 0, left: 0}
-			};
 		}
 
 		componentDidUpdate (prevProps) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Accessing `window` in the constructor is bad for isomorphic builds

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move the MutationObserver and ResizeObserver initialization to `componentDidMount` which is safe for iso
