### PR TITLE
ENYO-6023: Fix VideoPlayer to hide scrim if bottom controls are hidden

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - high contrast colors for `moonstone/Checkbox`, `moonstone/FormCheckbox`, `moonstone/Header`, `moonstone/RadioItem`, `moonstone/Slider`, and `moonstone/Switch`
+- `moonstone/VideoPlayer` to hide scrim for high contrast if bottom controls are hidden
 
 ## [3.0.0-alpha.3] - 2019-05-29
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.module.less
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.module.less
@@ -421,7 +421,7 @@
 		}
 
 		.overlay {
-			&::after {
+			&.high-contrast-scrim::after {
 				background: @moon-video-player-high-contrast-scrim-gradient-color
 			}
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fix VideoPlayer to hide scrim if bottom controls are hidden

### Resolution
Add `high-contrast-scrim` class name.
This class name is add or removed accoring to bottom controls visibility

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
ENYO-6023


### Comments
