### PR TITLE
ENYO-5910: Fix Touchable forwarding of mousedown events

### DIFF
--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -17,9 +17,9 @@ class ClickAllow {
 	}
 
 	shouldAllowMouseEvent (ev) {
-		const {type, timeStamp} = ev;
+		const {timeStamp} = ev;
 
-		return type.substring(0, 5) === 'mouse' && this.lastTouchEndTime !== timeStamp;
+		return this.lastTouchEndTime !== timeStamp;
 	}
 
 	shouldAllowTap (ev) {

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -93,8 +93,8 @@ const handleLeave = handle(
 // Mouse event handlers
 
 const handleMouseDown = handle(
-	call('shouldAllowMouseEvent'),
 	forward('onMouseDown'),
+	call('shouldAllowMouseEvent'),
 	handleDown
 );
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
5-way select of Expandables and ToggleItems doesn't work after #2192 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Spottable's mouse emulation was running afoul of Touchable which was checking the event type against starting with `'mouse'`. Removing that condition -- which isn't necessary due to method only used in a mouse event handler -- resolves the bug.

I also moved the event forwarding before the method call where it should have always been since we are guarding against Touchable reacting to the event and not the event itself.