### PR TITLE
ENYO-5999: Dropdown title fix for children of type array-obj

### DIFF
--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -249,12 +249,8 @@ const DropdownBase = kind({
 			const isSelectedValid = !(typeof selected === 'undefined' || selected === null || selected >= children.length || selected < 0);
 
 			if (children && children.length && isSelectedValid) {
-				const isArray = Array.isArray(selected);
-				if (typeof children[selected] === 'object') {
-					return children[selected].children;
-				} else {
-					return children[isArray ? selected[0] : selected];
-				}
+				const child = children[selected];
+				return typeof child === 'object' ? child.children : child;
 			}
 
 			return title;

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -250,7 +250,11 @@ const DropdownBase = kind({
 
 			if (children && children.length && isSelectedValid) {
 				const isArray = Array.isArray(selected);
-				return children[isArray ? selected[0] : selected];
+				if (typeof children[selected] === 'object') {
+					return children[selected].children;
+				} else {
+					return children[isArray ? selected[0] : selected];
+				}
 			}
 
 			return title;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The dropdown would not display a title when using `children` of type array of objects. 


### Resolution
If the `children` are an array of objects, use the `children` prop of the object as the `title`. This behavior mirrors `ExpandableList`.
