### PR TITLE
PLAT-77171: VirtualList and VirtualGridList CSS changes to avoid iOS render issues

### DIFF
--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -15,7 +15,9 @@
 	.listItem {
 		overflow: hidden;
 		width: 100%;
+	}
 
+	.willChange {
 		will-change: transform;
 	}
 }

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import equals from 'ramda/src/equals';
+import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -580,7 +581,8 @@ const VirtualListBaseFactory = (type) => {
 		// JS only
 		setScrollPosition (x, y, rtl = this.props.rtl) {
 			if (this.contentRef.current) {
-				this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
+				this.contentRef.current.style.transform =
+					platform.ios ? `translate(${rtl ? x : -x}px, -${y}px)` : `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
 				this.didScroll(x, y);
 			}
 		}
@@ -640,7 +642,7 @@ const VirtualListBaseFactory = (type) => {
 				style = {
 					position: 'absolute',
 					/* FIXME: RTL / this calculation only works for Chrome */
-					transform: `translate3d(${this.props.rtl ? -x : x}px, ${y}px, 0)`
+					transform: platform.ios ? `translate(${this.props.rtl ? -x : x}px, ${y}px)` : `translate3d(${this.props.rtl ? -x : x}px, ${y}px, 0)`
 				};
 
 			if (this.isItemSized) {
@@ -664,7 +666,7 @@ const VirtualListBaseFactory = (type) => {
 
 			this.cc[key] = React.cloneElement(itemElement, {
 				...componentProps,
-				className: classNames(css.listItem, itemElement.props.className),
+				className: classNames(css.listItem, itemElement.props.className, platform.ios ? null : css.willChange),
 				style: {...itemElement.props.style, ...(this.composeStyle(...rest))}
 			});
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
**In iOS safari only**, when I touch items of VirtualList and VirtualGridList (Also includes native components) there are two or three spotlights.


### Resolution
For iOS safari, translate3D and will-change CSS will cause issues with multiple spotlights.
So I changed translate3D to translate and removed will-change CSS when the platform is iOS.

### Additional Considerations
Scrolling performance has not been verified in iOS safari due to changes in these CSS entries.