### PR TITLE
PLAT-75396: Signage Enact -  Sampler allows zoom

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -8,6 +8,7 @@ import {Column, Cell} from '@enact/ui/Layout';
 import BodyText from '@enact/moonstone/BodyText';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
 import {Panels, Panel, Header} from '@enact/moonstone/Panels';
+import platform from '@enact/core/platform';
 import {boolean, select} from '../enact-knobs';
 import qs from 'query-string';
 
@@ -31,6 +32,10 @@ const PanelsBase = kind({
 	styles: {
 		css,
 		className: 'moonstoneEnvironmentPanels'
+	},
+
+	computed: {
+		className: ({styler}) => styler.append(platform.platformName)
 	},
 
 	render: ({children, description, title, ...rest}) => (

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.module.less
@@ -66,6 +66,11 @@
 			overflow-x: auto !important;
 		}
 	}
+
+	&.webos {
+		// disable gestures on webOS platforms
+		touch-action: none;
+	}
 }
 
 // Here, we target the storybook rendering canvas div. It's inserted as a child of our Panel, but it


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added platform name classes for the moonstone environment to enable platform-specific styling.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Multi-touch actions (i.e. pinch-zoom) are disabled on webOS platforms in moonstone samples.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Since this is only applied for the moonstone panels, it is still possible to pinch zoom Sampler app itself from the story list section or the knobs section.

### Links
[//]: # (Related issues, references)
PLAT-75396

### Comments
