### PR TITLE
ENYO-5978: Fixed large-text mode icon size for SelectableItem and RadioItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
+- `moonstone/DaySelector` item text size in large-text mode
 
 ## [3.0.0-alpha.1] - 2019-05-15
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
+
 ## [3.0.0-alpha.1] - 2019-05-15
 
 ### Removed

--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -26,6 +26,7 @@ import React from 'react';
 import DaySelectorDecorator from '../DaySelector/DaySelectorDecorator';
 import {Expandable} from '../ExpandableItem';
 import {ExpandableListBase} from '../ExpandableList';
+import Skinnable from '../Skinnable';
 
 /**
  * A day of the week selection component.
@@ -123,7 +124,8 @@ const DayPickerDecorator = compose(
 	Expandable,
 	Changeable({change: 'onSelect', prop: 'selected'}),
 	I18nContextDecorator({localeProp: 'locale'}),
-	DaySelectorDecorator
+	DaySelectorDecorator,
+	Skinnable
 );
 
 /**

--- a/packages/moonstone/RadioItem/RadioItem.module.less
+++ b/packages/moonstone/RadioItem/RadioItem.module.less
@@ -26,6 +26,11 @@
 			.position(3px);
 			border-radius: inherit;
 		}
+
+		.moon-custom-text({
+			width: @moon-radio-item-indicator-size-large;
+			height: @moon-radio-item-indicator-size-large;
+		});
 	}
 
 	// Skin colors

--- a/packages/moonstone/SelectableItem/SelectableIcon.module.less
+++ b/packages/moonstone/SelectableItem/SelectableIcon.module.less
@@ -1,18 +1,25 @@
 // SelectableItem.module.less
 //
-@import '../styles/mixins.less';
-@import '../styles/variables.less';
-@import '../styles/skin.less';
+@import "../styles/mixins.less";
+@import "../styles/variables.less";
+@import "../styles/skin.less";
 
 // Interally theme our implementation using published classes from ToggleIcon
 .toggleIcon {
 	.icon {
-		@dot-size: @moon-selectable-item-indicator-size - 3px * 2;
+		@dot-size: (@moon-selectable-item-indicator-size - 3px * 2);
 
 		font-size: @dot-size;
 		text-align: left;
 		width: @moon-selectable-item-indicator-width;
 		margin: 0;
+
+		.moon-custom-text({
+			@dot-size-large: (@moon-selectable-item-indicator-size-large - 3px * 2);
+
+			font-size: @dot-size-large;
+			width: @moon-selectable-item-indicator-width-large;
+		});
 	}
 
 	&:not(.selected) {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -328,7 +328,9 @@
 // Selectable Item
 // ---------------------------------------
 @moon-selectable-item-indicator-size: @moon-item-height;
-@moon-selectable-item-indicator-width: @moon-icon-size / 2;
+@moon-selectable-item-indicator-size-large: @moon-item-height-large;
+@moon-selectable-item-indicator-width: (@moon-icon-size / 2 - 3px);
+@moon-selectable-item-indicator-width-large: (@moon-selectable-item-indicator-width + 6px);
 
 // EditableIntegerPicker
 // ---------------------------------------
@@ -337,6 +339,7 @@
 // Radio Item
 // ---------------------------------------
 @moon-radio-item-indicator-size: 18px;
+@moon-radio-item-indicator-size-large: 24px;
 @moon-radio-item-indicator-border: 2px;  // ### Exceptional Case ###
 	// 2px, not being a multiple of 3, poses special problems. Any math or assignment related to
 	// this value must be specifically considered as to not impose layout issues related to, for


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
RadioItem and SelectableItem Icons are www.waytoobig.com


### Resolution
Added large-text mode sizing values and rules for these components.