### PR TITLE
PLAT-77739: [sampler, qa-sampler] Add css to prevent features that interfere with iOS, Android testing

### DIFF
--- a/packages/sampler/.qa-storybook/addons.js
+++ b/packages/sampler/.qa-storybook/addons.js
@@ -1,1 +1,2 @@
 import '../src/addons';
+import '../src/global.module.less';

--- a/packages/sampler/.storybook/addons.js
+++ b/packages/sampler/.storybook/addons.js
@@ -1,1 +1,2 @@
 import '../src/addons';
+import '../src/global.module.less';

--- a/packages/sampler/src/global.module.less
+++ b/packages/sampler/src/global.module.less
@@ -1,0 +1,6 @@
+body {
+	position: fixed;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
During cross-platform testing, the basic functionality of iOS safari and android chrome apps hinders testing.
iOS safari: When I try to scroll something in the sample, the entire viewport is moved, which interferes with the test.
Android chrome: When I try to scroll something downward, the page reloads with the reload icon, which interferes with the test.
- This issue is caused by the height of the samples being rendered larger than the viewport.

### Resolution
Add CSS to prevent sampler and qa-sampler apps from scrolling by placing CSS in the app body
- I changed samples to render to the viewport size, added CSS to disable the ios viewport movement and the android reload feature.

Code of css to prevent iOS viewport from being scrolled
`
body {
position: fixed;
width: 100%;
height: 100%;
}
`
Code of css that disable Android reload feature
`
body {
overflow: hidden;
}
`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)