### PR TITLE
ENYO-6032: Fix slider opacity when disabled and focused

### DIFF
--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -157,10 +157,6 @@
 				}
 			}
 
-			.disabled({
-				opacity: @moon-disabled-opacity;
-			});
-
 			.focus({
 				background-color: transparent;
 
@@ -174,6 +170,10 @@
 						border-color: @moon-slider-spotlight-knob-color;
 					}
 				}
+
+				.disabled({
+					opacity: @moon-disabled-opacity;
+				});
 			});
 		});
 


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Slider may display with wrong opacity when disabled and focused. This is due to disabled rule applied has the same specificity with general moonstone disable negation rule (i.e. .moonstone[disabled] [disabled]).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Extra opacity rule should only be applied when it's focused and disabled, which would increase the specificity.

See also #2347 

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
