### PR TITLE
 ENYO-5949: Header hides components block if there are none

### DIFF
--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -244,7 +244,7 @@ const HeaderBase = kind({
 								{titleBelowComponent}
 								{subTitleBelowComponent}
 							</Cell>
-							<Cell shrink component="nav" className={css.headerComponents}>{children}</Cell>
+							{children ? <Cell shrink component="nav" className={css.headerComponents}>{children}</Cell> : null}
 						</Layout>
 					</Cell>
 				</Layout>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Extra padding in the header when there are no header components


### Resolution
Don't render the headerComponents node if there are no children in it