### PR TITLE
PLAT-78718: Update disabled scrollbars to get a focus on page up/down

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -31,6 +31,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
 - `moonstone/Button`, `moonstone/Dropdown`, `moonstone/Icon`, `moonstone/IconButton`, `moonstone/Input`, and `moonstone/ToggleButton` default size to "small", which unifies their initial heights
 - `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrollbar button to gain focus when pressing a page up or down key if `focusableScrollbar` is true
 
 ### Fixed
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -254,36 +254,40 @@ class ScrollButtons extends Component {
 	onKeyDownPrev = (ev) => {
 		const
 			{focusableScrollButtons} = this.props,
-			{nextButtonDisabled} = this.state,
+			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (isPageDown(keyCode) && !nextButtonDisabled) {
+		if (isPageDown(keyCode)) {
 			if (focusableScrollButtons) {
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(ReactDOM.findDOMNode(this.nextButtonRef.current)); // eslint-disable-line react/no-find-dom-node
-			} else {
+			} else if (!nextButtonDisabled) {
 				this.onClickNext(ev);
 			}
 		} else if (isPageUp(keyCode)) {
-			this.onClickPrev(ev);
+			if (!prevButtonDisabled) {
+				this.onClickPrev(ev);
+			}
 		}
 	}
 
 	onKeyDownNext = (ev) => {
 		const
 			{focusableScrollButtons} = this.props,
-			{prevButtonDisabled} = this.state,
+			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (isPageUp(keyCode) && !prevButtonDisabled) {
+		if (isPageUp(keyCode)) {
 			if (focusableScrollButtons) {
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(ReactDOM.findDOMNode(this.prevButtonRef.current)); // eslint-disable-line react/no-find-dom-node
-			} else {
+			} else if (!prevButtonDisabled) {
 				this.onClickPrev(ev);
 			}
 		} else if (isPageDown(keyCode)) {
-			this.onClickNext(ev);
+			if (!nextButtonDisabled) {
+				this.onClickNext(ev);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
By enabling focus on disabled items, a focus should be able to move from a scrollbar button to the opposite button by page up/down key if `focusableScrollbar` is true in a scroller or a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update a key handling logic to move a focus.

### Links
[//]: # (Related issues, references)
PLAT-78718