### PR TITLE
PLAT-75397: Fix ExpandableInput to close on touch platforms when tapping off it

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/ExpandableInput` to close on touch platforms when tapping another component
+
 ## [2.5.0] - 2019-04-01
 
 ### Fixed

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -30,7 +30,7 @@ const handlePointerClick = handle(
 
 const handleTouchStart = handle(
 	shouldCapture,                // If we should capture the click
-	stop,						  // prevent other components from handling this event
+	stop,                         // prevent other components from handling this event
 	setCapturing(true)            // and flag that we've started capturing a down event
 );
 

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -19,7 +19,10 @@ const handlePointerUp = handle(
 	isCapturing,				// if a down event was captured
 	preventDefault,				// prevent the up event bubbling
 	stop,						// (and stop propagation to support touch)
-	() => active.blur()			// and blur the active node
+	(e) => {
+		if (active !== e.target) active.blur()
+		else active.focus();
+	}
 );
 
 const handlePointerClick = handle(

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -30,7 +30,7 @@ const handlePointerClick = handle(
 
 const handleTouchStart = handle(
 	shouldCapture,                // If we should capture the click
-	stop,
+	stop,						  // prevent other components from handling this event
 	setCapturing(true)            // and flag that we've started capturing a down event
 );
 

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -18,11 +18,7 @@ const handlePointerDown = handle(
 const handlePointerUp = handle(
 	isCapturing,				// if a down event was captured
 	preventDefault,				// prevent the up event bubbling
-	stop,						// (and stop propagation to support touch)
-	(e) => {
-		if (active !== e.target) active.blur()
-		else active.focus();
-	}
+	stop						// (and stop propagation to support touch)
 );
 
 const handlePointerClick = handle(
@@ -32,13 +28,18 @@ const handlePointerClick = handle(
 	() => active.blur()			// and blur the active node
 );
 
+const handleTouchStart = handle(
+	shouldCapture,                // If we should capture the click
+	stop,
+	setCapturing(true)            // and flag that we've started capturing a down event
+);
+
 // Lock the pointer from emitting click events until released
 const lockPointer = (target) => {
 	active = target;
 	document.addEventListener('mousedown', handlePointerDown, {capture: true});
 	document.addEventListener('mouseup', handlePointerUp, {capture: true});
-	document.addEventListener('touchstart', handlePointerDown, {capture: true});
-	document.addEventListener('touchend', handlePointerUp, {capture: true});
+	document.addEventListener('touchstart', handleTouchStart, {capture: true});
 	document.addEventListener('click', handlePointerClick, {capture: true});
 };
 
@@ -49,7 +50,6 @@ const releasePointer = (target) => {
 		document.removeEventListener('mousedown', handlePointerDown, {capture: true});
 		document.removeEventListener('mouseup', handlePointerUp, {capture: true});
 		document.removeEventListener('touchstart', handlePointerDown, {capture: true});
-		document.removeEventListener('touchend', handlePointerUp, {capture: true});
 		document.removeEventListener('click', handlePointerClick, {capture: true});
 	}
 };

--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -18,7 +18,8 @@ const handlePointerDown = handle(
 const handlePointerUp = handle(
 	isCapturing,				// if a down event was captured
 	preventDefault,				// prevent the up event bubbling
-	stop						// (and stop propagation to support touch)
+	stop,						// (and stop propagation to support touch)
+	() => active.blur()			// and blur the active node
 );
 
 const handlePointerClick = handle(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
ExpandableInput does not close when touching the second ExpandableInput.

### Resolution
Touch events needed a separate handler. 

Interesting test data.
https://patrickhlauke.github.io/touch/tests/results/