### PR TITLE
ENYO-5822: Enact QA-Sampler: create a sample to test long text and verify height of Notification extends

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
-## [unreleased]
-
-### Added
-- QA sample for `moonstone/Notification`
-
 ## [2.4.1] - 2019-03-11
 
 No significant changes.

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Added
+- QA sample for `moonstone/Notification`
+
 ## [2.4.1] - 2019-03-11
 
 No significant changes.

--- a/packages/sampler/stories/qa/Notification.js
+++ b/packages/sampler/stories/qa/Notification.js
@@ -12,13 +12,12 @@ const Config = mergeComponentMetadata('Notification', Notification, Popup);
 
 Notification.displayName = 'Notification';
 
-const filler = '0123456789abcdefghijklmnopqrstuvwxyz';
-
-const messageArray = [filler];
-
 class StatefulNotification extends React.Component {
 	constructor (props) {
 		super(props);
+
+		this.messageFiller = '0123456789abcdefghijklmnopqrstuvwxyz';
+		this.messageArray = [this.messageFiller];
 
 		this.state = {
 			message: this.parseMessage()
@@ -26,14 +25,14 @@ class StatefulNotification extends React.Component {
 	}
 
 	addToMessage = () => {
-		messageArray.push(filler);
+		this.messageArray.push(this.messageFiller);
 		this.setState({message: this.parseMessage()});
 	}
 
-	parseMessage = () => messageArray.join(' ')
+	parseMessage = () => this.messageArray.join(' ')
 
 	removeFromMessage = () => {
-		messageArray.pop();
+		this.messageArray.pop();
 		this.setState({message: this.parseMessage()});
 	}
 

--- a/packages/sampler/stories/qa/Notification.js
+++ b/packages/sampler/stories/qa/Notification.js
@@ -1,0 +1,64 @@
+import Notification from '@enact/moonstone/Notification';
+import Popup from '@enact/moonstone/Popup';
+import Button from '@enact/moonstone/Button';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {action} from '@storybook/addon-actions';
+
+import {boolean} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+const Config = mergeComponentMetadata('Notification', Notification, Popup);
+
+Notification.displayName = 'Notification';
+
+const filler = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+const messageArray = [filler];
+
+class StatefulNotification extends React.Component {
+	constructor (props) {
+		super(props);
+
+		this.state = {
+			message: this.parseMessage()
+		};
+	}
+
+	addToMessage = () => {
+		messageArray.push(filler);
+		this.setState({message: this.parseMessage()});
+	}
+
+	parseMessage = () => messageArray.join(' ')
+
+	removeFromMessage = () => {
+		messageArray.pop();
+		this.setState({message: this.parseMessage()});
+	}
+
+	render () {
+		const {message} = this.state;
+		return (
+			<Notification
+				open={boolean('open', Config, true)}
+				noAutoDismiss={boolean('noAutoDismiss', Config)}
+				onClose={action('onClose')}
+			>
+				<span>{message}</span>
+				<buttons>
+					<Button onClick={this.addToMessage}>Add a Line</Button>
+					<Button onClick={this.removeFromMessage}>Remove a Line</Button>
+				</buttons>
+			</Notification>
+		);
+	}
+}
+
+storiesOf('Notification', module)
+	.add(
+		'with dynamic content',
+		() => (
+			<StatefulNotification />
+		)
+	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It is difficult to quickly enter enough text with the VKB to make the `Notification` resize.  This QA sample lets you add or remove lines to allow quick verification of height changes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a QA sample for `moonstone/Notification` and dynamic text.

### Links
[//]: # (Related issues, references)
ENYO-5822