### PR TITLE
PLAT-77904: Fix flick action only for Safari browser on iOS

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1286,7 +1286,6 @@ class ScrollableBase extends Component {
 			childWrapperProps = {
 				className: css.content,
 				...(!noScrollByDrag && {
-					className: css.content,
 					onDrag: this.onDrag,
 					onDragEnd: this.onDragEnd,
 					onDragStart: this.onDragStart,

--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -35,4 +35,8 @@
 		overflow: hidden;
 		flex: 1 1 100%;
 	}
+
+	.contentNative {
+		-webkit-overflow-scrolling: touch;
+	}
 }

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1279,11 +1279,11 @@ class ScrollableBaseNative extends Component {
 			{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			scrollableClasses = classNames(css.scrollable, className),
+			contentClasses = classNames(css.content, css.contentNative),
 			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
 			childWrapperProps = {
-				className: css.content,
+				className: contentClasses,
 				...(!noScrollByDrag && {
-					className: css.content,
 					onDrag: this.onDrag,
 					onDragEnd: this.onDragEnd,
 					onDragStart: this.onDragStart,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A flick gesture does not work smoothly on iOS

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `-webkit-overflow-scrolling: touch` which is non-standard CSS property used only for Safari iOS for 'ui/ScrollableNative' to scroll smoothly.

### Links
[//]: # (Related issues, references)
PLAT-77904
https://developer.mozilla.org/ko/docs/Web/CSS/-webkit-overflow-scrolling