### PR TITLE
PLAT-78026: Adjust Scrollable container height

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -14,7 +14,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Scrollable` to adjust its container height
+- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to size properly
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` prop `size`
 
+### Fixed
+
+- `ui/Scrollable` to adjust its container height
+
 ## [2.5.2] - 2019-04-23
 
 ### Added

--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -16,7 +16,7 @@
 	.container {
 		display: flex;
 		width: 100%;
-		height: 100%;
+		height: 0;
 		flex: auto;
 		[data-container-muted="true"]::before {
 			position: absolute;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The `Scrollable` component's container was using an incorrect value which could result in the horizontal scroll bar being rendered out of the viewport of the scroller.


### Resolution
We need to remove the specified `100%` height value and let the flex layout handle the height instead.
