### PR TITLE
ENYO-6045: Deprecate Divider

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Input.InputBase` prop `focused` which will be handled by CSS in 3.0
 - `small` prop in `moonstone/Input` and `moonstone/ToggleButton`, which will be replaced by `size="small"` in 3.0
+- `moonstone/Divider`, to be moved to `moonstone/Heading` in 3.0.0
 
 ### Added
 

--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -15,6 +15,7 @@
  * @exports DividerDecorator
  */
 
+import deprecate from '@enact/core/internal/deprecate';
 import kind from '@enact/core/kind';
 import Uppercase from '@enact/i18n/Uppercase';
 import Pure from '@enact/ui/internal/Pure';
@@ -39,6 +40,7 @@ import css from './Divider.module.less';
  * @memberof moonstone/Divider
  * @ui
  * @public
+ * @deprecated since 2.6.0. Will be moved to {@link moonstone/Heading} in 3.0.0
  */
 const DividerBase = kind({
 	name: 'Divider',
@@ -91,6 +93,13 @@ const DividerBase = kind({
 
 	render: (props) => {
 		delete props.spacing;
+
+		deprecate({
+			name: 'moonstone/Divider',
+			replacedBy: 'moonstone/Heading',
+			since: '2.6.0',
+			until: '3.0.0'
+		});
 
 		return (
 			<h3 {...props} />

--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -91,20 +91,21 @@ const DividerBase = kind({
 		className: ({spacing, styler}) => styler.append(spacing)
 	},
 
-	render: (props) => {
-		delete props.spacing;
+	render: deprecate(
+		(props) => {
+			delete props.spacing;
 
-		deprecate({
+			return (
+				<h3 {...props} />
+			);
+		},
+		{
 			name: 'moonstone/Divider',
 			replacedBy: 'moonstone/Heading',
 			since: '2.6.0',
 			until: '3.0.0'
-		});
-
-		return (
-			<h3 {...props} />
-		);
-	}
+		}
+	)
 });
 
 /**

--- a/packages/moonstone/Divider/Divider.js
+++ b/packages/moonstone/Divider/Divider.js
@@ -40,7 +40,7 @@ import css from './Divider.module.less';
  * @memberof moonstone/Divider
  * @ui
  * @public
- * @deprecated since 2.6.0. Will be moved to {@link moonstone/Heading} in 3.0.0
+ * @deprecated since 2.6.0. Will be replaced by `moonstone/Heading` in 3.0.0
  */
 const DividerBase = kind({
 	name: 'Divider',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Deprecate `moonstone/Divider` which will be moved to `moonstone/Heading` in 3.0.0

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
