### PR TITLE
ENYO-5904: Fix TooltipDecorator to position tooltips within non-root floating layers

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/TooltipDecorator` to correctly position tooltips within the bounds of non-root floating layers
+
 ## [2.5.0] - 2019-04-01
 
 ### Fixed

--- a/packages/moonstone/TooltipDecorator/util.js
+++ b/packages/moonstone/TooltipDecorator/util.js
@@ -80,7 +80,7 @@ const adjustDirection = function (tooltipDirection, overflow, rtl) {
  * @returns {Object}                    Tooltip's calculated overflow
  * @private
  */
-const calcOverflow = function (tooltipNode, clientNode, tooltipDirection, tooltipHeight) {
+const calcOverflow = function (tooltipNode, clientNode, layer, tooltipDirection, tooltipHeight) {
 	// get the distance of space on both the right and left side of the client node. `clientNode.width / 2` because we want the tooltip to be positioned horizontally in middle of the client node.
 	const rightDelta = tooltipNode.width > clientNode.left + (clientNode.width / 2);
 	const leftDelta = tooltipNode.width > window.innerWidth - clientNode.right - (clientNode.width / 2);
@@ -90,17 +90,17 @@ const calcOverflow = function (tooltipNode, clientNode, tooltipDirection, toolti
 	if (tooltipDirection === 'above' || tooltipDirection === 'below') {
 		return {
 			isOverTop: clientNode.top - tooltipNode.height - tooltipHeight < 0,
-			isOverBottom: clientNode.bottom + tooltipNode.height + tooltipHeight > window.innerHeight,
+			isOverBottom: clientNode.bottom + tooltipNode.height + tooltipHeight > layer.height,
 			isOverLeft: clientNode.left - tooltipNode.width + clientNode.width / 2 < 0,
-			isOverRight: clientNode.right + tooltipNode.width - clientNode.width / 2 > window.innerWidth,
+			isOverRight: clientNode.right + tooltipNode.width - clientNode.width / 2 > layer.width,
 			isOverWide: isTooltipWide
 		};
 	} else if (tooltipDirection === 'left' || tooltipDirection === 'right') {
 		return {
 			isOverTop: clientNode.top - tooltipNode.height + clientNode.height / 2 < 0,
-			isOverBottom: clientNode.bottom + tooltipNode.height - clientNode.height / 2 > window.innerHeight,
+			isOverBottom: clientNode.bottom + tooltipNode.height - clientNode.height / 2 > layer.height,
 			isOverLeft: clientNode.left - tooltipNode.width < 0,
-			isOverRight: clientNode.right + tooltipNode.width > window.innerWidth,
+			isOverRight: clientNode.right + tooltipNode.width > layer.width,
 			isOverWide: isTooltipWide
 		};
 	}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/FloatingLayer` prop `onOpen` to include the layer's `node` in the event payload which may be required to position elements within the layer
+
 ## [2.5.0] - 2019-04-01
 
 ### Added

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -17,7 +17,7 @@ const forwardWithType = type => adaptEvent(
 
 const forwardDismiss = forwardWithType('onDismiss');
 const forwardClose = forwardWithType('onClose');
-const forwardOpen = forwardWithType('onOpen');
+const forwardOpen = forward('onOpen');
 
 /**
  * A component that creates an entry point to the new render tree.
@@ -149,7 +149,7 @@ class FloatingLayerBase extends React.Component {
 		) {
 			// when node has been rendered and either it was just rendered in this update cycle or
 			// the open prop changed in this cycle, forward open
-			forwardOpen(null, this.props);
+			forwardOpen({type: 'onOpen', node: this.node}, this.props);
 		}
 
 		if (scrimType === 'none') {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When tooltips are rendered within non-root `FloatingLayer`s as is the case in `VideoPlayer`, they are positioned incorrectly based on the viewport rather than the layer into which they are rendered.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add `node` to the `FloatingLayer.onOpen` payload to use as a reference point for positioning elements within the layer
* Update the positioning logic of Tooltip to "relativize" the bounds based on the floating layer

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Instead of updating `onOpen`, we could "find" the node using `closest()` DOM API but would require breaking encapsulation since there's no way from TooltipDecorator to "tag" the floating layer. Any props added to `FloatingLayerBase` are attached to a child of the node that is establishing the positioning context. Given that, exposing the node seemed like the right API but open to alternatives.
