### PR TITLE
PLAT-78786: Fix 5way navigation in VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -587,17 +587,13 @@ const VirtualListBaseFactory = (type) => {
 					this.focusOnItem(nextIndex);
 				} else {
 					this.isScrolledBy5way = true;
+					this.isWrappedBy5way = isWrapped;
 
-					if (isWrapped) {
-						const isNextAvailable = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}'].spottable`);
-						this.isWrappedBy5way = true;
-
-						if (wrap === true && !isNextAvailable) {
-							this.pause.pause();
-							target.blur();
-						} else {
-							this.focusOnItem(nextIndex);
-						}
+					if (isWrapped && wrap === true && (
+						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}'].spottable`) == null
+					)) {
+						this.pause.pause();
+						target.blur();
 					} else {
 						this.focusOnItem(nextIndex);
 					}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -588,11 +588,17 @@ const VirtualListBaseFactory = (type) => {
 				} else {
 					this.isScrolledBy5way = true;
 
-					if (isWrapped && wrap === true) {
+					if (isWrapped) {
+						const isNextAvailable = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}'].spottable`);
 						this.isWrappedBy5way = true;
-						this.pause.pause();
-						target.blur();
-					} else if (!isWrapped || wrap !== 'noAnimation') {
+
+						if (wrap === true && !isNextAvailable) {
+							this.pause.pause();
+							target.blur();
+						} else {
+							this.focusOnItem(nextIndex);
+						}
+					} else {
 						this.focusOnItem(nextIndex);
 					}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There are some cases where 5way navigation in a VirtualList does not behave as expected

### Resolution
When a VirtualList calculates the next target to set focus, there were cases where it was not taking into account whether there were available controls to focus before attempting to set focus to them (whether the controls were disabled or no further controls were available in the specified direction).

I've attempted to modify how VirtualList decides where focus should change to by determining whether or not spottable controls are first available in the 5way direction pressed. It's tough determining where to set focus in some cases where there are disabled components - strictly from a VirtualList POV - since we want to set focus on the nearest eligible component using spotlight proximity rules. In cases where the next target is disabled, we fallback to allowing spotlight to move focus where appropriate. 

There are other things to consider, whether or not any further controls are disabled and if/when wrapping should take place. There may be other edge-cases that need to be considered that I am not aware of or have not come across. Thorough testing of this proposed change would be appreciated.
