### PR TITLE
ENYO-5957: Fix Scroller to not blur when spotlight is paused

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -23,6 +23,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to change spotlight focus due to touch events
 - `moonstone/Slider` to not scroll the viewport when dragging on touch platforms
 - `moonstone/VirtualList` and `moonstone/Scroller` to animate with 5-way navigation by default
+- `moonstone/ExpandableInput` to retain focus when touching within the input field on touch platforms
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -303,7 +303,7 @@ class ScrollableBase extends Component {
 			isHorizontalScrollButtonFocused = horizontalScrollbarRef.current && horizontalScrollbarRef.current.isOneOfScrollButtonsFocused(),
 			isVerticalScrollButtonFocused = verticalScrollbarRef.current && verticalScrollbarRef.current.isOneOfScrollButtonsFocused();
 
-		if (focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
+		if (!Spotlight.isPaused() && focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
 			focusedItem.blur();
 		}
 	}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Tapping within the input field of an expandable input would close the expandable. If you tapped in the right place at the right time, the pointer would also get locked by the input field.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Prevent blurring on touch start when spotlight is paused.

The pointer lock was a red herring in this case. It was caused by quickly tapping such that `InputSpotlightDecorator` lost and regained focus while the input was closing. Since it thought it had focus (but didn't), it locked the pointer. This was exacerbated by the logic in `SpotlightContainerDecorator` which would also blur the input (via `silentBlur()`) when the input gained focus when the expandable was closed because `spotlightDisabled` is set on the container when `!open`.

Ultimately, not blurring the input what tapping inside it fixes :allthethings: