### PR TITLE
PLAT-77089: Add touch move handlers for VideoPlayer

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
+- `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
 
 ## [2.5.2] - 2019-04-23
 
@@ -19,7 +20,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/EditableIntegerPicker` text alignment when not editing the value
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support
 - `moonstone/VideoPlayer` to continue to display the thumbnail image while the slider is focused
-- `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
 
 ## [2.5.1] - 2019-04-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/EditableIntegerPicker` text alignment when not editing the value
 - `moonstone/Scroller` to scroll via dragging when the platform has touch support
 - `moonstone/VideoPlayer` to continue to display the thumbnail image while the slider is focused
+- `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
 
 ## [2.5.1] - 2019-04-09
 

--- a/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
+++ b/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
@@ -1,10 +1,10 @@
 import {adaptEvent, call, handle, forKey, forward, oneOf, preventDefault, returnsTrue, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import platform from '@enact/core/platform';
 import {calcProportion} from '@enact/ui/Slider/utils';
 import clamp from 'ramda/src/clamp';
 import PropTypes from 'prop-types';
 import React from 'react';
-import platform from '@enact/core/platform';
 
 // decrements the MediaKnob position if we're tracking
 const decrement = (state) => {
@@ -196,6 +196,10 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 
 			delete rest.onKnobMove;
 
+			if (platform.touch) {
+				rest.onTouchMove = this.handleTouchMove;
+			}
+
 			return (
 				<Wrapped
 					{...rest}
@@ -207,7 +211,6 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 					onMouseOver={this.handleMouseOver}
 					onMouseOut={this.handleMouseOut}
 					onMouseMove={this.handleMouseMove}
-					onTouchMove={platform.touch ? this.handleTouchMove : void 0}
 					preview={this.state.tracking}
 					previewProportion={this.state.x}
 					progressAnchor={progressAnchor}

--- a/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
+++ b/packages/moonstone/VideoPlayer/MediaSliderDecorator.js
@@ -4,6 +4,7 @@ import {calcProportion} from '@enact/ui/Slider/utils';
 import clamp from 'ramda/src/clamp';
 import PropTypes from 'prop-types';
 import React from 'react';
+import platform from '@enact/core/platform';
 
 // decrements the MediaKnob position if we're tracking
 const decrement = (state) => {
@@ -85,6 +86,9 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 			this.handleMouseOver = this.handleMouseOver.bind(this);
 			this.handleMouseOut = this.handleMouseOut.bind(this);
 			this.handleMouseMove = this.handleMouseMove.bind(this);
+			if (platform.touch) {
+				this.handleTouchMove = this.handleTouchMove.bind(this);
+			}
 
 			handleBlur.bindAs(this, 'handleBlur');
 			handleFocus.bindAs(this, 'handleFocus');
@@ -174,6 +178,11 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 			this.move(ev.clientX);
 		}
 
+		handleTouchMove (ev) {
+			// ignores multi touch
+			this.move(ev.touches[0].clientX);
+		}
+
 		render () {
 			const {selection, ...rest} = this.props;
 			let {backgroundProgress} = this.props;
@@ -198,6 +207,7 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line n
 					onMouseOver={this.handleMouseOver}
 					onMouseOut={this.handleMouseOut}
 					onMouseMove={this.handleMouseMove}
+					onTouchMove={platform.touch ? this.handleTouchMove : void 0}
 					preview={this.state.tracking}
 					previewProportion={this.state.x}
 					progressAnchor={progressAnchor}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -688,6 +688,9 @@ const VideoPlayerBase = class extends React.Component {
 
 	componentDidMount () {
 		on('mousemove', this.activityDetected);
+		if (platform.touch) {
+			on('touchmove', this.activityDetected);
+		}
 		on('keydown', this.handleGlobalKeyDown);
 		this.startDelayedFeedbackHide();
 		if (this.context && typeof this.context === 'function') {
@@ -791,6 +794,9 @@ const VideoPlayerBase = class extends React.Component {
 
 	componentWillUnmount () {
 		off('mousemove', this.activityDetected);
+		if (platform.touch) {
+			off('touchmove', this.activityDetected);
+		}
 		off('keydown', this.handleGlobalKeyDown);
 		this.stopRewindJob();
 		this.stopAutoCloseTimeout();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/VideoPlayer` doesn't support touch moves properly.
1. The media controls hiding timeout does not get reset when a user drags the knob and would eventually be closed. 
2. When `preview` is available, the knob would not follow the dragging position

Both of these are due to lack of touch move event handling.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `touchmove` event handlers that match the `mousemove` events.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
