### PR TITLE
PLAT-78617: Update default size to "small"

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -94,7 +94,16 @@ const ButtonBase = kind({
 		 * @default 'before'
 		 * @public
 		 */
-		iconPosition: PropTypes.oneOf(['before', 'after'])
+		iconPosition: PropTypes.oneOf(['before', 'after']),
+
+		/**
+		 * The size of the button.
+		 *
+		 * @type {('large'|'small')}
+		 * @default 'small'
+		 * @public
+		 */
+		size: PropTypes.string
 	},
 
 	defaultProps: {

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -98,7 +98,8 @@ const ButtonBase = kind({
 	},
 
 	defaultProps: {
-		iconPosition: 'before'
+		iconPosition: 'before',
+		size: 'small'
 	},
 
 	styles: {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -28,6 +28,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Panel` and `moonstone/Panels` now allocate slightly more screen edge space for a cleaner look
 - `moonstone/DaySelector` to have squared check boxes to match the rest of the checkmark components
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
+- `moonstone/Button`, `moonstone/Dropdown`, `moonstone/Icon`, `moonstone/IconButton`, `moonstone/Input`, and `moonstone/ToggleButton` default size to "small", which unifies their initial heights
 - `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
 
 ### Fixed

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -66,7 +66,6 @@ const DropdownButton = kind({
 		<Button
 			{...props}
 			iconPosition="after"
-			small
 		/>
 	)
 });

--- a/packages/moonstone/ExpandableInput/ExpandableInput.js
+++ b/packages/moonstone/ExpandableInput/ExpandableInput.js
@@ -315,7 +315,6 @@ class ExpandableInputBase extends React.Component {
 					onDeactivate={this.handleDeactivate}
 					onKeyDown={this.handleInputKeyDown}
 					placeholder={placeholder}
-					small
 					spotlightDisabled={spotlightDisabled}
 					type={type}
 					value={value}

--- a/packages/moonstone/Icon/Icon.js
+++ b/packages/moonstone/Icon/Icon.js
@@ -14,6 +14,7 @@
 import kind from '@enact/core/kind';
 import UiIcon from '@enact/ui/Icon';
 import Pure from '@enact/ui/internal/Pure';
+import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
@@ -33,6 +34,17 @@ import componentCss from './Icon.module.less';
  */
 const IconBase = kind({
 	name: 'Icon',
+
+	propTypes: /** @lends moonstone/Icon.IconBase.prototype */ {
+		/**
+		 * The size of the icon.
+		 *
+		 * @type {('large'|'small')}
+		 * @default 'small'
+		 * @public
+		 */
+		size: PropTypes.string
+	},
 
 	defaultProps: {
 		size: 'small'

--- a/packages/moonstone/Icon/Icon.js
+++ b/packages/moonstone/Icon/Icon.js
@@ -34,6 +34,10 @@ import componentCss from './Icon.module.less';
 const IconBase = kind({
 	name: 'Icon',
 
+	defaultProps: {
+		size: 'small'
+	},
+
 	render: (props) => UiIcon.inline({
 		...props,
 		css: componentCss,

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -85,6 +85,10 @@ const IconButtonBase = kind({
 		css: PropTypes.object
 	},
 
+	defaultProps: {
+		size: 'small'
+	},
+
 	styles: {
 		css: componentCss,
 		publicClassNames: ['iconButton', 'bg', 'large', 'selected', 'small']

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -240,7 +240,7 @@ const InputBase = kind({
 		dismissOnEnter: false,
 		invalid: false,
 		placeholder: '',
-		// size: 'large', // we won't set default props for `size` yet to support `small` prop
+		size: 'small',
 		type: 'text'
 	},
 

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -199,8 +199,8 @@ const InputBase = kind({
 		/**
 		 * The size of the input field.
 		 *
-		 * @type {('small'|'large')}
-		 * @default 'large'
+		 * @type {('large'|'small')}
+		 * @default 'small'
 		 * @public
 		 */
 		size: PropTypes.string,

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -155,7 +155,6 @@ const ToggleButtonBase = kind({
 		disabled: false,
 		minWidth: true,
 		selected: false,
-		// size: 'large', // we won't set default props for `size` yet to support `small` prop
 		toggleOffLabel: '',
 		toggleOnLabel: ''
 	},
@@ -184,7 +183,7 @@ const ToggleButtonBase = kind({
 		delete rest.small;
 
 		return (
-			<Button data-webos-voice-intent="SetToggleItem" {...rest} aria-pressed={selected} selected={selected} />
+			<Button css={css} data-webos-voice-intent="SetToggleItem" {...rest} aria-pressed={selected} selected={selected} />
 		);
 	}
 });

--- a/packages/sampler/stories/default/Button.js
+++ b/packages/sampler/stories/default/Button.js
@@ -34,7 +34,7 @@ storiesOf('Moonstone', module)
 				iconPosition={select('iconPosition', ['', 'before', 'after'], Config, '')}
 				minWidth={!!boolean('minWidth', Config)}
 				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', Config, 'click me')}
 			</Button>

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -1,4 +1,6 @@
 import Dropdown, {DropdownBase} from '@enact/moonstone/Dropdown';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -8,7 +10,7 @@ import {boolean, number, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
 Dropdown.displayName = 'Dropdown';
-const Config = mergeComponentMetadata('Dropdown', Dropdown, DropdownBase);
+const Config = mergeComponentMetadata('Dropdown', UIButtonBase, UIButton, ButtonBase, Button, DropdownBase, Dropdown);
 
 storiesOf('Moonstone', module)
 	.add(
@@ -26,6 +28,7 @@ storiesOf('Moonstone', module)
 					onClose={action('onClose')}
 					onOpen={action('onOpen')}
 					onSelect={action('onSelect')}
+					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
 				>
 					{items}

--- a/packages/sampler/stories/default/ExpandablePicker.js
+++ b/packages/sampler/stories/default/ExpandablePicker.js
@@ -29,7 +29,7 @@ storiesOf('Moonstone', module)
 				onOpen={action('onOpen')}
 				pickerAriaLabel={text('pickerAriaLabel', Config, '')}
 				title={text('title', Config, 'Favorite Emoji')}
-				width={select('width', ['small', 'medium', 'large'], Config, 'large')}
+				width={select('width', ['small', 'medium', 'large'], Config)}
 			>
 				{emoticons}
 			</ExpandablePicker>

--- a/packages/sampler/stories/default/IconButton.js
+++ b/packages/sampler/stories/default/IconButton.js
@@ -1,4 +1,6 @@
-import IconButton from '@enact/moonstone/IconButton';
+import IconButton, {IconButtonBase} from '@enact/moonstone/IconButton';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -6,6 +8,7 @@ import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
 import emptify from '../../src/utils/emptify.js';
 
 // import icons
@@ -19,6 +22,7 @@ const prop = {
 };
 
 IconButton.displayName = 'IconButton';
+const Config = mergeComponentMetadata('IconButton', Button, ButtonBase, UIButton, UIButtonBase, IconButtonBase, IconButton);
 
 storiesOf('Moonstone', module)
 	.add(
@@ -28,12 +32,12 @@ storiesOf('Moonstone', module)
 		})(() => (
 			<IconButton
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, IconButton, '')}
-				color={select('color', ['', 'red', 'green', 'yellow', 'blue'], IconButton, '')}
-				disabled={boolean('disabled', IconButton)}
-				selected={boolean('selected', IconButton)}
-				size={select('size', ['small', 'large'], IconButton, 'large')}
-				tooltipText={text('tooltipText', IconButton, '')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config, '')}
+				color={select('color', ['', 'red', 'green', 'yellow', 'blue'], Config, '')}
+				disabled={boolean('disabled', Config)}
+				selected={boolean('selected', Config)}
+				size={select('size', ['small', 'large'], Config)}
+				tooltipText={text('tooltipText', Config, '')}
 			>
 				{emptify(select('src', ['', docs, factory, logo], '')) + emptify(select('icon', ['', ...icons], 'plus')) + emptify(text('custom icon', ''))}
 			</IconButton>

--- a/packages/sampler/stories/default/Input.js
+++ b/packages/sampler/stories/default/Input.js
@@ -33,7 +33,7 @@ storiesOf('Moonstone', module)
 				invalid={boolean('invalid', Config)}
 				invalidMessage={text('invalidMessage', Config)}
 				placeholder={text('placeholder', Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 				type={select('type', prop.type, Config, prop.type[0])}
 			/>
 		))

--- a/packages/sampler/stories/default/LabeledIcon.js
+++ b/packages/sampler/stories/default/LabeledIcon.js
@@ -1,4 +1,6 @@
 import LabeledIcon from '@enact/moonstone/LabeledIcon';
+import Icon, {IconBase} from '@enact/moonstone/Icon';
+import UiIcon from '@enact/ui/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
@@ -8,7 +10,7 @@ import iconNames from './icons';
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select, text} from '../../src/enact-knobs';
 
-const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, LabeledIcon);
+const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, UiIcon, IconBase, Icon, LabeledIcon);
 Config.displayName = 'LabeledIcon';
 
 storiesOf('Moonstone', module)
@@ -22,7 +24,7 @@ storiesOf('Moonstone', module)
 				icon={select('icon', ['', ...iconNames], Config, 'fullscreen')}
 				inline={boolean('inline', Config)}
 				labelPosition={select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', Config, 'Hello LabeledIcon')}
 			</LabeledIcon>

--- a/packages/sampler/stories/default/LabeledIcon.js
+++ b/packages/sampler/stories/default/LabeledIcon.js
@@ -1,17 +1,17 @@
 import LabeledIcon from '@enact/moonstone/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import Icon, {IconBase} from '@enact/moonstone/Icon';
 import UiIcon from '@enact/ui/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
-import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 
 import iconNames from './icons';
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select, text} from '../../src/enact-knobs';
 
+LabeledIcon.displayName = 'LabeledIcon';
 const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, UiIcon, IconBase, Icon, LabeledIcon);
-Config.displayName = 'LabeledIcon';
 
 storiesOf('Moonstone', module)
 	.add(

--- a/packages/sampler/stories/default/LabeledIconButton.js
+++ b/packages/sampler/stories/default/LabeledIconButton.js
@@ -2,10 +2,10 @@ import LabeledIconButton from '@enact/moonstone/LabeledIconButton';
 import {IconButtonBase} from '@enact/moonstone/IconButton';
 import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
-import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 
 import iconNames from './icons';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/LabeledIconButton.js
+++ b/packages/sampler/stories/default/LabeledIconButton.js
@@ -1,4 +1,7 @@
 import LabeledIconButton from '@enact/moonstone/LabeledIconButton';
+import {IconButtonBase} from '@enact/moonstone/IconButton';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
@@ -8,8 +11,8 @@ import iconNames from './icons';
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select, text} from '../../src/enact-knobs';
 
-const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, LabeledIconButton);
-Config.displayName = 'LabeledIconButton';
+LabeledIconButton.displayName = 'LabeledIconButton';
+const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, Button, ButtonBase, UIButton, UIButtonBase, IconButtonBase, LabeledIconButton);
 
 storiesOf('Moonstone', module)
 	.add(
@@ -23,7 +26,7 @@ storiesOf('Moonstone', module)
 				inline={boolean('inline', Config)}
 				labelPosition={select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config)}
 				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'medium'], Config, 'medium')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', Config, 'Hello LabeledIconButton')}
 			</LabeledIconButton>

--- a/packages/sampler/stories/default/ToggleButton.js
+++ b/packages/sampler/stories/default/ToggleButton.js
@@ -1,4 +1,6 @@
 import ToggleButton from '@enact/moonstone/ToggleButton';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -12,8 +14,8 @@ const prop = {
 	backgroundOpacity: ['', 'translucent', 'lightTranslucent', 'transparent']
 };
 
-const Config = mergeComponentMetadata('ToggleButton', ToggleButton);
 ToggleButton.displayName = 'ToggleButton';
+const Config = mergeComponentMetadata('ToggleButton', UIButtonBase, UiButton, ButtonBase, Button, ToggleButton);
 
 storiesOf('Moonstone', module)
 	.add(
@@ -26,7 +28,7 @@ storiesOf('Moonstone', module)
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				onToggle={action('onToggle')}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 				toggleOffLabel={text('toggleOffLabel', Config, 'Off')}
 				toggleOnLabel={text('toggleOnLabel', Config, 'On')}
 			>

--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -36,7 +36,7 @@ storiesOf('Button', module)
 				icon={select('icon', prop.icons, Config)}
 				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{select('value', prop.longText, Config, 'Loooooooooooooooooog Button')}
 			</Button>
@@ -52,7 +52,7 @@ storiesOf('Button', module)
 				icon={select('icon', prop.icons, Config)}
 				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{select('value', prop.tallText, Config, 'ิ้  ไั  ஒ  து')}
 			</Button>
@@ -68,7 +68,7 @@ storiesOf('Button', module)
 				icon={select('icon', prop.icons, Config)}
 				minWidth={storybookBoolean('minWidth', false) ? void 0 : false}
 				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('value', Config, 'A')}
 			</Button>
@@ -85,7 +85,7 @@ storiesOf('Button', module)
 					icon={select('icon', prop.icons, Config)}
 					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 					selected={boolean('selected', Config)}
-					size={select('size', ['small', 'large'], Config, 'large')}
+					size={select('size', ['small', 'large'], Config)}
 				>
 					Normal Button
 				</Button>
@@ -106,7 +106,7 @@ storiesOf('Button', module)
 					icon={select('icon', prop.icons, Config)}
 					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 					selected={boolean('selected', Config)}
-					size={select('size', ['small', 'large'], Config, 'large')}
+					size={select('size', ['small', 'large'], Config)}
 				>
 					Normal Button
 				</Button>
@@ -119,7 +119,7 @@ storiesOf('Button', module)
 					icon={select('icon', prop.icons, Config)}
 					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
 					selected={boolean('selected', Config)}
-					size={select('size', ['small', 'large'], Config, 'large')}
+					size={select('size', ['small', 'large'], Config)}
 				>
 					Small Button
 				</Button>

--- a/packages/sampler/stories/qa/LabeledIcon.js
+++ b/packages/sampler/stories/qa/LabeledIcon.js
@@ -1,8 +1,10 @@
 import LabeledIcon from '@enact/moonstone/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
+import Icon, {IconBase} from '@enact/moonstone/Icon';
+import UiIcon from '@enact/ui/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import Scroller from '@enact/ui/Scroller';
-import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import Layout, {Cell} from '@enact/ui/Layout';
 
 import iconNames from '../default/icons';
@@ -11,7 +13,7 @@ import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select} from '../../src/enact-knobs';
 
 LabeledIcon.displayName = 'LabeledIcon';
-const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, LabeledIcon);
+const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, UiIcon, IconBase, Icon, LabeledIcon);
 
 storiesOf('LabeledIcon', module)
 	.add(

--- a/packages/sampler/stories/qa/LabeledIcon.js
+++ b/packages/sampler/stories/qa/LabeledIcon.js
@@ -29,7 +29,7 @@ storiesOf('LabeledIcon', module)
 									icon={icon}
 									disabled={disabled}
 									labelPosition={labelPosition}
-									size={select('size', ['small', 'large'], Config, 'large')}
+									size={select('size', ['small', 'large'], Config)}
 								>{icon}</LabeledIcon>
 							</Cell>
 						)}
@@ -52,7 +52,7 @@ storiesOf('LabeledIcon', module)
 							inline
 							disabled={disabled}
 							labelPosition={labelPosition}
-							size={select('size', ['small', 'large'], Config, 'large')}
+							size={select('size', ['small', 'large'], Config)}
 						>{icon}</LabeledIcon>
 					)}
 				</Scroller>

--- a/packages/sampler/stories/qa/LabeledIconButton.js
+++ b/packages/sampler/stories/qa/LabeledIconButton.js
@@ -29,7 +29,7 @@ storiesOf('LabeledIconButton', module)
 									icon={icon}
 									disabled={disabled}
 									labelPosition={labelPosition}
-									size={select('size', ['small', 'large'], Config, 'large')}
+									size={select('size', ['small', 'large'], Config)}
 								>{icon}</LabeledIconButton>
 							</Cell>
 						)}
@@ -52,7 +52,7 @@ storiesOf('LabeledIconButton', module)
 							inline
 							disabled={disabled}
 							labelPosition={labelPosition}
-							size={select('size', ['small', 'large'], Config, 'large')}
+							size={select('size', ['small', 'large'], Config)}
 						>{icon}</LabeledIconButton>
 					)}
 				</Scroller>

--- a/packages/sampler/stories/qa/LabeledIconButton.js
+++ b/packages/sampler/stories/qa/LabeledIconButton.js
@@ -1,8 +1,11 @@
 import LabeledIconButton from '@enact/moonstone/LabeledIconButton';
+import {IconButtonBase} from '@enact/moonstone/IconButton';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import Scroller from '@enact/ui/Scroller';
-import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import Layout, {Cell} from '@enact/ui/Layout';
 
 import iconNames from '../default/icons';
@@ -11,7 +14,7 @@ import {mergeComponentMetadata} from '../../src/utils';
 import {boolean, select} from '../../src/enact-knobs';
 
 LabeledIconButton.displayName = 'LabeledIconButton';
-const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, LabeledIconButton);
+const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, Button, ButtonBase, UIButton, UIButtonBase, IconButtonBase, LabeledIconButton);
 
 storiesOf('LabeledIconButton', module)
 	.add(

--- a/packages/sampler/stories/qa/ToggleButton.js
+++ b/packages/sampler/stories/qa/ToggleButton.js
@@ -1,11 +1,15 @@
 import ToggleButton from '@enact/moonstone/ToggleButton';
+import Button, {ButtonBase} from '@enact/moonstone/Button';
+import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
 
 ToggleButton.displayName = 'ToggleButton';
+const Config = mergeComponentMetadata('ToggleButton', UIButtonBase, UiButton, ButtonBase, Button, ToggleButton);
 
 // Set up some defaults for info and knobs
 const prop = {
@@ -19,11 +23,11 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, ToggleButton)}
-				disabled={boolean('disabled', ToggleButton)}
-				size={select('size', ['small', 'large'], ToggleButton, 'large')}
-				toggleOnLabel={text('toggleOnLabel', ToggleButton, 'Loooooooooooooooooog On')}
-				toggleOffLabel={text('toggleOffLabel', ToggleButton, 'Loooooooooooooooooog Off')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+				disabled={boolean('disabled', Config)}
+				size={select('size', ['small', 'large'], Config)}
+				toggleOnLabel={text('toggleOnLabel', Config, 'Loooooooooooooooooog On')}
+				toggleOffLabel={text('toggleOffLabel', Config, 'Loooooooooooooooooog Off')}
 			/>
 		)
 	)
@@ -32,11 +36,11 @@ storiesOf('ToggleButton', module)
 		() => (
 			<ToggleButton
 				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, ToggleButton)}
-				disabled={boolean('disabled', ToggleButton)}
-				size={select('size', ['small', 'large'], ToggleButton, 'large')}
-				toggleOnLabel={select('toggleOnLabel', prop.tallText, ToggleButton, 'ิ้  ไั  ஒ  து')}
-				toggleOffLabel={select('toggleOffLabel', prop.tallText, ToggleButton, 'ิ้  ไั  ஒ  து')}
+				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
+				disabled={boolean('disabled', Config)}
+				size={select('size', ['small', 'large'], Config)}
+				toggleOnLabel={select('toggleOnLabel', prop.tallText, Config, 'ิ้  ไั  ஒ  து')}
+				toggleOffLabel={select('toggleOffLabel', prop.tallText, Config, 'ิ้  ไั  ஒ  து')}
 			/>
 		)
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The latest design calls for all smaller components.


### Resolution
Default `size="small"` set for all components with a size prop.

### Additional Considerations
Several tests/samples needed updates to support properly detecting of default values.