### PR TITLE
PLAT-77150: Fix moonstone to suppress tap highlighting on Android

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
@@ -3,22 +3,15 @@
 
 // Core Rules
 @import "~@enact/ui/styles/core.less";
-@import '~@enact/ui/styles/mixins.less';
+@import "~@enact/ui/styles/mixins.less";
 
 // Moonstone Internal Rules
-@import '../styles/internal/fonts.less';
+@import "../styles/internal/fonts.less";
 
 // Moonstone Rules
 @import "../styles/mixins.less";
 @import "../styles/skin.less";
 @import "../styles/variables.less";
-
-:focus {
-	// Prevent Chrome's default focus treatment
-	outline: none;
-	// Prevent Android Chrome from highlighting tapped elements
-	-webkit-tap-highlight-color: transparent;
-}
 
 .applySkins({
 	color: @moon-text-color;
@@ -85,6 +78,13 @@
 
 	&:global(.enact-locale-right-to-left) {
 		direction: rtl;
+	}
+
+	:focus {
+		// Prevent Chrome's default focus treatment
+		outline: none;
+		// Prevent Android Chrome from highlighting tapped elements
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	// Skin colors

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
@@ -13,9 +13,11 @@
 @import "../styles/skin.less";
 @import "../styles/variables.less";
 
-/* Prevent browser's default focus treatment (at least in Chrome) */
 :focus {
+	// Prevent Chrome's default focus treatment
 	outline: none;
+	// Prevent Android Chrome from highlighting tapped elements
+	-webkit-tap-highlight-color: transparent;
 }
 
 .applySkins({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Android browser adds a tap highlight color to tapped elements and it clashes with Moonstone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Make the tap highlight color be `transparent`.

### Links
[//]: # (Related issues, references)
PLAT-77150
