### PR TITLE
ENYO-5890: Fix to move Spotlight between scroll buttons properly via 5-way keys

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -55,7 +55,18 @@ const ScrollButtonBase = kind({
 		 * @type {Boolean}
 		 * @public
 		 */
-		disabled: PropTypes.bool
+		disabled: PropTypes.bool,
+
+		/**
+		 * Returns a ref to the root node of the scroll button
+		 *
+		 * @type {Function|Object}
+		 * @private
+		 */
+		forwardRef: PropTypes.oneOfType([
+			PropTypes.func,
+			PropTypes.shape({current: PropTypes.any})
+		])
 	},
 
 	styles: {

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -1,6 +1,8 @@
 import kind from '@enact/core/kind';
+import ForwardRef from '@enact/ui/ForwardRef';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import IconButton from '../IconButton';
 
@@ -16,7 +18,7 @@ import css from './Scrollbar.module.less';
  * @ui
  * @private
  */
-const ScrollButton = kind({
+const ScrollButtonBase = kind({
 	name: 'ScrollButton',
 
 	propTypes: /** @lends moonstone/Scrollable.ScrollButton.prototype */ {
@@ -61,11 +63,29 @@ const ScrollButton = kind({
 		className: 'scrollButton'
 	},
 
+	handlers: {
+		forwardRef: (node, {forwardRef}) => {
+			// Allowing findDOMNode in the absence of a means to retrieve a node ref through IconButton
+			// eslint-disable-next-line react/no-find-dom-node
+			const current = ReactDOM.findDOMNode(node);
+
+			// Safely handle old ref functions and new ref objects
+			switch (typeof forwardRef) {
+				case 'object':
+					forwardRef.current = current;
+					break;
+				case 'function':
+					forwardRef(current);
+					break;
+			}
+		}
+	},
+
 	computed: {
 		'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel)
 	},
 
-	render: ({children, disabled, ...rest}) => {
+	render: ({children, disabled, forwardRef, ...rest}) => {
 		delete rest.active;
 
 		return (
@@ -73,6 +93,7 @@ const ScrollButton = kind({
 				{...rest}
 				backgroundOpacity="transparent"
 				disabled={disabled}
+				ref={forwardRef}
 				small
 			>
 				{children}
@@ -80,6 +101,8 @@ const ScrollButton = kind({
 		);
 	}
 });
+
+const ScrollButton = ForwardRef(ScrollButtonBase);
 
 export default ScrollButton;
 export {

--- a/packages/moonstone/Scrollable/ScrollButton.js
+++ b/packages/moonstone/Scrollable/ScrollButton.js
@@ -60,6 +60,8 @@ const ScrollButtonBase = kind({
 		/**
 		 * Returns a ref to the root node of the scroll button
 		 *
+		 * See: https://github.com/facebook/prop-types/issues/240
+		 *
 		 * @type {Function|Object}
 		 * @private
 		 */

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -9,8 +9,6 @@ import $L from '../internal/$L';
 
 import ScrollButton from './ScrollButton';
 
-const ScrollButtonWithForwardRef = React.forwardRef((props, ref) => <ScrollButton {...props} ref={ref} />);
-
 const
 	nop = () => {},
 	prepareButton = (isPrev) => (isVertical) => {
@@ -294,7 +292,7 @@ class ScrollButtons extends Component {
 			nextIcon = prepareNextButton(vertical);
 
 		return [
-			<ScrollButtonWithForwardRef
+			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || prevButtonDisabled}
@@ -310,9 +308,9 @@ class ScrollButtons extends Component {
 				ref={this.prevButtonRef}
 			>
 				{prevIcon}
-			</ScrollButtonWithForwardRef>,
+			</ScrollButton>,
 			thumbRenderer(),
-			<ScrollButtonWithForwardRef
+			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || nextButtonDisabled}
@@ -328,7 +326,7 @@ class ScrollButtons extends Component {
 				ref={this.nextButtonRef}
 			>
 				{nextIcon}
-			</ScrollButtonWithForwardRef>,
+			</ScrollButton>,
 			<Announce
 				key="announce"
 				ref={this.announceRef}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing the 5-way Up on the Down scroll button, Spotlight jumps not to the Up scroll button but to the item in the VirtuaList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We have to compare the current spotted DOM element and the Up / Down scroll button DOM elements to navigate between the Up / Down scroll buttons. But we compared the current spotted DOM element and the scroll button ref (Not DOM element). So Ryan fixed to pass the ref to the DOM element properly.

### Links
[//]: # (Related issues, references)

ENYO-5890
