### PR TITLE
ENYO-5885: Fix that 'removeEventListener' was undefined in VirtualList and Scroller samples

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
+
 ## [2.4.1] - 2019-03-11
 
 ### Changed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -637,7 +637,7 @@ class ScrollableBase extends Component {
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	addEventListeners = (childContainerRef) => {
-		if (childContainerRef && childContainerRef.current.addEventListener) {
+		if (childContainerRef.current && childContainerRef.current.addEventListener) {
 			childContainerRef.current.addEventListener('focusin', this.onFocus);
 			if (platform.webos) {
 				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
@@ -648,7 +648,7 @@ class ScrollableBase extends Component {
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	removeEventListeners = (childContainerRef) => {
-		if (childContainerRef && childContainerRef.current.removeEventListener) {
+		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
 			childContainerRef.current.removeEventListener('focusin', this.onFocus);
 			if (platform.webos) {
 				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -703,7 +703,7 @@ class ScrollableBaseNative extends Component {
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	addEventListeners = (childContainerRef) => {
-		if (childContainerRef && childContainerRef.current.addEventListener) {
+		if (childContainerRef.current && childContainerRef.current.addEventListener) {
 			childContainerRef.current.addEventListener('mouseover', this.onMouseOver, {capture: true});
 			childContainerRef.current.addEventListener('mousemove', this.onMouseMove, {capture: true});
 			childContainerRef.current.addEventListener('focusin', this.onFocus);
@@ -716,7 +716,7 @@ class ScrollableBaseNative extends Component {
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	removeEventListeners = (childContainerRef) => {
-		if (childContainerRef && childContainerRef.current.removeEventListener) {
+		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
 			childContainerRef.current.removeEventListener('mouseover', this.onMouseOver, {capture: true});
 			childContainerRef.current.removeEventListener('mousemove', this.onMouseMove, {capture: true});
 			childContainerRef.current.removeEventListener('focusin', this.onFocus);

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -368,7 +368,7 @@ class ScrollerBase extends Component {
 
 	initUiRef = (ref) => {
 		if (ref) {
-			this.uiRefCurrent = ref.currnet || ref;
+			this.uiRefCurrent = ref;
 			this.props.initUiChildRef(ref);
 		}
 	}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -867,7 +867,7 @@ const VirtualListBaseFactory = (type) => {
 
 		initUiRef = (ref) => {
 			if (ref) {
-				this.uiRefCurrent = ref.current || ref;
+				this.uiRefCurrent = ref;
 				this.props.initUiChildRef(ref);
 			}
 		}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1232,7 +1232,7 @@ class ScrollableBase extends Component {
 			containerRef.current.removeEventListener('keydown', this.onKeyDown);
 		}
 
-		if (childRefCurrent && childRefCurrent.containerRef.current && childRefCurrent.containerRef.current.removeEventListener) {
+		if (childRefCurrent.containerRef.current && childRefCurrent.containerRef.current.removeEventListener) {
 			childRefCurrent.containerRef.current.removeEventListener('mousedown', this.onMouseDown);
 		}
 
@@ -1245,7 +1245,7 @@ class ScrollableBase extends Component {
 
 	initChildRef = (ref) => {
 		if (ref) {
-			this.childRefCurrent = ref.current || ref;
+			this.childRefCurrent = ref;
 		}
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1237,7 +1237,7 @@ class ScrollableBase extends Component {
 		}
 
 		if (this.props.removeEventListeners) {
-			this.props.removeEventListeners(childRefCurrent.containerRef.current);
+			this.props.removeEventListeners(childRefCurrent.containerRef);
 		}
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1234,11 +1234,11 @@ class ScrollableBaseNative extends Component {
 	addEventListeners () {
 		const {childRefCurrent, containerRef} = this;
 
-		if (containerRef && containerRef.current.addEventListener) {
+		if (containerRef.current && containerRef.current.addEventListener) {
 			containerRef.current.addEventListener('wheel', this.onWheel);
 		}
 
-		if (childRefCurrent.containerRef) {
+		if (childRefCurrent.containerRef.current) {
 			if (childRefCurrent.containerRef.current.addEventListener) {
 				childRefCurrent.containerRef.current.addEventListener('scroll', this.onScroll, {capture: true, passive: true});
 				childRefCurrent.containerRef.current.addEventListener('mousedown', this.onMouseDown);
@@ -1255,11 +1255,11 @@ class ScrollableBaseNative extends Component {
 	removeEventListeners () {
 		const {childRefCurrent, containerRef} = this;
 
-		if (containerRef && containerRef.current.removeEventListener) {
+		if (containerRef.current && containerRef.current.removeEventListener) {
 			containerRef.current.removeEventListener('wheel', this.onWheel);
 		}
 
-		if (childRefCurrent.containerRef && childRefCurrent.containerRef.current.removeEventListener) {
+		if (childRefCurrent.containerRef.current && childRefCurrent.containerRef.current.removeEventListener) {
 			childRefCurrent.containerRef.current.removeEventListener('scroll', this.onScroll, {capture: true, passive: true});
 			childRefCurrent.containerRef.current.removeEventListener('mousedown', this.onMouseDown);
 		}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -227,6 +227,10 @@ const VirtualListBaseFactory = (type) => {
 
 			super(props);
 
+			this.containerRef = React.createRef();
+			this.contentRef = React.createRef();
+			this.itemContainerRef = React.createRef();
+
 			if (props.clientSize) {
 				this.calculateMetrics(props);
 				nextState = this.getStatesAndUpdateBounds(props);
@@ -241,10 +245,6 @@ const VirtualListBaseFactory = (type) => {
 				updateTo: 0,
 				...nextState
 			};
-
-			this.containerRef = React.createRef();
-			this.contentRef = React.createRef();
-			this.itemContainerRef = React.createRef();
 		}
 
 		static getDerivedStateFromProps (props, state) {
@@ -374,7 +374,7 @@ const VirtualListBaseFactory = (type) => {
 		calculateMetrics (props) {
 			const
 				{clientSize, direction, itemSize, spacing} = props,
-				node = this.containerRef && this.containerRef.current;
+				node = this.containerRef.current;
 
 			if (!clientSize && !node) {
 				return;
@@ -430,7 +430,7 @@ const VirtualListBaseFactory = (type) => {
 
 			// reset
 			this.scrollPosition = 0;
-			if (type === JS && this.contentRef && this.contentRef.current) {
+			if (type === JS && this.contentRef.current) {
 				this.contentRef.current.style.transform = null;
 			}
 		}
@@ -505,7 +505,7 @@ const VirtualListBaseFactory = (type) => {
 		calculateScrollBounds (props) {
 			const
 				{clientSize} = props,
-				node = this.containerRef && this.containerRef.current;
+				node = this.containerRef.current;
 
 			if (!clientSize && !node) {
 				return;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When unmounting the page including VirtualList or Scroller, there is the following error.
- Cannot read property 'removeEventListener' of undefined

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

I passed the wrong object and referenced its wrong property before.
So I fixed it and updated the guard condition. 

### Links
[//]: # (Related issues, references)
ENYO-5885
