### PR TITLE
ENYO-5926: Fix overriding default skin variants from Skinnable

### DIFF
--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -146,7 +146,10 @@
 
 	// Skin colors
 	.applySkins({
-		color: @moon-button-text-color;
+		&,
+		:global(.enact-a11y-high-contrast) & {
+			color: @moon-button-text-color;
+		}
 
 		.bg {
 			background-color: @moon-button-bg-color;
@@ -183,8 +186,15 @@
 		}
 
 		.focus({
-			color: @moon-spotlight-text-color;
-			background-color: transparent;
+			// The complexity below overrides the default high-contrast rules and applies
+			// non-high-contrast rules. The precedence for the general rule is too high for the
+			// basic button override rule to take effect, so we must overcome it by stacking more
+			// classes here.
+			&,
+			:global(.enact-a11y-high-contrast) &:not(:global(.highContrast)) {
+				color: @moon-spotlight-text-color;
+				background-color: transparent;
+			}
 
 			.bg {
 				background-color: @moon-spotlight-border-color;

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Skinnable` to allow overriding default `skinVariant` values
 - `ui/Touchable` to prevent events firing on different nodes for the same touch action
 - `ui/Touchable` to neither force focus to components nor blur components after they are touched
 

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -16,7 +16,6 @@ import hoc from '@enact/core/hoc';
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import mergeWith from 'ramda/src/mergeWith';
 
 import {objectify, preferDefined} from './util';
 
@@ -157,8 +156,15 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 		parentVariants = objectify(parentVariants);
 
 		// Merge all of the variants objects, preferring values in objects from left to right.
-		const mergedObj = [authorVariants, defaultVariants, parentVariants].reduce(
-			(obj, a) => mergeWith(preferDefined, obj, a)
+		const mergedObj = [defaultVariants, parentVariants, authorVariants].reduce(
+			(obj, a) => {
+				Object.keys(a).forEach(key => {
+					obj[key] = preferDefined(a[key], obj[key]);
+				});
+
+				return obj;
+			},
+			{}
 		);
 
 		// Clean up the merged object

--- a/packages/ui/Skinnable/tests/Skinnable-specs.js
+++ b/packages/ui/Skinnable/tests/Skinnable-specs.js
@@ -204,7 +204,7 @@ describe('Skinnable Specs', () => {
 
 		const subject = mount(<SkinnableComponent skinVariants="unicase" />);
 
-		const expected = 'darkSkin unicase normal';
+		const expected = 'darkSkin normal unicase';
 		const actual = subject.find('div').prop('className');
 
 		expect(actual).toEqual(expected);
@@ -307,7 +307,7 @@ describe('Skinnable Specs', () => {
 			</SkinnableParent>
 		);
 
-		const expected = 'darkSkin smallCaps normal unicase';
+		const expected = 'darkSkin normal unicase smallCaps';
 		const actual = subject.find('div').last().prop('className');
 
 		expect(actual).toEqual(expected);
@@ -343,4 +343,35 @@ describe('Skinnable Specs', () => {
 		expect(actual).toEqual(expected);
 	});
 
+	test('should inherit an overridden default variant', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			allowedVariants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const Component = (props) => (
+			<div {...props} />
+		);
+
+		const SkinnableParent = Skinnable(config, Component);
+		const SkinnableChild = Skinnable(config, Component);
+
+		const subject = mount(
+			<SkinnableParent>
+				<SkinnableChild skinVariants={{normal: false}}>
+					<SkinnableChild id="innerChild" />
+				</SkinnableChild>
+			</SkinnableParent>
+		);
+
+		const expected = 'darkSkin';
+		const actual = subject.find('div#innerChild').prop('className');
+
+		expect(actual).toEqual(expected);
+	});
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Default `skinVariant` values configured on `Skinnable` are overriding inherited `skinVariant` values from ancestral `Skinnable` instances.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix the merge logic to override default variants with parent variants and parent variants with author variants.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Reordered a couple unit test expected outputs to match the updated the logic.
