### PR TITLE
PLAT-78051: Updated Button designs

### DIFF
--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -67,51 +67,6 @@
 		animation-timing-function: ease-out;
 	}
 
-	// Standard Button Scenario
-	&.red,
-	&.green,
-	&.yellow,
-	&.blue {
-		&.minWidth .client {
-			-webkit-margin-start: @moon-button-colordot-size;
-			-webkit-padding-start: @moon-spotlight-outset;
-
-			&::before {
-				content: "";
-				position: absolute;
-				left: -@moon-button-colordot-size;
-				bottom: 50%;
-				width: @moon-button-colordot-size;
-				height: @moon-button-colordot-size;
-				border-radius: @moon-button-colordot-size;
-				transform: translateY(50%);
-
-				:global(.enact-locale-right-to-left) & {
-					left: initial;
-					right: -@moon-button-colordot-size;
-				}
-			}
-		}
-	}
-
-	// IconButton-like Button scenario
-	&.red,
-	&.green,
-	&.yellow,
-	&.blue {
-		&:not(.minWidth) .client::before {
-			// Colored under-bar
-			content: "";
-			position: absolute;
-			min-width: 24px;
-			height: 6px;
-			bottom: 18px;
-			left: 24px;
-			right: 24px;
-			border-radius: 6px;
-		}
-	}
-
 	.client {
 		padding: @moon-button-border-width;	// We match the amount removed by the line-height above, so the text doesn't overlap the border
 		border-radius: inherit;
@@ -121,13 +76,47 @@
 		-webkit-margin-start: (@moon-button-icon-small-h-margin - (@moon-button-h-padding - @moon-button-border-width));
 		-webkit-margin-end: @moon-button-icon-h-margin;
 	}
-	// Color prop set, and minWidth prop set, update icon's margin to allow more room for the colordot
+
 	&.red,
 	&.green,
 	&.yellow,
 	&.blue {
-		&.minWidth .icon {
-			-webkit-margin-start: 0;
+		// IconButton-like Button scenario
+		.client::before {
+			// Colored under-bar
+			content: "";
+			position: absolute;
+			bottom: 18px;
+			left: 50%;
+			width: @moon-button-colordot-width;
+			height: @moon-button-colordot-height;
+			border-radius: @moon-button-colordot-height;
+			transform: translate(-50%, 50%);
+		}
+
+		// Standard Button Scenario
+		&.minWidth {
+			// Update icon's margin to allow more room for the colordot
+			.icon {
+				-webkit-margin-start: 0;
+			}
+
+			.client {
+				-webkit-margin-start: @moon-button-colordot-width;
+				-webkit-padding-start: @moon-spotlight-outset;
+
+				&::before {
+					// Colored side-bar
+					bottom: 50%;
+					left: -@moon-button-colordot-width;
+					transform: translateY(50%);
+
+					:global(.enact-locale-right-to-left) & {
+						left: initial;
+						right: -@moon-button-colordot-width;
+					}
+				}
+			}
 		}
 	}
 
@@ -160,22 +149,34 @@
 		margin: 0 @moon-button-small-h-margin;
 		padding-left: @moon-button-small-h-padding;
 		padding-right: @moon-button-small-h-padding;
+		margin-left: @moon-button-small-h-margin;
+		margin-right: @moon-button-small-h-margin;
+
+		.icon {
+			-webkit-margin-start: (@moon-button-icon-small-h-margin - (@moon-button-h-padding - @moon-button-border-width));
+			-webkit-margin-end: @moon-button-icon-small-h-margin;
+		}
 
 		// Standard Button Scenario
 		&.minWidth {
 			min-width: @moon-button-small-min-width;
-
-			.client::before {
-				height: @moon-button-small-colordot-size;
-				width: @moon-button-small-colordot-size;
-			}
 		}
 
-		// IconButton-like Button scenario
-		&:not(.minWidth) .client::before {
-			bottom: 12px;
-			left: 18px;
-			right: 18px;
+		&.red,
+		&.green,
+		&.yellow,
+		&.blue {
+			// IconButton-like Button scenario
+			.client::before {
+				bottom: 12px;
+				width: @moon-button-small-colordot-width;
+				height: @moon-button-small-colordot-height;
+			}
+
+			// Standard Button Scenario
+			&.minWidth .client::before {
+				bottom: 50%;
+			}
 		}
 
 		.moon-taparea(@moon-button-small-height);
@@ -191,11 +192,6 @@
 			}
 		});
 
-		.icon {
-			-webkit-margin-start: (@moon-button-icon-small-h-margin - (@moon-button-h-padding - @moon-button-border-width));
-			-webkit-margin-end: @moon-button-icon-small-h-margin;
-		}
-
 		&.red,
 		&.green,
 		&.yellow,
@@ -204,6 +200,11 @@
 				-webkit-margin-start: 0;
 			}
 		}
+	}
+
+	// Large Button followed by another large Button has a custom wider margin between them
+	&:not(.small) + &:not(.small) {
+		margin-inline-start: (@moon-button-to-button-large-h-margin - @moon-button-h-margin);
 	}
 
 	// Button-non-disabled rules
@@ -260,13 +261,6 @@
 			background-color: @moon-remote-button-blue-color;
 		}
 
-		.disabled({
-			&.transparent {
-				.bg {
-					background-color: @moon-button-transparent-disabled-bg-color;
-				}
-			}
-		});
 
 		.focus({
 			// The complexity below overrides the default high-contrast rules and applies

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -60,7 +60,7 @@
 @moon-font-family-light: "Moonstone";  // Formerly weight: 300
 @moon-font-family-small: "Moonstone";  // Formerly weight: 500
 @moon-font-family-bold: "Moonstone";   // Formerly weight: 900
-@moon-alt-font-family: "Moonstone Condensed";
+@moon-alt-font-family: "Moonstone";
 @moon-non-latin-font-family: "Moonstone LG Display";
 @moon-non-latin-font-family-light: "Moonstone LG Display";  // Formerly weight: Light
 @moon-non-latin-font-family-bold: "Moonstone LG Display";   // Formerly weight: Bold
@@ -165,8 +165,11 @@
 @moon-button-pressed-scale: 0.05;
 @moon-button-icon-h-margin: 15px;
 @moon-button-icon-small-h-margin: 15px;
-@moon-button-colordot-size: 21px;
-@moon-button-small-colordot-size: 15px;
+@moon-button-colordot-width: 27px;
+@moon-button-colordot-height: 9px;
+@moon-button-small-colordot-width: 21px;
+@moon-button-small-colordot-height: @moon-button-colordot-height;
+@moon-button-to-button-large-h-margin: 30px;
 
 // Divider
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
New designs for the color-dot were supplied as well as custom margins for a special case, and the disabled+transparent Button looks awkward (being not transparent).


### Resolution
Changes include:
* Refactoring and cleanup color-dot rules and variables for better maintainability and readability, with included inline docs
* Large spacing between consecutive large buttons (30px)
* Removed bad disabled+transparent background color rule (we're back to always-transparent transparent buttons)


### Additional Considerations
A CHANGELOG entry was **not** created for this because the existing 3.0.0 changelog already has an entry loosely describing what this PR does: "updated the appearance to match designs"

The `@moon-alt-font-family` variable was also updated in this PR to "Moonstone" due to its visual impact on this component. This is duplicated by another PR but hopefully won't create merge conflicts since they're identical. Just included for completeness.
