### PR TITLE
PLAT-75858: Adjust focus timing when ContextualPopup is closed with a 'back' button

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
+- `moonstone/ContextualPopupDecorator` timing to read out `activator` button when the `ContextualPopup` is closed by pressing a back button of remote control
 
 ## [2.4.1] - 2019-03-11
 

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -554,7 +554,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (activator && activator === Spotlight.getCurrent()) {
 				activator.blur();
 			}
-
 			if (!Spotlight.focus(activator)) {
 				Spotlight.focus();
 			}

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -234,10 +234,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			this.state = {
+				activator: null,
+				activatorAriaHidden: false,
 				arrowPosition: {top: 0, left: 0},
-				containerPosition: {top: 0, left: 0},
 				containerId: Spotlight.add(this.props.popupSpotlightId),
-				activator: null
+				containerPosition: {top: 0, left: 0}
 			};
 
 			this.overflow = {};
@@ -488,7 +489,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			const current = Spotlight.getCurrent();
 			this.updateLeaveFor(current);
 			this.setState({
-				activator: current
+				activator: current,
+				activatorAriaHidden: true
 			});
 			this.spotPopupContent();
 		}
@@ -552,9 +554,21 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (activator && activator === Spotlight.getCurrent()) {
 				activator.blur();
 			}
+
 			if (!Spotlight.focus(activator)) {
 				Spotlight.focus();
 			}
+
+			this.setState({
+				activatorAriaHidden: false
+			});
+
+			setTimeout(() => {
+				if (Spotlight.getCurrent() === activator) {
+					Spotlight.getCurrent().blur();
+					Spotlight.focus(activator);
+				}
+			}, 800);
 		}
 
 		spotPopupContent = () => {
@@ -615,7 +629,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							<PopupComponent {...popupPropsRef} />
 						</ContextualPopupContainer>
 					</FloatingLayer>
-					<div ref={this.getClientNode}>
+					<div aria-hidden={this.state.activatorAriaHidden} ref={this.getClientNode}>
 						<Wrapped {...rest} />
 					</div>
 				</div>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A11y issue when closing the `ContextualPopup` by pressing the back button on the remote control
- The TV must read 'back' + 'activator button contents' but is reading the 'activator button contents' while reading 'back'. (Sometimes it reads 'B'(part of 'Back') 'activator button contents' button' (where the 'b' is stuttered))


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Modified to read activator button contents after 800 ms after reading 'back'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Code to avoid malfunction
- Added activatorAriaHidden state to prevent the activator from being unnecessarily read.
- I only blur and focus the spotlight when the current focus is the activator.