### PR TITLE
PLAT-76982: Cross-Platform Enact Ipad -Tablet: VKB does not dismiss on tap in blank area

### DIFF
--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.module.less
@@ -72,6 +72,7 @@
 
 .root {
 	.moon-text-base(@moon-sub-header-font-size, self);
+	cursor: pointer;
 	font-weight: normal;
 	font-style: normal;
 	letter-spacing: normal;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On ios, keyboard activity dismissal activity is handled by the developer (see "Dismissing the Keyboard" in https://developer.apple.com/library/archive/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html ).  This means that we need to either listen for touchstart events on non-text input elements after being focused on text input elements, or otherwise blur the focused input.

Having a style `cursor: pointer` causes the focused element to blur when tapping elsewhere, so it will allow the keyboard to dismiss.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It does make the pointer different for browser apps, so this might need to be limited to ios platform somehow.  We could add `[platform]` to the root of `MoonstoneDecorator` instead and put the cursor style in `.root&.ios`.

### Links
[//]: # (Related issues, references)
PLAT-76982