### PR TITLE
ENYO-5923: Remove duplicate label from locale knob

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -62,7 +62,7 @@ const MoonstoneFullscreen = MoonstoneDecorator({overlay: false}, FullscreenBase)
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
 	'local':                                                '',
-	'en-US - US English (Default)':                         'en-US',
+	'en-US - US English':                                   'en-US',
 	'ko-KR - Korean':                                       'ko-KR',
 	'es-ES - Spanish, with alternate weekends':             'es-ES',
 	'am-ET - Amharic, 6 meridiems':                         'am-ET',


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
![image](https://user-images.githubusercontent.com/788456/57106538-7e5ddc80-6ce2-11e9-8b32-b6648fa39a70.png)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the duplicate `(Default)` from the knob
![image](https://user-images.githubusercontent.com/788456/57106551-8cabf880-6ce2-11e9-87c9-8d0f26dac66f.png)
