### PR TITLE
PLAT-76982: Fix spotlight to unspot when tapping on a non-spottable target

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to unspot the current element when tapping on non-spottable target on touch platforms
+
 ## [2.5.2] - 2019-04-23
 
 No significant changes.

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -504,6 +504,13 @@ const Spotlight = (function () {
 		}
 	}
 
+	function onTouchEnd (evt) {
+		const current = getCurrent();
+		if (current && !current.contains(evt.target)) {
+			current.blur();
+		}
+	}
+
 	/*
 	 * public methods
 	 */
@@ -524,10 +531,16 @@ const Spotlight = (function () {
 				window.addEventListener('keyup', onKeyUp);
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
+
+				if (platform.touch) {
+					window.addEventListener('touchend', onTouchEnd);
+				}
+
 				if (platform.webos) {
 					window.top.document.addEventListener('webOSMouse', handleWebOSMouseEvent);
 					window.top.document.addEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);
 				}
+
 				setLastContainer(rootContainerId);
 				configureDefaults(containerDefaults);
 				configureContainer(rootContainerId);

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -563,6 +563,11 @@ const Spotlight = (function () {
 			window.removeEventListener('keyup', onKeyUp);
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
+
+			if (platform.touch) {
+				window.removeEventListener('touchend', onTouchEnd);
+			}
+
 			if (platform.webos) {
 				window.top.document.removeEventListener('webOSMouse', handleWebOSMouseEvent);
 				window.top.document.removeEventListener('keyboardStateChange', handleKeyboardStateChangeEvent);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On iOS, tapping non-spottable targets when another element is focused will not remove focus from it. Tapping on another focusable element will move focus to the new target.

Appears that when tapping a focusable element, iOS emits `mouseover` events triggering spotlight logic but it does not do so on non-focusable elements.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add a `touchend` handler in spotlight for touch platforms to blur the currently focused element if it doesn't contain the target of the touch event.