### PR TITLE
ENYO-5961: Fix slider to not scroll viewport on touch platforms

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -55,6 +55,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Input` refocusing on touch on iOS
 - `moonstone/VideoPlayer` to correctly handle touch events while moving slider knobs
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to change spotlight focus due to touch events
+- `moonstone/Slider` to not scroll the viewport when dragging on touch platforms
 - `moonstone/VirtualList` and `moonstone/Scroller` to animate with 5-way navigation by default
 
 ## [2.5.2] - 2019-04-23

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -15,6 +15,7 @@
 	width: @moon-slider-bar-height;
 	box-sizing: content-box;
 	direction: ltr;
+	touch-action: none;
 
 	.progressBar {
 		position: relative;

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -43,6 +43,10 @@
 		}
 	}
 
+	.disabled({
+		touch-action: auto;
+	});
+
 	.moon-custom-text({
 		.knob::before {
 			height: @moon-slider-knob-height-large;


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Dragging a Slider on touch platforms would scroll the viewport (if it could scroll).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `touch-action: none` to slider to prevent scroller when interacting.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Does allow scrolling when the slider is disabled. It _shouldn't_ scroll the sampler in this case either but that's a side effect of the sampler being a tad larger than the viewport. I have not fixed that issue here since it is sampler-specific and not a priority.