### PR TITLE
ENYO-6047: Header: title is not center-aligned

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## Fixed
 
-- `Header` to align centered
+- `moonstone/Header` to center text when `centered` is used and additional controls are included by `moonstone/Panels`
 - `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
 
 ## [3.0.0-alpha.4] - 2019-06-03

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## Fixed
 
+- `Header` to align centered
 - `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
 
 ## [3.0.0-alpha.4] - 2019-06-03

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -175,7 +175,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({fullBleed, type, styler}) => styler.append({fullBleed}, type),
+		className: ({centered, fullBleed, type, styler}) => styler.append({centered, fullBleed}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -155,6 +155,12 @@
 		.padding-start-end(0, var(--moon-panels-controls-width));
 	}
 
+	.header.centered.compact,
+	.header.centered.standard .title,
+	.header.centered.standard .headerInput {
+		.padding-start-end(var(--moon-panels-controls-width), var(--moon-panels-controls-width));
+	}
+
 	.header.compact {
 		.headerComponents {
 			border-right-width: @moon-header-controls-border-width;

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -155,7 +155,6 @@
 		.padding-start-end(0, var(--moon-panels-controls-width));
 	}
 
-	.header.centered.compact,
 	.header.centered.standard .title,
 	.header.centered.standard .headerInput {
 		.padding-start-end(var(--moon-panels-controls-width), var(--moon-panels-controls-width));


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The title is not center-aligned when centeted is set.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed center alignment issue of Header by adding CSS `padding-start` when centered.

### Links
[//]: # (Related issues, references)
ENYO-6047
