### PR TITLE
PLAT-75865: Fix to resume spotlight pauses when closing with animation

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
+- `moonstone/Popup` to resume spotlight pauses when closing with animation
 
 ## [2.4.1] - 2019-03-11
 

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -243,8 +243,9 @@ const checkScrimNone = (props) => {
 
 const OpenState = {
 	CLOSED: 0,
-	OPENING: 1,
-	OPEN: 2
+	OPENINGWIHOUTANIMATION: 1,
+	OPENING: 2,
+	OPEN: 3
 };
 
 /**
@@ -389,7 +390,7 @@ class Popup extends React.Component {
 	constructor (props) {
 		super(props);
 		this.paused = new Pause('Popup');
-		const animateOpen = this.props.noAnimation ? OpenState.OPEN : OpenState.OPENING;
+		const animateOpen = this.props.noAnimation ? OpenState.OPEN : OpenState.OPENINGWIHOUTANIMATION;
 		this.state = {
 			floatLayerOpen: this.props.open,
 			popupOpen: this.props.open ? animateOpen : OpenState.CLOSED,
@@ -454,7 +455,7 @@ class Popup extends React.Component {
 	handleFloatingLayerOpen = () => {
 		if (!this.props.noAnimation) {
 			this.setState({
-				popupOpen: OpenState.OPENING
+				popupOpen: (this.state.popupOpen === OpenState.OPENINGWIHOUTANIMATION) ? OpenState.OPEN : OpenState.OPENING
 			});
 		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
 			this.spotPopupContent();
@@ -575,7 +576,7 @@ class Popup extends React.Component {
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
 					onShow={this.handlePopupShow}
-					open={this.state.popupOpen >= OpenState.OPENING}
+					open={this.state.popupOpen >= OpenState.OPENINGWIHOUTANIMATION}
 					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
 				/>

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -576,7 +576,7 @@ class Popup extends React.Component {
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
 					onShow={this.handlePopupShow}
-					open={this.state.popupOpen > OpenState.CLOSED}
+					open={this.state.popupOpen >= OpenState.OPENING}
 					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
 				/>

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -452,7 +452,7 @@ class Popup extends React.Component {
 
 	handleFloatingLayerOpen = () => {
 		if (!this.props.noAnimation) {
-			if (this.state.popupOpen != OpenState.OPEN) {
+			if (this.state.popupOpen !== OpenState.OPEN) {
 				this.setState({
 					popupOpen: OpenState.OPENING
 				});

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -454,9 +454,9 @@ class Popup extends React.Component {
 
 	handleFloatingLayerOpen = () => {
 		if (!this.props.noAnimation) {
-			this.setState({
-				popupOpen: (this.state.popupOpen === OpenState.OPENINGWIHOUTANIMATION) ? OpenState.OPEN : OpenState.OPENING
-			});
+			this.setState((state) => ({
+				popupOpen: (state.popupOpen === OpenState.OPENINGWIHOUTANIMATION) ? OpenState.OPEN : OpenState.OPENING
+			}));
 		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
 			this.spotPopupContent();
 		}

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -422,7 +422,7 @@ class Popup extends React.Component {
 
 	// Spot the content after it's mounted.
 	componentDidMount () {
-		if (this.props.open) {
+		if (this.props.open && getContainerNode(this.state.containerId)) {
 			this.spotPopupContent();
 		}
 	}
@@ -451,12 +451,10 @@ class Popup extends React.Component {
 	}
 
 	handleFloatingLayerOpen = () => {
-		if (!this.props.noAnimation) {
-			if (this.state.popupOpen !== OpenState.OPEN) {
-				this.setState({
-					popupOpen: OpenState.OPENING
-				});
-			}
+		if (!this.props.noAnimation && this.state.popupOpen !== OpenState.OPEN) {
+			this.setState({
+				popupOpen: OpenState.OPENING
+			});
 		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
 			this.spotPopupContent();
 		}

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -243,9 +243,8 @@ const checkScrimNone = (props) => {
 
 const OpenState = {
 	CLOSED: 0,
-	OPENINGWIHOUTANIMATION: 1,
-	OPENING: 2,
-	OPEN: 3
+	OPENING: 1,
+	OPEN: 2
 };
 
 /**
@@ -390,10 +389,9 @@ class Popup extends React.Component {
 	constructor (props) {
 		super(props);
 		this.paused = new Pause('Popup');
-		const animateOpen = this.props.noAnimation ? OpenState.OPEN : OpenState.OPENINGWIHOUTANIMATION;
 		this.state = {
 			floatLayerOpen: this.props.open,
-			popupOpen: this.props.open ? animateOpen : OpenState.CLOSED,
+			popupOpen: this.props.open ? OpenState.OPEN : OpenState.CLOSED,
 			prevOpen: this.props.open,
 			containerId: Spotlight.add(),
 			activator: null
@@ -454,9 +452,11 @@ class Popup extends React.Component {
 
 	handleFloatingLayerOpen = () => {
 		if (!this.props.noAnimation) {
-			this.setState((state) => ({
-				popupOpen: (state.popupOpen === OpenState.OPENINGWIHOUTANIMATION) ? OpenState.OPEN : OpenState.OPENING
-			}));
+			if (this.state.popupOpen != OpenState.OPEN) {
+				this.setState({
+					popupOpen: OpenState.OPENING
+				});
+			}
 		} else if (this.state.popupOpen === OpenState.OPEN && this.props.open) {
 			this.spotPopupContent();
 		}
@@ -576,7 +576,7 @@ class Popup extends React.Component {
 					onCloseButtonClick={onClose}
 					onHide={this.handlePopupHide}
 					onShow={this.handlePopupShow}
-					open={this.state.popupOpen >= OpenState.OPENINGWIHOUTANIMATION}
+					open={this.state.popupOpen > OpenState.CLOSED}
 					spotlightId={this.state.containerId}
 					spotlightRestrict="self-only"
 				/>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When creating the popup with the {open: true, noAnimation: false} props, Spotlight could not be on any controls when hovering them after closing the popup.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Analysis
- When creating the popup with the {open: true, noAnimation: false} props
\- The `popupOpen` status in the `Popup` was initialized with `OpenState.OPENING`
\- When `FloatingLayer` opened, `this.handleFloatingLayerOpen` in the popup was called, then the `popupOpen` status was reset to `OpenState.OPENING` again.
\- The `popupOpen` status was always updated to `OpenState.OPEN` when the popup animation ended and `this.handlePopupShow` callback in the popup was called.
\- But there was no chance to make the `popupOpen` status the `OpenState.OPEN` when creating with those props because the popup showed without animation and there was no animation end event.

- When closing the popup
\- The `popupOpen` had the wrong value which was `OpenState.OPENING`.
\- So `floatLayerOpen` had `true`, then the popup hides without animtion
\- At that time, `this.paused.resume();` was already called.
\- So spotlight could not resume.
\- It means that `this.paused.pause();` was called, but `this.paused.resume();` was not called. when closing the popup

Solution
- Initialize the `popupOpen` with `OpenState.OPEN` when creating the popup with the {open: true, noAnimation: false} props because the popup shows without animation
- Prevent converting the `popupOpen` variable to `OpenState.OPENING` when FloatingLayer updated and `this.handleFloatingLayerOpen` was called.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Removed the unnecessary changelog commented in https://github.com/enactjs/enact/pull/2162#pullrequestreview-214034340. 

### Links
[//]: # (Related issues, references)

PLAT-75865