### PR TITLE
ENYO-5920: Fix Pickers to not error when min > max

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/util.clamp` to safely clamp a value between min and max bounds
+
 ## [2.5.1] - 2019-04-09
 
 ### Fixed

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -3,6 +3,7 @@
  *
  * @module core/util
  * @exports cap
+ * @exports clamp
  * @exports coerceArray
  * @exports coerceFunction
  * @exports extractAriaProps

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -42,7 +42,7 @@ const cap = function (str) {
  * @function
  * @param   {Number}    min   The minimum value of the range
  * @param   {Number}    max   The maximum value of the range
- * @param   {Number}    value THe value that must be within the range
+ * @param   {Number}    value The value that must be within the range
  *
  * @returns {Number}          The clamped value
  * @memberof core/util

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -34,6 +34,26 @@ const cap = function (str) {
 };
 
 /**
+ * Limits `value` to be between `min` and `max`.
+ *
+ * If `min` is greater than `max`, `min` is returned.
+ *
+ * @function
+ * @param   {Number}    min   The minimum value of the range
+ * @param   {Number}    max   The maximum value of the range
+ * @param   {Number}    value THe value that must be within the range
+ *
+ * @returns {Number}          The clamped value
+ * @memberof core/util
+ * @public
+ */
+const clamp = (min, max, value) => {
+	if (min > max || value < min) return min;
+	if (value > max) return max;
+	return value;
+};
+
+/**
  * If `arg` is a function, return it. Otherwise returns a function that returns `arg`.
  *
  * Example:
@@ -201,6 +221,7 @@ const memoize = (fn) => {
 
 export {
 	cap,
+	clamp,
 	coerceArray,
 	coerceFunction,
 	extractAriaProps,

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support
 
 ## [2.5.1] - 2019-04-09

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -13,11 +13,11 @@
  * @exports EditableIntegerPickerBase
  */
 
-import Changeable from '@enact/ui/Changeable';
-import clamp from 'ramda/src/clamp';
 import kind from '@enact/core/kind';
-import PropTypes from 'prop-types';
+import {clamp} from '@enact/core/util';
+import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import {MarqueeController} from '../Marquee';

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -85,7 +85,7 @@ const InputBase = kind({
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @deprected replaced by CSS `:focus-within` pseudo-selector
+		 * @deprecated handled by CSS in 3.0
 		 * @public
 		 */
 		focused: PropTypes.bool,

--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -11,12 +11,12 @@
  * @exports PickerBase
  */
 
-import Changeable from '@enact/ui/Changeable';
-import clamp from 'ramda/src/clamp';
 import kind from '@enact/core/kind';
-import React from 'react';
-import PropTypes from 'prop-types';
+import {clamp} from '@enact/core/util';
+import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {MarqueeController} from '../Marquee';
 import {validateRange} from '../internal/validators';

--- a/packages/moonstone/RangePicker/RangePicker.js
+++ b/packages/moonstone/RangePicker/RangePicker.js
@@ -9,12 +9,12 @@
  * @exports RangePickerBase
  */
 
-import Changeable from '@enact/ui/Changeable';
-import clamp from 'ramda/src/clamp';
 import kind from '@enact/core/kind';
-import React from 'react';
-import PropTypes from 'prop-types';
+import {clamp} from '@enact/core/util';
+import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {Picker, PickerItem} from '../internal/Picker';
 import {validateRange} from '../internal/validators';

--- a/packages/moonstone/Slider/utils.js
+++ b/packages/moonstone/Slider/utils.js
@@ -1,6 +1,6 @@
-import clamp from 'ramda/src/clamp';
 import {adaptEvent, forKey, forProp, forward, handle, oneOf, preventDefault, stop} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
+import {clamp} from '@enact/core/util';
 import {calcProportion} from '@enact/ui/Slider/utils';
 
 const calcStep = (knobStep, step) => {

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -1,8 +1,7 @@
 import {forward, stopImmediate} from '@enact/core/handle';
-import clamp from 'ramda/src/clamp';
 import equals from 'ramda/src/equals';
 import {is} from '@enact/core/keymap';
-import {cap, Job} from '@enact/core/util';
+import {cap, clamp, Job} from '@enact/core/util';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import platform from '@enact/core/platform';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `min` exceeded `max`, `EditableIntegerPicker`, `Picker`, and `RangePicker` would throw a runtime error from ramda's `clamp` method.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add a `clamp` method to `core/util` that safely clamps values
* Use `core/util.clamp` in the Pickers and Slider (which doesn't currently error but should use the same logic)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The logic used in clamp mirrors the logic used by `<input type="range">` in that it uses `min` as the value when `min` exceeds `max`.
