### PR TITLE
PLAT-76545: Fix core/kind to only apply static component props when provided

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Fixed
 
-- `core/kind` to only apply static component props when provided
+- `core/kind` to address warnings raised in React 16.8.6
 
 ## [2.5.0] - 2019-04-01
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/kind` to only apply static component props when provided
+
 ## [2.5.0] - 2019-04-01
 
 No significant changes.

--- a/packages/core/kind/kind.js
+++ b/packages/core/kind/kind.js
@@ -136,14 +136,6 @@ const kind = (config) => {
 	const Component = class extends React.Component {
 		static displayName = name || 'Component'
 
-		static propTypes = propTypes
-
-		static contextTypes = contextTypes
-
-		static contextType = contextType
-
-		static defaultProps = defaultProps
-
 		constructor () {
 			super();
 			this.handlers = {};
@@ -177,6 +169,11 @@ const kind = (config) => {
 			}, this.context);
 		}
 	};
+
+	if (propTypes) Component.propTypes = propTypes;
+	if (contextTypes) Component.contextTypes = contextTypes;
+	if (contextType) Component.contextType = contextType;
+	if (defaultProps) Component.defaultProps = defaultProps;
 
 	// Decorate the Component with the computed property object in DEV for easier testability
 	if (__DEV__ && cfgComputed) Component.computed = cfgComputed;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Recent React release added warnings for invalid `contextType` values on a component. We are currently blindly applying several statics in `core/kind` even when those are not set by authors.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Conditionally apply statics outside the class body
