### PR TITLE
ENYO-5897: Viewport: it tries to make panel when child is null

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Popup` to resume spotlight pauses when closing with animation
+- `moonstone/Panels` to check that child is valid before generating spotlightId
 
 ## [2.4.1] - 2019-03-11
 

--- a/packages/moonstone/Panels/Viewport.js
+++ b/packages/moonstone/Panels/Viewport.js
@@ -128,17 +128,21 @@ const ViewportBase = class extends React.Component {
 	)
 
 	mapChildren = (children, generateId) => React.Children.map(children, (child, index) => {
-		const {spotlightId = generateId(index, 'panel-container', Spotlight.remove)} = child.props;
-		const props = {
-			spotlightId,
-			'data-index': index
-		};
+		if (child) {
+			const {spotlightId = generateId(index, 'panel-container', Spotlight.remove)} = child.props;
+			const props = {
+				spotlightId,
+				'data-index': index
+			};
 
-		if (child.props.autoFocus == null && this.state.direction === 'forward') {
-			props.autoFocus = 'default-element';
+			if (child.props.autoFocus == null && this.state.direction === 'forward') {
+				props.autoFocus = 'default-element';
+			}
+
+			return React.cloneElement(child, props);
+		} else {
+			return null;
 		}
-
-		return child ? React.cloneElement(child, props) : null;
 	})
 
 	getEnteringProp = (noAnimation) => noAnimation ? null : 'hideChildren'


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This issue is related to ENYO-5630. So, I can reproduce it since `2.4.0`.
In viewport, it tries to make Panel when child is null.

If application defines child(panel) depend on any condition or state, Panel child array have a null value.
Viewport generate `spotlightId` using with information from props. But, it shouldn't get props when child is null.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added condition whether child is valid or not before generating spotlightId of Panel.

### Links
[//]: # (Related issues, references)
ENYO-5897
