### PR TITLE
ENYO-6035: Dropdown closes if it is disabled after opening

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Dropdown` closes if it becomes disabled after opening
+
 ## [3.0.0-alpha.5] - 2019-06-10
 
 ### Added
 
 - `moonstone/Dropdown` property `width` to support `'small'`, `'medium'`, and `'large'` sizes
 
-## Fixed
+### Fixed
 
 - `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
 - `moonstone/VirtualList` to restore focus to an item when scrollbars are visible

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Dropdown` closes if it becomes disabled after opening
+- `moonstone/Dropdown` remaining open after it becomes `disabled`
 
 ## [3.0.0-alpha.5] - 2019-06-10
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -279,7 +279,7 @@ const DropdownBase = kind({
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
 		const hasChildren = children && children.length;
-		const openDropdown = hasChildren ? open : false;
+		const openDropdown = (hasChildren && !disabled) ? open : false;
 		delete rest.width;
 
 		return (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
A Dropdown with an open menu will remain open when it becomes disabled.

### Resolution
Dropdown closes if it is disabled after opening.