### PR TITLE
PLAT-77054: Change components to allow disabled components to be focusable

### DIFF
--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -114,6 +114,7 @@
 
 	.client {
 		padding: @moon-button-border-width;	// We match the amount removed by the line-height above, so the text doesn't overlap the border
+		border-radius: inherit;
 	}
 
 	.icon {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button` and `moonstone/Panels.Header` prop `casing` which is no longer supported
 - `moonstone/Input.InputBase` prop `focused` which was used to indicate when the internal input field had focused but was replaced by the `:focus-within` pseudo-selector
+- `moonstone/VirtualList` and `moonstone/VirtualList.VirtualGridList` property `isItemDisabled`
 
 ### Changed
 

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -128,6 +128,7 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 
 		handleKeyDown = (ev) => {
 			const keyCode = ev.keyCode;
+			if (this.props.disabled) return;
 			if ((is('enter', keyCode) && !this.state.isActive) || (is('numSet', keyCode) && !this.state.isActive) || (is('plus', keyCode) || is('minus', keyCode))) {
 				this.prepareInput();
 			} else if (this.state.isActive && (is('enter', keyCode) || is('cancel', keyCode) || is('up', keyCode) || is('down', keyCode))) {

--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -397,7 +397,7 @@ const ExpandableItemBase = kind({
 				aria-disabled={disabled}
 				disabled={disabled}
 				ref={setContainerNode}
-				spotlightDisabled={spotlightDisabled || disabled}
+				spotlightDisabled={spotlightDisabled}
 			>
 				<LabeledItem
 					{...ariaProps}

--- a/packages/moonstone/ExpandableItem/ExpandableItem.module.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.module.less
@@ -1,6 +1,6 @@
 // ExpandableItem.module.less
 //
-@import '../styles/variables.less';
+@import "../styles/variables.less";
 @import "../styles/mixins.less";
 
 .expandableItem {
@@ -44,4 +44,8 @@
 			}
 		}
 	}
+
+	.disabled({
+		opacity: 1;
+	});
 }

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -162,6 +162,10 @@
 		.disabled({
 			.vendor-opacity(@moon-input-disabled-opacity);
 
+			.focus({
+				.vendor-opacity(@moon-input-disabled-opacity);
+			});
+
 			.input,
 			.decoratorIcon {
 				color: @moon-input-text-disabled-color;

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -146,7 +146,7 @@
 		.focus({
 			background-color: @moon-input-decorator-focus-bg-color;
 			color: @moon-input-text-color;
-			box-shadow: 0px 0px 0px @moon-input-border-outline-width @moon-input-border-active-outline-color;
+			box-shadow: @moon-input-border-active-shadow;
 
 			.input {
 				.input-placeholder({

--- a/packages/moonstone/LabeledItem/LabeledItem.module.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.module.less
@@ -1,8 +1,8 @@
 // LabeledItem.module.less
 //
-@import '../styles/mixins.less';
-@import '../styles/variables.less';
-@import '../styles/skin.less';
+@import "../styles/mixins.less";
+@import "../styles/variables.less";
+@import "../styles/skin.less";
 
 .labeledItem {
 	//// Locally scoped LESS variables ////
@@ -77,6 +77,10 @@
 			.label {
 				color: inherit;
 			}
+		});
+
+		.disabled({
+			opacity: @moon-disabled-opacity;
 		});
 	});
 }

--- a/packages/moonstone/MediaOverlay/MediaOverlay.module.less
+++ b/packages/moonstone/MediaOverlay/MediaOverlay.module.less
@@ -1,6 +1,6 @@
-@import '../styles/skin.less';
-@import '../styles/variables.less';
-@import '../styles/mixins.less';
+@import "../styles/mixins.less";
+@import "../styles/variables.less";
+@import "../styles/skin.less";
 
 .mediaOverlay {
 	display: block;
@@ -23,7 +23,7 @@
 	}
 
 	.textLayout {
-		margin: @moon-mediaoverlay-spotlight-outset-width * 2;
+		margin: (@moon-mediaoverlay-spotlight-outset-width * 2);
 	}
 
 	.image {
@@ -35,4 +35,22 @@
 	.text {
 		font-weight: @moon-mediaoverlay-font-weight;
 	}
+
+	.applySkins({
+		.disabled({
+			// The global disabled rule handles the non-focused state, so no rules are necessary here.
+
+			.focus({
+				opacity: @moon-disabled-opacity;
+
+				.media,
+				.image,
+				.textLayout {
+					// We're setting the parent's opacity, so we need to "unset" the children,
+					// so they don't get double-set, becoming more transparent than our intent.
+					opacity: 1;
+				}
+			});
+		});
+	});
 }

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -235,6 +235,7 @@ const SliderBase = kind({
 			forward('onActivate')
 		),
 		onKeyDown: handle(
+			forProp('disabled', false),
 			forwardWithPrevent('onKeyDown'),
 			anyPass([
 				handleIncrement,
@@ -242,6 +243,7 @@ const SliderBase = kind({
 			])
 		),
 		onKeyUp: handle(
+			forProp('disabled', false),
 			forwardWithPrevent('onKeyUp'),
 			forProp('activateOnFocus', false),
 			forKey('enter'),

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -1,10 +1,13 @@
 // Slider.module.less
 //
-@import '../styles/mixins.less';
-@import '../styles/variables.less';
-@import '../styles/skin.less';
+@import "../styles/mixins.less";
+@import "../styles/variables.less";
+@import "../styles/skin.less";
 
 .slider {
+	@knob-transform-resting: @moon-translate-center scale(@moon-slider-knob-resting-state-scale);
+	@knob-transform-active: @moon-translate-center scale(1);
+
 	position: relative;
 	margin: 0 @moon-spotlight-outset;
 	// Set both the V and H sizes here, so they can be easily overridden, both internally below and by component consumers.
@@ -30,9 +33,7 @@
 			position: absolute;
 			height: @moon-slider-knob-height;
 			width: @moon-slider-knob-width;
-			// Vertically and horizontally center this knob.
-			// Using this method rather than -top -left so the knob is more intuitively customizable.
-			transform: @moon-translate-center scale(@moon-slider-knob-resting-state-scale);
+			transform: @knob-transform-resting;
 			border-radius: (@moon-slider-knob-height / 2);
 			border: @moon-button-border-width solid transparent;
 			box-sizing: border-box;
@@ -106,15 +107,23 @@
 			}
 		}
 
-		&:not([disabled]) {
+		&.pressed,
+		&:focus.activateOnFocus,
+		&:focus.active {
+			.knob::before {
+				transform: @knob-transform-active;
+			}
+		}
+
+		.disabled({
 			&.pressed,
 			&:focus.activateOnFocus,
 			&:focus.active {
 				.knob::before {
-					transform: @moon-translate-center scale(1);
+					transform: @knob-transform-resting;
 				}
 			}
-		}
+		});
 	});
 
 	.applySkins({

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -106,11 +106,13 @@
 			}
 		}
 
-		&.pressed,
-		&:focus.activateOnFocus,
-		&:focus.active {
-			.knob::before {
-				transform: @moon-translate-center scale(1);
+		&:not([disabled]) {
+			&.pressed,
+			&:focus.activateOnFocus,
+			&:focus.active {
+				.knob::before {
+					transform: @moon-translate-center scale(1);
+				}
 			}
 		}
 	});

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -319,9 +319,7 @@ const VirtualListBaseFactory = (type) => {
 		findSpottableItem = (indexFrom, indexTo) => {
 			const
 				{dataSize} = this.props,
-				safeIndexFrom = clamp(0, dataSize - 1, indexFrom),
-				safeIndexTo = clamp(-1, dataSize, indexTo),
-				delta = (indexFrom < indexTo) ? 1 : -1;
+				safeIndexFrom = clamp(0, dataSize - 1, indexFrom);
 
 			if (indexFrom < 0 && indexTo < 0 || indexFrom >= dataSize && indexTo >= dataSize) {
 				return -1;

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -596,7 +596,7 @@ const PickerBase = class extends React.Component {
 		const {keyCode} = ev;
 		forwardKeyDown(ev, this.props);
 
-		if (joined) {
+		if (joined && !this.props.disabled) {
 			const direction = getDirection(keyCode);
 
 			const directions = {
@@ -631,7 +631,7 @@ const PickerBase = class extends React.Component {
 		const {keyCode} = ev;
 		forwardKeyUp(ev, this.props);
 
-		if (joined) {
+		if (joined && !this.props.disabled) {
 			const isVertical = orientation === 'vertical' && (isUp(keyCode) || isDown(keyCode));
 			const isHorizontal = orientation === 'horizontal' && (isRight(keyCode) || isLeft(keyCode));
 

--- a/packages/moonstone/internal/Picker/Picker.module.less
+++ b/packages/moonstone/internal/Picker/Picker.module.less
@@ -69,10 +69,14 @@
 	}
 
 	&.joined {
+		@joined-arrow-transform-resting: scale(0.7);
+		@joined-arrow-transform-focus: scale(0.95);
+		@joined-arrow-transform-active: @joined-arrow-transform-resting;
+
 		&::before {
 			.position(0);
 
-			content: '';
+			content: "";
 			display: block;
 			position: absolute;
 			border-width: 0;
@@ -92,7 +96,7 @@
 		.incrementer,
 		.decrementer {
 			will-change: transform;
-			transform: scale(0.7);
+			transform: @joined-arrow-transform-resting;
 
 			&.hidden {
 				visibility: hidden;
@@ -100,17 +104,22 @@
 		}
 
 		.focus({
-			&:not([disabled]) {
+			.incrementer,
+			.decrementer {
+				transform: @joined-arrow-transform-focus;
+			}
+
+			&.incrementing .incrementer,
+			&.decrementing .decrementer {
+				transform: @joined-arrow-transform-active;
+			}
+
+			.disabled({
 				.incrementer,
 				.decrementer {
-					transform: scale(0.95);
+					transform: @joined-arrow-transform-resting;
 				}
-
-				&.incrementing .incrementer,
-				&.decrementing .decrementer {
-					transform: scale(0.7);
-				}
-			}
+			});
 		});
 
 		&.horizontal {

--- a/packages/moonstone/internal/Picker/Picker.module.less
+++ b/packages/moonstone/internal/Picker/Picker.module.less
@@ -198,8 +198,12 @@
 			}
 
 			.focus({
-				background-color: @moon-spotlight-border-color;
+				background-color: @moon-picker-joined-focused-bg-color;
 				color: @moon-spotlight-text-color;
+
+				.disabled({
+					color: @moon-spotlight-disabled-text-color;
+				});
 			});
 		}
 	});

--- a/packages/moonstone/internal/Picker/Picker.module.less
+++ b/packages/moonstone/internal/Picker/Picker.module.less
@@ -100,14 +100,16 @@
 		}
 
 		.focus({
-			.incrementer,
-			.decrementer {
-				transform: scale(0.95);
-			}
+			&:not([disabled]) {
+				.incrementer,
+				.decrementer {
+					transform: scale(0.95);
+				}
 
-			&.incrementing .incrementer,
-			&.decrementing .decrementer {
-				transform: scale(0.7);
+				&.incrementing .incrementer,
+				&.decrementing .decrementer {
+					transform: scale(0.7);
+				}
 			}
 		});
 

--- a/packages/moonstone/internal/Picker/SpottablePicker.js
+++ b/packages/moonstone/internal/Picker/SpottablePicker.js
@@ -15,11 +15,9 @@ const SpottablePicker = kind({
 
 	computed: {
 		selectionKeys: ({disabled, orientation}) => {
-			if (disabled) {
-				return void 0;
-			} else {
-				return orientation === 'horizontal' ? [37, 39] : [38, 40];
-			}
+			if (disabled) return;
+
+			return orientation === 'horizontal' ? [37, 39] : [38, 40];
 		}
 	},
 

--- a/packages/moonstone/internal/Picker/SpottablePicker.js
+++ b/packages/moonstone/internal/Picker/SpottablePicker.js
@@ -13,7 +13,13 @@ const SpottablePicker = kind({
 	},
 
 	computed: {
-		selectionKeys: ({orientation}) => orientation === 'horizontal' ? [37, 39] : [38, 40]
+		selectionKeys: ({disabled, orientation}) => {
+			if (disabled) {
+				return void 0;
+			} else {
+				return orientation === 'horizontal' ? [37, 39] : [38, 40];
+			}
+		}
 	},
 
 	render: ({selectionKeys, ...rest}) => {

--- a/packages/moonstone/internal/Picker/SpottablePicker.js
+++ b/packages/moonstone/internal/Picker/SpottablePicker.js
@@ -9,6 +9,7 @@ const SpottablePicker = kind({
 	name: 'SpottablePicker',
 
 	propTypes: {
+		disabled: PropTypes.bool,
 		orientation: PropTypes.string
 	},
 

--- a/packages/moonstone/styles/colors-highcontrast.less
+++ b/packages/moonstone/styles/colors-highcontrast.less
@@ -45,6 +45,10 @@
 @moon-gridlist-item-selected-icon-border-color: @high-contrast-black;
 @moon-gridlist-item-selected-icon-color: @moon-gridlist-item-selected-icon-border-color;
 
+// Input
+// ---------------------------------------
+@moon-input-border-active-shadow: 0px 0px 0px 6px @moon-input-border-focus-border-color;
+
 // Progress Bar
 // ---------------------------------------
 @moon-progress-bar-fill-bg-color: @high-contrast-white;

--- a/packages/moonstone/styles/colors-light-highcontrast.less
+++ b/packages/moonstone/styles/colors-light-highcontrast.less
@@ -47,7 +47,7 @@
 // Input
 // ---------------------------------------
 @moon-input-border-active-border-color: @moon-accent;
-@moon-input-border-active-outline-color: @moon-input-border-active-border-color;
+@moon-input-border-active-shadow: 0px 0px 0px 6px @moon-input-border-active-border-color;
 
 // Picker
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -164,7 +164,7 @@
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-decorator-active-bg-color: @moon-input-decorator-focus-bg-color;
 @moon-input-border-active-border-color: transparent;
-@moon-input-border-active-outline-color: @moon-input-border-focus-border-color;
+@moon-input-border-active-shadow: 0px 0px 0px 3px @moon-input-border-focus-border-color;
 
 // LabeledItem
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -188,6 +188,7 @@
 @moon-picker-joined-text-color: @moon-text-color;
 @moon-picker-joined-bg-color: transparent;
 @moon-picker-joined-fingernail-border-color: fade(@moon-black, 20%);
+@moon-picker-joined-focused-bg-color: @moon-spotlight-bg-color;
 
 // Popup
 // ---------------------------------------

--- a/packages/sampler/stories/default/MediaOverlay.js
+++ b/packages/sampler/stories/default/MediaOverlay.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import {select} from '../../src/enact-knobs';
+import {boolean, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
 const prop = {
@@ -77,6 +77,7 @@ storiesOf('Moonstone', module)
 			const placeholder = prop.placeholder[placeholderName];
 			return (
 				<MediaOverlay
+					disabled={boolean('disabled', Config)}
 					imageOverlay={imageSource}
 					placeholder={placeholder}
 					text={select('text', prop.text, Config, prop.text[0])}

--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -1,5 +1,6 @@
 import Button, {ButtonBase} from '@enact/moonstone/Button';
 import IconButton from '@enact/moonstone/IconButton';
+import Divider from '@enact/moonstone/Divider';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
@@ -95,6 +96,7 @@ storiesOf('Button', module)
 		'with tap area displayed',
 		() => (
 			<div>
+				<Divider>Button</Divider>
 				<Button
 					className={css.tapArea}
 					onClick={action('onClick')}
@@ -120,9 +122,29 @@ storiesOf('Button', module)
 					small
 				>
 					Small Button
-				</Button><br />
-				<IconButton color={select('color', prop.color, Config)}>{select('icon', prop.icons, Config) || '☃'}</IconButton>
-				<IconButton small color={select('color', prop.color, Config)}>{select('icon', prop.icons, Config) || '☃'}</IconButton>
+				</Button>
+				<Divider>IconButton</Divider>
+				<IconButton
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+					className={css.tapArea}
+					color={select('color', prop.color, Config)}
+					disabled={boolean('disabled', Config)}
+					onClick={action('onClick')}
+					selected={boolean('selected', Config)}
+				>
+					{select('icon', prop.icons, Config) || '☃'}
+				</IconButton>
+				<IconButton
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+					className={css.tapArea}
+					color={select('color', prop.color, Config)}
+					disabled={boolean('disabled', Config)}
+					onClick={action('onClick')}
+					small
+					selected={boolean('selected', Config)}
+				>
+					{select('icon', prop.icons, Config) || '☃'}
+				</IconButton>
 			</div>
 		)
 	);

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight/Spottable` to allow disabled items to be focused
+
 ## [2.5.2] - 2019-04-23
 
 No significant changes.

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -46,7 +46,7 @@ const isKeyboardAccessible = (node) => {
 	);
 };
 
-const isSpottable = (props) => !props.disabled && !props.spotlightDisabled;
+const isSpottable = (props) => !props.spotlightDisabled;
 
 // Last instance of spottable to be focused
 let lastSelectTarget = null;
@@ -359,7 +359,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleFocus = (ev) => {
-			if (this.props.disabled || this.props.spotlightDisabled) {
+			if (this.props.spotlightDisabled) {
 				this.shouldPreventBlur = true;
 				ev.target.blur();
 				this.shouldPreventBlur = false;
@@ -393,7 +393,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		render () {
 			const {disabled, spotlightId, spotlightDisabled, ...rest} = this.props;
-			this.focusedWhenDisabled = this.isFocused && (disabled || spotlightDisabled);
+			this.focusedWhenDisabled = this.isFocused && spotlightDisabled;
 			const spottable = this.focusedWhenDisabled || isSpottable(this.props);
 
 			let tabIndex = rest.tabIndex;

--- a/packages/spotlight/Spottable/tests/Spottable-specs.js
+++ b/packages/spotlight/Spottable/tests/Spottable-specs.js
@@ -18,7 +18,7 @@ describe('Spottable', () => {
 		expect(actual).toEqual(expected);
 	});
 
-	test('should not add the spottable class to a {disabled} component', () => {
+	test('should add the spottable class to a {disabled} component', () => {
 		const Component = Spottable('div');
 
 		const subject = mount(
@@ -28,7 +28,7 @@ describe('Spottable', () => {
 		const expected = 'spottable';
 		const actual = subject.find('div').prop('className');
 
-		expect(actual).not.toEqual(expected);
+		expect(actual).toEqual(expected);
 	});
 
 	test('should not add the spottable class to a {spotlightDisabled} component', () => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Disabled spottable elements should be focusable.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update `Spottable` to allow focus onto disabled items.  Disabled items themselves are still non-interactive but can have spotlight.  Updated focus CSS for many items as disabled + focused was not used before.  Also, I removed the `isItemDisabled` property from VL and VGL.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Design of some components may still be in flux so it is possible these designs will change further.  We don't have any specific guidelines for how disabled + focused should look, but in most cases it will be an opacity applied to the focused element.

I did not add a PR for deprecating the `isItemDisabled` property.

### Links
[//]: # (Related issues, references)
PLAT-77054

### Comments
