### PR TITLE
PLAT-77722: Removed logic for restoring the scroll position on focus for old browsers

### DIFF
--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -265,9 +265,6 @@ class ScrollableBaseNative extends Component {
 		vertical: {before: null, after: null}
 	}
 
-	// browser native scrolling
-	resetPosition = null // prevent auto-scroll on focus by Spotlight
-
 	onMouseDown = (ev) => {
 		if (this.props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
@@ -289,20 +286,6 @@ class ScrollableBaseNative extends Component {
 			direction === 'horizontal' && this.uiRef.current.canScrollHorizontally(bounds)
 		) && !this.props['data-spotlight-container-disabled']) {
 			this.childRef.current.setContainerDisabled(true);
-		}
-	}
-
-	onMouseOver = () => {
-		this.resetPosition = this.uiRef.current.childRefCurrent.containerRef.current.scrollTop;
-	}
-
-	onMouseMove = () => {
-		if (this.resetPosition !== null) {
-			const childContainerRef = this.uiRef.current.childRefCurrent.containerRef;
-			childContainerRef.current.style.scrollBehavior = null;
-			childContainerRef.current.scrollTop = this.resetPosition;
-			childContainerRef.current.style.scrollBehavior = 'smooth';
-			this.resetPosition = null;
 		}
 	}
 
@@ -704,8 +687,6 @@ class ScrollableBaseNative extends Component {
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	addEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.addEventListener) {
-			childContainerRef.current.addEventListener('mouseover', this.onMouseOver, {capture: true});
-			childContainerRef.current.addEventListener('mousemove', this.onMouseMove, {capture: true});
 			childContainerRef.current.addEventListener('focusin', this.onFocus);
 			if (platform.webos) {
 				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
@@ -717,8 +698,6 @@ class ScrollableBaseNative extends Component {
 	// FIXME setting event handlers directly to work on the V8 snapshot.
 	removeEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
-			childContainerRef.current.removeEventListener('mouseover', this.onMouseOver, {capture: true});
-			childContainerRef.current.removeEventListener('mousemove', this.onMouseMove, {capture: true});
 			childContainerRef.current.removeEventListener('focusin', this.onFocus);
 			if (platform.webos) {
 				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have a logic to prevent a list or a scroller from unexpected scrolling by focus. But the restoring logic consumes CPU more than expectation on embedded systems.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We are using `{preventScroll: true}` option to focus a node without scrolling already, so simply removed the restoring logic.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This change does not affect any public components, so the changelog is not updated.

### Links
[//]: # (Related issues, references)
PLAT-77722
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Parameters

### Comments
