### PR TITLE
ENYO-6022: Fix setting initial focus of short VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -194,9 +194,7 @@ const VirtualListBaseFactory = (type) => {
 				containerNode.addEventListener('keyup', this.onKeyUp);
 			}
 
-			setTimeout(() => {
-				this.restoreFocus();
-			}, 0);
+			this.forceUpdate();
 		}
 
 		componentDidUpdate (prevProps) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -193,6 +193,10 @@ const VirtualListBaseFactory = (type) => {
 				containerNode.addEventListener('keydown', this.onKeyDown);
 				containerNode.addEventListener('keyup', this.onKeyUp);
 			}
+
+			setTimeout(() => {
+				this.restoreFocus();
+			}, 0);
 		}
 
 		componentDidUpdate (prevProps) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -193,8 +193,6 @@ const VirtualListBaseFactory = (type) => {
 				containerNode.addEventListener('keydown', this.onKeyDown);
 				containerNode.addEventListener('keyup', this.onKeyUp);
 			}
-
-			this.forceUpdate();
 		}
 
 		componentDidUpdate (prevProps) {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -283,15 +283,20 @@ const VirtualListBaseFactory = (type) => {
 				this.calculateMetrics(this.props);
 				// eslint-disable-next-line react/no-did-mount-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
+			} else {
+				this.emitUpdateItems();
 			}
+
 			this.setContainerSize();
 		}
 
 		componentDidUpdate (prevProps, prevState) {
+			const {firstIndex, numOfItems} = this.state;
+
 			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
 			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
 
-			if (prevState.firstIndex !== this.state.firstIndex) {
+			if (prevState.firstIndex !== firstIndex || prevState.numOfItems !== numOfItems) {
 				this.emitUpdateItems();
 			}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When items of list is small, initial focus is not exist in VirtualList

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When items is small, componentDidUpdate is not called.
In current status, restoreFocus() is only declared in componentDidUpdate.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-6022

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>