### PR TITLE
ENYO-5959: [qa-sampler] Fix to display ContextualPopup above the button when direction prop is up

### DIFF
--- a/packages/sampler/stories/qa/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/qa/ContextualPopupDecorator.js
@@ -148,7 +148,7 @@ storiesOf('ContextualPopupDecorator', module)
 	.add(
 		'with 5-way selectable activator',
 		() => (
-			<div style={{textAlign: 'center', marginTop: ri.unit(99, 'rem')}}>
+			<div style={{textAlign: 'center', marginTop: ri.unit(180, 'rem')}}>
 				<ContextualPopupWithActivator
 					direction={select('direction', ['up', 'down', 'left', 'right'], Config, 'down')}
 					popupComponent={renderPopup}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When `direction` prop is 'up', ContextualPopup shows only down direction in qa-sampler.

![ENYO-5959](https://user-images.githubusercontent.com/15621154/57686099-eeba1580-7673-11e9-9c9a-6591574385af.png)


### Resolution
Compared to the develop branch, the ui-update branch has a reduced height of the header.
As a result, there is not enough space to display ContextualPopup above the button.
So I enlarged the space above the button to display ContextualPopup.


### Additional Considerations