### PR TITLE
ENYO-5979: Fix VL unexpected focus change to to last focused items

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -517,11 +517,12 @@ const VirtualListBaseFactory = (type) => {
 						this.isWrappedBy5way = true;
 						this.pause.pause();
 						target.blur();
+						this.nodeIndexToBeFocused = nextIndex;
 					} else if (!isWrapped || wrap !== 'noAnimation') {
 						this.focusOnItem(nextIndex);
+					} else {
+						this.nodeIndexToBeFocused = nextIndex;
 					}
-
-					this.nodeIndexToBeFocused = nextIndex;
 
 					cbScrollTo({
 						index: nextIndex,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There are cases where `VirtualList` focus could unexpectedly change to a last-focused item.


### Resolution
Each time when setting focus to "next" items, `VirtualList` was needlessly setting the current index value to `this.nodeIndexToBeFocused`. This value only needs to be set prior to explicitly setting scroll position/focus elsewhere (e.g. a wrap or page event). As a result, `this.nodeIndexToBeFocused` was not being nullified, causing unexpected focus changes when items were mounted.
