### PR TITLE
ENYO-5964: Restore full height Scrollable

### DIFF
--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -17,6 +17,7 @@
 		display: flex;
 		width: 100%;
 		height: 100%;
+		min-height: 0;
 		flex: auto;
 		[data-container-muted="true"]::before {
 			position: absolute;

--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -16,7 +16,7 @@
 	.container {
 		display: flex;
 		width: 100%;
-		height: 0;
+		height: 100%;
 		flex: auto;
 		[data-container-muted="true"]::before {
 			position: absolute;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
This reverts code added by a previous commit to restore dropdown's sizing


### Additional Considerations
I'm unclear as to what this change was made to support, or what the consequences outside of dropdown are for reverting this.