### PR TITLE
PLAT-78894: Updated caret color for latest designs

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Header` with `Input` to not have a distracting white background color
+- `moonstone/Input` caret color to match the designs (black bar on white background, white bar on black background, standard inversion)
 
 ## [3.0.0-alpha.1] - 2019-05-15
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Header` with `Input` to not have a distracting white background color
+
 ## [3.0.0-alpha.1] - 2019-05-15
 
 ### Removed

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -123,7 +123,6 @@
 	.applySkins({
 		background-color: @moon-input-decorator-bg-color;
 		color: @moon-input-text-color;
-		caret-color: @moon-input-caret-color;
 
 		.input {
 			background: transparent;

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -195,6 +195,7 @@ const HeaderBase = kind({
 						<ComponentOverride
 							component={headerInput}
 							css={css}
+							size="large"
 						/>
 					</Cell>
 				);

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -115,16 +115,14 @@
 
 		&.standard {
 			.decorator {
-				&:not(:focus-within) {
-					background-color: transparent;
+				background-color: transparent;
 
-					.input {
+				.input {
+					color: @moon-header-text-color;
+
+					.input-placeholder({
 						color: @moon-header-text-color;
-
-						.input-placeholder({
-							color: @moon-header-text-color;
-						});
-					}
+					});
 				}
 			}
 		}

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -117,6 +117,10 @@
 			.decorator {
 				background-color: transparent;
 
+				.focus({
+					background-color: transparent;
+				});
+
 				.input {
 					color: @moon-header-text-color;
 

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -160,7 +160,6 @@
 
 // Input
 // ---------------------------------------
-@moon-input-caret-color:              @moon-spotlight-bg-color;
 @moon-input-text-color:               @moon-black;
 @moon-input-text-disabled-color:      fade(@moon-black, 25%);
 @moon-input-border-color:             #eaeaea;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Caret color is too pink.


### Resolution
Caret color has been reverted to natural (default) state.

This is based on #2293 to allow validation of the caret color on a non-white background color. It's not 💯 necessary, but this hierarchy is helpful for testing.