### PR TITLE
ENYO-5965: Fix ContextualPopup padding

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
@@ -158,7 +158,7 @@ const ContextualPopupBase = kind({
 	},
 
 	computed: {
-		className: ({showArrow, showCloseButton, styler}) => styler.append({reserveClose: showCloseButton, showArrow}),
+		className: ({showCloseButton, styler}) => styler.append({reserveClose: showCloseButton}),
 		closeButton: ({showCloseButton, onCloseButtonClick}) => {
 			if (showCloseButton) {
 				return (

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
@@ -30,10 +30,6 @@
 		&.reserveClose {
 			.padding-start-end(@moon-contextual-popup-padding, @moon-icon-button-small-size + @moon-spotlight-outset);
 		}
-
-		&.showArrow {
-			padding: @moon-contextual-popup-show-arrow-padding;
-		}
 	}
 
 	.moon-custom-text({

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -411,7 +411,7 @@
 // ---------------------------------------
 @moon-contextual-popup-border-width: 1px;
 @moon-contextual-popup-border-radius: @moon-button-border-width;
-@moon-contextual-popup-padding: 18px;
+@moon-contextual-popup-padding: @moon-spotlight-outset;
 @moon-contextual-popup-arrow-height: 30px;
 @moon-contextual-popup-arrow-width: 30px;
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -411,8 +411,7 @@
 // ---------------------------------------
 @moon-contextual-popup-border-width: 1px;
 @moon-contextual-popup-border-radius: @moon-button-border-width;
-@moon-contextual-popup-padding: @moon-spotlight-outset;
-@moon-contextual-popup-show-arrow-padding: 18px;
+@moon-contextual-popup-padding: 18px;
 @moon-contextual-popup-arrow-height: 30px;
 @moon-contextual-popup-arrow-width: 30px;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Close button overlaps with the content of the contextual popup when `showClose` is set to true. This is because `.showArrow` class padding definition wins over `.reserveClose`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Padding for the contextual popup is always 18px with or without showing the arrow so we can remove `.showArrow` and simply update the contextual popup padding value to 18px.


Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
