### PR TITLE
ENYO-5980: Updated sample to statically set button sizes

### DIFF
--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -1,6 +1,6 @@
 import Button, {ButtonBase} from '@enact/moonstone/Button';
 import IconButton from '@enact/moonstone/IconButton';
-import Divider from '@enact/moonstone/Divider';
+import Heading from '@enact/moonstone/Heading';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
@@ -96,54 +96,39 @@ storiesOf('Button', module)
 		'with tap area displayed',
 		() => (
 			<div>
-				<Divider>Button</Divider>
+				<Heading>Button</Heading>
 				<Button
 					className={css.tapArea}
 					onClick={action('onClick')}
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
-					color={select('color', prop.color, Config)}
 					disabled={boolean('disabled', Config)}
-					icon={select('icon', prop.icons, Config)}
-					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
-					selected={boolean('selected', Config)}
-					size={select('size', ['small', 'large'], Config)}
+					size="large"
 				>
 					Normal Button
 				</Button>
 				<Button
 					className={css.tapArea}
 					onClick={action('onClick')}
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
-					color={select('color', prop.color, Config)}
 					disabled={boolean('disabled', Config)}
-					icon={select('icon', prop.icons, Config)}
-					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
-					selected={boolean('selected', Config)}
-					size={select('size', ['small', 'large'], Config)}
+					size="small"
 				>
 					Small Button
 				</Button>
-				<Divider>IconButton</Divider>
+				<Heading>IconButton</Heading>
 				<IconButton
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 					className={css.tapArea}
-					color={select('color', prop.color, Config)}
 					disabled={boolean('disabled', Config)}
 					onClick={action('onClick')}
-					selected={boolean('selected', Config)}
+					size="large"
 				>
-					{select('icon', prop.icons, Config) || '☃'}
+					star
 				</IconButton>
 				<IconButton
-					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 					className={css.tapArea}
-					color={select('color', prop.color, Config)}
 					disabled={boolean('disabled', Config)}
 					onClick={action('onClick')}
-					small
-					selected={boolean('selected', Config)}
+					size="small"
 				>
-					{select('icon', prop.icons, Config) || '☃'}
+					star
 				</IconButton>
 			</div>
 		)


### PR DESCRIPTION
…and only include relevant knobs

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
QA Sample is incorrect, not setting button sizes and including lots of irrelevant knobs for this test

### Resolution
Simplified the sample, statically assigned sizes, and updated the Divider to Heading instead.