### PR TITLE
ENYO-5955: Fix ContextualPopupDecorator methods to be bound to the instance

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/ContextualPopupDecorator` imperative methods to be correctly bound to the instance
 - `moonstone/EditableIntegerPicker`, `moonstone/Picker`, and `moonstone/RangePicker` to not error when the `min` prop exceeds the `max` prop
 - `moonstone/Input` refocusing on touch on iOS
 - `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs

--- a/packages/moonstone/VideoPlayer/MediaControls.js
+++ b/packages/moonstone/VideoPlayer/MediaControls.js
@@ -837,15 +837,15 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			this.mediaControlsNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 		}
 
-		areMoreComponentsAvailable () {
+		areMoreComponentsAvailable = () => {
 			return this.state.showMoreComponents;
 		}
 
-		showMoreComponents () {
+		showMoreComponents = () => {
 			this.setState({showMoreComponents: true});
 		}
 
-		hideMoreComponents () {
+		hideMoreComponents = () => {
 			this.setState({showMoreComponents: false});
 		}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
root cause is same as https://github.com/enactjs/enact/pull/2173

### Resolution
Change following function to arrow function
`areMoreComponentsAvailable`
`showMoreComponents`
`hideMoreComponents`

### Additional Considerations

### Links
ENYO-5955