### PR TITLE
ENYO-6007: Corrected spacing between Header and content

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -39,15 +39,14 @@ const PanelsBase = kind({
 	render: ({children, description, noHeader, noPanel, noPanels, title, ...rest}) => (
 		!noPanels ? <Panels {...rest} onApplicationClose={reloadPage}>
 			{!noPanel ? <Panel className={css.panel}>
-				{!noHeader ? <React.Fragment>
-					<Header type="compact" title={title} casing="preserve" />
-					<Column>
+				{!noHeader ? [<Header type="compact" title={title} casing="preserve" key="header" />,
+					<Column key="body">
 						{description ? (
 							<Cell shrink component={BodyText} className={css.description}>{description}</Cell>
 						) : null}
 						<Cell className={css.storyCell}>{children}</Cell>
-					</Column>
-				</React.Fragment> : children}
+					</Column>] : children
+				}
 			</Panel> : children}
 		</Panels> : children
 	)


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There's no gap between the Sampler Header and content.

### Resolution
`Slottable` does not recognize/handle `React.Fragment`. The Sampler Environment component was updated to use a more traditional component layout to allow `Slottable` to continue to function normally in this scenario.