### PR TITLE
ENYO-6015: Updated Radio Dot to more closely match the design

### DIFF
--- a/packages/moonstone/RadioItem/RadioItem.module.less
+++ b/packages/moonstone/RadioItem/RadioItem.module.less
@@ -18,12 +18,12 @@
 		flex-shrink: 0;
 		margin-right: 0;
 		margin-left: 0;
-		box-shadow: 0 0 0 @moon-radio-item-indicator-border;
+		box-shadow: inset 0 0 0 @moon-radio-item-indicator-border;
 
 		&::before {
 			content: "";
 			position: absolute;
-			.position(3px);
+			.position(4px);
 			border-radius: inherit;
 		}
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -340,7 +340,7 @@
 
 // Radio Item
 // ---------------------------------------
-@moon-radio-item-indicator-size: 18px;
+@moon-radio-item-indicator-size: 21px;
 @moon-radio-item-indicator-size-large: 24px;
 @moon-radio-item-indicator-border: 2px;  // ### Exceptional Case ###
 	// 2px, not being a multiple of 3, poses special problems. Any math or assignment related to


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`RadioItem` dot does not horizontally align with its intended boundaries.


### Resolution
Updated the implementation to be closer to the intended design. The design specifies a 20px size, so the new size is 21, up from 18 with a 2px outset (for a final size of 22). The new dot has a 21 total outer width, and a 2px inset stroke. The center selected dot is now 4px, and although it's not a multiple of 3, the element this size is assigned to does not impact the layout in any way, so it seems permissible, given the drastic visual difference if we choose any other size than what is specified in the design. The positive size is now the stroke and the pink area when selected now match in width, which was previously off by 1px.