### PR TITLE
PLAT-79783: Apply accessibility on Dropdown

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Dropdown` to support voice readout
+
 ## [3.0.0-alpha.5] - 2019-06-10
 
 ### Added

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Changed
+### Fixed
 
 - `moonstone/Dropdown` to support voice readout
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -35,8 +35,6 @@ import Skinnable from '../Skinnable';
 
 import css from './Dropdown.module.less';
 
-const filterChildren = children => children ? children.filter(Boolean) : [];
-
 const compareChildren = (a, b) => {
 	if (!a || !b || a.length !== b.length) return false;
 
@@ -263,7 +261,9 @@ const DropdownBase = kind({
 
 	computed: {
 		children: ({children, selected}) => {
-			return filterChildren(children).map((child, i) => {
+			if (!Array.isArray(children)) return [];
+
+			return children.map((child, i) => {
 				const aria = {
 					role: 'checkbox',
 					'aria-checked': selected === i
@@ -285,9 +285,7 @@ const DropdownBase = kind({
 		},
 		className: ({width, styler}) => styler.append(width),
 		title: ({children, selected, title}) => {
-			const isSelectedValid = !(typeof selected === 'undefined' || selected === null || selected >= children.length || selected < 0);
-
-			if (children && children.length && isSelectedValid) {
+			if (Array.isArray(children) && children[selected] != null) {
 				const child = children[selected];
 				return typeof child === 'object' ? child.children : child;
 			}
@@ -299,8 +297,9 @@ const DropdownBase = kind({
 	render: ({children, disabled, onOpen, onSelect, open, selected, width, title, ...rest}) => {
 		const popupProps = {children, onSelect, selected, width, role: ''};
 
-		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
-		const hasChildren = filterChildren(children).length;
+		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
+		// prevent Dropdown to open if there are no children.
+		const hasChildren = children.length > 0;
 		const openDropdown = hasChildren ? open : false;
 		delete rest.width;
 
@@ -322,7 +321,8 @@ const DropdownBase = kind({
 });
 
 /**
- * Applies Moonstone specific behaviors and functionality to [DropdownBase]{@link moonstone/Dropdown.DropdownBase}.
+ * Applies Moonstone specific behaviors and functionality to
+ * [DropdownBase]{@link moonstone/Dropdown.DropdownBase}.
  *
  * @hoc
  * @memberof moonstone/Dropdown
@@ -349,10 +349,10 @@ const DropdownDecorator = compose(
 /**
  * A Moonstone Dropdown component.
  *
- * By default, `Dropdown` maintains the state of its `selected` property.
- * Supply the `defaultSelected` property to control its initial value. If you
- * wish to directly control updates to the component, supply a value to `selected` at creation time
- * and update it in response to `onSelected` events.
+ * By default, `Dropdown` maintains the state of its `selected` property. Supply the
+ * `defaultSelected` property to control its initial value. If you wish to directly control updates
+ * to the component, supply a value to `selected` at creation time and update it in response to
+ * `onSelected` events.
  *
  * @class Dropdown
  * @memberof moonstone/Dropdown

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -26,6 +26,7 @@ import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import {compose, equals} from 'ramda';
 import React from 'react';
+import warning from 'warning';
 
 import Button from '../Button';
 import ContextualPopupDecorator from '../ContextualPopupDecorator/ContextualPopupDecorator';
@@ -268,6 +269,11 @@ const DropdownBase = kind({
 					role: 'checkbox',
 					'aria-checked': selected === i
 				};
+
+				warning(
+					child != null,
+					`Unsupported null or undefined child provided at index ${i} which will not be visible when rendered.`
+				);
 
 				if (typeof child === 'string') {
 					return {

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -133,7 +133,10 @@ const DropdownList = Skinnable(
 					select="radio"
 					selected={selected}
 				>
-					{children}
+					{children.map((o, i) => {
+						const {children = o, key = i} = o; // eslint-disable-next-line no-shadow
+						return ({children, key, role: 'checkbox', 'aria-checked': selected === i});
+					})}
 				</Group>
 			);
 		}
@@ -275,7 +278,8 @@ const DropdownBase = kind({
 	},
 
 	render: ({children, disabled, onOpen, onSelect, open, selected, width, title, ...rest}) => {
-		const popupProps = {children, onSelect, selected, width};
+		const role = '';
+		const popupProps = {children, onSelect, selected, width, role};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
 		const hasChildren = children && children.length;

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -118,7 +118,14 @@ const DropdownList = Skinnable(
 		},
 
 		computed: {
-			className: ({width, styler}) => styler.append(width)
+			className: ({width, styler}) => styler.append(width),
+			children: ({children, selected}) =>
+				children.filter(el => (el != null)).map((o, i) => ({
+					children: (o.children || o),
+					key: (o.key != null ? o.key : `item${i}`),
+					role: 'checkbox',
+					'aria-checked': (selected === i)
+				}))
 		},
 
 		render: ({children, onSelect, selected, ...rest}) => {
@@ -133,11 +140,7 @@ const DropdownList = Skinnable(
 					select="radio"
 					selected={selected}
 				>
-					{children.map((o, i) => {
-						// eslint-disable-next-line no-shadow
-						const {children = o, key = i} = o;
-						return ({children, key, role: 'checkbox', 'aria-checked': selected === i});
-					})}
+					{children}
 				</Group>
 			);
 		}
@@ -279,8 +282,7 @@ const DropdownBase = kind({
 	},
 
 	render: ({children, disabled, onOpen, onSelect, open, selected, width, title, ...rest}) => {
-		const role = '';
-		const popupProps = {children, onSelect, selected, width, role};
+		const popupProps = {children, onSelect, selected, width, role: ''};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
 		const hasChildren = children && children.length;

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -134,7 +134,8 @@ const DropdownList = Skinnable(
 					selected={selected}
 				>
 					{children.map((o, i) => {
-						const {children = o, key = i} = o; // eslint-disable-next-line no-shadow
+						// eslint-disable-next-line no-shadow
+						const {children = o, key = i} = o;
 						return ({children, key, role: 'checkbox', 'aria-checked': selected === i});
 					})}
 				</Group>

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -35,6 +35,7 @@ import Skinnable from '../Skinnable';
 
 import css from './Dropdown.module.less';
 
+const filterChildren = children => children ? children.filter(Boolean) : [];
 
 const compareChildren = (a, b) => {
 	if (!a || !b || a.length !== b.length) return false;
@@ -118,14 +119,7 @@ const DropdownList = Skinnable(
 		},
 
 		computed: {
-			className: ({width, styler}) => styler.append(width),
-			children: ({children, selected}) =>
-				children.filter(el => (el != null)).map((o, i) => ({
-					children: (o.children || o),
-					key: (o.key != null ? o.key : `item${i}`),
-					role: 'checkbox',
-					'aria-checked': (selected === i)
-				}))
+			className: ({width, styler}) => styler.append(width)
 		},
 
 		render: ({children, onSelect, selected, ...rest}) => {
@@ -268,6 +262,27 @@ const DropdownBase = kind({
 	},
 
 	computed: {
+		children: ({children, selected}) => {
+			return filterChildren(children).map((child, i) => {
+				const aria = {
+					role: 'checkbox',
+					'aria-checked': selected === i
+				};
+
+				if (typeof child === 'string') {
+					return {
+						...aria,
+						children: child,
+						key: `item${i}`
+					};
+				}
+
+				return {
+					...aria,
+					...child
+				};
+			});
+		},
 		className: ({width, styler}) => styler.append(width),
 		title: ({children, selected, title}) => {
 			const isSelectedValid = !(typeof selected === 'undefined' || selected === null || selected >= children.length || selected < 0);
@@ -285,7 +300,7 @@ const DropdownBase = kind({
 		const popupProps = {children, onSelect, selected, width, role: ''};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and prevent Dropdown to open if there are no children.
-		const hasChildren = children && children.length;
+		const hasChildren = filterChildren(children).length;
 		const openDropdown = hasChildren ? open : false;
 		delete rest.width;
 

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -34,7 +34,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should be disabled when there children is omitted', () => {
+	test('should be disabled when `children` is omitted', () => {
 		const dropDown = mount(
 			<DropdownBase title={title} />
 		);
@@ -45,7 +45,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should be disabled when there are no children', () => {
+	test('should be disabled when there are no `children`', () => {
 		const dropDown = mount(
 			<DropdownBase title={title}>
 				{[]}
@@ -58,7 +58,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should be disabled when there are no valid children', () => {
+	test('should be disabled when there are no valid `children`', () => {
 		const dropDown = mount(
 			<DropdownBase title={title}>
 				{[null, undefined, ''] /* eslint-disable-line no-undefined */}
@@ -102,7 +102,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should set the role of items to "checkbox"', () => {
+	test('should set the `role` of items to "checkbox"', () => {
 		const dropDown = shallow(
 			<DropdownBase title={title} defaultOpen>
 				{['item']}
@@ -115,7 +115,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should set the aria-checked state of the selected item', () => {
+	test('should set the `aria-checked` state of the `selected` item', () => {
 		const dropDown = shallow(
 			<DropdownBase title={title} selected={0}>
 				{['item']}

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -34,9 +34,35 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should be disabled when there is no children', () => {
+	test('should be disabled when there children is omitted', () => {
 		const dropDown = mount(
 			<DropdownBase title={title} />
+		);
+
+		const expected = true;
+		const actual = dropDown.find('DropdownButton').prop('disabled');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should be disabled when there are no children', () => {
+		const dropDown = mount(
+			<DropdownBase title={title}>
+				{[]}
+			</DropdownBase>
+		);
+
+		const expected = true;
+		const actual = dropDown.find('DropdownButton').prop('disabled');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should be disabled when there are no valid children', () => {
+		const dropDown = mount(
+			<DropdownBase title={title}>
+				{[null, undefined, ''] /* eslint-disable-line no-undefined */}
+			</DropdownBase>
 		);
 
 		const expected = true;
@@ -74,5 +100,70 @@ describe('Dropdown', () => {
 		const actual = dropDown.children().length;
 
 		expect(actual).toBe(expected);
+	});
+
+	test('should set the role of items to "checkbox"', () => {
+		const dropDown = shallow(
+			<DropdownBase title={title} defaultOpen>
+				{['item']}
+			</DropdownBase>
+		);
+
+		const expected = 'checkbox';
+		const actual = dropDown.prop('popupProps').children[0].role;
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should set the aria-checked state of the selected item', () => {
+		const dropDown = shallow(
+			<DropdownBase title={title} selected={0}>
+				{['item']}
+			</DropdownBase>
+		);
+
+		const expected = true;
+		const actual = dropDown.prop('popupProps').children[0]['aria-checked'];
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should pass through members of child objects to props for each item', () => {
+		const dropDown = shallow(
+			<DropdownBase title={title}>
+				{[{
+					disabled: true,
+					children: 'child',
+					key: 'item-0'
+				}]}
+			</DropdownBase>
+		);
+
+		const expected = true;
+		const actual = dropDown.prop('popupProps').children[0].disabled;
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should allow members in child object ts to override injected aria values', () => {
+		const dropDown = shallow(
+			<DropdownBase title={title} selected={0}>
+				{[{
+					disabled: true,
+					children: 'child',
+					key: 'item-0',
+					role: 'button',
+					'aria-checked': false
+				}]}
+			</DropdownBase>
+		);
+
+		const expected = {
+			role: 'button',
+			'aria-checked': false
+		};
+		const actual = dropDown.prop('popupProps').children[0];
+
+		expect(actual).toMatchObject(expected);
 	});
 });

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -6,7 +6,7 @@ const title = 'Dropdown select';
 const children = ['option1', 'option2', 'option3'];
 
 describe('Dropdown', () => {
-	test('should have title', () => {
+	test('should have `title`', () => {
 		const dropDown = mount(
 			<DropdownBase title={title}>
 				{children}
@@ -19,7 +19,20 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should have title that reflects selected option', () => {
+	test('should have `title` when `children` is invalid', () => {
+		const dropDown = mount(
+			<DropdownBase title={title}>
+				{null}
+			</DropdownBase>
+		);
+
+		const expected = title;
+		const actual = dropDown.find('.text').text();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should have `title` that reflects `selected` option', () => {
 		const selectedIndex = 1;
 
 		const dropDown = mount(
@@ -29,6 +42,19 @@ describe('Dropdown', () => {
 		);
 
 		const expected = children[selectedIndex];
+		const actual = dropDown.find('.text').text();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should have `title` when `selected` is invalid', () => {
+		const dropDown = mount(
+			<DropdownBase title={title} selected={-1}>
+				{children}
+			</DropdownBase>
+		);
+
+		const expected = title;
 		const actual = dropDown.find('.text').text();
 
 		expect(actual).toBe(expected);
@@ -54,34 +80,6 @@ describe('Dropdown', () => {
 
 		const expected = true;
 		const actual = dropDown.find('DropdownButton').prop('disabled');
-
-		expect(actual).toBe(expected);
-	});
-
-	test('should be disabled when there are no valid `children`', () => {
-		const dropDown = mount(
-			<DropdownBase title={title}>
-				{[null, undefined, ''] /* eslint-disable-line no-undefined */}
-			</DropdownBase>
-		);
-
-		const expected = true;
-		const actual = dropDown.find('DropdownButton').prop('disabled');
-
-		expect(actual).toBe(expected);
-	});
-
-	test('should have title that reflects default selected option', () => {
-		const selectedIndex = 2;
-
-		const dropDown = mount(
-			<Dropdown defaultSelected={selectedIndex} title={title}>
-				{children}
-			</Dropdown>
-		);
-
-		const expected = children[selectedIndex];
-		const actual = dropDown.find('.text').text();
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -145,7 +145,7 @@ describe('Dropdown', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should allow members in child object ts to override injected aria values', () => {
+	test('should allow members in child object to override injected aria values', () => {
 		const dropDown = shallow(
 			<DropdownBase title={title} selected={0}>
 				{[{


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Apply accessibility on new Dropdown component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `role=alert` from the ContextualButton for avoiding read all internal items when drop opens
Add `role=checkbox` and `aria-checked` for reading selected status and X of Y

