### PR TITLE
ENYO-5906: Add check for demote to avoid setState call

### DIFF
--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -393,7 +393,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		demote () {
 			this.promoteJob.stop();
-			this.demoteJob.idle();
+			if (this.state.promoted) {
+				this.demoteJob.idle();
+			}
 		}
 
 		promote (delay = this.props.marqueeDelay) {
@@ -567,9 +569,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				});
 			}
 
-			if (this.state.promoted) {
-				this.demote();
-			}
+			this.demote();
 		}
 
 		/*

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -567,7 +567,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				});
 			}
 
-			this.demote();
+			if (this.state.promoted) {
+				this.demote();
+			}
 		}
 
 		/*


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`MarqueeDecorator` queues up `demoteJob` and fires `setState` calls when it's not promoted.

[//]: # (Describe the issue resolved or feature added by this pull request)
<img width="1920" alt="idlecallbacks" src="https://user-images.githubusercontent.com/3284947/55446738-bd7aff80-5575-11e9-8651-ec44b1148bba.png">


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add check before queuing up

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>