### PR TITLE
PLAT-79105: Add Header sample

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- The ability to set and customize the Moonstone Decorator, Panels, Panel, and Header of `MoonstoneEnvironment`
+- `moonstone/Header` sample
+
 ## [3.0.0-alpha.2] - 2019-05-20
 
 No significant changes.

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -25,6 +25,9 @@ const PanelsBase = kind({
 
 	propTypes: {
 		description: PropTypes.string,
+		noHeader: PropTypes.bool,
+		noPanel: PropTypes.bool,
+		noPanels: PropTypes.bool,
 		title: PropTypes.string
 	},
 
@@ -33,18 +36,20 @@ const PanelsBase = kind({
 		className: 'moonstoneEnvironmentPanels'
 	},
 
-	render: ({children, description, title, ...rest}) => (
-		<Panels {...rest} onApplicationClose={reloadPage}>
-			<Panel className={css.panel}>
-				<Header type="compact" title={title} casing="preserve" />
-				<Column>
-					{description ? (
-						<Cell shrink component={BodyText} className={css.description}>{description}</Cell>
-					) : null}
-					<Cell className={css.storyCell}>{children}</Cell>
-				</Column>
-			</Panel>
-		</Panels>
+	render: ({children, description, noHeader, noPanel, noPanels, title, ...rest}) => (
+		!noPanels ? <Panels {...rest} onApplicationClose={reloadPage}>
+			{!noPanel ? <Panel className={css.panel}>
+				{!noHeader ? <React.Fragment>
+					<Header type="compact" title={title} casing="preserve" />
+					<Column>
+						{description ? (
+							<Cell shrink component={BodyText} className={css.description}>{description}</Cell>
+						) : null}
+						<Cell className={css.storyCell}>{children}</Cell>
+					</Column>
+				</React.Fragment> : children}
+			</Panel> : children}
+		</Panels> : children
 	)
 });
 
@@ -177,6 +182,11 @@ const StorybookDecorator = (story, config) => {
 				'--moon-env-background': backgroundLabelMap[select('background', backgroundLabels, Config, getKnobFromArgs(args, 'background'))]
 			}}
 			skin={select('skin', skins, Config, getKnobFromArgs(args, 'skin'))}
+			noHeader={config.noHeader}
+			noPanel={config.noPanel}
+			noPanels={config.noPanels}
+			{...config.moonstoneProps}
+			{...config.panelsProps}
 		>
 			{sample}
 		</Moonstone>

--- a/packages/sampler/stories/default/Header.js
+++ b/packages/sampler/stories/default/Header.js
@@ -23,7 +23,7 @@ const prop = {
 			<IconButton>gear</IconButton>
 		</React.Fragment>
 	},
-	marqueeOn: ['', 'focus', 'hover', 'render'],
+	marqueeOn: ['', 'hover', 'render'],
 	type: ['compact', 'standard']
 };
 

--- a/packages/sampler/stories/default/Header.js
+++ b/packages/sampler/stories/default/Header.js
@@ -1,0 +1,60 @@
+import {Header, HeaderBase} from '@enact/moonstone/Panels';
+import Button from '@enact/moonstone/Button';
+import IconButton from '@enact/moonstone/IconButton';
+import Input from '@enact/moonstone/Input';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import {boolean, select, text} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+const Config = mergeComponentMetadata('Header', HeaderBase, Header);
+
+// Set up some defaults for info and knobs
+const prop = {
+	casing: ['', 'preserve', 'sentence', 'word', 'upper'],
+	children: {
+		'no buttons': null,
+		'1 button': <IconButton>gear</IconButton>,
+		'2 buttons': <React.Fragment>
+			<Button>A Button</Button>
+			<IconButton>gear</IconButton>
+		</React.Fragment>
+	},
+	marqueeOn: ['', 'focus', 'hover', 'render'],
+	type: ['compact', 'standard']
+};
+
+storiesOf('Moonstone', module)
+	.add(
+		'Header',
+		withInfo({
+			text: 'A block to use as a screen\'s title and description. Supports additional buttons and up to two subtitles.'
+		})((context) => {
+			context.noHeader = true;
+
+			const noCloseButton = boolean('noCloseButton', {displayName: 'Panels'});
+			context.panelsProps = {noCloseButton: noCloseButton || false};
+
+			const headerInput = boolean('headerInput', Config) ? <Input placeholder="placeholder text" /> : null;
+			const childrenSelection = select('children', ['no buttons', '1 button', '2 buttons'], Config);
+			const children = prop.children[childrenSelection];
+
+			return (
+				<Header
+					title={text('title', Config, 'The Matrix')}
+					titleBelow={text('titleBelow', Config, 'Free your mind')}
+					subTitleBelow={text('subTitleBelow', Config, 'A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.')}
+					type={select('type', prop.type, Config)}
+					centered={boolean('centered', Config)}
+					casing={select('casing', prop.casing, Config)}
+					fullBleed={boolean('fullBleed', Config)}
+					headerInput={headerInput}
+					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
+				>
+					{children}
+				</Header>
+			);
+		})
+	);

--- a/packages/sampler/stories/default/Header.js
+++ b/packages/sampler/stories/default/Header.js
@@ -9,6 +9,7 @@ import {withInfo} from '@storybook/addon-info';
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
+Header.displayName = 'Header';
 const Config = mergeComponentMetadata('Header', HeaderBase, Header);
 
 // Set up some defaults for info and knobs


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There is no sample for Header and its many options. There is also no way to make alterations to the MoonstoneEnvironment kind.


### Resolution
Added both things!

Moonstone stories now accept props and toggle specific components' presence.