### PR TITLE
PLAT-76082: restore the last scroll position on remounting

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -270,6 +270,7 @@ class ScrollableBase extends Component {
 	isWheeling = false
 
 	// spotlight
+	animateOnFocus = false
 	lastScrollPositionOnFocus = null
 	indexToFocus = null
 	nodeToFocus = null

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -251,6 +251,7 @@ class ScrollableBaseNative extends Component {
 	isWheeling = false
 
 	// spotlight
+	animateOnFocus = false
 	lastScrollPositionOnFocus = null
 	indexToFocus = null
 	nodeToFocus = null

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -850,7 +850,15 @@ const VirtualListBaseFactory = (type) => {
 				(preservedIndex < moreInfo.firstVisibleIndex || preservedIndex > moreInfo.lastVisibleIndex)) {
 				// If we need to restore last focus and the index is beyond the screen,
 				// we call `scrollTo` to create DOM for it.
-				cbScrollTo({index: preservedIndex, animate: false, focus: true});
+				// A little trick here; both `position` and `index` are specified.
+				// the scroll position is determined by `position` and
+				// the item specified by `index` will be focused.
+				cbScrollTo({
+					position: this.uiRefCurrent.getXY(this.uiRefCurrent.scrollPosition, 0),
+					index: preservedIndex,
+					animate: false,
+					focus: true
+				});
 				this.isScrolledByJump = true;
 
 				return true;

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -290,9 +290,8 @@ const VirtualListBaseFactory = (type) => {
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
 			} else if (this.hasDataSizeChanged) {
-				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
 				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(newState);
+				this.setState(this.getStatesAndUpdateBounds(this.props, this.state.firstIndex));
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
 				const {x, y} = this.getXY(this.scrollPosition, 0);
@@ -371,7 +370,7 @@ const VirtualListBaseFactory = (type) => {
 			clientHeight: node.clientHeight
 		})
 
-		calculateMetrics (props) {
+		calculateMetrics (props, preservePosition = false) {
 			const
 				{clientSize, direction, itemSize, spacing} = props,
 				node = this.containerRef.current;
@@ -428,10 +427,12 @@ const VirtualListBaseFactory = (type) => {
 			this.primary = primary;
 			this.secondary = secondary;
 
-			// reset
-			this.scrollPosition = 0;
-			if (type === JS && this.contentRef.current) {
-				this.contentRef.current.style.transform = null;
+			if (!preservePosition) {
+				// reset
+				this.scrollPosition = 0;
+				if (type === JS && this.contentRef.current) {
+					this.contentRef.current.style.transform = null;
+				}
 			}
 		}
 
@@ -742,8 +743,8 @@ const VirtualListBaseFactory = (type) => {
 				{scrollBounds} = this;
 
 			if (clientWidth !== scrollBounds.clientWidth || clientHeight !== scrollBounds.clientHeight) {
-				this.calculateMetrics(props);
-				this.setState(this.getStatesAndUpdateBounds(props));
+				this.calculateMetrics(props, true);
+				this.setState(this.getStatesAndUpdateBounds(props, this.state.firstIndex));
 				this.setContainerSize();
 				return true;
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a virtual list is remounted (by panel transition or something), the last focused item is restored with the focus but the scroll position is not exactly same as before remounting.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated restoring logic to recover the scroll position.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-76082

### Comments
Changelog is not updated yet to avoid any conflict.