### PR TITLE
ENYO-5999: Extended Dropdown to support objects, like Group

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,9 +4,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `moonstone/Dropdown` `children` propType so it supports the same format as `ui/Group` (an array of strings or an array of objects with props)
 ### Changed
 
 - `moonstone/Scroller` to scroll when no spottable child exists in the pressed 5-way key direction and, when `focusableScrollbar` is set, focus the scrollbar button
@@ -14,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - Fonts to correctly use the new font files and updated the international font name from "Moonstone LG Display" to "Moonstone Global"
+- `moonstone/Dropdown` `children` propType so it supports the same format as `ui/Group` (an array of strings or an array of objects with props)
 - `moonstone/VideoPlayer` to have correct sized control buttons
 
 ## [3.0.0-alpha.2] - 2019-05-20

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Dropdown` `children` propType so it supports the same format as `ui/Group` (an array of strings or an array of objects with props)
+
 ## [3.0.0-alpha.2] - 2019-05-20
 
 ### Added

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -81,7 +81,6 @@ const DropdownList = Skinnable(
 			 * The selections for Dropdown
 			 *
 			 * @type {String[]|Object[]}
-			 * @required
 			 * @private
 			 */
 			children: PropTypes.oneOfType([
@@ -89,7 +88,7 @@ const DropdownList = Skinnable(
 				PropTypes.arrayOf(PropTypes.shape({
 					key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 				}))
-			]).isRequired,
+			]),
 
 			/**
 			 * Called when an item is selected.
@@ -151,7 +150,6 @@ const DropdownBase = kind({
 		 * the generated components as the readable text.
 		 *
 		 * @type {String[]|Object[]}
-		 * @required
 		 * @public
 		 */
 		children: PropTypes.oneOfType([
@@ -159,7 +157,7 @@ const DropdownBase = kind({
 			PropTypes.arrayOf(PropTypes.shape({
 				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 			}))
-		]).isRequired,
+		]),
 
 		/**
 		 * Disables Dropdown and becomes non-interactive.

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -80,10 +80,16 @@ const DropdownList = Skinnable(
 			/**
 			 * The selections for Dropdown
 			 *
-			 * @type {String[]}
+			 * @type {String[]|Object[]}
+			 * @required
 			 * @private
 			 */
-			children: PropTypes.node,
+			children: PropTypes.oneOfType([
+				PropTypes.arrayOf(PropTypes.string),
+				PropTypes.arrayOf(PropTypes.shape({
+					key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+				}))
+			]).isRequired,
 
 			/**
 			 * Called when an item is selected.
@@ -144,11 +150,16 @@ const DropdownBase = kind({
 		 * Takes an array of strings and the strings will be used in
 		 * the generated components as the readable text.
 		 *
-		 * @type {String[]}
+		 * @type {String[]|Object[]}
 		 * @required
 		 * @public
 		 */
-		children: PropTypes.node,
+		children: PropTypes.oneOfType([
+			PropTypes.arrayOf(PropTypes.string),
+			PropTypes.arrayOf(PropTypes.shape({
+				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+			}))
+		]).isRequired,
 
 		/**
 		 * Disables Dropdown and becomes non-interactive.

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -148,7 +148,8 @@ const DropdownBase = kind({
 		 *
 		 * Takes either an array of strings or an array of objects. When strings, the values will be
 		 * used in the generated components as the readable text. When objects, the properties will
-		 * be passed onto an `Item` component and a unique `key` property is required.
+		 * be passed onto an `Item` component and `children` as well as a unique `key` property are
+		 * required.
 		 *
 		 * @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
 		 * @public

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -76,11 +76,11 @@ const DropdownList = Skinnable(
 	kind({
 		name: 'DropdownList',
 
-		propTypes: /** @lends moonstone/Dropdown.DropdownBase.prototype */ {
-			/**
+		propTypes: {
+			/*
 			 * The selections for Dropdown
 			 *
-			 * @type {String[]|Object[]}
+			 * @type {String[]|Array.<{key: Number|String}>}
 			 * @private
 			 */
 			children: PropTypes.oneOfType([
@@ -90,7 +90,7 @@ const DropdownList = Skinnable(
 				}))
 			]),
 
-			/**
+			/*
 			 * Called when an item is selected.
 			 *
 			 * @type {Function}
@@ -98,7 +98,7 @@ const DropdownList = Skinnable(
 			 */
 			onSelect: PropTypes.func,
 
-			/**
+			/*
 			 * Index of the selected item.
 			 *
 			 * @type {Number}
@@ -145,11 +145,13 @@ const DropdownBase = kind({
 
 	propTypes: /** @lends moonstone/Dropdown.DropdownBase.prototype */ {
 		/**
-		 * The selection items to be displayed in the `DropdownList`.
-		 * Takes an array of strings and the strings will be used in
-		 * the generated components as the readable text.
+		 * The selection items to be displayed in the `Dropdown` when `open`.
 		 *
-		 * @type {String[]|Object[]}
+		 * Takes either an array of strings or an array of objects. When strings, the values will be
+		 * used in the generated components as the readable text. When objects, the properties will
+		 * be passed onto an `Item` component and a unique `key` property is required.
+		 *
+		 * @type {String[]|Array.<{key: (Number|String)}>}
 		 * @public
 		 */
 		children: PropTypes.oneOfType([
@@ -192,7 +194,7 @@ const DropdownBase = kind({
 		onSelect: PropTypes.func,
 
 		/**
-		 * Displays the `DropdownList`.
+		 * Displays the items.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -20,6 +20,7 @@
 import Changeable from '@enact/ui/Changeable';
 import Toggleable from '@enact/ui/Toggleable';
 import equals from 'ramda/src/equals';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import Group from '@enact/ui/Group';
 import kind from '@enact/core/kind';
 import Pure from '@enact/ui/internal/Pure';
@@ -80,12 +81,12 @@ const DropdownList = Skinnable(
 			/*
 			 * The selections for Dropdown
 			 *
-			 * @type {String[]|Array.<{key: Number|String}>}
-			 * @private
+			 * @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
 			 */
 			children: PropTypes.oneOfType([
 				PropTypes.arrayOf(PropTypes.string),
 				PropTypes.arrayOf(PropTypes.shape({
+					children: EnactPropTypes.renderable.isRequired,
 					key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 				}))
 			]),
@@ -94,7 +95,6 @@ const DropdownList = Skinnable(
 			 * Called when an item is selected.
 			 *
 			 * @type {Function}
-			 * @private
 			 */
 			onSelect: PropTypes.func,
 
@@ -102,7 +102,6 @@ const DropdownList = Skinnable(
 			 * Index of the selected item.
 			 *
 			 * @type {Number}
-			 * @private
 			 */
 			selected: PropTypes.number
 		},
@@ -151,12 +150,13 @@ const DropdownBase = kind({
 		 * used in the generated components as the readable text. When objects, the properties will
 		 * be passed onto an `Item` component and a unique `key` property is required.
 		 *
-		 * @type {String[]|Array.<{key: (Number|String)}>}
+		 * @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
 		 * @public
 		 */
 		children: PropTypes.oneOfType([
 			PropTypes.arrayOf(PropTypes.string),
 			PropTypes.arrayOf(PropTypes.shape({
+				children: EnactPropTypes.renderable.isRequired,
 				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 			}))
 		]),

--- a/packages/moonstone/ExpandableList/ExpandableList.js
+++ b/packages/moonstone/ExpandableList/ExpandableList.js
@@ -16,6 +16,7 @@
  */
 
 import Changeable from '@enact/ui/Changeable';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import equals from 'ramda/src/equals';
 import Group from '@enact/ui/Group';
 import kind from '@enact/core/kind';
@@ -86,13 +87,14 @@ const ExpandableListBase = kind({
 		 * item. [Read about keys](https://reactjs.org/docs/lists-and-keys.html#keys) for more
 		 * information.
 		 *
-		 * @type {String[]|Array.<{key: (Number|String)}>}
+		 * @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
 		 * @required
 		 * @public
 		 */
 		children: PropTypes.oneOfType([
 			PropTypes.arrayOf(PropTypes.string),
 			PropTypes.arrayOf(PropTypes.shape({
+				children: EnactPropTypes.renderable.isRequired,
 				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 			}))
 		]).isRequired,

--- a/packages/moonstone/ExpandableList/ExpandableList.js
+++ b/packages/moonstone/ExpandableList/ExpandableList.js
@@ -86,7 +86,7 @@ const ExpandableListBase = kind({
 		 * item. [Read about keys](https://reactjs.org/docs/lists-and-keys.html#keys) for more
 		 * information.
 		 *
-		 * @type {String[]|Object[]}
+		 * @type {String[]|Array.<{key: (Number|String)}>}
 		 * @required
 		 * @public
 		 */

--- a/packages/ui/Group/Group.js
+++ b/packages/ui/Group/Group.js
@@ -52,7 +52,7 @@ const GroupBase = kind({
 		 * item. [Read about keys](https://reactjs.org/docs/lists-and-keys.html#keys) for more
 		 * information.
 		 *
-		 * @type {String[]|Object[]}
+		 * @type {String[]|Array.<{key: (Number|String)}>}
 		 * @required
 		 * @public
 		 */

--- a/packages/ui/Repeater/Repeater.js
+++ b/packages/ui/Repeater/Repeater.js
@@ -48,7 +48,7 @@ const RepeaterBase = kind({
 		 * > **NOTE**: When an array of objects is provided, make sure a unique `key` is assigned to each
 		 * data. See https://fb.me/react-warning-keys for more information.
 		 *
-		 * @type {String[]|Object[]}
+		 * @type {String[]|Array.<{key: (Number|String)}>}
 		 * @required
 		 * @public
 		 */


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Blake Stephens <blake.stephens@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Dropdown` uses `Group` internally, but doesn't accept the same set of features as `Group`


### Resolution
Updated the propType definition for `children` of `Dropdown` to include the same options as `Group`.
