### PR TITLE
PLAT-77194: Deprecate moonstone/Input.InputBase focused prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [2.5.2] - 2019-04-23
+## [unreleased]
 
 ### Deprecated
 
-- `moonstone/Input.InputBase` prop `focused` which will be replaced in 3.0 with the `:focus-within` CSS pseudo-selector
+- `moonstone/Input.InputBase` prop `focused` which will be handled by CSS in 3.0
+
+## [2.5.2] - 2019-04-23
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Deprecated
+
+- `moonstone/Input.InputBase` prop `focused` which will be replaced in 3.0 with the `:focus-within` CSS pseudo-selector
+
 ### Fixed
 
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -9,6 +9,7 @@
  * @exports InputBase
  */
 
+import deprecate from '@enact/core/internal/deprecate';
 import kind from '@enact/core/kind';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {isRtlText} from '@enact/i18n/util';
@@ -84,6 +85,7 @@ const InputBase = kind({
 		 *
 		 * @type {Boolean}
 		 * @default false
+		 * @deprected replaced by CSS `:focus-within` pseudo-selector
 		 * @public
 		 */
 		focused: PropTypes.bool,
@@ -296,6 +298,27 @@ const InputBase = kind({
 	}
 });
 
+let InputBaseExternal = InputBase;
+if (__DEV__) {
+	const deprecateFocused = deprecate(() => {}, {
+		name: 'moonstone/Input.InputBase#focused',
+		replacedBy: 'the :focus-within CSS pseudo-selector',
+		since: '2.6.0',
+		until: '3.0.0'
+	});
+
+	// eslint-disable-next-line enact/display-name
+	InputBaseExternal = function (props) {
+		if ('focused' in props) {
+			deprecateFocused();
+		}
+
+		return (
+			<InputBase {...props} />
+		);
+	};
+}
+
 /**
  * A Spottable, Moonstone styled input component with embedded icon support.
  *
@@ -412,5 +435,6 @@ export {
 	calcAriaLabel,
 	extractInputProps,
 	Input,
-	InputBase
+	InputBaseExternal as InputBase,
+	InputBase as InputBaseInternal
 };

--- a/packages/sampler/stories/default/Input.js
+++ b/packages/sampler/stories/default/Input.js
@@ -1,4 +1,4 @@
-import Input, {InputBase} from '@enact/moonstone/Input';
+import Input, {InputBaseInternal as InputBase} from '@enact/moonstone/Input';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';

--- a/packages/sampler/stories/qa/Input.js
+++ b/packages/sampler/stories/qa/Input.js
@@ -1,5 +1,5 @@
 import {icons} from '@enact/moonstone/Icon';
-import {Input, InputBase} from '@enact/moonstone/Input';
+import {Input, InputBaseInternal as InputBase} from '@enact/moonstone/Input';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`focused` prop will be removed by #2200 in 3.0 and must be deprecated in 2.x

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Mark the prop `@deprecated` and add a dev-mode wrapper to warn on prop usage.