### PR TITLE
PLAT-77050: Update to check marqueeOn prop behavior with long title header

### DIFF
--- a/packages/sampler/stories/qa/Header.js
+++ b/packages/sampler/stories/qa/Header.js
@@ -5,7 +5,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {mergeComponentMetadata} from '../../src/utils';
-import {boolean, text} from '../../src/enact-knobs';
+import {boolean, select, text} from '../../src/enact-knobs';
 
 Header.displayName = 'Header';
 const Config = mergeComponentMetadata('Header', HeaderBase, Header);
@@ -102,9 +102,10 @@ storiesOf('Header', module)
 		'with long text and headerComponent',
 		() => (
 			<Header
-				title={text('title', Config, 'Title')}
+				title={text('title', Config, 'Title is very very very very very very very long.')}
 				titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
 				subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				marqueeOn={select('marqueeOn', ['', 'hover', 'render'], Header, '')}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -115,9 +116,10 @@ storiesOf('Header', module)
 		() => (
 			<Header
 				type="compact"
-				title={text('title', Config, 'Title')}
+				title={text('title', Config, 'Title is very very very very very very very long.')}
 				titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
 				subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
+				marqueeOn={select('marqueeOn', ['', 'hover', 'render'], Header, '')}
 			>
 				<Button small>On / Off</Button>
 			</Header>

--- a/packages/sampler/stories/qa/Header.js
+++ b/packages/sampler/stories/qa/Header.js
@@ -105,7 +105,7 @@ storiesOf('Header', module)
 				title={text('title', Config, 'Title is very very very very very very very long.')}
 				titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
 				subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				marqueeOn={select('marqueeOn', ['', 'hover', 'render'], Header, '')}
+				marqueeOn={select('marqueeOn', ['hover', 'render'], Config)}
 			>
 				<Button small>On / Off</Button>
 			</Header>
@@ -119,7 +119,7 @@ storiesOf('Header', module)
 				title={text('title', Config, 'Title is very very very very very very very long.')}
 				titleBelow={text('titleBelow', Config, 'This is a header sample with long titleBelow text and header components to test positioning of header components.')}
 				subTitleBelow={text('subTitleBelow', Config, 'This is a header sample with long titleBelow, subTitleBelow text and header components to test positioning of header components.')}
-				marqueeOn={select('marqueeOn', ['', 'hover', 'render'], Header, '')}
+				marqueeOn={select('marqueeOn', ['hover', 'render'], Config)}
 			>
 				<Button small>On / Off</Button>
 			</Header>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixed to check whether marquee is flowing without touch or hover on cross-platform(iOS, Android) when the title of header component is long.


### Resolution
[qa-sampler] Added selector of marqueeOn prop to header sample to make it possible to test marquee with long title.


### Additional Considerations
