### PR TITLE
ENYO-5818: Fix list QA samples when dataSize is greater than 1000

### DIFF
--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -56,7 +56,7 @@ storiesOf('VirtualList.VirtualGridList', module)
 		'Horizontal VirtualGridList',
 		() => (
 			<VirtualGridList
-				dataSize={number('dataSize', Config, defaultDataSize)}
+				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 				direction="horizontal"
 				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 				itemRenderer={renderItem}

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -12,6 +12,7 @@ import {mergeComponentMetadata} from '../../src/utils/propTables';
 const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
 
 const
+	defaultDataSize = 1000,
 	items = [],
 	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
@@ -27,23 +28,35 @@ const
 		);
 	};
 
-for (let i = 0; i < 1000; i++) {
+const updateDataSize = (dataSize) => {
 	const
-		count = ('00' + i).slice(-3),
-		text = `Item ${count}`,
-		subText = `SubItem ${count}`,
-		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
-		source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`;
+		itemNumberDigits = dataSize > 0 ? ((dataSize - 1) + '').length : 0,
+		headingZeros = Array(itemNumberDigits).join('0');
 
-	items.push({text, subText, source});
-}
+	items.length = 0;
+
+	for (let i = 0; i < dataSize; i++) {
+		const
+			count = (headingZeros + i).slice(-itemNumberDigits),
+			text = `Item ${count}`,
+			subText = `SubItem ${count}`,
+			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
+			source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`;
+
+		items.push({text, subText, source});
+	}
+
+	return dataSize;
+};
+
+updateDataSize(defaultDataSize);
 
 storiesOf('VirtualList.VirtualGridList', module)
 	.add(
 		'Horizontal VirtualGridList',
 		() => (
 			<VirtualGridList
-				dataSize={number('dataSize', Config, items.length)}
+				dataSize={number('dataSize', Config, defaultDataSize)}
 				direction="horizontal"
 				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 				itemRenderer={renderItem}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -18,6 +18,7 @@ const
 		boxSizing: 'border-box'
 	},
 	items = [],
+	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
 		const style = {height: size + 'px', ...itemStyle};
@@ -28,9 +29,21 @@ const
 		);
 	};
 
-for (let i = 0; i < 1000; i++) {
-	items.push({item :'Item ' + ('00' + i).slice(-3), selected: false});
-}
+const updateDataSize = (dataSize) => {
+	const
+		itemNumberDigits = dataSize > 0 ? ((dataSize - 1) + '').length : 0,
+		headingZeros = Array(itemNumberDigits).join('0');
+
+	items.length = 0;
+
+	for (let i = 0; i < dataSize; i++) {
+		items.push({item :'Item ' + (headingZeros + i).slice(-itemNumberDigits), selected: false});
+	}
+
+	return dataSize;
+};
+
+updateDataSize(defaultDataSize);
 
 class StatefulSwitchItem extends React.Component {
 	static propTypes = {
@@ -82,7 +95,7 @@ storiesOf('VirtualList', module)
 			const itemSize = ri.scale(number('itemSize', Config, 72));
 			return (
 				<VirtualList
-					dataSize={number('dataSize', Config, items.length)}
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In `VirtualList` and `VirtualGridList` samples in QA-sampler, if `dataSize` is set to any number grater than 1000, no item is rendered after 'Item 999'.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Data were initially generated with the size of 1000 and was never updated even if `dataSize` was changed.
To support any number of items, items will be re-generated whenever `dataSize` is changed. It is a natural behavior since the change of  `dataSize` means the change of data in real apps.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Heading '0's for list subjects will be changed along with the number of digits to show. (For example, there will be no '0' if a list shows items from '0' to '9')

### Links
[//]: # (Related issues, references)
ENYO-5818

### Comments
