### PR TITLE
PLAT-77055: Change Scroller to scroll and focus button when no focus target found

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Scroller` to scroll when no spottable child exists in the 5-way key direction then focus a scrollbar button if `focusableScrollbar` is true
+
 ## [3.0.0-alpha.2] - 2019-05-20
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
-- `moonstone/Scroller` to scroll when no spottable child exists in the 5-way key direction then focus a scrollbar button if `focusableScrollbar` is true
+- `moonstone/Scroller` to scroll when no spottable child exists in the pressed 5-way key direction and, when `focusableScrollbar` is set, focus the scrollbar button
 
 ## [3.0.0-alpha.2] - 2019-05-20
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Changed
 
 - `moonstone/Scroller` to scroll when no spottable child exists in the pressed 5-way key direction and, when `focusableScrollbar` is set, focus the scrollbar button
+
 ### Fixed
 
 - Fonts to correctly use the new font files and updated the international font name from "Moonstone LG Display" to "Moonstone Global"

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -204,6 +204,10 @@ class ScrollButtons extends Component {
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 	}
 
+	focusOnButton = (isPrev) => {
+		Spotlight.focus(isPrev ? this.prevButtonRef.current : this.nextButtonRef.current);
+	}
+
 	focusOnOppositeScrollButton = (ev, direction) => {
 		const buttonNode = (ev.target === this.nextButtonRef.current) ? this.prevButtonRef.current : this.nextButtonRef.current;
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -614,6 +614,22 @@ class ScrollableBase extends Component {
 		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
 	}
 
+	scrollAndFocusScrollbarButton = (direction) => {
+		const
+			isRtl = this.uiRef.current.state.rtl,
+			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
+			isVerticalScrollBar = direction === 'up' || direction === 'down';
+
+		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar});
+
+		if (this.props.focusableScrollbar) {
+			const scrollbar = this.uiRef.current[
+				(isVerticalScrollBar ? 'vertical' : 'horizontal') + 'ScrollbarRef'
+			];
+			scrollbar.current.focusOnButton(isPreviousScrollButton);
+		}
+	}
+
 	stop = () => {
 		if (!this.props['data-spotlight-container-disabled']) {
 			this.childRef.current.setContainerDisabled(false);
@@ -874,6 +890,7 @@ class ScrollableBase extends Component {
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.childRef,
 									rtl,
+									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
 									spotlightId
 								})}
 							</ChildWrapper>

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -610,6 +610,22 @@ class ScrollableBaseNative extends Component {
 		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
 	}
 
+	scrollAndFocusScrollbarButton = (direction) => {
+		const
+			isRtl = this.uiRef.current.state.rtl,
+			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
+			isVerticalScrollBar = direction === 'up' || direction === 'down';
+
+		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar});
+
+		if (this.props.focusableScrollbar) {
+			const scrollbar = this.uiRef.current[
+				(isVerticalScrollBar ? 'vertical' : 'horizontal') + 'ScrollbarRef'
+			];
+			scrollbar.current.focusOnButton(isPreviousScrollButton);
+		}
+	}
+
 	scrollStopOnScroll = () => {
 		if (!this.props['data-spotlight-container-disabled']) {
 			this.childRef.current.setContainerDisabled(false);
@@ -869,6 +885,7 @@ class ScrollableBaseNative extends Component {
 									onUpdate: this.handleScrollerUpdate,
 									ref: this.childRef,
 									rtl,
+									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
 									spotlightId
 								})}
 							</ChildWrapper>

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -104,13 +104,14 @@ class ScrollbarBase extends Component {
 		this.startHidingThumb = startHidingThumb;
 		this.uiUpdate = uiUpdate;
 
-		const {isOneOfScrollButtonsFocused, updateButtons} = this.scrollButtonsRef.current;
+		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = this.scrollButtonsRef.current;
 
 		this.isOneOfScrollButtonsFocused = isOneOfScrollButtonsFocused;
 		this.update = (bounds) => {
 			updateButtons(bounds);
 			this.uiUpdate(bounds);
 		};
+		this.focusOnButton = focusOnButton;
 	}
 
 	render () {
@@ -153,6 +154,7 @@ class ScrollbarBase extends Component {
  */
 const Scrollbar = ApiDecorator(
 	{api: [
+		'focusOnButton',
 		'getContainerRef',
 		'isOneOfScrollButtonsFocused',
 		'showThumb',

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -26,12 +26,7 @@ import React, {Component} from 'react';
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
 
-const
-	dataContainerDisabledAttribute = 'data-spotlight-container-disabled',
-	reverseDirections = {
-		left: 'right',
-		right: 'left'
-	};
+const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
 
 /**
  * A Moonstone-styled base component for [Scroller]{@link moonstone/Scroller.Scroller}.
@@ -72,6 +67,15 @@ class ScrollerBase extends Component {
 		 * @private
 		 */
 		rtl: PropTypes.bool,
+
+		/**
+		 * Called when [Scroller]{@link moonstone/Scroller.Scroller} should be scrolled
+		 * and the focus should be moved to a scrollbar button.
+		 *
+		 * @type {function}
+		 * @private
+		 */
+		scrollAndFocusScrollbarButton: PropTypes.func,
 
 		/**
 		 * The spotlight id for the component.
@@ -343,26 +347,20 @@ class ScrollerBase extends Component {
 		return candidateNode;
 	}
 
-	scrollToBoundary = (direction) => {
-		const
-			{scrollBounds, scrollPos} = this.uiRefCurrent,
-			isVerticalDirection = (direction === 'up' || direction === 'down');
-
-		if (isVerticalDirection) {
-			if (scrollPos.top > 0 && scrollPos.top < scrollBounds.maxTop) {
-				this.uiRefCurrent.props.cbScrollTo({align: direction === 'up' ? 'top' : 'bottom'});
-			}
-		} else if (scrollPos.left > 0 && scrollPos.left < scrollBounds.maxLeft) {
-			this.uiRefCurrent.props.cbScrollTo({align: this.props.rtl ? reverseDirections[direction] : direction});
-		}
-	}
-
 	handleLeaveContainer = ({direction, target}) => {
 		const contentsContainer = this.uiRefCurrent.containerRef.current;
 		// ensure we only scroll to boundary from the contents and not a scroll button which
 		// lie outside of this.uiRefCurrent.containerRef but within the spotlight container
 		if (contentsContainer && contentsContainer.contains(target)) {
-			this.scrollToBoundary(direction);
+			const
+				{scrollBounds: {maxLeft, maxTop}, scrollPos: {left, top}} = this.uiRefCurrent,
+				isVerticalDirection = (direction === 'up' || direction === 'down'),
+				pos = isVerticalDirection ? top : left,
+				max = isVerticalDirection ? maxTop : maxLeft;
+
+			if (pos > 0 && pos < max) {
+				this.props.scrollAndFocusScrollbarButton(direction);
+			}
 		}
 	}
 
@@ -378,6 +376,7 @@ class ScrollerBase extends Component {
 
 		delete props.initUiChildRef;
 		delete props.onUpdate;
+		delete props.scrollAndFocusScrollbarButton;
 		delete props.spotlightId;
 
 		return (

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -762,6 +762,8 @@ const VirtualListBaseFactory = (type) => {
 				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
 
 			delete rest.initUiChildRef;
+			// not used by VirtualList
+			delete rest.scrollAndFocusScrollbarButton;
 			delete rest.spotlightId;
 			delete rest.wrap;
 

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -331,6 +331,24 @@ storiesOf('Scroller', module)
 				</Scroller>
 			);
 		}
+	)
+	.add(
+		'Test scrolling to boundary with long overflow',
+		() => {
+			const size = number('Spacer size', 200, {max: 300, min: 0, range: true});
+			return (
+				<Scroller
+					style={{height: ri.scaleToRem(200)}}
+					focusableScrollbar={boolean('focusableScrollbar', {}, true)}
+				>
+					<div style={{height: ri.scaleToRem(size), paddingLeft: ri.scaleToRem(40)}}>{size}px Spacer</div>
+					<Item>1</Item>
+					<div style={{height: ri.scaleToRem(size), paddingLeft: ri.scaleToRem(40)}}>{size}px Spacer</div>
+					<Item>3</Item>
+					<div style={{height: ri.scaleToRem(size), paddingLeft: ri.scaleToRem(40)}}>{size}px Spacer</div>
+				</Scroller>
+			);
+		}
 	).add(
 		'With Spotlight Target Calculation',
 		() => (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a user press 5-way `down` key on the last spottable component when there is non-spottable content at the end of a scroller, scroller's behavior depends on the position of the last spottable item and `focusableScrollbar` option. If `focusableScrollbar` is false, it can scroll to the end. If `focusableScrollbar` is true, the behavior will be determined by the relative position of the currently focused item and a scrollbar button.
So, user experience is not consistent and a user may need to move focus to a scrollbar button to see underlying contents.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The UX rule for `Scroller` is changed not to scroll to the end of its contents but to scroll like pagination when no spottable component exists in the 5-way key direction. In addition to this, the focus will move to a scrollbar button if `focusableScrollbar` is true. So users can scroll down more simply by clicking the button.

### Links
[//]: # (Related issues, references)
PLAT-77055