### PR TITLE
ENYO-5982: Fix Dropdown item height in non-latin locales and large-text mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
 - `moonstone/DaySelector` item text size in large-text mode
+- `moonstone/Item` height in non-latin locales
+- `moonstone/Dropdown` popup scroller arrows showing in non-latin locales and added large-text mode support
 
 ## [3.0.0-alpha.1] - 2019-05-15
 

--- a/packages/moonstone/Dropdown/Dropdown.module.less
+++ b/packages/moonstone/Dropdown/Dropdown.module.less
@@ -1,5 +1,6 @@
 // Dropdown.module.less
 //
+@import "../styles/mixins.less";
 @import "../styles/variables.less";
 @import "../styles/skin.less";
 
@@ -12,6 +13,10 @@
 	width: @moon-dropdown-list-width;
 	max-height: @moon-dropdown-list-max-height;
 	display: flex;
+
+	.moon-custom-text({
+		max-height: @moon-dropdown-list-max-height-large;
+	});
 
 	.group {
 		height: auto;

--- a/packages/moonstone/Item/Item.module.less
+++ b/packages/moonstone/Item/Item.module.less
@@ -11,9 +11,17 @@
 	position: relative;
 	color: inherit;
 
+	.moon-locale-non-latin({
+		line-height: @moon-item-line-height;
+	});
+
 	.moon-custom-text({
 		font-size: @moon-item-font-size-large;
 		line-height: @moon-item-line-height-large;
+
+		.moon-locale-non-latin({
+			line-height: @moon-item-line-height-large;
+		});
 	});
 
 	&.inline {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -212,7 +212,8 @@
 @moon-dropdown-border-radius: @moon-button-border-radius;
 @moon-dropdown-width: @moon-button-max-width;
 @moon-dropdown-list-width: (@moon-dropdown-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
-@moon-dropdown-list-max-height: 300px;
+@moon-dropdown-list-max-height: (5 * @moon-item-height);
+@moon-dropdown-list-max-height-large: (5 * @moon-item-height-large);
 
 // Heading
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Dropdown shows scroll arrows with 5 items listed (when it shouldn't) in non-latin locales.


### Resolution
Item line-height was based on an `em` value in non-latin, which is variable and was adding one unintentional pixel to the Item height. This cascaded into problems with the Dropdown's sizing. Large-text mode support was also added to Dropdown so it always respects the design doc's wishes of "5 items visible without scrolling". The max-height was updated to correlate with the height of 5 items as well, instead of a static value.