### PR TITLE
PLAT-79571: Updated to prescribed Dropdown widths

### DIFF
--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -210,9 +210,9 @@
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-border-radius: @moon-button-border-radius;
-@moon-dropdown-small-width: @moon-button-min-width;
-@moon-dropdown-medium-width: (@moon-dropdown-large-width - 96px);
-@moon-dropdown-large-width: @moon-button-max-width;
+@moon-dropdown-small-width: 210px;
+@moon-dropdown-medium-width: 300px;
+@moon-dropdown-large-width: 390px;
 @moon-dropdown-list-small-width: (@moon-dropdown-small-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-medium-width: (@moon-dropdown-medium-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-large-width: (@moon-dropdown-large-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -210,8 +210,8 @@
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-border-radius: @moon-button-border-radius;
-@moon-dropdown-small-width: 210px;
-@moon-dropdown-medium-width: 300px;
+@moon-dropdown-small-width: @moon-button-min-width;
+@moon-dropdown-medium-width: 345px;
 @moon-dropdown-large-width: 390px;
 @moon-dropdown-list-small-width: (@moon-dropdown-small-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-medium-width: (@moon-dropdown-medium-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Dropdown uses made-up sizes

### Resolution
Updted the size values


### Additional Considerations
Dropdown supports the `size` prop which lets you choose what size (Button) the activator/text should be. The medium and large `width` plus the combination of `size` small and large result in the **same** width button/activator, while `width=small` + `size=small` vs `width=small` + `size=large` results in a **different** button/activator width.

This is due to `<Button size="large">` having a smaller `min-width` than the small Dropdown width size.