### PR TITLE
ENYO-5919: Fix alignment of content in moonstone/EditableIntegerPicker

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/EditableIntegerPicker` alignment of text when not editing the value
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support
 
 ## [2.5.1] - 2019-04-09

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -269,12 +269,17 @@ const EditableIntegerPickerBase = kind({
 				);
 			}
 
+			let children = label;
+			if (unit) {
+				children = `${label} ${unit}`;
+			}
+
 			return (
 				<PickerItem
 					key={value}
 					onClick={onPickerItemClick}
 				>
-					{`${label} ${unit}`}
+					{children}
 				</PickerItem>
 			);
 		},


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The content of the picker when not editing was slightly off center. The root cause was an extra space in the DOM content.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix up the logic to only add the space when `unit` is also valued