### PR TITLE
Dropdown: Not allowed to move spotlight past the top and bottom of the popup

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
+- `moonstone/Dropdown` to prevent spotlight moving out of the popup
 - `moonstone/Dropdown` to use radio selection which allows only changing the selection but not deselection
 
 ## [3.0.0-alpha.3] - 2019-05-29

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -274,6 +274,7 @@ const DropdownBase = kind({
 				popupComponent={DropdownList}
 				onClick={onOpen}
 				open={openDropdown}
+				spotlightRestrict="self-only"
 			>
 				{title}
 			</ContextualButton>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
[New requirement]
Not allowed to move spotlight past the top and bottom of the popup.
Users can close the Dropdown list via back key or selecting any options.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added prop `spotlightRestrict: "self-only"` to ContextualButton of Dropdown.  

### Links
[//]: # (Related issues, references)
ENYO-6020
