### PR TITLE
PLAT-78612: Updated the font-size in breadcrumb to not wrap

### DIFF
--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -291,7 +291,7 @@
 @moon-panel-h-padding: (@moon-app-keepout - @moon-spotlight-outset);
 @moon-panels-handle-width: 132px;
 @moon-panel-handle-icon-font-size: 144px;
-@moon-breadcrumb-text-size: 36px;
+@moon-breadcrumb-text-size: @moon-body-font-size;
 @moon-breadcrumb-width: 96px;
 
 // Toggle Item


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Breadcrumb text in Panels wraps when it really shouldn't, now with the new fonts.

### Resolution
Updated the font size to match the body text font size. (Probably in-line with the GUI/UX plan.)