### PR TITLE
PLAT-76988: Add noScrollByWheel to prevent scrolling on wheel events

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -38,6 +38,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
+- `moonstone/Input` refocusing on touch on iOS
+- `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to change spotlight focus due to touch events
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
 
 ## [2.5.2] - 2019-04-23

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -34,21 +34,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Deprecated
 
 - `moonstone/Input.InputBase` prop `focused` which will be handled by CSS in 3.0
-- `small` prop in `moonstone/Input` and `moonstone/ToggleButton`, which will be replaced by `size="small"` in 3.0
-
-### Added
-
-- `moonstone/Input` and `moonstone/ToggleButton` prop `size`
-- `moonstone/Button`, `moonstone/IconButton`, and `moonstone/LabeledIconButton` public class name `large` to support customizing the style for the new `size` prop on `ui/Button`
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` prop `noScrollByWheel` for preventing scroll by wheel
 
 ### Fixed
 
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
-- `moonstone/Input` refocusing on touch on iOS
-- `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to change spotlight focus due to touch events
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -34,6 +34,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Deprecated
 
 - `moonstone/Input.InputBase` prop `focused` which will be handled by CSS in 3.0
+- `small` prop in `moonstone/Input` and `moonstone/ToggleButton`, which will be replaced by `size="small"` in 3.0
+
+### Added
+
+- `moonstone/Input` and `moonstone/ToggleButton` prop `size`
+- `moonstone/Button`, `moonstone/IconButton`, and `moonstone/LabeledIconButton` public class name `large` to support customizing the style for the new `size` prop on `ui/Button`
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` prop `noScrollByWheel` for preventing scroll by wheel
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -38,6 +38,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -142,7 +142,7 @@ class ScrollableBaseNative extends Component {
 		 * @default false
 		 * @private
 		 */
-		noScrollHorizontalByWheel: PropTypes.bool,
+		noScrollByWheel: PropTypes.bool,
 
 		/**
 		 * Specifies overscroll effects shows on which type of inputs.
@@ -206,7 +206,7 @@ class ScrollableBaseNative extends Component {
 		'data-spotlight-container-disabled': false,
 		animate: false,
 		focusableScrollbar: false,
-		noScrollHorizontalByWheel: false,
+		noScrollByWheel: false,
 		overscrollEffectOn: {
 			arrowKey: false,
 			drag: false,
@@ -353,7 +353,7 @@ class ScrollableBaseNative extends Component {
 				}
 				needToHideThumb = true;
 			}
-		} else if (canScrollHorizontally && !this.props.noScrollHorizontalByWheel) { // this routine handles wheel events on any children for horizontal scroll.
+		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 			if (eventDelta < 0 && this.uiRef.current.scrollLeft > 0 || eventDelta > 0 && this.uiRef.current.scrollLeft < bounds.maxLeft) {
 				if (!this.isWheeling) {
 					if (!this.props['data-spotlight-container-disabled']) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -136,6 +136,15 @@ class ScrollableBaseNative extends Component {
 		focusableScrollbar: PropTypes.bool,
 
 		/**
+		 * Prevents scroll by wheeling on the list or the scroller.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		noScrollHorizontalByWheel: PropTypes.bool,
+
+		/**
 		 * Specifies overscroll effects shows on which type of inputs.
 		 *
 		 * @type {Object}
@@ -197,6 +206,7 @@ class ScrollableBaseNative extends Component {
 		'data-spotlight-container-disabled': false,
 		animate: false,
 		focusableScrollbar: false,
+		noScrollHorizontalByWheel: false,
 		overscrollEffectOn: {
 			arrowKey: false,
 			drag: false,
@@ -330,16 +340,20 @@ class ScrollableBaseNative extends Component {
 					(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(ev.target))) {
 					delta = this.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
+
+					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
 					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 				}
+
+				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (eventDelta < 0 && this.uiRef.current.scrollTop <= 0 || eventDelta > 0 && this.uiRef.current.scrollTop >= bounds.maxTop)) {
 					this.uiRef.current.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
 			}
-		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
+		} else if (canScrollHorizontally && !this.props.noScrollHorizontalByWheel) { // this routine handles wheel events on any children for horizontal scroll.
 			if (eventDelta < 0 && this.uiRef.current.scrollLeft > 0 || eventDelta > 0 && this.uiRef.current.scrollLeft < bounds.maxLeft) {
 				if (!this.isWheeling) {
 					if (!this.props['data-spotlight-container-disabled']) {
@@ -349,6 +363,9 @@ class ScrollableBaseNative extends Component {
 				}
 				delta = this.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				needToHideThumb = !delta;
+
+				ev.preventDefault();
+				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (eventDelta < 0 && this.uiRef.current.scrollLeft <= 0 || eventDelta > 0 && this.uiRef.current.scrollLeft >= bounds.maxLeft)) {
 					this.uiRef.current.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -140,7 +140,7 @@ class ScrollableBaseNative extends Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		noScrollByWheel: PropTypes.bool,
 

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -360,65 +360,68 @@ storiesOf('Scroller', module)
 	)
 	.add(
 		'With Nested Scroller',
-		() => (
-			<Scroller
-				direction="vertical"
-				verticalScrollbar="visible"
-			>
+		() => {
+			let noScrollByWheel = boolean('noScrollByWheel', Scroller, false);
+			return (
 				<Scroller
-					direction="horizontal"
-					horizontalScrollbar="visible"
-					noScrollByWheel={boolean('noScrollByWheel', Scroller, false)}
-					style={{
-						height: 'auto',
-						width: '90%'
-					}}
+					direction="vertical"
+					verticalScrollbar="visible"
 				>
-					<div
+					<Scroller
+						direction="horizontal"
+						horizontalScrollbar="visible"
+						noScrollByWheel={noScrollByWheel}
 						style={{
-							backgroundColor: '#444',
-							width: ri.unit(2400, 'rem')
+							height: 'auto',
+							width: '90%'
 						}}
 					>
-						<Item>The first nested scroller.</Item>
-						<br />
-						<br />
-						<Item>This is the upper horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
-						<br />
-						<br />
-						<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
-						<br />
-						<br />
-						<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
-					</div>
-				</Scroller>
-				<Scroller
-					direction="horizontal"
-					horizontalScrollbar="visible"
-					noScrollByWheel={boolean('noScrollByWheel', Scroller, false)}
-					style={{
-						height: 'auto',
-						width: '90%'
-					}}
-				>
-					<div
+						<div
+							style={{
+								backgroundColor: '#444',
+								width: ri.unit(2400, 'rem')
+							}}
+						>
+							<Item>The first nested scroller.</Item>
+							<br />
+							<br />
+							<Item>This is the upper horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
+							<br />
+							<br />
+							<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
+							<br />
+							<br />
+							<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
+						</div>
+					</Scroller>
+					<Scroller
+						direction="horizontal"
+						horizontalScrollbar="visible"
+						noScrollByWheel={noScrollByWheel}
 						style={{
-							backgroundColor: '#444',
-							width: ri.unit(2400, 'rem')
+							height: 'auto',
+							width: '90%'
 						}}
 					>
-						<Item>The second nested scroller.</Item>
-						<br />
-						<br />
-						<Item>This is the lower horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
-						<br />
-						<br />
-						<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
-						<br />
-						<br />
-						<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
-					</div>
+						<div
+							style={{
+								backgroundColor: '#444',
+								width: ri.unit(2400, 'rem')
+							}}
+						>
+							<Item>The second nested scroller.</Item>
+							<br />
+							<br />
+							<Item>This is the lower horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
+							<br />
+							<br />
+							<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
+							<br />
+							<br />
+							<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
+						</div>
+					</Scroller>
 				</Scroller>
-			</Scroller>
-		)
+			);
+		}
 	);

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -357,4 +357,68 @@ storiesOf('Scroller', module)
 				</ExpandableList>
 			</Scroller>
 		)
+	)
+	.add(
+		'With Nested Scroller',
+		() => (
+			<Scroller
+				direction="vertical"
+				verticalScrollbar="visible"
+			>
+				<Scroller
+					direction="horizontal"
+					horizontalScrollbar="visible"
+					noScrollByWheel={boolean('noScrollByWheel', Scroller, false)}
+					style={{
+						height: 'auto',
+						width: '90%'
+					}}
+				>
+					<div
+						style={{
+							backgroundColor: '#444',
+							width: ri.unit(2400, 'rem')
+						}}
+					>
+						<Item>The first nested scroller.</Item>
+						<br />
+						<br />
+						<Item>This is the upper horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
+						<br />
+						<br />
+						<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
+						<br />
+						<br />
+						<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
+					</div>
+				</Scroller>
+				<Scroller
+					direction="horizontal"
+					horizontalScrollbar="visible"
+					noScrollByWheel={boolean('noScrollByWheel', Scroller, false)}
+					style={{
+						height: 'auto',
+						width: '90%'
+					}}
+				>
+					<div
+						style={{
+							backgroundColor: '#444',
+							width: ri.unit(2400, 'rem')
+						}}
+					>
+						<Item>The second nested scroller.</Item>
+						<br />
+						<br />
+						<Item>This is the lower horizontal scroller. If noScrollByWheel is not specified, this scroller will be scrolled by wheel and the outer scroller will not be scrolled.</Item>
+						<br />
+						<br />
+						<Item>If noScrollByWheel is specified, this scroller will NOT be scrolled by wheel but the outer scroller will be scrolled.</Item>
+						<br />
+						<br />
+						<Item>To set or unset noScrollByWheel prop, click KNOBS below.</Item>
+					</div>
+				</Scroller>
+			</Scroller>
+		)
 	);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 - `ui/Button` public class `.hasIcon` which is present on the root node only when an icon has been provided
 
 ## [2.5.2] - 2019-04-23
+- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` prop `noScrollByWheel` for preventing scroll by wheel
 
 ### Fixed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,25 +8,11 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Measurable` HOC and Hook for quick and convenient measuring of simple components
 - `ui/Button` public class `.hasIcon` which is present on the root node only when an icon has been provided
-
-## [2.5.2] - 2019-04-23
 - `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` prop `noScrollByWheel` for preventing scroll by wheel
 
 ### Fixed
 
 - `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
-
-### Deprecated
-
-- `small` prop in `ui/Button.ButtonBase`, `ui/Icon.IconBase`, `ui/IconButton.IconButtonBase`, and `ui/LabeledIcon.LabeledIconBase`, which will be replaced by `size="small"` in 3.0
-
-### Added
-
-- `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` prop `size`
-
-### Fixed
-
-- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to size properly
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,6 +13,12 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
+
+## [2.5.2] - 2019-04-23
+
+### Fixed
+
 - `ui/Skinnable` to allow overriding default `skinVariant` values
 - `ui/Touchable` to prevent events firing on different nodes for the same touch action
 - `ui/Touchable` to neither force focus to components nor blur components after they are touched

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,18 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` not to scroll by wheel at the same time when multiple lists/scrollers are nested
 
+### Deprecated
+
+- `small` prop in `ui/Button.ButtonBase`, `ui/Icon.IconBase`, `ui/IconButton.IconButtonBase`, and `ui/LabeledIcon.LabeledIconBase`, which will be replaced by `size="small"` in 3.0
+
+### Added
+
+- `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` prop `size`
+
+### Fixed
+
+- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to size properly
+
 ## [2.5.2] - 2019-04-23
 
 ### Fixed

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -203,7 +203,7 @@ class ScrollableBase extends Component {
 		 * @default false
 		 * @private
 		 */
-		noScrollHorizontalByWheel: PropTypes.bool,
+		noScrollByWheel: PropTypes.bool,
 
 		/**
 		 * Called when flicking with a mouse or a touch screen.
@@ -390,7 +390,7 @@ class ScrollableBase extends Component {
 		horizontalScrollbar: 'auto',
 		noAnimation: false,
 		noScrollByDrag: false,
-		noScrollHorizontalByWheel: false,
+		noScrollByWheel: false,
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
@@ -672,9 +672,13 @@ class ScrollableBase extends Component {
 
 			this.lastInputType = 'wheel';
 
+			if (this.props.noScrollByWheel) {
+				return;
+			}
+
 			if (canScrollVertically) {
 				delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
-			} else if (canScrollHorizontally && !this.props.noScrollHorizontalByWheel) {
+			} else if (canScrollHorizontally) {
 				delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 			}
 
@@ -1314,7 +1318,7 @@ class ScrollableBase extends Component {
 		delete rest.clearOverscrollEffect;
 		delete rest.horizontalScrollbar;
 		delete rest.noAnimation;
-		delete rest.noScrollHorizontalByWheel;
+		delete rest.noScrollByWheel;
 		delete rest.onFlick;
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -197,6 +197,15 @@ class ScrollableBase extends Component {
 		noScrollByDrag: PropTypes.bool,
 
 		/**
+		 * Prevents scroll by wheeling on the list or the scroller.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		noScrollHorizontalByWheel: PropTypes.bool,
+
+		/**
 		 * Called when flicking with a mouse or a touch screen.
 		 *
 		 * @type {Function}
@@ -381,6 +390,7 @@ class ScrollableBase extends Component {
 		horizontalScrollbar: 'auto',
 		noAnimation: false,
 		noScrollByDrag: false,
+		noScrollHorizontalByWheel: false,
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
@@ -645,9 +655,10 @@ class ScrollableBase extends Component {
 	}
 
 	onWheel = (ev) => {
-		ev.preventDefault();
-
-		if (!this.isDragging) {
+		if (this.isDragging) {
+			ev.preventDefault();
+			ev.stopPropagation();
+		} else {
 			const
 				{verticalScrollbarRef, horizontalScrollbarRef} = this,
 				bounds = this.getScrollBounds(),
@@ -663,7 +674,7 @@ class ScrollableBase extends Component {
 
 			if (canScrollVertically) {
 				delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
-			} else if (canScrollHorizontally) {
+			} else if (canScrollHorizontally && !this.props.noScrollHorizontalByWheel) {
 				delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 			}
 
@@ -678,6 +689,8 @@ class ScrollableBase extends Component {
 
 			if (delta !== 0) {
 				this.scrollToAccumulatedTarget(delta, canScrollVertically, this.props.overscrollEffectOn.wheel);
+				ev.preventDefault();
+				ev.stopPropagation();
 			}
 		}
 	}
@@ -1301,6 +1314,7 @@ class ScrollableBase extends Component {
 		delete rest.clearOverscrollEffect;
 		delete rest.horizontalScrollbar;
 		delete rest.noAnimation;
+		delete rest.noScrollHorizontalByWheel;
 		delete rest.onFlick;
 		delete rest.onKeyDown;
 		delete rest.onMouseDown;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -201,7 +201,7 @@ class ScrollableBase extends Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		noScrollByWheel: PropTypes.bool,
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -186,7 +186,7 @@ class ScrollableBaseNative extends Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		noScrollByWheel: PropTypes.bool,
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -188,7 +188,7 @@ class ScrollableBaseNative extends Component {
 		 * @default false
 		 * @private
 		 */
-		noScrollHorizontalByWheel: PropTypes.bool,
+		noScrollByWheel: PropTypes.bool,
 
 		/**
 		 * Called when flicking with a mouse or a touch screen.
@@ -375,7 +375,7 @@ class ScrollableBaseNative extends Component {
 		horizontalScrollbar: 'auto',
 		noAnimation: false,
 		noScrollByDrag: false,
-		noScrollHorizontalByWheel: false,
+		noScrollByWheel: false,
 		onScroll: nop,
 		onScrollStart: nop,
 		onScrollStop: nop,
@@ -664,6 +664,14 @@ class ScrollableBaseNative extends Component {
 
 			this.lastInputType = 'wheel';
 
+			if (this.props.noScrollByWheel) {
+				if (canScrollVertically) {
+					ev.preventDefault();
+				}
+
+				return;
+			}
+
 			if (this.props.onWheel) {
 				forward('onWheel', ev, this.props);
 				return;
@@ -695,7 +703,7 @@ class ScrollableBaseNative extends Component {
 					}
 					needToHideThumb = true;
 				}
-			} else if (canScrollHorizontally && !this.props.noScrollHorizontalByWheel) { // this routine handles wheel events on any children for horizontal scroll.
+			} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 				if (eventDelta < 0 && this.scrollLeft > 0 || eventDelta > 0 && this.scrollLeft < bounds.maxLeft) {
 					delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
@@ -1311,7 +1319,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.clearOverscrollEffect;
 		delete rest.horizontalScrollbar;
 		delete rest.noAnimation;
-		delete rest.noScrollHorizontalByWheel;
+		delete rest.noScrollByWheel;
 		delete rest.onFlick;
 		delete rest.onMouseDown;
 		delete rest.onScroll;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a scroller/list is inside another scroller/list, wheel input invokes scrolling on both scrollers.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fixed a scroller/list to consume the wheel input when it scrolls on the input. If it does not scroll since it already reached to the edge on the direction, then the outer scroller/list can scroll by the wheel input.
- Added a prop `noScrollHorizontalByWheel` to disable horizontal scrolling by wheel which may be useful to disable the inner scroller for UX reasons

### Links
[//]: # (Related issues, references)
PLAT-76988
