### PR TITLE
PLAT-77085: Remove data-spotlight-* props from Scrollable

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -76,7 +76,7 @@ const navigableFilter = (elem) => {
 	}
 };
 
-const configureSpotlightContainer = ({'data-spotlight-id': spotlightId, focusableScrollbar}) => {
+const configureSpotlightContainer = ({spotlightId, focusableScrollbar}) => {
 	Spotlight.set(spotlightId, {
 		navigableFilter: focusableScrollbar ? null : navigableFilter
 	});
@@ -200,7 +200,7 @@ class ScrollableBase extends Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		spotlightDisabled: PropTypes.bool,
 
@@ -209,7 +209,7 @@ class ScrollableBase extends Component {
 		 * it to customize the spotlight container for its use case.
 		 *
 		 * @type {String}
-		 * @private
+		 * @public
 		 */
 		spotlightId: PropTypes.string
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -27,6 +27,15 @@ import Skinnable from '../Skinnable';
 import overscrollCss from './OverscrollEffect.module.less';
 import scrollbarCss from './Scrollbar.module.less';
 
+const Container = SpotlightContainerDecorator(
+	{
+		overflow: true,
+		preserveId: true,
+		restrict: 'self-first'
+	},
+	'div'
+);
+
 const
 	{
 		animationDuration,
@@ -103,32 +112,6 @@ class ScrollableBase extends Component {
 		 * @private
 		 */
 		animate: PropTypes.bool,
-
-		/**
-		 * This is set to `true` by SpotlightContainerDecorator
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		'data-spotlight-container': PropTypes.bool,
-
-		/**
-		 * `false` if the content of the list or the scroller could get focus
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		'data-spotlight-container-disabled': PropTypes.bool,
-
-		/**
-		 * This is passed onto the wrapped component to allow
-		 * it to customize the spotlight container for its use case.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		'data-spotlight-id': PropTypes.string,
 
 		/**
 		 * Direction of the list or the scroller.
@@ -209,11 +192,29 @@ class ScrollableBase extends Component {
 		 * @default $L('scroll up')
 		 * @public
 		 */
-		scrollUpAriaLabel: PropTypes.string
+		scrollUpAriaLabel: PropTypes.string,
+
+
+		/**
+		 * `false` if the content of the list or the scroller could get focus
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		spotlightDisabled: PropTypes.bool,
+
+		/**
+		 * This is passed onto the wrapped component to allow
+		 * it to customize the spotlight container for its use case.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		spotlightId: PropTypes.string
 	}
 
 	static defaultProps = {
-		'data-spotlight-container-disabled': false,
 		animate: false,
 		focusableScrollbar: false,
 		overscrollEffectOn: {
@@ -222,7 +223,8 @@ class ScrollableBase extends Component {
 			pageKey: false,
 			scrollbarButton: false,
 			wheel: true
-		}
+		},
+		spotlightDisabled: false
 	}
 
 	constructor (props) {
@@ -253,7 +255,7 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidUpdate (prevProps) {
-		if (prevProps['data-spotlight-id'] !== this.props['data-spotlight-id'] ||
+		if (prevProps.spotlightId !== this.props.spotlightId ||
 				prevProps.focusableScrollbar !== this.props.focusableScrollbar) {
 			configureSpotlightContainer(this.props);
 		}
@@ -295,13 +297,13 @@ class ScrollableBase extends Component {
 		if ((
 			direction === 'vertical' && this.uiRef.current.canScrollVertically(bounds) ||
 			direction === 'horizontal' && this.uiRef.current.canScrollHorizontally(bounds)
-		) && !this.props['data-spotlight-container-disabled']) {
+		) && !this.props.spotlightDisabled) {
 			this.childRef.current.setContainerDisabled(true);
 		}
 	}
 
 	onMouseDown = (ev) => {
-		if (this.props['data-spotlight-container-disabled']) {
+		if (this.props.spotlightDisabled) {
 			ev.preventDefault();
 		}
 	}
@@ -318,7 +320,7 @@ class ScrollableBase extends Component {
 
 		if (delta !== 0) {
 			this.isWheeling = true;
-			if (!this.props['data-spotlight-container-disabled']) {
+			if (!this.props.spotlightDisabled) {
 				this.childRef.current.setContainerDisabled(true);
 			}
 		}
@@ -544,7 +546,7 @@ class ScrollableBase extends Component {
 	}
 
 	stop = () => {
-		if (!this.props['data-spotlight-container-disabled']) {
+		if (!this.props.spotlightDisabled) {
 			this.childRef.current.setContainerDisabled(false);
 		}
 		this.focusOnItem();
@@ -736,9 +738,8 @@ class ScrollableBase extends Component {
 			{
 				animate,
 				childRenderer,
-				'data-spotlight-container': spotlightContainer,
-				'data-spotlight-container-disabled': spotlightContainerDisabled,
-				'data-spotlight-id': spotlightId,
+				spotlightDisabled,
+				spotlightId,
 				focusableScrollbar,
 				scrollDownAriaLabel,
 				scrollLeftAriaLabel,
@@ -752,90 +753,92 @@ class ScrollableBase extends Component {
 			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
 		return (
-			<UiScrollableBase
-				noScrollByDrag={!platform.touch}
-				{...rest}
-				addEventListeners={this.addEventListeners}
-				applyOverscrollEffect={this.applyOverscrollEffect}
-				clearOverscrollEffect={this.clearOverscrollEffect}
-				noAnimation={!animate}
-				onFlick={this.onFlick}
-				onKeyDown={this.onKeyDown}
-				onMouseDown={this.onMouseDown}
-				onWheel={this.onWheel}
-				ref={this.uiRef}
-				removeEventListeners={this.removeEventListeners}
-				scrollTo={this.scrollTo}
-				stop={this.stop}
-				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
-					childWrapper: ChildWrapper,
-					childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
-					className,
-					componentCss,
-					containerRef: uiContainerRef,
-					handleScroll,
-					horizontalScrollbarProps,
-					initChildRef: initUiChildRef,
-					isHorizontalScrollbarVisible,
-					isVerticalScrollbarVisible,
-					rtl,
-					scrollTo,
-					style,
-					verticalScrollbarProps
-				}) => (
-					<div
-						className={classNames(className, overscrollCss.scrollable)}
-						data-spotlight-container={spotlightContainer}
-						data-spotlight-container-disabled={spotlightContainerDisabled}
-						data-spotlight-id={spotlightId}
-						ref={uiContainerRef}
-						style={style}
-					>
-						<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={this.overscrollRefs.vertical}>
-							<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={this.overscrollRefs.horizontal} {...restChildWrapperProps}>
-								{childRenderer({
-									...childComponentProps,
-									cbScrollTo: scrollTo,
-									className: componentCss.scrollableFill,
-									initUiChildRef,
-									isVerticalScrollbarVisible,
-									onScroll: handleScroll,
-									onUpdate: this.handleScrollerUpdate,
-									ref: this.childRef,
-									rtl,
-									spotlightId
-								})}
-							</ChildWrapper>
-							{isVerticalScrollbarVisible ?
+			<Container
+				spotlightDisabled={spotlightDisabled}
+				spotlightId={spotlightId}
+			>
+				<UiScrollableBase
+					noScrollByDrag={!platform.touch}
+					{...rest}
+					addEventListeners={this.addEventListeners}
+					applyOverscrollEffect={this.applyOverscrollEffect}
+					clearOverscrollEffect={this.clearOverscrollEffect}
+					noAnimation={!animate}
+					onFlick={this.onFlick}
+					onKeyDown={this.onKeyDown}
+					onMouseDown={this.onMouseDown}
+					onWheel={this.onWheel}
+					ref={this.uiRef}
+					removeEventListeners={this.removeEventListeners}
+					scrollTo={this.scrollTo}
+					stop={this.stop}
+					containerRenderer={({ // eslint-disable-line react/jsx-no-bind
+						childComponentProps,
+						childWrapper: ChildWrapper,
+						childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
+						className,
+						componentCss,
+						containerRef: uiContainerRef,
+						handleScroll,
+						horizontalScrollbarProps,
+						initChildRef: initUiChildRef,
+						isHorizontalScrollbarVisible,
+						isVerticalScrollbarVisible,
+						rtl,
+						scrollTo,
+						style,
+						verticalScrollbarProps
+					}) => (
+						<div
+							className={classNames(className, overscrollCss.scrollable)}
+							ref={uiContainerRef}
+							style={style}
+						>
+							<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={this.overscrollRefs.vertical}>
+								<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={this.overscrollRefs.horizontal} {...restChildWrapperProps}>
+									{childRenderer({
+										...childComponentProps,
+										cbScrollTo: scrollTo,
+										className: componentCss.scrollableFill,
+										initUiChildRef,
+										isVerticalScrollbarVisible,
+										onScroll: handleScroll,
+										onUpdate: this.handleScrollerUpdate,
+										ref: this.childRef,
+										rtl,
+										spotlightId
+									})}
+								</ChildWrapper>
+								{isVerticalScrollbarVisible ?
+									<Scrollbar
+										{...verticalScrollbarProps}
+										{...this.scrollbarProps}
+										disabled={!isVerticalScrollbarVisible}
+										focusableScrollButtons={focusableScrollbar}
+										nextButtonAriaLabel={downButtonAriaLabel}
+										previousButtonAriaLabel={upButtonAriaLabel}
+										rtl={rtl}
+									/> :
+									null
+								}
+							</div>
+							{isHorizontalScrollbarVisible ?
 								<Scrollbar
-									{...verticalScrollbarProps}
+									{...horizontalScrollbarProps}
 									{...this.scrollbarProps}
-									disabled={!isVerticalScrollbarVisible}
+									corner={isVerticalScrollbarVisible}
+									disabled={!isHorizontalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
-									nextButtonAriaLabel={downButtonAriaLabel}
-									previousButtonAriaLabel={upButtonAriaLabel}
+									nextButtonAriaLabel={rightButtonAriaLabel}
+									previousButtonAriaLabel={leftButtonAriaLabel}
 									rtl={rtl}
 								/> :
 								null
 							}
 						</div>
-						{isHorizontalScrollbarVisible ?
-							<Scrollbar
-								{...horizontalScrollbarProps}
-								{...this.scrollbarProps}
-								corner={isVerticalScrollbarVisible}
-								disabled={!isHorizontalScrollbarVisible}
-								focusableScrollButtons={focusableScrollbar}
-								nextButtonAriaLabel={rightButtonAriaLabel}
-								previousButtonAriaLabel={leftButtonAriaLabel}
-								rtl={rtl}
-							/> :
-							null
-						}
-					</div>
-				)}
-			/>
+					)}
+				/>
+			</Container>
 		);
 	}
 }
@@ -851,16 +854,9 @@ class ScrollableBase extends Component {
  * @public
  */
 const Scrollable = Skinnable(
-	SpotlightContainerDecorator(
-		{
-			overflow: true,
-			preserveId: true,
-			restrict: 'self-first'
-		},
-		I18nContextDecorator(
-			{rtlProp: 'rtl'},
-			ScrollableBase
-		)
+	I18nContextDecorator(
+		{rtlProp: 'rtl'},
+		ScrollableBase
 	)
 );
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -180,7 +180,7 @@ class ScrollableBaseNative extends Component {
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @private
+		 * @public
 		 */
 		spotlightDisabled: PropTypes.bool,
 
@@ -189,7 +189,7 @@ class ScrollableBaseNative extends Component {
 		 * it to customize the spotlight container for its use case.
 		 *
 		 * @type {String}
-		 * @private
+		 * @public
 		 */
 		spotlightId: PropTypes.string
 	}
@@ -901,16 +901,9 @@ class ScrollableBaseNative extends Component {
  * @private
  */
 const ScrollableNative = Skinnable(
-	SpotlightContainerDecorator(
-		{
-			overflow: true,
-			preserveId: true,
-			restrict: 'self-first'
-		},
-		I18nContextDecorator(
-			{rtlProp: 'rtl'},
-			ScrollableBaseNative
-		)
+	I18nContextDecorator(
+		{rtlProp: 'rtl'},
+		ScrollableBaseNative
 	)
 );
 

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -162,7 +162,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', Scroller, false)}
+				spotlightDisabled={boolean('spotlightDisabled', Scroller, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 			>
 				<Group childComponent={Item}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Turning on `data-spotlight-container-disabled` in qa-sampler still allows touch devices to focus elements. The problem is two-fold. 1) Touch hold will focus the element on touch devices and 2) `SpotlightContainerDecorator` handles the focus event and prevents by checking `spotlightDisabled` prop, not `data-spotlight-container-disabled` attribute.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Switch `data-spotlight-container-disabled` to `spotlightDisabled` in the sampler

Technically this would be enough to resolve the immediate issue, but also cleaned up the structure so that it respects `SpotlightContainerDecorator` props properly.

- Removed `data-spotlight-*` props from `Scrollable`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- When digging into as to why it was structured this way, I could only find this [comment](https://github.com/enactjs/enact/pull/1985#issuecomment-430105171). 
- This change requires related tests to be updated.
- As a fallback option, the simpler way to fix this issue may be to prevent focus event to propagate by checking the attribute instead of the prop. See  https://github.com/enactjs/enact/compare/develop...feature/PLAT-77085-stephen-1

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
