### PR TITLE
PLAT-77085: Fix scroller sample to use spotlightDisabled

### DIFF
--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -162,7 +162,7 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				data-spotlight-container-disabled={boolean('data-spotlight-container-disabled', Scroller, false)}
+				spotlightDisabled={boolean('spotlightDisabled', Scroller, false)}
 				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
 			>
 				<Group childComponent={Item}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Touch devices invoke `focus` on long touch hold and focus handler in `SpotlightContainerDecorator` prevents focus on `spotlightDisabled` prop and not `data-spotlight-container-disabled` attribute.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change qa sampler to use `spotlightDisabled` prop instead of `data-spotlight-container-disabled`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
See https://github.com/enactjs/enact/pull/2265 for the other possible solution

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
