### PR TITLE
PLAT-78053: Updated Panel and Panels margins/paddings

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -18,7 +18,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Changed
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
-- `moonstone/Button` and `moonstone/Header` appearance to match the latest designs
 - `moonstone/Panel` and `moonstone/Panels` now allocate slightly more screen edge space for a cleaner look
 - `moonstone/DaySelector` to have squared check boxes to match the rest of the checkmark components
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -17,6 +17,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
 - `moonstone/Button` and `moonstone/Header` appearance to match the latest designs
+- `moonstone/Panel` and `moonstone/Panels` now allocate slightly more screen edge space for a cleaner look
 
 ## [2.5.3] - ???
 

--- a/packages/moonstone/Panels/Panel.module.less
+++ b/packages/moonstone/Panels/Panel.module.less
@@ -1,13 +1,13 @@
 // Panel.module.less
 //
-@import '../styles/variables.less';
+@import "../styles/variables.less";
 
 .panel {
 	position: absolute;
 	height: 100%;
 	width: 100%;
 	overflow: hidden;
-	padding: @moon-app-keepout @moon-spotlight-outset;
+	padding: @moon-panel-v-padding @moon-panel-h-padding;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -108,7 +108,10 @@ const PanelsBase = kind({
 		 * @type {Function}
 		 * @private
 		 */
-		controlsRef: PropTypes.func,
+		controlsRef: PropTypes.oneOfType([
+			PropTypes.func,
+			PropTypes.shape({current: PropTypes.any})
+		]),
 
 		/**
 		 * Unique identifier for the Panels instance

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -105,7 +105,7 @@ const PanelsBase = kind({
 		 * The method which receives the reference node to the controls element, used to determine
 		 * the `controlsMeasurements`.
 		 *
-		 * @type {Function}
+		 * @type {Function|Object}
 		 * @private
 		 */
 		controlsRef: PropTypes.oneOfType([

--- a/packages/moonstone/Panels/Panels.module.less
+++ b/packages/moonstone/Panels/Panels.module.less
@@ -14,7 +14,7 @@
 	.controls {
 		position: absolute;
 		top: (@moon-app-keepout + @moon-spotlight-outset);
-		.position-start-end(auto, @moon-spotlight-outset * 2);
+		.position-start-end(auto, @moon-panel-h-padding);
 		z-index: 1;
 		.padding-start-end(18px, initial);
 		.remove-margin-on-edge-children();
@@ -35,7 +35,7 @@
 
 			.breadcrumbHeader {
 				padding-top: 3px;
-				margin: @moon-app-keepout;
+				margin: @moon-panel-v-padding @moon-panel-h-padding;
 				font-family: @moon-super-header-font-family;
 				font-size: @moon-breadcrumb-text-size;
 			}
@@ -48,7 +48,7 @@
 		overflow: hidden;
 
 		&.transitioning::before {
-			content: '';
+			content: "";
 			position: absolute;
 			.position(0);
 			z-index: 10000;
@@ -69,7 +69,7 @@
 		.breadcrumbs {
 			.breadcrumb {
 				.focus({
-					background: @moon-spotlight-color;
+					background-color: @moon-spotlight-color;
 					color: @moon-spotlight-text-color;
 
 					.breadcrumbHeader {
@@ -135,13 +135,13 @@
 			clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
 		}
 
-		> :not([data-index='0']) {
+		> :not([data-index="0"]) {
 			padding-left: 0;
 			width: calc(~"100% - " @moon-breadcrumb-width);
 		}
 	}
 
-	&[data-index='0'] {
+	&[data-index="0"] {
 		// prevents breadcrumbs from capturing pointer events when the first panel is visible
 		// without any breadcrumbs
 		.breadcrumbs {
@@ -150,7 +150,7 @@
 		}
 	}
 
-	&:not([data-index='0']) {
+	&:not([data-index="0"]) {
 		:global(.enact-locale-right-to-left) & .controls {
 			// allocate space for breadcrumb + header margin
 			left: @moon-breadcrumb-width + @moon-spotlight-outset;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -130,7 +130,7 @@
 
 // Spotlight
 // ---------------------------------------
-@moon-spotlight-outset: 12px;
+@moon-spotlight-outset: 9px;
 
 // Header
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -3,7 +3,7 @@
 
 // App
 // ---------------------------------------
-@moon-app-keepout: 18px;
+@moon-app-keepout: 24px;
 
 // Font Sizes
 // ---------------------------------------
@@ -262,6 +262,8 @@
 
 // Panels
 // ---------------------------------------
+@moon-panel-v-padding: @moon-app-keepout;
+@moon-panel-h-padding: (@moon-app-keepout - @moon-spotlight-outset);
 @moon-panels-handle-width: 132px;
 @moon-panel-handle-icon-font-size: 144px;
 @moon-breadcrumb-text-size: 36px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Panel rules must be updated to account for the new smaller `@moon-spotlight-outset` universal spacing rule.


### Resolution
Updated Panel and Panels margins/paddings. Included a PropTypes update to accommodate the newer `ref` format.


### Additional Considerations
Included the new spotlight-outset spacing value (though it's duplicated by another PR) to make this PR more straightforward to review.
Also, some minor cleanup of CSS quoting characters.