### PR TITLE
PLAT-78459: Spotlight focus not applied to Slider knob after dragging

### DIFF
--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -1,6 +1,8 @@
+import {findDOMNode} from 'react-dom';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import Pause from '@enact/spotlight/Pause';
+import platform from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -93,6 +95,15 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			return null;
 		}
 
+		componentDidUpdate (prevProps, prevState) {
+			// on touch platforms, we want sliders to focus when dragging begins
+			if (platform.touch && this.state.dragging && !prevState.dragging) {
+				const thisNode = findDOMNode(this);
+				const sliderNode = thisNode.getAttribute('role') === 'slider' ? thisNode : thisNode.querySelector('[role="slider"]');
+				sliderNode.focus();
+			}
+		}
+
 		componentWillUnmount () {
 			this.paused.resume();
 		}
@@ -137,6 +148,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleFocus (ev) {
+			console.log('HANDLING FOCUS', ev);
 			if (!this.props.disabled) {
 				forward('onFocus', ev, this.props);
 				this.setState({focused: true});

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -1,9 +1,9 @@
-import {findDOMNode} from 'react-dom';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import Pause from '@enact/spotlight/Pause';
 import platform from '@enact/core/platform';
+import Pause from '@enact/spotlight/Pause';
 import PropTypes from 'prop-types';
+import {findDOMNode} from 'react-dom';
 import React from 'react';
 
 import $L from '../internal/$L';

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -98,7 +98,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		componentDidUpdate (prevProps, prevState) {
 			// on touch platforms, we want sliders to focus when dragging begins
 			if (platform.touch && this.state.dragging && !prevState.dragging) {
-				const thisNode = findDOMNode(this);
+				const thisNode = findDOMNode(this); // eslint-disable-line react/no-find-dom-node
 				const sliderNode = thisNode.getAttribute('role') === 'slider' ? thisNode : thisNode.querySelector('[role="slider"]');
 				sliderNode.focus();
 			}
@@ -148,7 +148,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleFocus (ev) {
-			console.log('HANDLING FOCUS', ev);
 			if (!this.props.disabled) {
 				forward('onFocus', ev, this.props);
 				this.setState({focused: true});

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -506,9 +506,8 @@ const Spotlight = (function () {
 
 	function onTouchEnd (evt) {
 		const current = getCurrent();
-		const target = getNavigableTarget(evt.target); // account for child controls
-		if (!current || (current && !current.contains(target))) {
-			focusElement(target, getContainersForNode(target), true);
+		if (current && !current.contains(evt.target)) {
+			current.blur();
 		}
 	}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -506,8 +506,9 @@ const Spotlight = (function () {
 
 	function onTouchEnd (evt) {
 		const current = getCurrent();
-		if (current && !current.contains(evt.target)) {
-			current.blur();
+		const target = getNavigableTarget(evt.target); // account for child controls
+		if (!current || (current && !current.contains(target))) {
+			focusElement(target, getContainersForNode(target), true);
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On touch platforms, dragging an element before a press applies focus will result in focus not being applied with the drag/touch ends.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Rather than have `Spotlight` blur an incorrectly focused element, make it always focus the element that ends the touch.

### Links
[//]: # (Related issues, references)
PLAT-78459
