### PR TITLE
PLAT-77174: Set focus to scroll buttons during touch events

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
 - `moonstone/Input` refocusing on touch on iOS
 - `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
+- `moonstone/Scroller` to set focus to scroll buttons during touch events
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -287,10 +287,21 @@ class ScrollButtons extends Component {
 		}
 	}
 
+	onTouchStart = ({currentTarget}) => {
+		if (currentTarget !== Spotlight.getCurrent()) {
+			currentTarget.focus();
+		}
+	}
+
 	render () {
 		const
 			{disabled, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
+			prevDisabled = disabled || prevButtonDisabled,
+			nextDisabled = disabled || nextButtonDisabled,
+			touchProps = {onTouchStart: this.onTouchStart},
+			prevTouchProps = {...(!prevDisabled) && touchProps},
+			nextTouchProps = {...(!nextDisabled) && touchProps},
 			prevIcon = preparePrevButton(vertical),
 			nextIcon = prepareNextButton(vertical);
 
@@ -298,7 +309,7 @@ class ScrollButtons extends Component {
 			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
 				data-spotlight-overflow="ignore"
-				disabled={disabled || prevButtonDisabled}
+				disabled={prevDisabled}
 				key="prevButton"
 				onClick={this.onClickPrev}
 				onDown={this.onDownPrev}
@@ -309,6 +320,7 @@ class ScrollButtons extends Component {
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
 				ref={this.prevButtonRef}
+				{...prevTouchProps}
 			>
 				{prevIcon}
 			</ScrollButton>,
@@ -316,7 +328,7 @@ class ScrollButtons extends Component {
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"
-				disabled={disabled || nextButtonDisabled}
+				disabled={nextDisabled}
 				key="nextButton"
 				onClick={this.onClickNext}
 				onDown={this.onDownNext}
@@ -327,6 +339,7 @@ class ScrollButtons extends Component {
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
 				ref={this.nextButtonRef}
+				{...nextTouchProps}
 			>
 				{nextIcon}
 			</ScrollButton>,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
In #2198, we removed the behavior of setting focus due to touch events in `Touchable`. This had a side-effect of preventing focus changes from a last-focused element when performing an initial `touchstart` event on a new element. This issue was most easily seen when changing focus from a list item to holding the scroll button - where a focused element would be recycled while scrolling in a list, resulting in obvious odd spotlight behavior.


### Resolution
This is a more localized fix than the one proposed in #2254 - which we concluded may have been too aggressively setting focus.

This fix simply applies the same logic only to the scroll buttons - only setting focus immediately on the touchstart event (when not focused or disabled). This alleviates the "double-spotlight" and "spotlight wrapping" issues seen when a focused item exists in a list and you touch and hold a scroll button.

This appears to be the least impactful fix. That being said, there are other things we could consider and change, if needed.
- This fix always sets focus to the scroll button. An item *outside* the scrollable list (ex: header item) could have focus and pressing the scroll button would immediately change focus. Is this expected? Should we be considering changing focus only if a scroll item has focus? I think the scroll buttons should show consistent behavior so I opted for the current implementation.

