### PR TITLE
PLAT-78047: Updated font size for BodyText and added size prop

### DIFF
--- a/packages/moonstone/BodyText/BodyText.js
+++ b/packages/moonstone/BodyText/BodyText.js
@@ -73,11 +73,22 @@ const BodyTextBase = kind({
 		 * @default false
 		 * @public
 		 */
-		noWrap: PropTypes.bool
+		noWrap: PropTypes.bool,
+
+		/**
+		 * Sets the text size to one of the preset sizes.
+		 * Available sizes: 'large' (default) and 'small'.
+		 *
+		 * @type {('small'|'large')}
+		 * @default 'large'
+		 * @public
+		 */
+		size: PropTypes.oneOf(['small', 'large'])
 	},
 
 	defaultProps: {
-		noWrap: false
+		noWrap: false,
+		size: 'large'
 	},
 
 	styles: {
@@ -86,7 +97,7 @@ const BodyTextBase = kind({
 	},
 
 	computed: {
-		className: ({noWrap, styler}) => styler.append({noWrap})
+		className: ({noWrap, size, styler}) => styler.append(size, {noWrap})
 	},
 
 	render: ({centered, css, noWrap, ...rest}) => {

--- a/packages/moonstone/BodyText/BodyText.js
+++ b/packages/moonstone/BodyText/BodyText.js
@@ -101,6 +101,8 @@ const BodyTextBase = kind({
 	},
 
 	render: ({centered, css, noWrap, ...rest}) => {
+		delete rest.size;
+
 		if (noWrap) {
 			return (
 				<MarqueeBodyText

--- a/packages/moonstone/BodyText/BodyText.module.less
+++ b/packages/moonstone/BodyText/BodyText.module.less
@@ -8,6 +8,14 @@
 	margin-left: @moon-spotlight-outset;
 	margin-right: @moon-spotlight-outset;
 
+	&.small {
+		font-size: @moon-body-small-font-size;
+
+		.moon-locale-non-latin({
+			font-size: @moon-non-latin-body-small-font-size;
+		});
+	}
+
 	:global(.enact-locale-right-to-left) & {
 		text-align: right;
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Panels` slot `<controls>` to easily add custom controls next to the Panels' "close" button
+- `moonstone/BodyText` prop `size` to offer a new "small" size
 
 ### Removed
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -16,7 +16,8 @@
 @moon-sub-header-below-font-size:   30px;
 @moon-small-header-font-size:       60px;
 @moon-small-header-sub-header-font-size:   @moon-sub-header-below-font-size;
-@moon-body-font-size:               33px;
+@moon-body-font-size:               30px;
+@moon-body-small-font-size:         27px;
 @moon-item-font-size:               33px;
 @moon-item-font-size-large:         39px;
 @moon-popup-header-font-size:       72px;
@@ -48,6 +49,7 @@
 @moon-non-latin-sub-header-font-size:   33px;
 @moon-non-latin-super-header-font-size: 33px;
 @moon-non-latin-body-font-size:         27px;
+@moon-non-latin-body-small-font-size:   24px;
 @moon-non-latin-divider-font-size:      27px;
 @moon-non-latin-button-large-font-size: 36px;
 @moon-non-latin-button-small-font-size: 27px;

--- a/packages/sampler/stories/default/BodyText.js
+++ b/packages/sampler/stories/default/BodyText.js
@@ -1,11 +1,14 @@
-import BodyText from '@enact/moonstone/BodyText';
+import BodyText, {BodyTextBase} from '@enact/moonstone/BodyText';
+import UiBodyText, {BodyTextBase as UiBodyTextBase} from '@enact/ui/BodyText';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
-import {boolean, text} from '../../src/enact-knobs';
+import {boolean, text, select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
 
 BodyText.displayName = 'BodyText';
+const Config = mergeComponentMetadata('BodyText', UiBodyTextBase, UiBodyText, BodyTextBase, BodyText);
 
 storiesOf('Moonstone', module)
 	.add(
@@ -14,10 +17,11 @@ storiesOf('Moonstone', module)
 			text: 'The basic BodyText'
 		})(() => (
 			<BodyText
-				centered={boolean('centered', BodyText)}
-				noWrap={boolean('noWrap', BodyText)}
+				centered={boolean('centered', Config)}
+				noWrap={boolean('noWrap', Config)}
+				size={select('size', ['', 'large', 'small'], Config)}
 			>
-				{text('children', BodyText, 'This is Body Text')}
+				{text('children', Config, 'This is Body Text')}
 			</BodyText>
 		))
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The main BodyText size needs to be a bit smaller and an alternate size is needed as an option.


### Resolution
Font size decreased to 30px, added a `size` prop to allow the user to specify a "small" value for a font size of 27px. Also updated the Storybook sample.