### PR TITLE
PLAT-77174: Set focus due to touch events

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to set focus due to touch events
+
 ## [2.5.2] - 2019-04-23
 
 No significant changes.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
In #2198, we removed the behavior of setting focus due to touch events in `Touchable`. This had a side-effect of preventing focus changes from a last-focused element when performing an initial `touchstart` event on a new element. This issue was most easily seen when changing focus from a list item to holding the scroll button - where a focused element would be recycled while scrolling in a list, resulting in obvious odd spotlight behavior.


### Resolution
This fix ultimately re-adds the implementation that was removed from `Touchable` (in #2198), just in `Spottable` instead. `Touchable` should have no assumption or knowledge of spotlight. Spotlight assumes some platform awareness - and while I'd rather it remain agnostic, it isn't at this point and appears to be the best place for this behavior, since we can assume its elements can be touchable.