### PR TITLE
PLAT-78052: Updated LabeledIcon and LabeledIconButton text size

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,6 +17,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
 - `moonstone/Button` and `moonstone/Header` appearance to match the latest designs
+- `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
 
 ## [2.5.3] - ???
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,7 +17,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Changed
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
-- `moonstone/Button` and `moonstone/Header` appearance to match the latest designs
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
 - `moonstone/FormCheckbox` and `moonstone/FormCheckboxItem` appearance to match the latest designs
 - `moonstone/Button`, `moonstone/ContextualPopupDecorator`, `moonstone/Header`, and `moonstone/Notification` appearance to match the latest designs

--- a/packages/moonstone/LabeledIcon/LabeledIcon.module.less
+++ b/packages/moonstone/LabeledIcon/LabeledIcon.module.less
@@ -7,6 +7,7 @@
 	max-width: 300px;
 	margin: @moon-spotlight-outset;
 	padding: 0 @moon-spotlight-outset;
+	font-size: @moon-labeledicon-font-size;
 
 	// The following rules adjust the margin of icon so it behaves in a predictable way for users of
 	// this component, when applying their own styling/layout rules.

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -32,6 +32,7 @@
 @moon-button-font-size-large:       48px;
 @moon-button-small-font-size:       30px;
 @moon-button-small-font-size-large: 36px;
+@moon-labeledicon-font-size:        24px;
 @moon-clock-minute-font-size:       60px;
 @moon-clock-text-font-size:         54px;
 @moon-clock-meridiem-font-size:     24px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The text for `LabeledIcon` and `LabeledIconButton` is too large and doesn't match the designs.


### Resolution
The font size for the text of the aforementioned components has been decreased, to `24px`.