### PR TITLE
ENYO-6014: Remove Unneeded Scroller sample

### DIFF
--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -73,37 +73,6 @@ class ScrollerWithResizable extends React.Component {
 	}
 }
 
-class ScrollerTopMostVisibleItemInTheScroller extends React.Component {
-	componentDidMount () {
-		this.blurEvent = document.createEvent('Event');
-		this.blurEvent.initEvent('blur', true, true);
-		this.focusEvent = document.createEvent('Event');
-		this.focusEvent.initEvent('focus', true, true);
-	}
-
-	handleScrollStop = () => {
-		window.dispatchEvent(this.blurEvent);
-		window.dispatchEvent(this.focusEvent);
-	}
-
-	render () {
-		return (
-			<Scroller
-				focusableScrollbar
-				onScrollStop={this.handleScrollStop}
-				style={{height: ri.scale(200)}}
-				verticalScrollbar="visible"
-			>
-				<Item>Item</Item>
-				<Item>Focus me, press right, then select on down arrow</Item>
-				<Item>Focus should return here</Item>
-				<Item>Item</Item>
-				<Item>Item</Item>
-			</Scroller>
-		);
-	}
-}
-
 class ScrollerWithTwoExpandableList extends React.Component {
 	render () {
 		return (
@@ -282,12 +251,6 @@ storiesOf('Scroller', module)
 		'With Resizable',
 		() => (
 			<ScrollerWithResizable />
-		)
-	)
-	.add(
-		'Top Most Visible Item in the Scroller',
-		() => (
-			<ScrollerTopMostVisibleItemInTheScroller />
 		)
 	)
 	.add(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Previously, when a scroll button was focused & disabled - then the window was blurred and re-focused, we would set focus to the top-most spottable element in the scroller - since the scroll button would be disabled and couldn't become focused again. However, now that disabled components can be re-focused, it means that the disabled scroll button is the last-focused element and regains focus.

This appears to be expected behavior now. We could revisit this behavior later, but I think we can remove this sample (and associated test cases), since this test does not benefit us for now.
