### PR TITLE
ENYO-5890: Fix to move Spotlight between scroll buttons properly via 5-way keys

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move Spotlight between paging controls properly via 5-way keys
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
 
 ## [2.4.1] - 2019-03-11

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move Spotlight between paging controls properly via 5-way keys
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to remove event listeners properly
 
 ## [2.4.1] - 2019-03-11

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -203,12 +203,10 @@ class ScrollButtons extends Component {
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 	}
 
-	focusOnOppositeScrollButton = (ev, direction) => {
-		const buttonNode = (ev.target === this.nextButtonRef.current) ? this.prevButtonRef.current : this.nextButtonRef.current;
-
+	focusOnOppositeScrollButton = (ev, direction, oppositeScrollButtonNode) => {
 		ev.stopPropagation();
 
-		if (!Spotlight.focus(buttonNode)) {
+		if (!Spotlight.focus(oppositeScrollButtonNode)) {
 			Spotlight.move(direction);
 		}
 	}
@@ -223,12 +221,15 @@ class ScrollButtons extends Component {
 			const
 				direction = getDirection(ev.keyCode),
 				fromNextToPrev = (vertical && direction === 'up') || (!vertical && direction === (rtl ? 'right' : 'left')),
-				fromPrevToNext = (vertical && direction === 'down') || (!vertical && direction === (rtl ? 'left' : 'right'));
+				fromPrevToNext = (vertical && direction === 'down') || (!vertical && direction === (rtl ? 'left' : 'right')),
+				nextButtonNode = ReactDOM.findDOMNode(this.nextButtonRef.current),
+				prevButtonNode = ReactDOM.findDOMNode(this.prevButtonRef.current);
 
 			// manually focus the opposite scroll button when 5way pressed
-			if ((fromNextToPrev && target === this.nextButtonRef.current) ||
-				(fromPrevToNext && target === this.prevButtonRef.current)) {
-				this.focusOnOppositeScrollButton(ev, direction);
+			if (fromNextToPrev && target === nextButtonNode) {
+				this.focusOnOppositeScrollButton(ev, direction, prevButtonNode);
+			} else if (fromPrevToNext && target === prevButtonNode) {
+				this.focusOnOppositeScrollButton(ev, direction, nextButtonNode);
 			}
 		} else {
 			// If it is vertical `Scrollable`, move focus to the left for ltr or to the right for rtl

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -222,8 +222,8 @@ class ScrollButtons extends Component {
 				direction = getDirection(ev.keyCode),
 				fromNextToPrev = (vertical && direction === 'up') || (!vertical && direction === (rtl ? 'right' : 'left')),
 				fromPrevToNext = (vertical && direction === 'down') || (!vertical && direction === (rtl ? 'left' : 'right')),
-				nextButtonNode = ReactDOM.findDOMNode(this.nextButtonRef.current),
-				prevButtonNode = ReactDOM.findDOMNode(this.prevButtonRef.current);
+				nextButtonNode = ReactDOM.findDOMNode(this.nextButtonRef.current), // eslint-disable-line react/no-find-dom-node
+				prevButtonNode = ReactDOM.findDOMNode(this.prevButtonRef.current); // eslint-disable-line react/no-find-dom-node
 
 			// manually focus the opposite scroll button when 5way pressed
 			if (fromNextToPrev && target === nextButtonNode) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing the 5-way Up on the Down scroll button, Spotlight jumps not to the Up scroll button but to the item in the VirtuaList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We have to compare the current spotted DOM element and the Up / Down scroll button DOM elements to navigate between the Up / Down scroll buttons. But we compared the current spotted DOM element and the scroll button ref (Not DOM element). So I used `React.findDONNode() to find the scroll button DOM element.

### Links
[//]: # (Related issues, references)
ENYO-5890
