### PR TITLE
ENYO-5990: Update prop-types to variable range dependency.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "invariant": "^2.2.2",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "ramda": "^0.24.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@enact/core": "^3.0.0-alpha.1",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "ramda": "^0.24.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.5",
     "eases": "^1.0.8",
     "invariant": "^2.2.2",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "ramda": "^0.24.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@enact/core": "^3.0.0-alpha.1",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "ramda": "^0.24.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,7 @@
     "classnames": "^2.2.5",
     "direction": "^1.0.1",
     "invariant": "^2.2.2",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "ramda": "^0.24.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@enact/core": "^3.0.0-alpha.2",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* We previously restricted `prop-types` to a locked version in https://github.com/enactjs/enact/pull/2111/ as a way to avoid an issue with null values in `oneOf`.
* However the latest versions of React have greater dependencies of `prop-types`. As a result, there are multiple copies of `prop-types` within `./node_modules`

### Resolution
* Updates `prop-type` dependencies to `^15.7.2`.
* The `prop-types@15.7.2` release fixes the null `oneOf` issue, so we are safe to use that as a base for the variable-range.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>