### PR TITLE
PLAT-76982: Cross-Platform Enact Ipad -Tablet: VKB does not dismiss on tap in blank area

### DIFF
--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -34,11 +34,20 @@ const handleTouchStart = handle(
 	setCapturing(true)            // and flag that we've started capturing a down event
 );
 
+const handleTouchEnd = handle(
+	isCapturing,				// if a down event was captured
+	preventDefault,				// prevent the touchend event bubbling
+	stop,						// prevent the touchend event from propagating
+	setCapturing(false),		// clear the capturing flag
+	() => active.blur()			// and blur the active node
+);
+
 // Lock the pointer from emitting click events until released
 const lockPointer = (target) => {
 	active = target;
 	document.addEventListener('mousedown', handlePointerDown, {capture: true});
 	document.addEventListener('mouseup', handlePointerUp, {capture: true});
+	document.addEventListener('touchend', handleTouchEnd, {capture: true});
 	document.addEventListener('touchstart', handleTouchStart, {capture: true});
 	document.addEventListener('click', handlePointerClick, {capture: true});
 };
@@ -49,6 +58,7 @@ const releasePointer = (target) => {
 		active = null;
 		document.removeEventListener('mousedown', handlePointerDown, {capture: true});
 		document.removeEventListener('mouseup', handlePointerUp, {capture: true});
+		document.removeEventListener('touchend', handleTouchEnd, {capture: true});
 		document.removeEventListener('touchstart', handlePointerDown, {capture: true});
 		document.removeEventListener('click', handlePointerClick, {capture: true});
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On ios, keyboard activity dismissal activity is handled by the developer (see "Dismissing the Keyboard" in https://developer.apple.com/library/archive/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html ).  This means that we need to either listen for touchstart events on non-text input elements after being focused on text input elements, or otherwise blur the focused input.

This patch updates `Input` to handle touchend events to blur the active item.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This is an alternative patch for #2218 

### Links
[//]: # (Related issues, references)
PLAT-76982