### PR TITLE
PLAT-75397 & PLAT-75394 && PLAT-75395: Fixed to blur on handlePointerUp for ExpandableInput.

### DIFF
--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -12,7 +12,8 @@ const handlePointerDown = handle(
 	shouldCapture,				// If we should capture the click
 	preventDefault,				// prevent the down event bubbling
 	stop,						// (and stop propagation to support touch)
-	setCapturing(true)			// and flag that we've started capturing a down event
+	setCapturing(true),			// and flag that we've started capturing a down event
+	() => active.blur()			// and blur the active node
 );
 
 const handlePointerUp = handle(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
ExpandableInput does not close when touching the second ExpandableInput.
This solution also resolves the PLAT-75394 issue. `ExpandableInput`'s `Input` field did not always collapse, but with this fix, it correctly collapses.

### Resolution
 It is fixed by adding blur for handlePointerUp(). Adding blur() on handlePointerUp() ended up opening all the inputs.