### PR TITLE
ENYO-6006: Fix doc warning in Divider

### DIFF
--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -48,9 +48,10 @@ const DividerBase = kind({
 
 
 /**
- * @name DividerDecorator
  * Applies Moonstone specific behaviors to [DividerBase]{@link moonstone/Divider.DividerBase}.
  *
+ * @name DividerDecorator
+ * @class
  * @hoc
  * @memberof moonstone/Divider
  * @mixes i18n/Uppercase.Uppercase


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Doc warning when parsed, bad doc output

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Text must come at top!

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6006

### Comments
