### PR TITLE
Deprecate Uppercase HOC

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Deprecated
+
+- `i18n/Uppercase`, to be replaced by `i18n/util` in 3.0.0
+
 ## [2.5.3] - 2019-06-06
 
 No significant changes.

--- a/packages/i18n/Uppercase/Uppercase.js
+++ b/packages/i18n/Uppercase/Uppercase.js
@@ -26,8 +26,6 @@ const formatContent = (casing, content) => {
 	}
 };
 
-deprecate({name: 'i18n/Uppercase', until: '3.0.0', replacedBy: 'i18n/util', since: '2.6.0'});
-
 /**
  * A higher-order component that is used to wrap an element to provide locale-aware uppercasing of
  * `children`, provided that `children` is a single string. Other values for `children` are
@@ -83,7 +81,10 @@ const Uppercase = hoc((config, Wrapped) => kind({	// eslint-disable-line no-unus
 	}
 }));
 
-export default Uppercase;
+const WrappedUppercase = deprecate(Uppercase, {name: 'i18n/Uppercase', until: '3.0.0', replacedBy: 'i18n/util', since: '2.6.0'});
+
+export default WrappedUppercase;
 export {
-	Uppercase
+	Uppercase as privateUppercase,
+	WrappedUppercase as Uppercase
 };

--- a/packages/i18n/Uppercase/Uppercase.js
+++ b/packages/i18n/Uppercase/Uppercase.js
@@ -5,6 +5,7 @@
  * @exports Uppercase
  */
 
+import deprecate from '@enact/core/internal/deprecate';
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import React from 'react';
@@ -24,6 +25,8 @@ const formatContent = (casing, content) => {
 			return toUpperCase(content);
 	}
 };
+
+deprecate({name: 'i18n/Uppercase', until: '3.0.0', replacedBy: 'i18n/util', since: '2.6.0'});
 
 /**
  * A higher-order component that is used to wrap an element to provide locale-aware uppercasing of

--- a/packages/i18n/Uppercase/tests/Uppercase-specs.js
+++ b/packages/i18n/Uppercase/tests/Uppercase-specs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import Uppercase from '../Uppercase';
+import {privateUppercase as Uppercase} from '../Uppercase';
 import {updateLocale} from '../../locale';
 
 describe('Uppercase', () => {

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -11,7 +11,7 @@
  */
 
 import kind from '@enact/core/kind';
-import Uppercase from '@enact/i18n/Uppercase';
+import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import Spottable from '@enact/spotlight/Spottable';
 import {ButtonBase as UiButtonBase, ButtonDecorator as UiButtonDecorator} from '@enact/ui/Button';
 import Pure from '@enact/ui/internal/Pure';

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -6,7 +6,7 @@
  * @exports DialogBase
  */
 
-import kind from '@enact/core/kind';
+ import kind from '@enact/core/kind';
 import Uppercase from '@enact/i18n/Uppercase';
 import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';
@@ -55,6 +55,7 @@ const DialogBase = kind({
 		 * @type {String}
 		 * @default 'upper'
 		 * @public
+		 * @deprecated
 		 */
 		casing: PropTypes.oneOf(['upper', 'preserve', 'word', 'sentence']),
 

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -7,7 +7,7 @@
  */
 
  import kind from '@enact/core/kind';
-import Uppercase from '@enact/i18n/Uppercase';
+import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -6,7 +6,7 @@
  * @exports DialogBase
  */
 
- import kind from '@enact/core/kind';
+import kind from '@enact/core/kind';
 import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import Slottable from '@enact/ui/Slottable';
 import PropTypes from 'prop-types';

--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -16,7 +16,7 @@
  */
 
 import kind from '@enact/core/kind';
-import Uppercase from '@enact/i18n/Uppercase';
+import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';

--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -157,6 +157,7 @@ const Divider = DividerDecorator(DividerBase);
  * @memberof moonstone/Divider.Divider.prototype
  * @see i18n/Uppercase#casing
  * @public
+ * @deprecated
  */
 
 /**

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -1,7 +1,7 @@
 import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
-import Uppercase from '@enact/i18n/Uppercase';
+import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import {isRtlText} from '@enact/i18n/util';
 import {Layout, Cell} from '@enact/ui/Layout';
 import Slottable from '@enact/ui/Slottable';

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -54,6 +54,7 @@ const HeaderBase = kind({
 		 * @type {String}
 		 * @default 'upper'
 		 * @public
+		 * @deprecated
 		 */
 		casing: PropTypes.oneOf(['upper', 'preserve', 'word', 'sentence']),
 

--- a/packages/moonstone/TooltipDecorator/Tooltip.js
+++ b/packages/moonstone/TooltipDecorator/Tooltip.js
@@ -1,5 +1,5 @@
 import kind from '@enact/core/kind';
-import Uppercase from '@enact/i18n/Uppercase';
+import {privateUppercase as Uppercase} from '@enact/i18n/Uppercase';
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -93,6 +93,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * @type {String}
 			 * @default 'upper'
 			 * @public
+			 * @deprecated
 			 */
 			tooltipCasing: PropTypes.oneOf(['upper', 'preserve', 'word', 'sentence']),
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Deprecate `i18n/Uppercase` HOC for `i18n/util`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Should `casing` prop added by the Uppercase HOC also be marked deprecated and warn?

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
