### PR TITLE
PLAT-77174: Set pointer mode true on touch start

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -504,6 +504,10 @@ const Spotlight = (function () {
 		}
 	}
 
+	function onTouchStart () {
+		setPointerMode(true);
+	}
+
 	function onTouchEnd (evt) {
 		const current = getCurrent();
 		if (current && !current.contains(evt.target)) {
@@ -533,6 +537,7 @@ const Spotlight = (function () {
 				window.addEventListener('mousemove', onMouseMove);
 
 				if (platform.touch) {
+					window.addEventListener('touchstart', onTouchStart);
 					window.addEventListener('touchend', onTouchEnd);
 				}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Spottable` restores focus when it rerenders in 5-way mode. Touch does not enable pointer mode, and restores the focused item in scroller while dragging.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set pointer mode to true on touch start

### Links
[//]: # (Related issues, references)
#2259 


Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
