### PR TITLE
ENYO-5986: Fix the color of the translucent family of buttons

### DIFF
--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -257,11 +257,11 @@
 		}
 
 		&.translucent .bg {
-			background-color: fade(@moon-button-bg-color, @moon-button-translucent-opacity);
+			background-color: @moon-button-translucent-bg-color;
 		}
 
 		&.lightTranslucent .bg {
-			background-color: fade(@moon-button-lightTranslucent-bg-color, @moon-button-translucent-opacity);
+			background-color: @moon-button-lightTranslucent-bg-color;
 		}
 
 		&.transparent {
@@ -363,11 +363,11 @@
 				}
 
 				&.translucent .bg {
-					background-color: fade(@moon-button-bg-color, @moon-button-translucent-opacity);
+					background-color: @moon-button-translucent-bg-color;
 				}
 
 				&.lightTranslucent .bg {
-					background-color: fade(@moon-button-lightTranslucent-bg-color, @moon-button-translucent-opacity);
+					background-color: @moon-button-lightTranslucent-bg-color;
 				}
 
 				&.transparent {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
 - `moonstone/DaySelector` item text size in large-text mode
+- `moonstone/Button` background colors for translucent and lightTranslucent
 
 ## [3.0.0-alpha.1] - 2019-05-15
 

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -57,8 +57,8 @@
 // ---------------------------------------
 @moon-button-text-color: @moon-white;
 @moon-button-bg-color: #686868;
-@moon-button-translucent-opacity: 30%;
-@moon-button-lightTranslucent-bg-color: @moon-white;
+@moon-button-translucent-bg-color: fade(@moon-black, 56%);
+@moon-button-lightTranslucent-bg-color: fade(@moon-white, 22%);
 @moon-button-transparent-bg-color: transparent;
 @moon-button-transparent-active-text-color: @moon-text-color;
 @moon-button-transparent-disabled-bg-color: @moon-button-disabled-bg-color;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -54,8 +54,8 @@
 // ---------------------------------------
 @moon-button-text-color: @moon-gray;
 @moon-button-bg-color: #383838;
-@moon-button-translucent-opacity: 30%;
-@moon-button-lightTranslucent-bg-color: @moon-white;
+@moon-button-translucent-bg-color: fade(@moon-button-bg-color, 22%);
+@moon-button-lightTranslucent-bg-color: fade(@moon-white, 22%);
 @moon-button-transparent-bg-color: transparent;
 @moon-button-transparent-active-text-color: @moon-white;
 @moon-button-transparent-disabled-bg-color: @moon-button-disabled-bg-color;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The background colors for translucent and lightTranslucent Buttons are incorrect.


### Resolution
Updated translucent and lightTranslucent background colors in light and dark skins to match the design-intent.

In dark skin, the lightTranslucent button should appear identical to the normal button when on the default black background. Conversely, the sight skin translucent button should appear identical to the normal button when on the standard off-white background. All versions should have a translucent background, through which, you can see a background-image, if one is present behind the button.