### PR TITLE
ENYO-6019 Fixed ExpandableList with selected array

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to not scroll the viewport when dragging on touch platforms
 - `moonstone/VirtualList` and `moonstone/Scroller` to animate with 5-way navigation by default
 - `moonstone/ExpandableInput` to retain focus when touching within the input field on touch platforms
+- `moonstone/ExpandableList` to not error if `selected` is passed as an array to a non-multi-select list
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/ExpandableList/ExpandableList.js
+++ b/packages/moonstone/ExpandableList/ExpandableList.js
@@ -313,13 +313,13 @@ const ExpandableListBase = kind({
 			if (label) {
 				return label;
 			} else if (children.length && (selected || selected === 0)) {
-				const isArray = Array.isArray(selected);
-				if (select === 'multiple' && isArray) {
+				const firstSelected = Array.isArray(selected) ? selected[0] : selected;
+				if (select === 'multiple' && Array.isArray(selected)) {
 					return selected.map(i => typeof children[i] === 'object' ? children[i].children : children[i]).filter(str => !!str).join(', ');
-				} else if (typeof children[selected] === 'object') {
-					return children[selected].children;
+				} else if (typeof children[firstSelected] === 'object') {
+					return children[firstSelected].children;
 				} else {
-					return children[isArray ? selected[0] : selected];
+					return children[firstSelected];
 				}
 			}
 		},

--- a/packages/moonstone/ExpandableList/tests/ExpandableList-specs.js
+++ b/packages/moonstone/ExpandableList/tests/ExpandableList-specs.js
@@ -64,4 +64,67 @@ describe('ExpandableList', () => {
 
 		expect(actual).toBe(expected);
 	});
+
+	test('should allow for selected as array when not multi-select', () => {
+		const children = ['option1', 'option2', 'option3'];
+
+		const expandableList = mount(
+			<ExpandableList selected={[0, 1]} title="Item">
+				{children}
+			</ExpandableList>
+		);
+
+		const expected = children[0];
+		const actual = expandableList.text().slice(-1 * expected.length);
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should allow for selected as array when not multi-select with object', () => {
+		const children = [{
+			children: 'option1',
+			key: 'a'
+		}, {
+			children: 'option2',
+			key: 'b'
+		}, {
+			children: 'option3',
+			key: 'c'
+		}];
+
+		const expandableList = mount(
+			<ExpandableList selected={[1, 2]} title="Item">
+				{children}
+			</ExpandableList>
+		);
+
+		const expected = children[1].children;
+		const actual = expandableList.text().slice(-1 * expected.length);
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should show noneText when selected is empty array', () => {
+		const children = [{
+			children: 'option1',
+			key: 'a'
+		}, {
+			children: 'option2',
+			key: 'b'
+		}, {
+			children: 'option3',
+			key: 'c'
+		}];
+
+		const expandableList = mount(
+			<ExpandableList selected={[]} title="Item" noneText="hello">
+				{children}
+			</ExpandableList>
+		);
+
+		const expected = 'hello';
+		const actual = expandableList.text().slice(-1 * expected.length);
+
+		expect(actual).toBe(expected);
+	});
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It was possible for an `ExpandableList` to error if an array of selected items was passed to
a non-multi-select.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Refactor the logic to deal better with `selected` as array.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Added tests

### Links
[//]: # (Related issues, references)
ENYO-6019

### Comments
