### PR TITLE
ENYO-6033: VirtualList: Add missing findSpottableItem method

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -1,3 +1,4 @@
+import clamp from 'ramda/src/clamp';
 import {is} from '@enact/core/keymap';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -325,6 +326,16 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			return -1;
+		}
+
+		findSpottableItem = (indexFrom, indexTo) => {
+			const {dataSize} = this.props;
+
+			if (indexFrom < 0 && indexTo < 0 || indexFrom >= dataSize && indexTo >= dataSize) {
+				return -1;
+			} else {
+				return clamp(0, dataSize - 1, indexFrom);
+			}
 		}
 
 		getNextIndex = ({index, keyCode, repeat}) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The component will throw an error when attempting to wrap, causing applications to crash.


### Resolution
Re-adding back the `findSpottableItem` method that was removed in #2262 - the method was being used elsewhere in the component.

