### PR TITLE
ENYO-6021: Fix Scroller paging control focus behaviors

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to not scroll the viewport when dragging on touch platforms
 - `moonstone/VirtualList` and `moonstone/Scroller` to animate with 5-way navigation by default
 - `moonstone/ExpandableInput` to retain focus when touching within the input field on touch platforms
+- `moonstone/Scroller` to allow changing spotlight focus to opposite scroll button when switching to 5way mode
 
 ## [2.5.2] - 2019-04-23
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -207,7 +207,9 @@ class ScrollButtons extends Component {
 	focusOnOppositeScrollButton = (ev, direction) => {
 		const buttonNode = (ev.target === this.nextButtonRef.current) ? this.prevButtonRef.current : this.nextButtonRef.current;
 
+		ev.preventDefault();
 		ev.stopPropagation();
+		Spotlight.setPointerMode(false);
 
 		if (!Spotlight.focus(buttonNode)) {
 			Spotlight.move(direction);


### PR DESCRIPTION
…n switching modes

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Scroller` cannot change focus from a scroll button to the opposite scroll button when changing from pointer to 5way mode. Additionally, the browser (not the `Scroller`) will scroll in the 5way direction pressed.


### Resolution
We programmatically set focus to the opposite scroll button, but failed to prevent the default browser scroll behavior or turn off pointer mode. It should be safe to explicitly turn off pointer mode, since we are guarded by a directional key press.
