### PR TITLE
PLAT-75346: Update design of moonstone/Header with Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [3.0.0] - tbd
+
+### NOTE: Webkit 53 support has been dropped from this version of Enact
+
 ## [2.5.1] - 2019-04-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ## [3.0.0] - tbd
 
-### NOTE: Webkit 53 support has been dropped from this version of Enact
+> NOTE:  Support for 2019 TV platform (Blink <68) has been dropped from this version of Enact
 
 ## [2.5.1] - 2019-04-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Panels` slot `<controls>` to easily add custom controls next to the Panels' "close" button
-- `moonstone/Input` public class name `focused`
 
 ### Removed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,11 +11,12 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Removed
 
 - `moonstone/Button` and `moonstone/Panels.Header` prop `casing` which is no longer supported
+- `moonstone/Input.InputBase` prop `focused` which was used to indicate when the internal input field had focused but was replaced by the `:focus-within` pseudo-selector
 
 ### Changed
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
-- `moonstone/Button` appearance to match the latest designs
+- `moonstone/Button` and `moonstone/Header` appearance to match the latest designs
 
 ## [2.5.1] - 2019-04-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Panels` slot `<controls>` to easily add custom controls next to the Panels' "close" button
+- `moonstone/Input` public class name `focused`
 
 ### Removed
 

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -231,7 +231,7 @@ const InputBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'decorator',
-		publicClassNames: ['decorator', 'input']
+		publicClassNames: ['decorator', 'focused', 'input']
 	},
 
 	handlers: {

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -49,7 +49,6 @@ const InputBase = kind({
 		 * The following classes are supported:
 		 *
 		 * * `decorator` - The root class name
-		 * * `focused` - Applied to the root when the <input> is focused
 		 * * `input` - The <input> class name
 		 *
 		 * @type {Object}
@@ -79,15 +78,6 @@ const InputBase = kind({
 		 * @public
 		 */
 		dismissOnEnter: PropTypes.bool,
-
-		/**
-		 * Adds a `focused` class to the input decorator.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		focused: PropTypes.bool,
 
 		/**
 		 * The icon to be placed at the end of the input.
@@ -232,7 +222,7 @@ const InputBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'decorator',
-		publicClassNames: ['decorator', 'focused', 'input']
+		publicClassNames: ['decorator', 'input']
 	},
 
 	handlers: {
@@ -248,7 +238,7 @@ const InputBase = kind({
 			const title = (value == null || value === '') ? placeholder : '';
 			return calcAriaLabel(title, type, value);
 		},
-		className: ({focused, invalid, small, styler}) => styler.append({focused, invalid, small}),
+		className: ({invalid, small, styler}) => styler.append({invalid, small}),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
 		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.'), rtl}) => {
 			if (invalid && invalidMessage) {
@@ -267,7 +257,6 @@ const InputBase = kind({
 	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, small, type, value, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-intent' : voiceIntent, 'data-webos-voice-label': voiceLabel, ...rest}) => {
 		const inputProps = extractInputProps(rest);
 		delete rest.dismissOnEnter;
-		delete rest.focused;
 		delete rest.invalid;
 		delete rest.invalidMessage;
 		delete rest.rtl;

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -49,6 +49,7 @@ const InputBase = kind({
 		 * The following classes are supported:
 		 *
 		 * * `decorator` - The root class name
+		 * * `focused` - Applied to the root when the <input> is focused
 		 * * `input` - The <input> class name
 		 *
 		 * @type {Object}

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -132,7 +132,7 @@
 				color: @moon-input-placeholder-color;
 			});
 
-			.focused& {
+			&:focus-within {
 				.input-placeholder({
 					color: @moon-input-placeholder-active-color;
 				});
@@ -155,7 +155,7 @@
 			}
 		});
 
-		&.focused {
+		&:focus-within {
 			background-color: @moon-input-decorator-active-bg-color;
 		}
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -325,7 +325,6 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			return (
 				<Component
 					{...props}
-					focused={this.state.focused === 'input'}
 					onBlur={this.onBlur}
 					onMouseDown={this.onMouseDown}
 					onFocus={this.onFocus}

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -177,7 +177,7 @@ const HeaderBase = kind({
 		titleOrInput: ({headerInput, marqueeOn, title}) => {
 			if (headerInput) {
 				return (
-					<Cell>
+					<Cell className={css.headerInput}>
 						<ComponentOverride
 							component={headerInput}
 							css={css}

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -119,22 +119,9 @@
 
 						.input-placeholder({
 							color: @moon-header-text-color;
-							opacity: 1;
 						});
 					}
 				}
-
-				.focus({
-					background-color: @moon-header-input-bg-color;
-
-					.input {
-						color: @moon-header-input-text-color;
-
-						.input-placeholder({
-							color: @moon-header-input-text-color;
-						});
-					}
-				});
 			}
 		}
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -36,8 +36,6 @@
 
 	.decorator {
 		padding: 0;
-		border-radius: 0;
-		border: none;
 	}
 
 	.titleBelow,
@@ -113,7 +111,7 @@
 
 		&.standard {
 			.decorator {
-				&:not(.focused) {
+				&:not(:focus-within) {
 					background-color: transparent;
 
 					.input {

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -63,7 +63,7 @@
 			// This `margin-top: 2px;` is intended to account for the height disparity and visual
 			// offset when switching between Header+Input and a Standard Header's title height.
 			// The height is determined by the line-height below, but we want to maintain that as a
-			// relative unit (`em`) rather than dictate specific pixels. The -3px offset may need to
+			// relative unit (`em`) rather than dictate specific pixels. The 2px offset may need to
 			// be updated or removed to accomodate taller glyphs.
 			margin-top: 2px;
 			line-height: @moon-medium-header-line-height;

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -62,12 +62,12 @@
 		height: @moon-header-height-medium;
 
 		.title {
-			// This `margin-top: -3px;` is intended to account for the height disparity and visual
+			// This `margin-top: 2px;` is intended to account for the height disparity and visual
 			// offset when switching between Header+Input and a Standard Header's title height.
 			// The height is determined by the line-height below, but we want to maintain that as a
 			// relative unit (`em`) rather than dictate specific pixels. The -3px offset may need to
 			// be updated or removed to accomodate taller glyphs.
-			margin-top: -3px;
+			margin-top: 2px;
 			line-height: @moon-medium-header-line-height;
 
 			.moon-locale-non-latin({line-height: @moon-non-latin-medium-header-line-height;});
@@ -113,13 +113,23 @@
 
 		&.standard {
 			.decorator {
-				background-color: transparent;
-
-				.focus({
+				&:not(.focused) {
 					background-color: transparent;
 
 					.input {
-						background-color: @moon-header-input-bg-color;
+						color: @moon-header-text-color;
+
+						.input-placeholder({
+							color: @moon-header-text-color;
+							opacity: 1;
+						});
+					}
+				}
+
+				.focus({
+					background-color: @moon-header-input-bg-color;
+
+					.input {
 						color: @moon-header-input-text-color;
 
 						.input-placeholder({
@@ -127,10 +137,6 @@
 						});
 					}
 				});
-
-				.input {
-					color: @moon-header-text-color;
-				}
 			}
 		}
 
@@ -149,7 +155,7 @@
 :global(.moon-panels-hasControls) {
 	.header.compact,
 	.header.standard .title,
-	.header.standard .decorator {
+	.header.standard .headerInput {
 		.padding-start-end(0, var(--moon-panels-controls-width));
 	}
 

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -135,8 +135,6 @@
 @moon-header-full-bleed-text-color:   #f5f5f5;
 @moon-header-title-below-full-bleed-text-color: @moon-light-gray;
 @moon-header-full-bleed-border-color: fade(@moon-white, 25%);
-@moon-header-input-bg-color:          @moon-spotlight-color;
-@moon-header-input-text-color:        @moon-spotlight-text-color;
 @moon-header-controls-border-color:   #383838;
 
 // IconButton


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [X] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/Header` needs to be updated to reflect the new designs when using a `headerInput`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Expose the `focused` class on `moonstone/Input` to adjust the necessary colors from `Header`
* Update the CSS in `Header` for the new designs

### Additional Considerations
* Changed the `.title` margin to 2px which, though non-standard and not divisible by 3, allows the input and title text to match in all resolutions except HD (where 3px does the trick). Would like to find a better alternative to this approach.