### PR TITLE
PLAT-79791: Update font weights for non-latin mixed text

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+## Fixed
+
+- `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
+
 ## [3.0.0-alpha.4] - 2019-06-03
 
 ### Changed

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -82,7 +82,7 @@
 .buildFontFamily("Moonstone Global"; @font-system-src-non-latin-400; @font-system-src-moonstone-500);
 .buildFontFamily("Moonstone Global"; @font-system-src-non-latin-300; @font-system-src-moonstone-300; 300);
 .buildFontFamily("Moonstone Global"; @font-system-src-non-latin-400; @font-system-src-moonstone-500; 400);
-.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-700; @font-system-src-moonstone-700; 700);
+.buildFontFamily("Moonstone Global"; @font-system-src-non-latin-700; @font-system-src-moonstone-500; 700);
 
 /* ----- Moonstone (Icons) ------ */
 .buildFontFace("Moonstone Icons"; @font-system-src-moonstone-icons);

--- a/packages/sampler/stories/qa/Text.js
+++ b/packages/sampler/stories/qa/Text.js
@@ -33,6 +33,8 @@ const inputData = {
 	urdu: 'ہم گیسسٹون کے بعد موضوعات کا نام دیتے ہیں'
 };
 
+const mixedText = 'ข้MอiคxวeาdมTผeสxมt - M混i合x文e字d';
+
 Divider.displayName = 'Divider';
 
 const prop = {
@@ -102,4 +104,33 @@ storiesOf('Text', module)
 				{inputData[key]}
 			</SlotItem>
 		)
+	)
+	.add(
+		'Mixed Scripts',
+		() => <div>
+			<SlotItem style={{fontWeight: 300}}>
+				<slotBefore>
+					<span style={{minWidth: '10ex', display: 'inline-block'}}>light</span>
+				</slotBefore>
+				{mixedText}
+			</SlotItem>
+			<SlotItem style={{fontWeight: 400}}>
+				<slotBefore>
+					<span style={{minWidth: '10ex', display: 'inline-block'}}>regular</span>
+				</slotBefore>
+				{mixedText}
+			</SlotItem>
+			<SlotItem style={{fontWeight: 600}}>
+				<slotBefore>
+					<span style={{minWidth: '10ex', display: 'inline-block'}}>semi-bold</span>
+				</slotBefore>
+				{mixedText}
+			</SlotItem>
+			<SlotItem style={{fontWeight: 700}}>
+				<slotBefore>
+					<span style={{minWidth: '10ex', display: 'inline-block'}}>bold</span>
+				</slotBefore>
+				{mixedText}
+			</SlotItem>
+		</div>
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Mixing Latin and non-Latin text when in a non-Latin locale causes mismatched font weights.


### Resolution
Assigned the Latin-fallback for non-Latin rules to be a weight that matches the available non-Latin fonts.