### PR TITLE
ENYO-5728: Fix spotlight to guard against accessing non-existent containers

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,10 +7,6 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight` to guard against runtime errors caused by attempting to access containers that do not exist
-## [Unreleased]
-
-### Fixed
-
 - `spotlight/Spottable` to prevent unnecessary updates due to focus and blur changes
 
 ## [2.4.1] - 2019-03-11

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to guard against runtime errors caused by attempting to access containers that do not exist
+
 ## [2.4.1] - 2019-03-11
 
 ### Fixed

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -727,7 +727,7 @@ function getContainerNavigableElements (containerId) {
 		// if there isn't a preferred entry on an overflow container, filter the visible elements
 		if (overflow) {
 			const containerRect = getContainerRect(containerId);
-			next = spottables.filter(element => {
+			next = containerRect && spottables.filter(element => {
 				const elementRect = getRect(element);
 				if (isContainer(element)) {
 					return intersects(containerRect, elementRect);

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -1220,7 +1220,7 @@ describe('container', () => {
 		);
 
 		test(
-			'should return an empty array for a unmounted, configured container',
+			'should return an empty array for an unmounted, configured container',
 			testScenario(
 				scenarios.onlySpottables,
 				() => {

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -687,7 +687,7 @@ describe('container', () => {
 		));
 	});
 
-	describe.skip('#isNavigable', () => {
+	describe('#isNavigable', () => {
 		beforeEach(setupContainers);
 		afterEach(teardownContainers);
 
@@ -1218,5 +1218,22 @@ describe('container', () => {
 				}
 			)
 		);
+
+		test(
+			'should return an empty array for a unmounted, configured container',
+			testScenario(
+				scenarios.onlySpottables,
+				() => {
+					configureContainer('first-container', {
+						overflow: true
+					});
+
+					const expected = [];
+					const actual = getContainerNavigableElements('first-container');
+
+					expect(actual).toEqual(expected);
+				}
+			)
+		)
 	});
 });

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -1234,6 +1234,6 @@ describe('container', () => {
 					expect(actual).toEqual(expected);
 				}
 			)
-		)
+		);
 	});
 });

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -160,6 +160,10 @@ function getViewportRect () {
 function getContainerRect (containerId) {
 	const containerNode = getContainerNode(containerId);
 
+	if (!containerNode) {
+		return null;
+	}
+
 	if (containerNode === document) {
 		return getViewportRect();
 	}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Attempting to focus a configured container that wasn't mounted threw a runtime error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a couple guards to prevent throwing errors

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This was originally manifest in unit testing an application but could be reproduced in standalone scenarios as well.
