### PR TITLE
PLAT-77177, 77175: Fix issues where scroller and lists does not scroll when in RTL, horizontal  mode

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Fixed
+
+- `ui/ScrollableNative`, `ui/Scroller`, and `ui/VirtualListBase` to scroll correctly on iOS and Safari
+
 ### Deprecated
 
 - `small` prop in `ui/Button.ButtonBase`, `ui/Icon.IconBase`, `ui/IconButton.IconButtonBase`, and `ui/LabeledIcon.LabeledIconBase`, which will be replaced by `size="small"` in 3.0

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
-### Fixed
-
-- `ui/ScrollableNative`, `ui/Scroller`, and `ui/VirtualListBase` to scroll correctly on iOS and Safari
-
 ### Deprecated
 
 - `small` prop in `ui/Button.ButtonBase`, `ui/Icon.IconBase`, `ui/IconButton.IconButtonBase`, and `ui/LabeledIcon.LabeledIconBase`, which will be replaced by `size="small"` in 3.0
@@ -19,6 +15,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to size properly
+- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to scroll correctly on iOS and Safari
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -531,7 +531,7 @@ class ScrollableBaseNative extends Component {
 	animator = new ScrollAnimator()
 
 	// platform info
-	platform = platform
+	platformInfo = platform
 
 	// event handler for browser native scroll
 
@@ -728,7 +728,7 @@ class ScrollableBaseNative extends Component {
 
 		if (this.props.rtl && canScrollHorizontally) {
 			/* FIXME: RTL / this calculation only works for Chrome and Safari */
-			scrollLeft = platform.ios || platform.safari ? -scrollLeft : bounds.maxLeft - scrollLeft;
+			scrollLeft = this.platformInfo.ios || this.platformInfo.safari ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -725,8 +725,8 @@ class ScrollableBaseNative extends Component {
 
 		if (this.props.rtl && canScrollHorizontally) {
 			/* FIXME: RTL / this calculation only works for Chrome and Safari */
-			const rightEndPositionX = (platform.ios || platform.safari) ? 0 : bounds.maxLeft;
-			scrollLeft = rightEndPositionX - scrollLeft;
+			const bias = (platform.ios || platform.safari) ? 0 : bounds.maxLeft;
+			scrollLeft = bias - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -530,9 +530,6 @@ class ScrollableBaseNative extends Component {
 	// scroll animator
 	animator = new ScrollAnimator()
 
-	// platform info
-	platformInfo = platform
-
 	// event handler for browser native scroll
 
 	getRtlX = (x) => (this.props.rtl ? -x : x)
@@ -728,7 +725,8 @@ class ScrollableBaseNative extends Component {
 
 		if (this.props.rtl && canScrollHorizontally) {
 			/* FIXME: RTL / this calculation only works for Chrome and Safari */
-			scrollLeft = this.platformInfo.ios || this.platformInfo.safari ? -scrollLeft : bounds.maxLeft - scrollLeft;
+			const rightEndPositionX = (platform.ios || platform.safari) ? 0 : bounds.maxLeft;
+			scrollLeft = rightEndPositionX - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -725,8 +725,7 @@ class ScrollableBaseNative extends Component {
 
 		if (this.props.rtl && canScrollHorizontally) {
 			/* FIXME: RTL / this calculation only works for Chrome and Safari */
-			const bias = (platform.ios || platform.safari) ? 0 : bounds.maxLeft;
-			scrollLeft = bias - scrollLeft;
+			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -724,7 +724,6 @@ class ScrollableBaseNative extends Component {
 		}
 
 		if (this.props.rtl && canScrollHorizontally) {
-			/* FIXME: RTL / this calculation only works for Chrome and Safari */
 			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -2,10 +2,11 @@ import clamp from 'ramda/src/clamp';
 import classNames from 'classnames';
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
-import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
+import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import Registry from '@enact/core/internal/Registry';
 
 import {ResizeContext} from '../Resizable';
 import ri from '../resolution';
@@ -529,6 +530,9 @@ class ScrollableBaseNative extends Component {
 	// scroll animator
 	animator = new ScrollAnimator()
 
+	// platform info
+	platform = platform
+
 	// event handler for browser native scroll
 
 	getRtlX = (x) => (this.props.rtl ? -x : x)
@@ -723,8 +727,8 @@ class ScrollableBaseNative extends Component {
 		}
 
 		if (this.props.rtl && canScrollHorizontally) {
-			/* FIXME: RTL / this calculation only works for Chrome */
-			scrollLeft = bounds.maxLeft - scrollLeft;
+			/* FIXME: RTL / this calculation only works for Chrome and Safari */
+			scrollLeft = platform.ios || platform.safari ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -112,8 +112,7 @@ class ScrollerBase extends Component {
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			const bias = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
-			return bias - x;
+			return (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
 		}
 		return x;
 	}

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -112,8 +112,8 @@ class ScrollerBase extends Component {
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			const rightEndPositionX = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
-			return rightEndPositionX - x;
+			const bias = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
+			return bias - x;
 		}
 		return x;
 	}

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -8,6 +8,7 @@
  */
 
 import classNames from 'classnames';
+import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -107,9 +108,16 @@ class ScrollerBase extends Component {
 		left: 0
 	}
 
+	platform = platform
+
 	getScrollBounds = () => this.scrollBounds
 
-	getRtlPositionX = (x) => (this.props.rtl ? this.scrollBounds.maxLeft - x : x)
+	getRtlPositionX = (x) => {
+		if (this.props.rtl) {
+			return platform.ios || platform.safari ? -x : this.scrollBounds.maxLeft - x;
+		}
+		return x;
+	}
 
 	// for Scrollable
 	setScrollPosition (x, y) {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -108,13 +108,12 @@ class ScrollerBase extends Component {
 		left: 0
 	}
 
-	platformInfo = platform
-
 	getScrollBounds = () => this.scrollBounds
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			return this.platformInfo.ios || this.platformInfo.safari ? -x : this.scrollBounds.maxLeft - x;
+			const rightEndPositionX = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
+			return rightEndPositionX - x;
 		}
 		return x;
 	}

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -108,13 +108,13 @@ class ScrollerBase extends Component {
 		left: 0
 	}
 
-	platform = platform
+	platformInfo = platform
 
 	getScrollBounds = () => this.scrollBounds
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			return platform.ios || platform.safari ? -x : this.scrollBounds.maxLeft - x;
+			return this.platformInfo.ios || this.platformInfo.safari ? -x : this.scrollBounds.maxLeft - x;
 		}
 		return x;
 	}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -334,7 +334,7 @@ const VirtualListBaseFactory = (type) => {
 		cc = []
 		scrollPosition = 0
 
-		platform = platform
+		platformInfo = platform
 
 		isVertical = () => this.isPrimaryDirectionVertical
 
@@ -575,7 +575,7 @@ const VirtualListBaseFactory = (type) => {
 		scrollToPosition (x, y, rtl = this.props.rtl) {
 			const scrollX = (rtl && !this.isPrimaryDirectionVertical) ? this.scrollBounds.maxLeft - x : x;
 			if (this.containerRef.current) {
-				this.containerRef.current.scrollTo(platform.ios || platform.safari ? -x : scrollX, y);
+				this.containerRef.current.scrollTo(this.platformInfo.ios || this.platformInfo.safari ? -x : scrollX, y);
 			}
 		}
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -334,8 +334,6 @@ const VirtualListBaseFactory = (type) => {
 		cc = []
 		scrollPosition = 0
 
-		platformInfo = platform
-
 		isVertical = () => this.isPrimaryDirectionVertical
 
 		isHorizontal = () => !this.isPrimaryDirectionVertical
@@ -573,9 +571,13 @@ const VirtualListBaseFactory = (type) => {
 
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
-			const scrollX = (rtl && !this.isPrimaryDirectionVertical) ? this.scrollBounds.maxLeft - x : x;
 			if (this.containerRef.current) {
-				this.containerRef.current.scrollTo(this.platformInfo.ios || this.platformInfo.safari ? -x : scrollX, y);
+				if (rtl && !this.isPrimaryDirectionVertical) {
+					const rightEndPositionX = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
+					this.containerRef.current.scrollTo(rightEndPositionX - x, y);
+				} else {
+					this.containerRef.current.scrollTo(x, y);
+				}
 			}
 		}
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -572,8 +572,8 @@ const VirtualListBaseFactory = (type) => {
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
 			if (this.containerRef.current) {
-				const bias = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
-				this.containerRef.current.scrollTo((rtl && !this.isPrimaryDirectionVertical) ? bias - x : x, y);
+				const rtlCompensator = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
+				this.containerRef.current.scrollTo((rtl && !this.isPrimaryDirectionVertical) ? rtlCompensator - x : x, y);
 			}
 		}
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -572,12 +572,8 @@ const VirtualListBaseFactory = (type) => {
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
 			if (this.containerRef.current) {
-				if (rtl && !this.isPrimaryDirectionVertical) {
-					const rightEndPositionX = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
-					this.containerRef.current.scrollTo(rightEndPositionX - x, y);
-				} else {
-					this.containerRef.current.scrollTo(x, y);
-				}
+				const bias = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
+				this.containerRef.current.scrollTo((rtl && !this.isPrimaryDirectionVertical) ? bias - x : x, y);
 			}
 		}
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import equals from 'ramda/src/equals';
+import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -333,6 +334,8 @@ const VirtualListBaseFactory = (type) => {
 		cc = []
 		scrollPosition = 0
 
+		platform = platform
+
 		isVertical = () => this.isPrimaryDirectionVertical
 
 		isHorizontal = () => !this.isPrimaryDirectionVertical
@@ -570,10 +573,9 @@ const VirtualListBaseFactory = (type) => {
 
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
+			const scrollX = (rtl && !this.isPrimaryDirectionVertical) ? this.scrollBounds.maxLeft - x : x;
 			if (this.containerRef.current) {
-				this.containerRef.current.scrollTo(
-					(rtl && !this.isPrimaryDirectionVertical) ? this.scrollBounds.maxLeft - x : x, y
-				);
+				this.containerRef.current.scrollTo(platform.ios || platform.safari ? -x : scrollX, y);
 			}
 		}
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -572,8 +572,10 @@ const VirtualListBaseFactory = (type) => {
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
 			if (this.containerRef.current) {
-				const rtlCompensator = (platform.ios || platform.safari) ? 0 : this.scrollBounds.maxLeft;
-				this.containerRef.current.scrollTo((rtl && !this.isPrimaryDirectionVertical) ? rtlCompensator - x : x, y);
+				if (rtl) {
+					x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+				}
+				this.containerRef.current.scrollTo(x, y);
 			}
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[Safari only] Scroller and VirtualLists does not scroll and items disappear when RTL, Horizontal mode.


### Resolution
If the platform is safari or ios, I modified to scroll using the correct scrollLeft value.
- Chrome and Safari have different scrollLeft values in RTL, horizontal mode.
  - Chrome: The left endpoint is 0, the right endpoint is the size of a positive content (e.g., 0 to 1000)
  - Safari: The left endpoint is the size of negative content, the right endpoint is 0 (e.g., -1000 to 0)
