### PR TITLE
ENYO-5975: Fix Disabled+Focused IconButton and Switch

### DIFF
--- a/packages/moonstone/IconButton/IconButton.module.less
+++ b/packages/moonstone/IconButton/IconButton.module.less
@@ -68,16 +68,5 @@
 				background-color: transparent;
 			}
 		}
-
-		.focus({
-			.disabled({
-				color: @moon-spotlight-disabled-text-color;
-
-				.icon {
-					.vendor-opacity(0.6);
-					color: @moon-spotlight-text-color;
-				}
-			});
-		});
 	});
 }

--- a/packages/moonstone/Switch/Switch.module.less
+++ b/packages/moonstone/Switch/Switch.module.less
@@ -123,10 +123,6 @@
 		.toggleIcon {
 			.applySkins({
 				opacity: @moon-disabled-opacity;
-
-				// .disabled({
-				// 	opacity: 1;
-				// });
 			});
 		}
 	});

--- a/packages/moonstone/Switch/Switch.module.less
+++ b/packages/moonstone/Switch/Switch.module.less
@@ -16,6 +16,13 @@
 	text-align: left;
 	cursor: default;
 
+	.moon-custom-text({
+		width: @moon-toggleswitch-width-large;
+		height: @moon-toggleswitch-height-large;
+		border-radius: (@moon-toggleswitch-height-large / 2);
+	});
+
+
 	.moon-taparea(@moon-toggleswitch-height);
 
 	.icon {
@@ -67,6 +74,7 @@
 
 		.disabled({
 			background-color: @moon-checkbox-toggle-switch-bg-color;
+			opacity: @moon-disabled-opacity;
 
 			.icon {
 				color: @moon-checkbox-toggle-switch-color;
@@ -82,6 +90,15 @@
 		});
 	});
 }
+
+// When a parent is disabled
+.disabled({
+	.toggleIcon {
+		.applySkins({
+			opacity: 1;
+		});
+	}
+});
 
 // Keep the switch handle (the icon) a constant color regardless of focus state.
 .focus({
@@ -101,13 +118,16 @@
 			}
 		});
 	}
-}, parent);
 
-// When a parent is disabled
-.disabled({
-	.toggleIcon {
-		.applySkins({
-			opacity: @moon-disabled-opacity;
-		});
-	}
-});
+	.disabled({
+		.toggleIcon {
+			.applySkins({
+				opacity: @moon-disabled-opacity;
+
+				// .disabled({
+				// 	opacity: 1;
+				// });
+			});
+		}
+	});
+}, parent);

--- a/packages/moonstone/Switch/Switch.module.less
+++ b/packages/moonstone/Switch/Switch.module.less
@@ -38,6 +38,10 @@
 	&.selected {
 		.icon {
 			left: (@moon-toggleswitch-width - @moon-toggleswitch-height);
+
+			.moon-custom-text({
+				left: (@moon-toggleswitch-width-large - @moon-toggleswitch-height-large);
+			});
 		}
 	}
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -358,6 +358,8 @@
 // ---------------------------------------
 @moon-toggleswitch-height: 30px;
 @moon-toggleswitch-width: 60px;
+@moon-toggleswitch-height-large: 42px;
+@moon-toggleswitch-width-large: 84px;
 @moon-toggleswitch-margin: @moon-toggleswitch-width + @moon-spotlight-outset;
 
 // Progress Bar


### PR DESCRIPTION
as well as large-text Switch

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
IconButton and Switch are too translucent when disabled and focused.
Switch is misshapen when in large-text mode.


### Resolution
Updated/simplified the disabled focused rules for IconButton and Switch, added proper sizes for Switch in large-text mode