### PR TITLE
ENYO-5985: Fix font names from PostScript names to full names

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `Fonts` to correctly use the new font files and updated the international font name from "Moonstone LG Display" to "Moonstone Global"
+
 ## [3.0.0-alpha.2] - 2019-05-20
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `Fonts` to correctly use the new font files and updated the international font name from "Moonstone LG Display" to "Moonstone Global"
+- Fonts to correctly use the new font files and updated the international font name from "Moonstone LG Display" to "Moonstone Global"
 
 ## [3.0.0-alpha.2] - 2019-05-20
 

--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -11,8 +11,9 @@ const fontName = 'Moonstone Global';
 // Locale Configuration Block
 const fonts = {
 	'NonLatin': {
-		regular: 'LG Smart UI Global-Light',
-		bold:    'LG Smart UI Global-Regular'
+		// Hacky solution to add support for full-name and postscript names of the same font (support for multiple different operating systems font handling)
+		regular: 'LG Smart UI Global-Light"), local("LGSmartUIGlobal-Light',
+		bold:    'LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular'
 	},
 	'am': {
 		regular: 'LG Display_Amharic'

--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -6,13 +6,13 @@
 // eslint-disable-next-line no-var
 var {addLocalizedFont, generateFontRules, generateFontOverrideRules} = require('@enact/ui/internal/localized-fonts');
 
-const fontName = 'Moonstone LG Display';
+const fontName = 'Moonstone Global';
 
 // Locale Configuration Block
 const fonts = {
 	'NonLatin': {
-		regular: 'LGSmartUIGlobal-Light',
-		bold:    'LGSmartUIGlobal-Regular'
+		regular: 'LG Smart UI Global-Light',
+		bold:    'LG Smart UI Global-Regular'
 	},
 	'am': {
 		regular: 'LG Display_Amharic'

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -1,22 +1,22 @@
 // ----- SYSTEM FONT NAMES ------
-@font-system-src-moonstone-condensed-300:  local("LGSmartUICond-Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
-@font-system-src-moonstone-condensed-400:  local("LGSmartUICond-Regular"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
-@font-system-src-moonstone-condensed-600:  local("LGSmartUICond-SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
-@font-system-src-moonstone-condensed-700:  local("LGSmartUICond-Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-300:  local("LG Smart UI Cond Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
+@font-system-src-moonstone-condensed-400:  local("LG Smart UI Cond"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
+@font-system-src-moonstone-condensed-600:  local("LG Smart UI Cond SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-700:  local("LG Smart UI Cond Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
 
-@font-system-src-moonstone-100:    local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Thin.ttf") format("truetype");
-@font-system-src-moonstone-300:    local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
-@font-system-src-moonstone-500:    local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
-@font-system-src-moonstone-500-i:  local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
-@font-system-src-moonstone-600:    local("LGSmartUI-SemiBold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
-@font-system-src-moonstone-700:    local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
-@font-system-src-moonstone-700-i:  local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
-@font-system-src-moonstone-900:    local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
-@font-system-src-moonstone-900-i:  local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
+@font-system-src-moonstone-100:    local("LG Smart UI Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Thin.ttf") format("truetype");
+@font-system-src-moonstone-300:    local("LG Smart UI Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
+@font-system-src-moonstone-500:    local("LG Smart UI"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
+@font-system-src-moonstone-500-i:  local("LG Smart UI"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
+@font-system-src-moonstone-600:    local("LG Smart UI SemiBold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
+@font-system-src-moonstone-700:    local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
+@font-system-src-moonstone-700-i:  local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
+@font-system-src-moonstone-900:    local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
+@font-system-src-moonstone-900-i:  local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
 
-@font-system-src-non-latin-300:  local("LGSmartUIGlobal-Light");
-@font-system-src-non-latin-400:  local("LGSmartUIGlobal-Regular");
-@font-system-src-non-latin-700:  local("LGSmartUIGlobal-Regular");
+@font-system-src-non-latin-300:  local("LG Smart UI Global-Light");
+@font-system-src-non-latin-400:  local("LG Smart UI Global-Regular");
+@font-system-src-non-latin-700:  local("LG Smart UI Global-Regular");
 
 @font-system-src-moonstone-icons:  local("Moonstone"), url("../../fonts/Moonstone.ttf") format("truetype");
 @font-system-src-lg-icons:         local("LG Display_Dingbat");
@@ -79,10 +79,10 @@
 .buildFontFamily("Moonstone"; @font-system-src-moonstone-900-i; @font-system-src-non-latin-700; 900; italic);
 
 /* ----- LG Display ------ */
-.buildFontFamily("Moonstone LG Display"; @font-system-src-non-latin-400; @font-system-src-moonstone-500);
-.buildFontFamily("Moonstone LG Display"; @font-system-src-non-latin-300; @font-system-src-moonstone-300; 300);
-.buildFontFamily("Moonstone LG Display"; @font-system-src-non-latin-400; @font-system-src-moonstone-500; 400);
-.buildFontFamily("Moonstone LG Display"; @font-system-src-non-latin-700; @font-system-src-moonstone-700; 700);
+.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-400; @font-system-src-moonstone-500);
+.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-300; @font-system-src-moonstone-300; 300);
+.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-400; @font-system-src-moonstone-500; 400);
+.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-700; @font-system-src-moonstone-700; 700);
 
 /* ----- Moonstone (Icons) ------ */
 .buildFontFace("Moonstone Icons"; @font-system-src-moonstone-icons);

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -1,22 +1,22 @@
 // ----- SYSTEM FONT NAMES ------
-@font-system-src-moonstone-condensed-300:  local("LG Smart UI Cond Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
-@font-system-src-moonstone-condensed-400:  local("LG Smart UI Cond"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
-@font-system-src-moonstone-condensed-600:  local("LG Smart UI Cond SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
-@font-system-src-moonstone-condensed-700:  local("LG Smart UI Cond Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-300:  local("LG Smart UI Cond Light"), local("LGSmartUICond-Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
+@font-system-src-moonstone-condensed-400:  local("LG Smart UI Cond"), local("LGSmartUICond-Regular"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
+@font-system-src-moonstone-condensed-600:  local("LG Smart UI Cond SemiBold"), local("LGSmartUICond-SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-700:  local("LG Smart UI Cond Bold"), local("LGSmartUICond-Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
 
-@font-system-src-moonstone-100:    local("LG Smart UI Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Thin.ttf") format("truetype");
-@font-system-src-moonstone-300:    local("LG Smart UI Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
-@font-system-src-moonstone-500:    local("LG Smart UI"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
-@font-system-src-moonstone-500-i:  local("LG Smart UI"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
-@font-system-src-moonstone-600:    local("LG Smart UI SemiBold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
-@font-system-src-moonstone-700:    local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
-@font-system-src-moonstone-700-i:  local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
-@font-system-src-moonstone-900:    local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
-@font-system-src-moonstone-900-i:  local("LG Smart UI Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
+@font-system-src-moonstone-100:    local("LG Smart UI Light"), local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Thin.ttf") format("truetype");
+@font-system-src-moonstone-300:    local("LG Smart UI Light"), local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
+@font-system-src-moonstone-500:    local("LG Smart UI"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
+@font-system-src-moonstone-500-i:  local("LG Smart UI"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
+@font-system-src-moonstone-600:    local("LG Smart UI SemiBold"), local("LGSmartUI-SemiBold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
+@font-system-src-moonstone-700:    local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
+@font-system-src-moonstone-700-i:  local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
+@font-system-src-moonstone-900:    local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
+@font-system-src-moonstone-900-i:  local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
 
-@font-system-src-non-latin-300:  local("LG Smart UI Global-Light");
-@font-system-src-non-latin-400:  local("LG Smart UI Global-Regular");
-@font-system-src-non-latin-700:  local("LG Smart UI Global-Regular");
+@font-system-src-non-latin-300:  local("LG Smart UI Global-Light"), local("LGSmartUIGlobal-Light");
+@font-system-src-non-latin-400:  local("LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular");
+@font-system-src-non-latin-700:  local("LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular");
 
 @font-system-src-moonstone-icons:  local("Moonstone"), url("../../fonts/Moonstone.ttf") format("truetype");
 @font-system-src-lg-icons:         local("LG Display_Dingbat");

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -68,9 +68,9 @@
 @moon-font-family-small: "Moonstone";  // Formerly weight: 500
 @moon-font-family-bold: "Moonstone";   // Formerly weight: 900
 @moon-alt-font-family: "Moonstone";
-@moon-non-latin-font-family: "Moonstone LG Display";
-@moon-non-latin-font-family-light: "Moonstone LG Display";  // Formerly weight: Light
-@moon-non-latin-font-family-bold: "Moonstone LG Display";   // Formerly weight: Bold
+@moon-non-latin-font-family: "Moonstone Global";
+@moon-non-latin-font-family-light: "Moonstone Global";  // Formerly weight: Light
+@moon-non-latin-font-family-bold: "Moonstone Global";   // Formerly weight: Bold
 @moon-non-latin-font-weight: 500;
 @moon-non-latin-font-weight-bold: 500;
 @moon-non-latin-font-weight-light: 300;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The font definition file(s) refer to the PostScript names, which seem to not be available on the TV. The configs need to be updated to refer to the "full name" for the font files, rather than the PostScript names.


### Resolution
Updated font names


### Additional Considerations
Also updated the defined name of the international font. Changed from "Moonstone LG Display" to "Moonstone Global" to be more in-line with a font-name-agnostic naming convention for the generalized fonts.