### PR TITLE
PLAT-79571: Add prop width to moonstone/Dropdown

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Added
 
-- `moonstone/Dropdown` support for `'small'`, `'medium'`, and `'large'` sizes
+- `moonstone/Dropdown` support for `'small'`, `'medium'`, and `'large'` sizes via the new `width` prop
 
 ## Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `moonstone/Dropdown` support for `'small'`, `'medium'`, and `'large'` sizes
+
 ## Fixed
 
 - `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.module.less
@@ -15,7 +15,7 @@
 		border-width: @moon-contextual-popup-border-width;
 		border-style: solid;
 		border-radius: @moon-contextual-popup-border-radius;
-		padding:  @moon-contextual-popup-padding;
+		padding: @moon-contextual-popup-padding;
 		background-clip: padding-box;
 		-webkit-background-clip: padding-box;
 		-moz-background-clip: padding-box;

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -16,22 +16,21 @@
  * @exports DropdownBaseDecorator
  */
 
-
+import kind from '@enact/core/kind';
+import EnactPropTypes from '@enact/core/internal/prop-types';
+import {handle, forward} from '@enact/core/handle';
 import Changeable from '@enact/ui/Changeable';
 import Toggleable from '@enact/ui/Toggleable';
-import equals from 'ramda/src/equals';
-import EnactPropTypes from '@enact/core/internal/prop-types';
 import Group from '@enact/ui/Group';
-import kind from '@enact/core/kind';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
-import compose from 'ramda/src/compose';
+import {compose, equals} from 'ramda';
 import React from 'react';
 
-import {Button} from '../Button/Button';
+import Button from '../Button';
 import ContextualPopupDecorator from '../ContextualPopupDecorator/ContextualPopupDecorator';
-import {Item} from '../Item/Item';
-import {Scroller} from '../Scroller/Scroller';
+import Item from '../Item';
+import Scroller from '../Scroller';
 import Skinnable from '../Skinnable';
 
 import css from './Dropdown.module.less';
@@ -106,38 +105,36 @@ const DropdownList = Skinnable(
 			selected: PropTypes.number,
 
 			/**
-			 * The size of DropdownList.
+			 * The width of DropdownList.
 			 *
 			 * @type {('large'|'medium'|'small')}
 			 */
-			size: PropTypes.oneOf(['large', 'medium', 'small'])
+			width: PropTypes.oneOf(['large', 'medium', 'small'])
 		},
 
 		styles: {
-			className: 'dropDownList',
-			css
+			css,
+			className: 'dropDownList'
 		},
 
 		computed: {
-			className: ({size, styler}) => styler.append(size)
+			className: ({width, styler}) => styler.append(width)
 		},
 
 		render: ({children, onSelect, selected, ...rest}) => {
-			delete rest.size;
+			delete rest.width;
 
 			return (
-				<div {...rest}>
-					<Group
-						childComponent={Item}
-						className={css.group}
-						component={children ? Scroller : null}
-						onSelect={onSelect}
-						select="radio"
-						selected={selected}
-					>
-						{children}
-					</Group>
-				</div>
+				<Group
+					{...rest}
+					childComponent={Item}
+					component={children ? Scroller : null}
+					onSelect={onSelect}
+					select="radio"
+					selected={selected}
+				>
+					{children}
+				</Group>
 			);
 		}
 	})
@@ -226,15 +223,6 @@ const DropdownBase = kind({
 		selected: PropTypes.number,
 
 		/**
-		 * The size of Dropdown.
-		 *
-		 * @type {('large'|'medium'|'small')}
-		 * @default 'medium'
-		 * @public
-		 */
-		size: PropTypes.oneOf(['large', 'medium', 'small']),
-
-		/**
 		 * The primary title text of Dropdown.
 		 * The title will be replaced if an item is selected.
 		 *
@@ -242,25 +230,29 @@ const DropdownBase = kind({
 		 * @required
 		 * @public
 		 */
-		title: PropTypes.string
+		title: PropTypes.string,
+
+		/**
+		 * The width of Dropdown.
+		 *
+		 * @type {('large'|'medium'|'small')}
+		 * @default 'medium'
+		 * @public
+		 */
+		width: PropTypes.oneOf(['large', 'medium', 'small'])
 	},
 
 	defaultProps: {
 		direction: 'down',
 		open: false,
-		size: 'medium'
+		width: 'medium'
 	},
 
 	handlers: {
-		onSelect: (ev, {onClose, onSelect}) => {
-			if (onClose) {
-				onClose(ev);
-			}
-
-			if (onSelect) {
-				onSelect(ev);
-			}
-		}
+		onSelect: handle(
+			forward('onSelect'),
+			forward('onClose')
+		)
 	},
 
 	styles: {
@@ -269,7 +261,7 @@ const DropdownBase = kind({
 	},
 
 	computed: {
-		className: ({size, styler}) => styler.append(size),
+		className: ({width, styler}) => styler.append(width),
 		title: ({children, selected, title}) => {
 			const isSelectedValid = !(typeof selected === 'undefined' || selected === null || selected >= children.length || selected < 0);
 
@@ -282,12 +274,13 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({children, disabled, onOpen, onSelect, open, selected, size, title, ...rest}) => {
-		const popupProps = {children, onSelect, open, selected, size};
+	render: ({children, disabled, onOpen, onSelect, open, selected, width, title, ...rest}) => {
+		const popupProps = {children, onSelect, selected, width};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
 		const hasChildren = children && children.length;
 		const openDropdown = hasChildren ? open : false;
+		delete rest.width;
 
 		return (
 			<ContextualButton
@@ -298,7 +291,6 @@ const DropdownBase = kind({
 				popupComponent={DropdownList}
 				onClick={onOpen}
 				open={openDropdown}
-				size={size}
 				spotlightRestrict="self-only"
 			>
 				{title}

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -103,7 +103,14 @@ const DropdownList = Skinnable(
 			 *
 			 * @type {Number}
 			 */
-			selected: PropTypes.number
+			selected: PropTypes.number,
+
+			/**
+			 * The size of DropdownList.
+			 *
+			 * @type {('large'|'medium'|'small')}
+			 */
+			size: PropTypes.oneOf(['large', 'medium', 'small'])
 		},
 
 		styles: {
@@ -111,7 +118,13 @@ const DropdownList = Skinnable(
 			css
 		},
 
+		computed: {
+			className: ({size, styler}) => styler.append(size)
+		},
+
 		render: ({children, onSelect, selected, ...rest}) => {
+			delete rest.size;
+
 			return (
 				<div {...rest}>
 					<Group
@@ -213,6 +226,15 @@ const DropdownBase = kind({
 		selected: PropTypes.number,
 
 		/**
+		 * The size of Dropdown.
+		 *
+		 * @type {('large'|'medium'|'small')}
+		 * @default 'medium'
+		 * @public
+		 */
+		size: PropTypes.oneOf(['large', 'medium', 'small']),
+
+		/**
 		 * The primary title text of Dropdown.
 		 * The title will be replaced if an item is selected.
 		 *
@@ -225,7 +247,8 @@ const DropdownBase = kind({
 
 	defaultProps: {
 		direction: 'down',
-		open: false
+		open: false,
+		size: 'medium'
 	},
 
 	handlers: {
@@ -246,6 +269,7 @@ const DropdownBase = kind({
 	},
 
 	computed: {
+		className: ({size, styler}) => styler.append(size),
 		title: ({children, selected, title}) => {
 			const isSelectedValid = !(typeof selected === 'undefined' || selected === null || selected >= children.length || selected < 0);
 
@@ -258,8 +282,8 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({children, disabled, onOpen, onSelect, open, selected, title, ...rest}) => {
-		const popupProps = {children, onSelect, open, selected};
+	render: ({children, disabled, onOpen, onSelect, open, selected, size, title, ...rest}) => {
+		const popupProps = {children, onSelect, open, selected, size};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
 		const hasChildren = children && children.length;
@@ -274,6 +298,7 @@ const DropdownBase = kind({
 				popupComponent={DropdownList}
 				onClick={onOpen}
 				open={openDropdown}
+				size={size}
 				spotlightRestrict="self-only"
 			>
 				{title}

--- a/packages/moonstone/Dropdown/Dropdown.module.less
+++ b/packages/moonstone/Dropdown/Dropdown.module.less
@@ -21,7 +21,6 @@
 .dropDownList {
 	border-radius: @moon-dropdown-border-radius;
 	max-height: @moon-dropdown-list-max-height;
-	display: flex;
 
 	&.small {
 		width: @moon-dropdown-list-small-width;
@@ -39,18 +38,11 @@
 		max-height: @moon-dropdown-list-max-height-large;
 	});
 
-	.group {
-		height: auto;
-		flex: 1 1 auto;
-	}
-
 	// Skin colors
 	.applySkins({
-		.group {
-			[data-selected="true"] {
-				&:not(:focus) {
-					color: @moon-dropdown-selected-text-color;
-				}
+		[data-selected="true"] {
+			&:not(:focus) {
+				color: @moon-dropdown-selected-text-color;
 			}
 		}
 	});

--- a/packages/moonstone/Dropdown/Dropdown.module.less
+++ b/packages/moonstone/Dropdown/Dropdown.module.less
@@ -5,14 +5,35 @@
 @import "../styles/skin.less";
 
 .dropdown {
-	width: @moon-dropdown-width;
+	&.small {
+		width: @moon-dropdown-small-width;
+	}
+
+	&.medium {
+		width: @moon-dropdown-medium-width;
+	}
+
+	&.large {
+		width: @moon-dropdown-large-width;
+	}
 }
 
 .dropDownList {
 	border-radius: @moon-dropdown-border-radius;
-	width: @moon-dropdown-list-width;
 	max-height: @moon-dropdown-list-max-height;
 	display: flex;
+
+	&.small {
+		width: @moon-dropdown-list-small-width;
+	}
+
+	&.medium {
+		width: @moon-dropdown-list-medium-width;
+	}
+
+	&.large {
+		width: @moon-dropdown-list-large-width;
+	}
 
 	.moon-custom-text({
 		max-height: @moon-dropdown-list-max-height-large;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -210,8 +210,12 @@
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-border-radius: @moon-button-border-radius;
-@moon-dropdown-width: @moon-button-max-width;
-@moon-dropdown-list-width: (@moon-dropdown-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
+@moon-dropdown-small-width: @moon-button-small-min-width + 100;
+@moon-dropdown-medium-width: @moon-button-max-width - 100;
+@moon-dropdown-large-width: @moon-button-max-width;
+@moon-dropdown-list-small-width: (@moon-dropdown-small-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
+@moon-dropdown-list-medium-width: (@moon-dropdown-medium-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
+@moon-dropdown-list-large-width: (@moon-dropdown-large-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-max-height: (5 * @moon-item-height);
 @moon-dropdown-list-max-height-large: (5 * @moon-item-height-large);
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -210,8 +210,8 @@
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-border-radius: @moon-button-border-radius;
-@moon-dropdown-small-width: @moon-button-small-min-width + 100;
-@moon-dropdown-medium-width: @moon-button-max-width - 100;
+@moon-dropdown-small-width: @moon-button-min-width;
+@moon-dropdown-medium-width: (@moon-dropdown-large-width - 96px);
 @moon-dropdown-large-width: @moon-button-max-width;
 @moon-dropdown-list-small-width: (@moon-dropdown-small-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-medium-width: (@moon-dropdown-medium-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -28,7 +28,7 @@ storiesOf('Moonstone', module)
 					onClose={action('onClose')}
 					onOpen={action('onOpen')}
 					onSelect={action('onSelect')}
-					size={select('size', ['small', 'large'], Config)}
+					size={select('size', ['small', 'medium', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
 				>
 					{items}

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -28,8 +28,9 @@ storiesOf('Moonstone', module)
 					onClose={action('onClose')}
 					onOpen={action('onOpen')}
 					onSelect={action('onSelect')}
-					size={select('size', ['small', 'medium', 'large'], Config)}
+					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
+					width={select('width', ['small', 'medium', 'large'], Config)}
 				>
 					{items}
 				</Dropdown>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added support for `'small'`, `'medium'`, and `'large'` sizes for `Dropdown`.
The sizes were based on `Button` sizes:
`'small'` = small button min-width + 100px
`'medium'` = large button max-width - 100px
`'large'` = large button max-width

### Links
[//]: # (Related issues, references)
PLAT-79571
