### PR TITLE
PLAT-76786: Change Touchable to not gain focus when activated by touch

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Touchable` to neither force focus to components nor blur components after they are touched
+
 ## [2.5.1] - 2019-04-09
 
 ### Fixed

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -8,7 +8,6 @@
 
 import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';
 import complement from 'ramda/src/complement';
 import platform from '@enact/core/platform';
@@ -406,11 +405,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			this.drag = new Drag();
 			this.flick = new Flick();
 			this.hold = new Hold();
-			this.blurJob = new Job(target => {
-				if (target.blur) {
-					target.blur();
-				}
-			}, 400);
 
 			this.clickAllow = new ClickAllow();
 
@@ -466,7 +460,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		componentWillUnmount () {
 			this.clearTarget();
 			this.hold.end();
-			this.blurJob.stop();
 
 			if (platform.touch) {
 				off('touchend', this.handleGlobalUp, document);

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -501,18 +501,10 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 				this.setState(activate);
 			}
 
-			if (ev && 'changedTouches' in ev) {
-				this.target.focus();
-			}
-
 			return true;
 		}
 
-		deactivate (ev) {
-			if (ev && 'changedTouches' in ev) {
-				this.blurJob.start(this.target);
-			}
-
+		deactivate () {
 			this.clearTarget();
 			if (activeProp) {
 				this.setState(deactivate);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Spotlight is on item when 'data-spotlight-container-disabled' is touched.

### Resolution
Removing focus and blur from Touchable resolved this issue. Removing these don't affect other issues. Spotlight is taken care of from Spottable. 

