### PR TITLE
ENYO-6017: Change Dropdown to use radio selection

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
-- `moonstone/Dropdown` prop `select` prop to `radio`
+- `moonstone/Dropdown` to use radio selection which allows only changing the selection but not deselection
 
 ## [3.0.0-alpha.3] - 2019-05-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Dropdown` prop `select` prop to `radio`
+
 ## [3.0.0-alpha.3] - 2019-05-29
 
 ### Added

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -119,6 +119,7 @@ const DropdownList = Skinnable(
 						className={css.group}
 						component={children ? Scroller : null}
 						onSelect={onSelect}
+						select="radio"
 						selected={selected}
 					>
 						{children}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If select a selected value again, selected is removed. Because selected will be null value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added select prop to `radio` to retain a selected value.

### Links
[//]: # (Related issues, references)
ENYO-6017
