### PR TITLE
Feature/plat 76981 roysutton

### DIFF
--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -126,9 +126,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * | `'right top'` | Right of the component, contents at the top |
 			 *
 			 * `TooltipDectorator` attempts to choose the best direction to meet layout and language
-			 * requirements. Left and right directions will reverse for RTL languages and may switch
-			 * if the tooltip would overflow the viewport. Above and below may switch if the tooltip
-			 * would extend past the top or bottom of the viewport.
+			 * requirements. Left and right directions will reverse for RTL languages. Additionally,
+			 * the tooltip will reverse direction if it will prevent overflowing off the viewport
 			 *
 			 * @type {String}
 			 * @default 'above'

--- a/packages/ui/Touchable/ClickAllow.js
+++ b/packages/ui/Touchable/ClickAllow.js
@@ -1,3 +1,5 @@
+import {platform} from '@enact/core/platform';
+
 // It's possible that emitting `onTap` will cause a DOM change before the mousedown fires resulting
 // in multiple tap/click events for the same user action. To avoid this, we store the last touchend
 // target and timestamp to compare against the next mouse down. If the timestamp is different (e.g
@@ -39,7 +41,8 @@ class ClickAllow {
 	shouldAllowMouseEvent (ev) {
 		const {timeStamp} = ev;
 
-		return this.lastTouchEndTime !== timeStamp && shouldAllowMouseDown(ev);
+		// iOS Safari sends both touch and mouse events (with differing timestamps)
+		return !platform.ios && this.lastTouchEndTime !== timeStamp && shouldAllowMouseDown(ev);
 	}
 
 	shouldAllowTap (ev) {

--- a/packages/ui/Touchable/tests/Touchable-specs.js
+++ b/packages/ui/Touchable/tests/Touchable-specs.js
@@ -8,13 +8,8 @@ import Touchable from '../Touchable';
 import {activate, deactivate} from '../state';
 import {configure, getConfig, resetDefaultConfig} from '../config';
 
-jest.mock('@enact/core/platform', () => {
-	return {
-		touch: true
-	};
-});
-
 describe('Touchable', () => {
+
 	const DivComponent = ({children = 'Toggle', id, onClick, onMouseDown, onMouseLeave, onMouseUp, onTouchStart, onTouchEnd}) => {
 		return (
 			<div


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
iOS Safari emits both touch and mouse events, causing doubled processing in `Touchable`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Disable all mouse events when on iOS.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We don't distinguish between Safari and Chrome on iOS. Not sure it matters...
Also, removed mock that added `touch` to platform.  This was not needed and it did not appear correctly mocked, so caused errors.

### Links
[//]: # (Related issues, references)
PLAT-76981

### Comments
