### PR TITLE
ENYO-5880: Better layout of overflowing Tooltip

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
+- `moonstone/Tooltip` to better support long tooltips
 
 ## [2.4.1] - 2019-03-11
 

--- a/packages/moonstone/TooltipDecorator/Tooltip.js
+++ b/packages/moonstone/TooltipDecorator/Tooltip.js
@@ -44,6 +44,17 @@ const TooltipBase = kind({
 		arrowAnchor: PropTypes.oneOf(['left', 'center', 'right', 'top', 'middle', 'bottom']),
 
 		/**
+		 * Style object for tooltip arrow position.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		arrowPosition: PropTypes.shape({
+			left: PropTypes.number,
+			right: PropTypes.number
+		}),
+
+		/**
 		 * Direction of label in relation to the activator.
 		 *
 		 * * Values: `'above'`, `'below'`, `'left'`, and `'right'`
@@ -109,14 +120,14 @@ const TooltipBase = kind({
 		}
 	},
 
-	render: ({children, tooltipRef, arrowType, width, ...rest}) => {
+	render: ({children, tooltipRef, arrowType, width, arrowPosition, ...rest}) => {
 		delete rest.arrowAnchor;
 		delete rest.direction;
 		delete rest.position;
 
 		return (
 			<div {...rest}>
-				<svg className={css.tooltipArrow} viewBox="0 0 3 5">
+				<svg style={arrowPosition} className={css.tooltipArrow} viewBox="0 0 3 5">
 					<path d={arrowType} />
 				</svg>
 				<TooltipLabel tooltipRef={tooltipRef} width={width}>

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
 
 import {Tooltip, TooltipBase} from './Tooltip';
-import {adjustDirection, adjustAnchor, calcOverflow, getPosition} from './util';
+import {adjustDirection, adjustAnchor, calcOverflow, getPosition, getArrowPosition} from './util';
 
 let currentTooltip; // needed to know whether or not we should stop a showing job when unmounting
 
@@ -235,13 +235,15 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			tooltipDirection = adjustDirection(tooltipDirection, overflow, this.props.rtl);
 			arrowAnchor = adjustAnchor(arrowAnchor, tooltipDirection, overflow, this.props.rtl);
 
-			const tooltipPosition = getPosition(tooltipNode, clientNode, arrowAnchor, tooltipDirection, this.TOOLTIP_HEIGHT);
+			const tooltipPosition = getPosition(tooltipNode, clientNode, arrowAnchor, tooltipDirection, this.TOOLTIP_HEIGHT, overflow, this.props.rtl);
+			const arrowPosition = getArrowPosition(clientNode, overflow, this.props.rtl);
 			const {top, left} = this.state.position;
 
 			if ((tooltipPosition.top !== top) || (tooltipPosition.left !== left)) {
 				this.setState({
 					tooltipDirection,
 					arrowAnchor,
+					arrowPosition,
 					position: tooltipPosition
 				});
 			}
@@ -372,6 +374,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 							role="alert"
 							{...tooltipProps}
 							arrowAnchor={this.state.arrowAnchor}
+							arrowPosition={this.state.arrowPosition}
 							casing={tooltipCasing}
 							direction={this.state.tooltipDirection}
 							position={this.state.position}

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
 
 import {Tooltip, TooltipBase} from './Tooltip';
-import {adjustDirection, adjustAnchor, calcOverflow, getPosition, getArrowPosition} from './util';
+import {adjustDirection, adjustAnchor, calcOverflow, getArrowPosition, getPosition} from './util';
 
 let currentTooltip; // needed to know whether or not we should stop a showing job when unmounting
 

--- a/packages/moonstone/TooltipDecorator/util.js
+++ b/packages/moonstone/TooltipDecorator/util.js
@@ -75,19 +75,21 @@ const adjustDirection = function (tooltipDirection, overflow, rtl) {
  * @private
  */
 const calcOverflow = function (tooltipNode, clientNode, tooltipDirection, tooltipHeight) {
+	const isTooltipWide = (clientNode.left + clientNode.width + tooltipNode.width > window.innerWidth) || (clientNode.right + clientNode.width + tooltipNode.width > window.innerWidth);
+
 	if (tooltipDirection === 'above' || tooltipDirection === 'below') {
 		return {
 			isOverTop: clientNode.top - tooltipNode.height - tooltipHeight < 0,
 			isOverBottom: clientNode.bottom + tooltipNode.height + tooltipHeight > window.innerHeight,
-			isOverLeft: clientNode.left - tooltipNode.width + clientNode.width / 2 < 0,
-			isOverRight: clientNode.right + tooltipNode.width - clientNode.width / 2 > window.innerWidth
+			isOverLeft: isTooltipWide ? false : clientNode.left - tooltipNode.width + clientNode.width / 2 < 0,
+			isOverRight: isTooltipWide ? false : clientNode.right + tooltipNode.width - clientNode.width / 2 > window.innerWidth
 		};
 	} else if (tooltipDirection === 'left' || tooltipDirection === 'right') {
 		return {
 			isOverTop: clientNode.top - tooltipNode.height + clientNode.height / 2 < 0,
 			isOverBottom: clientNode.bottom + tooltipNode.height - clientNode.height / 2 > window.innerHeight,
-			isOverLeft: clientNode.left - tooltipNode.width < 0,
-			isOverRight: clientNode.right + tooltipNode.width > window.innerWidth
+			isOverLeft: isTooltipWide ? false : clientNode.left - tooltipNode.width < 0,
+			isOverRight: isTooltipWide ? false : clientNode.right + tooltipNode.width > window.innerWidth
 		};
 	}
 };

--- a/packages/moonstone/TooltipDecorator/util.js
+++ b/packages/moonstone/TooltipDecorator/util.js
@@ -48,7 +48,7 @@ const adjustDirection = function (tooltipDirection, overflow, rtl) {
 		tooltipDirection = tooltipDirection === 'left' ? 'right' : 'left';
 	}
 
-	// Flip tooltip if it overlows towards the tooltip direction
+	// Flip tooltip if it overflows towards the tooltip direction
 	if (overflow.isOverTop && tooltipDirection === 'above') {
 		tooltipDirection = 'below';
 	} else if (overflow.isOverBottom && tooltipDirection === 'below') {
@@ -81,15 +81,17 @@ const calcOverflow = function (tooltipNode, clientNode, tooltipDirection, toolti
 		return {
 			isOverTop: clientNode.top - tooltipNode.height - tooltipHeight < 0,
 			isOverBottom: clientNode.bottom + tooltipNode.height + tooltipHeight > window.innerHeight,
-			isOverLeft: isTooltipWide ? false : clientNode.left - tooltipNode.width + clientNode.width / 2 < 0,
-			isOverRight: isTooltipWide ? false : clientNode.right + tooltipNode.width - clientNode.width / 2 > window.innerWidth
+			isOverLeft: clientNode.left - tooltipNode.width + clientNode.width / 2 < 0,
+			isOverRight: clientNode.right + tooltipNode.width - clientNode.width / 2 > window.innerWidth,
+			isOverWide: isTooltipWide
 		};
 	} else if (tooltipDirection === 'left' || tooltipDirection === 'right') {
 		return {
 			isOverTop: clientNode.top - tooltipNode.height + clientNode.height / 2 < 0,
 			isOverBottom: clientNode.bottom + tooltipNode.height - clientNode.height / 2 > window.innerHeight,
-			isOverLeft: isTooltipWide ? false : clientNode.left - tooltipNode.width < 0,
-			isOverRight: isTooltipWide ? false : clientNode.right + tooltipNode.width > window.innerWidth
+			isOverLeft: clientNode.left - tooltipNode.width < 0,
+			isOverRight: clientNode.right + tooltipNode.width > window.innerWidth,
+			isOverWide: isTooltipWide
 		};
 	}
 };

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -36,7 +36,7 @@ class TooltipTest extends React.Component {
 					<TooltipButton
 						onClick={this.handleClick}
 						tooltipDelay={5000}
-						tooltipText="Tooltip!"
+						tooltipText="Tooltip position!"
 					>
 						Click me
 					</TooltipButton>
@@ -279,7 +279,7 @@ storiesOf('Tooltip', module)
 		'tooltip overflows',
 		() => (
 			<div>
-				<div style={{position: 'absolute', top: '-90px'}}>
+				<div style={{position: 'absolute', top: '-90px', display: 'flex', width: '100%', justifyContent: 'space-between'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}
@@ -290,8 +290,6 @@ storiesOf('Tooltip', module)
 					>
 						Top Left
 					</TooltipNormalButton>
-				</div>
-				<div style={{position: 'absolute', top: '-90px', left: '50%', transform: 'translate(-50%)'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}
@@ -302,8 +300,6 @@ storiesOf('Tooltip', module)
 					>
 						Top
 					</TooltipNormalButton>
-				</div>
-				<div style={{position: 'absolute', top: '-90px', right: '0'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}
@@ -350,7 +346,7 @@ storiesOf('Tooltip', module)
 						Right
 					</TooltipButton>
 				</div>
-				<div style={{position: 'absolute', bottom: '0'}}>
+				<div style={{position: 'absolute', bottom: '0', display: 'flex', width: '100%', justifyContent: 'space-between'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}
@@ -361,8 +357,6 @@ storiesOf('Tooltip', module)
 					>
 						Bottom Left
 					</TooltipNormalButton>
-				</div>
-				<div style={{position: 'absolute', bottom: '0', left: '50%', transform: 'translate(-50%)'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}
@@ -373,8 +367,6 @@ storiesOf('Tooltip', module)
 					>
 						Bottom
 					</TooltipNormalButton>
-				</div>
-				<div style={{position: 'absolute', bottom: '0', right: '0'}}>
 					<TooltipNormalButton
 						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
 						tooltipDelay={number('tooltipDelay', Config, 500)}

--- a/packages/sampler/stories/qa/Tooltip.js
+++ b/packages/sampler/stories/qa/Tooltip.js
@@ -10,6 +10,9 @@ import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
+import {number, object, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
 const TooltipButton = TooltipDecorator(Button);
 
 class TooltipTest extends React.Component {
@@ -228,6 +231,33 @@ class TooltipFollow extends React.Component {
 	}
 }
 
+const Config = mergeComponentMetadata('TooltipDecorator', TooltipDecorator);
+const TooltipNormalButton = TooltipDecorator(Button);
+
+const prop = {
+	tooltipPosition: {
+		'above': 'above',
+		'above center': 'above center',
+		'above left': 'above left',
+		'above right': 'above right',
+		'below': 'below',
+		'below center': 'below center',
+		'below left': 'below left',
+		'below right': 'below right',
+		'left bottom': 'left bottom',
+		'left middle': 'left middle',
+		'left top': 'left top',
+		'right bottom': 'right bottom',
+		'right middle': 'right middle',
+		'right top': 'right top'
+	},
+	ariaObject: {
+		'aria-hidden': false,
+		'aria-label': 'Tooltip Label',
+		'role': 'alert'
+	}
+};
+
 storiesOf('Tooltip', module)
 	.add(
 		'that shows after Button is unmounted (ENYO-3809)',
@@ -244,5 +274,118 @@ storiesOf('Tooltip', module)
 		'tooltip to follow component when changed',
 		() => (
 			<TooltipFollow />
+		)
+	).add(
+		'tooltip overflows',
+		() => (
+			<div>
+				<div style={{position: 'absolute', top: '-90px'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Top Left
+					</TooltipNormalButton>
+				</div>
+				<div style={{position: 'absolute', top: '-90px', left: '50%', transform: 'translate(-50%)'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Top
+					</TooltipNormalButton>
+				</div>
+				<div style={{position: 'absolute', top: '-90px', right: '0'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Top Right
+					</TooltipNormalButton>
+				</div>
+				<div style={{display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'space-between'}}>
+					<TooltipButton
+						style={{transform: 'translateY(-50%)'}}
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Left
+					</TooltipButton>
+					<TooltipButton
+						style={{transform: 'translateY(-50%)'}}
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Center
+					</TooltipButton>
+					<TooltipButton
+						style={{transform: 'translateY(-50%)'}}
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Right
+					</TooltipButton>
+				</div>
+				<div style={{position: 'absolute', bottom: '0'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Bottom Left
+					</TooltipNormalButton>
+				</div>
+				<div style={{position: 'absolute', bottom: '0', left: '50%', transform: 'translate(-50%)'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Bottom
+					</TooltipNormalButton>
+				</div>
+				<div style={{position: 'absolute', bottom: '0', right: '0'}}>
+					<TooltipNormalButton
+						tooltipCasing={select('tooltipCasing', ['preserve', 'sentence', 'word', 'upper'], Config, 'upper')}
+						tooltipDelay={number('tooltipDelay', Config, 500)}
+						tooltipText={text('tooltipText', Config, 'tooltip position!')}
+						tooltipPosition={select('tooltipPosition', prop.tooltipPosition, Config, 'above')}
+						tooltipWidth={number('tooltipWidth', Config)}
+						tooltipProps={object('tooltipProps', Config, prop.ariaObject)}
+					>
+						Bottom Right
+					</TooltipNormalButton>
+				</div>
+			</div>
 		)
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Better support for tooltips that are too big or that still overflows after adjusting for overflow.
Add qa-sample for `Tooltip` overflows

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Starting with `calcOverflow`, we calculate the to see if the tooltip width is:
1. bigger than the viewport or
2. bigger than the space on the left side of the `clientNode` and the space on the right side of the `clientNode`

Once we determine that the tooltip will overflow no matter how we adjust the position, then we position the tooltip so that the tooltip can be read from the beginning and it'll take up the whole width of the viewport, and adjust the position of arrow anchor.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Open to suggestions on naming `isOverWide`; something that suggests, the tooltip will overflow no matter where we put it.

Also would like to hear suggestions on how to customize the tooltip arrow anchor without adding a new prop. 

### Links
[//]: # (Related issues, references)
ENYO-5880
