### PR TITLE
PLAT-76981: Fix Touchable to prevent handling events on multiple nodes

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Touchable` to prevent events firing on different nodes for the same touch action
+
 ## [2.5.1] - 2019-04-09
 
 ### Fixed

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -1,13 +1,18 @@
 // It's possible that emitting `onTap` will cause a DOM change before the mousedown fires resulting
 // in multiple tap/click events for the same user action. To avoid this, we store the last touchend
-// target to compare against the next mouse down. If the target is the same (or no previous target
-// was set if no touch events are emitted), we allow the mousedown *across Touchable instances*.
-let _lastTouchEndTarget = null;
+// target and timestamp to compare against the next mouse down. If the timestamp is different (e.g
+// we're on a hybrid device that emitted a touch event but the next was a mouse event) or the target
+// is the same (or no previous target was set if no touch events have been emitted), we allow the
+// mousedown *across Touchable instances*.
+let _lastTouchEnd = {
+	target: null,
+	timeStamp: 0
+};
 
 const shouldAllowMouseDown = (ev) => {
-	return (
-		ev.target === _lastTouchEndTarget ||
-		_lastTouchEndTarget === null
+	return ev.timeStamp !== _lastTouchEnd.timeStamp || (
+		ev.target === _lastTouchEnd.target ||
+		_lastTouchEnd.target === null
 	);
 };
 
@@ -20,7 +25,8 @@ class ClickAllow {
 	setLastTouchEnd (ev) {
 		if (ev && ev.type === 'touchend') {
 			this.lastTouchEndTime = ev.timeStamp;
-			_lastTouchEndTarget = ev.target;
+			_lastTouchEnd.timeStamp = ev.timeStamp;
+			_lastTouchEnd.target = ev.target;
 		}
 	}
 

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -1,3 +1,16 @@
+// It's possible that emitting `onTap` will cause a DOM change before the mousedown fires resulting
+// in multiple tap/click events for the same user action. To avoid this, we store the last touchend
+// target to compare against the next mouse down. If the target is the same (or no previous target
+// was set if no touch events are emitted), we allow the mousedown *across Touchable instances*.
+let _lastTouchEndTarget = null;
+
+const shouldAllowMouseDown = (ev) => {
+	return (
+		ev.target === _lastTouchEndTarget ||
+		ev.target === null
+	);
+};
+
 class ClickAllow {
 	constructor () {
 		this.lastTouchEndTime = 0;
@@ -7,6 +20,7 @@ class ClickAllow {
 	setLastTouchEnd (ev) {
 		if (ev && ev.type === 'touchend') {
 			this.lastTouchEndTime = ev.timeStamp;
+			_lastTouchEndTarget = ev.target;
 		}
 	}
 
@@ -19,7 +33,7 @@ class ClickAllow {
 	shouldAllowMouseEvent (ev) {
 		const {timeStamp} = ev;
 
-		return this.lastTouchEndTime !== timeStamp;
+		return this.lastTouchEndTime !== timeStamp && shouldAllowMouseDown(ev);
 	}
 
 	shouldAllowTap (ev) {

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -7,7 +7,7 @@ let _lastTouchEndTarget = null;
 const shouldAllowMouseDown = (ev) => {
 	return (
 		ev.target === _lastTouchEndTarget ||
-		ev.target === null
+		_lastTouchEndTarget === null
 	);
 };
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -6,7 +6,7 @@
  * @exports configure
  */
 
-import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue} from '@enact/core/handle';
+import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue, stop} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -6,7 +6,7 @@
  * @exports configure
  */
 
-import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue, stop} from '@enact/core/handle';
+import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When touching on a component that handles `onTap` *and* reveals another Touchable instance in the same position as the tap, the mouse events could occur on a different target than the touch events.

The event order for touch events and mouse events in Touchable:

* `onTouchStart`
* `onDown`
* `onTouchEnd`
* `onUp`
* `onTap`
* `onMouseDown`
* `onMouseUp`
* `onClick`

If `onTap` changes the DOM, the subsequent `onMouseDown` might happen over a different DOM node causing this bug.

### Resolution;
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add (back? possibly a regression from #2195) a global Touchable variable to verify that the `mousedown` came from the same `target` as `touchend` before handling it.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Doesn't appear to be any good way to test this in unit tests. Perhaps we could simulate it in UI tests but it could be difficult.
