### PR TITLE
PLAT-78893: Add moonstone/Heading prop spacing

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -5,7 +5,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## [unreleased]
 
 ### Added
-- `moonstone/Heading` default prop `spacing` with value `'small'`
+
+- `moonstone/Heading` prop `spacing` with default value `'small'`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+- `moonstone/Heading` default prop `spacing` with value `'small'`
+
 ### Fixed
 
 - `moonstone/Header` with `Input` to not have a distracting white background color

--- a/packages/moonstone/Heading/Heading.js
+++ b/packages/moonstone/Heading/Heading.js
@@ -59,7 +59,7 @@ const HeadingBase = kind({
 		 * The size of the spacing around the Heading.
 		 *
 		 * Allowed values include:
-		 * * `'auto'` (default) - Lets this value be based on the `size` prop for automatic usage.
+		 * * `'auto'` - Value is based on the `size` prop for automatic usage.
 		 * * `'large'` - Specifically assign the `'large'` spacing.
 		 * * `'medium'` - Specifically assign the `'medium'` spacing.
 		 * * `'small'` - Specifically assign the `'small'` spacing.

--- a/packages/moonstone/Heading/Heading.js
+++ b/packages/moonstone/Heading/Heading.js
@@ -53,7 +53,27 @@ const HeadingBase = kind({
 		 * @type {Boolean}
 		 * @public
 		 */
-		showLine: PropTypes.bool
+		showLine: PropTypes.bool,
+
+		/**
+		 * The size of the spacing around the Heading.
+		 *
+		 * Allowed values include:
+		 * * `'auto'` (default) - Lets this value be based on the `size` prop for automatic usage.
+		 * * `'large'` - Specifically assign the `'large'` spacing.
+		 * * `'medium'` - Specifically assign the `'medium'` spacing.
+		 * * `'small'` - Specifically assign the `'small'` spacing.
+		 * * `'none'` - No spacing at all. Neighboring elements will directly touch the Heading.
+		 *
+		 * @type {('auto'|'large'|'medium'|'small'|'none')}
+		 * @default 'small'
+		 * @public
+		 */
+		spacing: PropTypes.oneOf(['auto', 'large', 'medium', 'small', 'none'])
+	},
+
+	defaultProps: {
+		spacing: 'small'
 	},
 
 	styles: {

--- a/packages/ui/Heading/Heading.js
+++ b/packages/ui/Heading/Heading.js
@@ -79,7 +79,7 @@ const Heading = kind({
 		 * The size of the spacing around the Heading.
 		 *
 		 * These have no built-in measurements, as they are intended to be defined by the theme
-		 * consuming this UI element. The values correlate with customizable classes bade available
+		 * consuming this UI element. The values correlate with customizable classes made available
 		 * by this component's `css` prop.
 		 *
 		 * Allowed values include:


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
All `moonstone/Heading` components should have the same `spacing` (`"small"`) regardless of their `size` prop by default.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set a default value for the `spacing` prop in `moonstone/Heading`.

### Links
[//]: # (Related issues, references)
PLAT-78893
