### PR TITLE
ENYO-5993: Fix VirtualList to restore focus to an item when scrollbars are visible

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ## Fixed
 
 - `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
+- `moonstone/VirtualList` to restore focus to an item when scrollbars are visible
 
 ## [3.0.0-alpha.4] - 2019-06-03
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -281,14 +281,15 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		/*
-		 * Restores the data-index into the placeholder if its the only element. Tries to find a
-		 * matching child otherwise.
+		 * Restores the data-index into the placeholder if it exists. Tries to find a matching child
+		 * otherwise.
 		 */
 		lastFocusedRestore = ({key}, all) => {
-			if (all.length === 1 && 'vlPlaceholder' in all[0].dataset) {
-				all[0].dataset.index = key;
+			const placeholder = all.find(el => 'vlPlaceholder' in el.dataset);
+			if (placeholder) {
+				placeholder.dataset.index = key;
 
-				return all[0];
+				return placeholder;
 			}
 
 			return all.reduce((focused, node) => {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The logic within VL to restore focus assumed that the vl-placeholder element would be the only spottable on first render when trying to restore. By forcing the vertical scrollbar and setting focusableScrollbar and support focused + disabled (since the scroll buttons are initially disabled until the bounds and scroll position are sorted out), the assumption breaks down and VL fails to cache the last focused index.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace that assumption and instead find the placeholder, if it exists, set the index and return.
