### PR TITLE
ENYO-5966: Fix LabeledItem font color

### DIFF
--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -150,7 +150,7 @@
 
 // LabeledItem
 // ---------------------------------------
-@moon-labeled-item-label-color: @moon-sub-header-text-color;
+@moon-labeled-item-label-color: @moon-text-color;
 
 // Notification
 // ---------------------------------------

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -150,7 +150,7 @@
 
 // LabeledItem
 // ---------------------------------------
-@moon-labeled-item-label-color: @moon-text-color;
+@moon-labeled-item-label-color: inherit;
 
 // Notification
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -178,7 +178,7 @@
 
 // LabeledItem
 // ---------------------------------------
-@moon-labeled-item-label-color: @moon-text-color;
+@moon-labeled-item-label-color: inherit;
 
 // Notification
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -178,7 +178,7 @@
 
 // LabeledItem
 // ---------------------------------------
-@moon-labeled-item-label-color: @moon-sub-header-text-color;
+@moon-labeled-item-label-color: @moon-text-color;
 
 // Notification
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`LabeledItem`'s item should have the same text color as the label.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
