### PR TITLE
ENYO-5898: Fix VideoPlayer to continue to display thumbnail image

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support
+- `moonstone/VideoPlayer` to continue to display the thumbnail image while the slider is focused
 
 ## [2.5.1] - 2019-04-09
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -1017,7 +1017,7 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	hideFeedback = () => {
-		if (this.state.feedbackVisible) {
+		if (this.state.feedbackVisible && this.state.feedbackAction !== 'focus') {
 			this.setState({
 				feedbackVisible: false,
 				feedbackAction: 'idle'


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Pressing a remote button to play/pause the video while the slider was focused would trigger the timer to hide the feedback. Instead, the thumbnail should remain visible while the slider is focused and visible.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a condition to only hide the feedback when it isn't being shown due to slider focus.
