### PR TITLE
ENYO-6005: Add moonstone style changes to 3.0 migration guide

### DIFF
--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -42,10 +42,18 @@ files, you may need to address these changes.
 #### variables
 * `@moon-button-large-font-size` has been renamed to `@moon-button-font-size`
 * `@moon-button-large-font-size-large` has been renamed to `@moon-button-font-size-large`
-* `@moon-header-border-top-width` has been removed
 * `@moon-button-large-text-size` has been removed
 * `@moon-button-small-text-size` has been removed
 * `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
+* `@moon-button-icon-start-margin` has been renamed to `@moon-button-icon-margin-start`
+* `@moon-button-icon-end-margin` has been renamed to `@moon-button-icon-margin-end`
+* `@moon-button-icon-small-start-margin` has been renamed to `@moon-button-icon-small-margin-start`
+* `@moon-button-icon-small-end-margin` has been renamed to `@moon-button-icon-small-margin-end`
+* `@moon-button-icon-position-after-start-margin` has been renamed to `@moon-button-icon-position-after-margin-start`
+* `@moon-button-icon-position-after-end-margin` has been renamed to `@moon-button-icon-position-after-margin-end`
+* `@moon-button-icon-position-after-small-start-margin` has been renamed to `@moon-button-icon-position-after-small-margin-start`
+* `@moon-button-icon-position-after-small-end-margin` has been renamed to `@moon-button-icon-position-after-small-margin-end`
+* `@moon-header-border-top-width` has been removed
 * `@moon-icon-button-size` has been removed
 * `@moon-icon-button-size-large` has been removed
 * `@moon-icon-button-small-size` has been removed

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -40,12 +40,17 @@ files, you may need to address these changes.
 * `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
 
 #### variables
-* `@moon-button-large-font-size` has been removed
-* `@moon-button-large-font-size-large` has been removed
+* `@moon-button-large-font-size` has been renamed to `@moon-button-font-size`
+* `@moon-button-large-font-size-large` has been renamed to `@moon-button-font-size-large`
 * `@moon-header-border-top-width` has been removed
 * `@moon-button-large-text-size` has been removed
 * `@moon-button-small-text-size` has been removed
 * `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
+* `@moon-icon-button-size` has been removed
+* `@moon-icon-button-size-large` has been removed
+* `@moon-icon-button-small-size` has been removed
+* `@moon-icon-button-small-size-large` has been removed
+* `@moon-notification-out-border-radius` has been removed
 * `@moon-notification-button-gap` has been removed
 * `@moon-tooltip-h-padding` has been replaced by `@moon-tooltip-padding`
 

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -18,10 +18,12 @@ Enact 3.0 no longer supports the 2019 TV platform or earlier versions.
 
 ## moonstone
 
-### Styles
+### Style
 Various styling changes have been made to support new UI/UX designs for the webOS TV platform.  In
 addition, some LESS variables have been changed or removed.  If you were importing `moonstone/styles/*.less`
-files, you may need to address these changes:
+files, you may need to address these changes.
+
+#### colors
 * `@moon-button-translucent-opacity` has been removed
 * `@moon-checkbox-check-color` has been renamed to `@moon-checkbox-text-color`
 * `@moon-checkbox-spotlight-bg-color` (`@moon-checkbox-bg-spotlight-color` in `colors-light.less`) has been renamed to `@moon-checkbox-focus-bg-color`
@@ -36,6 +38,16 @@ files, you may need to address these changes:
 * `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
 * `@moon-radio-item-selected-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-selected-focus-indicator-bg-color`
 * `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
+
+#### variables
+* `@moon-button-large-font-size` has been removed
+* `@moon-button-large-font-size-large` has been removed
+* `@moon-header-border-top-width` has been removed
+* `@moon-button-large-text-size` has been removed
+* `@moon-button-small-text-size` has been removed
+* `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
+* `@moon-notification-button-gap` has been removed
+* `@moon-tooltip-h-padding` has been replaced by `@moon-tooltip-padding`
 
 ### `Button`
 The `casing` prop has been removed.

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -18,6 +18,25 @@ Enact 3.0 no longer supports the 2019 TV platform or earlier versions.
 
 ## moonstone
 
+### Styles
+Various styling changes have been made to support new UI/UX designs for the webOS TV platform.  In
+addition, some LESS variables have been changed or removed.  If you were importing `moonstone/styles/*.less`
+files, you may need to address these changes:
+* `@moon-button-translucent-opacity` has been removed
+* `@moon-checkbox-check-color` has been renamed to `@moon-checkbox-text-color`
+* `@moon-checkbox-spotlight-bg-color` (`@moon-checkbox-bg-spotlight-color` in `colors-light.less`) has been renamed to `@moon-checkbox-focus-bg-color`
+* `@moon-checkbox-spotlight-color` has been renamed to `@moon-checkbox-focus-text-color`
+* `@moon-header-input-bg-color` has been removed
+* `@moon-header-input-text-color` has been removed
+* `@moon-input-border-active-outline-color` has been renamed to `@moon-input-border-active-shadow`
+* `@moon-radio-item-indicator-border-color` has been removed
+* `@moon-radio-item-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-focus-indicator-bg-color`
+* `@moon-radio-item-spotlight-indicator-border-color` has been removed
+* `@moon-radio-item-selected-indicator-border-color` has been removed
+* `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
+* `@moon-radio-item-selected-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-selected-focus-indicator-bg-color`
+* `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
+
 ### `Button`
 The `casing` prop has been removed.
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Adds `moonstone` styling changes to the Enact 3.0 migration guide.

### Links
[//]: # (Related issues, references)
ENYO-6005