### PR TITLE
PLAT-80079: Cleanup code in VirtualList and Scroller

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -1,9 +1,9 @@
-import {Announce} from '@enact/ui/AnnounceDecorator';
 import {is} from '@enact/core/keymap';
+import {Announce} from '@enact/ui/AnnounceDecorator';
+import Spotlight, {getDirection} from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
-import Spotlight, {getDirection} from '@enact/spotlight';
 
 import $L from '../internal/$L';
 

--- a/packages/moonstone/Scrollable/ScrollThumb.js
+++ b/packages/moonstone/Scrollable/ScrollThumb.js
@@ -1,6 +1,6 @@
+import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
 
 const nop = () => {};
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -594,7 +594,7 @@ class ScrollableBase extends Component {
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
-			} else if (getDirection(keyCode)) {
+			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 
 				this.uiRef.current.lastInputType = 'arrowKey';
@@ -877,8 +877,8 @@ class ScrollableBase extends Component {
 				onFlick={this.onFlick}
 				onKeyDown={this.onKeyDown}
 				onMouseDown={this.onMouseDown}
-				onWheel={this.onWheel}
 				onScroll={this.handleScroll}
+				onWheel={this.onWheel}
 				ref={this.uiRef}
 				removeEventListeners={this.removeEventListeners}
 				scrollTo={this.scrollTo}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -7,18 +7,17 @@
  */
 
 import classNames from 'classnames';
-import {constants, ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import handle, {forward} from '@enact/core/handle';
-import {getDirection} from '@enact/spotlight';
-import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
-import {I18nContextDecorator} from '@enact/i18n/I18nDecorator/I18nDecorator';
-import {Job} from '@enact/core/util';
-import {onWindowReady} from '@enact/core/snapshot';
 import platform from '@enact/core/platform';
+import {onWindowReady} from '@enact/core/snapshot';
+import {Job} from '@enact/core/util';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
+import {constants, ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
+import Spotlight, {getDirection} from '@enact/spotlight';
+import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import Spotlight from '@enact/spotlight';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -594,7 +594,7 @@ class ScrollableBase extends Component {
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
-			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
+			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 
 				this.uiRef.current.lastInputType = 'arrowKey';

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -903,7 +903,7 @@ class ScrollableBaseNative extends Component {
 
 	handleScroll = handle(
 		forward('onScroll'),
-		(ev, {id}, context) => id && context && this.context.set,
+		(ev, {id}, context) => id && context && context.set,
 		({scrollLeft: x, scrollTop: y}, {id}, context) => {
 			context.set(`${id}.scrollPosition`, {x, y});
 		}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -1,16 +1,15 @@
 import classNames from 'classnames';
-import {constants, ScrollableBaseNative as UiScrollableBaseNative} from '@enact/ui/Scrollable/ScrollableNative';
-import {getDirection} from '@enact/spotlight';
-import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import handle, {forward} from '@enact/core/handle';
-import {I18nContextDecorator} from '@enact/i18n/I18nDecorator/I18nDecorator';
-import {Job} from '@enact/core/util';
-import {onWindowReady} from '@enact/core/snapshot';
 import platform from '@enact/core/platform';
+import {onWindowReady} from '@enact/core/snapshot';
+import {Job} from '@enact/core/util';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
+import {constants, ScrollableBaseNative as UiScrollableBaseNative} from '@enact/ui/Scrollable/ScrollableNative';
+import Spotlight, {getDirection} from '@enact/spotlight';
+import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import Spotlight from '@enact/spotlight';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -364,7 +364,7 @@ class ScrollableBaseNative extends Component {
 			isHorizontalScrollButtonFocused = horizontalScrollbarRef.current && horizontalScrollbarRef.current.isOneOfScrollButtonsFocused(),
 			isVerticalScrollButtonFocused = verticalScrollbarRef.current && verticalScrollbarRef.current.isOneOfScrollButtonsFocused();
 
-		if (focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
+		if (!Spotlight.isPaused() && focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
 			focusedItem.blur();
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 import ApiDecorator from '@enact/core/internal/ApiDecorator';
+import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
 
 import ScrollButtons from './ScrollButtons';
 import ScrollThumb from './ScrollThumb';

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -16,9 +16,9 @@
  * @exports ScrollerBase
  */
 
+import {Spotlight} from '@enact/spotlight';
 import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
-import {Spotlight} from '@enact/spotlight';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 

--- a/packages/moonstone/VirtualList/VirtualList.js
+++ b/packages/moonstone/VirtualList/VirtualList.js
@@ -10,8 +10,8 @@
  * @exports VirtualListNative
  */
 
-import {gridListItemSizeShape} from '@enact/ui/VirtualList';
 import kind from '@enact/core/kind';
+import {gridListItemSizeShape} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -392,7 +392,7 @@ const VirtualListBaseFactory = (type) => {
 				this.lastFocusedIndex = nextIndex;
 
 				if (isNextItemInView) {
-					this.focusOnItem(nextIndex);
+					this.focusByIndex(nextIndex);
 				} else {
 					this.isScrolledBy5way = true;
 					this.isWrappedBy5way = isWrapped;
@@ -404,12 +404,12 @@ const VirtualListBaseFactory = (type) => {
 							this.pause.pause();
 							target.blur();
 						} else {
-							this.focusOnItem(nextIndex);
+							this.focusByIndex(nextIndex);
 						}
 
 						this.nodeIndexToBeFocused = nextIndex;
 					} else {
-						this.focusOnItem(nextIndex);
+						this.focusByIndex(nextIndex);
 					}
 
 					cbScrollTo({
@@ -487,7 +487,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		focusOnItem = (index) => {
+		focusByIndex = (index) => {
 			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}'].spottable`);
 
 			if (this.isWrappedBy5way) {
@@ -504,22 +504,15 @@ const VirtualListBaseFactory = (type) => {
 		initItemRef = (ref, index) => {
 			if (ref) {
 				if (type === JS) {
-					this.focusOnItem(index);
+					this.focusByIndex(index);
 				} else {
 					// If focusing the item of VirtuallistNative, `onFocus` in Scrollable will be called.
 					// Then VirtualListNative tries to scroll again differently from VirtualList.
 					// So we would like to skip `focus` handling when focusing the item as a workaround.
 					this.isScrolledByJump = true;
-					this.focusOnItem(index);
+					this.focusByIndex(index);
 				}
 			}
-		}
-
-		focusByIndex = (index) => {
-			// We have to focus node async for now since list items are not yet ready when it reaches componentDid* lifecycle methods
-			setTimeout(() => {
-				this.focusOnItem(index);
-			}, 0);
 		}
 
 		/**

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -376,11 +376,10 @@ const VirtualListBaseFactory = (type) => {
 		 * Handle `onKeyDown` event
 		 */
 
-		onAcceleratedKeyDown = ({keyCode, repeat, target}) => {
+		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
 			const {cbScrollTo, spacing, wrap} = this.props;
 			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPosition} = this.uiRefCurrent;
 			const index = getNumberValue(target.dataset.index);
-			const {isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
 
 			this.isScrolledBy5way = false;
 			this.isScrolledByJump = false;
@@ -442,7 +441,7 @@ const VirtualListBaseFactory = (type) => {
 					if (nextIndex >= 0) {
 						ev.preventDefault();
 						ev.stopPropagation();
-						this.onAcceleratedKeyDown({index, isWrapped, keyCode, nextIndex, repeat, target});
+						this.onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
 					} else {
 						const {dataSize} = this.props;
 						const {dimensionToExtent} = this.uiRefCurrent;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -1,12 +1,12 @@
-import Accelerator from '@enact/spotlight/Accelerator';
-import clamp from 'ramda/src/clamp';
 import {is} from '@enact/core/keymap';
-import Pause from '@enact/spotlight/Pause';
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
 import Spotlight, {getDirection} from '@enact/spotlight';
+import Accelerator from '@enact/spotlight/Accelerator';
+import Pause from '@enact/spotlight/Pause';
 import Spottable from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
+import PropTypes from 'prop-types';
+import clamp from 'ramda/src/clamp';
+import React, {Component} from 'react';
 
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -300,34 +300,6 @@ const VirtualListBaseFactory = (type) => {
 			}, null);
 		}
 
-		/**
-		 * Handle a Page up/down key with disabled items
-		 */
-
-		findSpottableItemWithPositionInExtent = (indexFrom, indexTo, position) => {
-			const
-				{dataSize} = this.props,
-				{dimensionToExtent} = this.uiRefCurrent;
-
-			if (0 <= indexFrom && indexFrom < dataSize &&
-				-1 <= indexTo && indexTo <= dataSize &&
-				0 <= position && position < dimensionToExtent) {
-				const
-					direction = (indexFrom < indexTo) ? 1 : -1,
-					delta = direction * dimensionToExtent,
-					diffPosition = (indexFrom % dimensionToExtent) - position,
-					// When direction is 1 (forward) and diffPosition is positive, add dimensionToExtent.
-					// When direction is -1 (backward) and diffPosition is negative, substract dimensionToExtent.
-					candidateIndex = indexFrom - diffPosition + ((direction * diffPosition > 0) ? delta : 0);
-
-				if (direction * (indexTo - candidateIndex) > 0) {
-					return candidateIndex;
-				}
-			}
-
-			return -1;
-		}
-
 		findSpottableItem = (indexFrom, indexTo) => {
 			const {dataSize} = this.props;
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -1,11 +1,11 @@
+import Accelerator from '@enact/spotlight/Accelerator';
 import clamp from 'ramda/src/clamp';
 import {is} from '@enact/core/keymap';
+import Pause from '@enact/spotlight/Pause';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import Spotlight, {getDirection} from '@enact/spotlight';
-import Pause from '@enact/spotlight/Pause';
 import Spottable from '@enact/spotlight/Spottable';
-import Accelerator from '@enact/spotlight/Accelerator';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 
 import {Scrollable, dataIndexAttribute} from '../Scrollable';

--- a/packages/ui/Scrollable/ScrollAnimator.js
+++ b/packages/ui/Scrollable/ScrollAnimator.js
@@ -1,5 +1,5 @@
-import clamp from 'ramda/src/clamp';
 import {perfNow} from '@enact/core/util';
+import clamp from 'ramda/src/clamp';
 
 const
 	// Use eases library

--- a/packages/ui/Scrollable/ScrollThumb.js
+++ b/packages/ui/Scrollable/ScrollThumb.js
@@ -1,6 +1,6 @@
 import kind from '@enact/core/kind';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import css from './ScrollThumb.module.less';
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -12,10 +12,10 @@ import clamp from 'ramda/src/clamp';
 import classNames from 'classnames';
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
-import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import Registry from '@enact/core/internal/Registry';
 
 import ForwardRef from '../ForwardRef';
 import {ResizeContext} from '../Resizable';
@@ -1200,10 +1200,10 @@ class ScrollableBase extends Component {
 					scrollTop: this.scrollTop
 				};
 
-			if (curHorizontalScrollbarVisible && this.horizontalScrollbarRef) {
+			if (curHorizontalScrollbarVisible && this.horizontalScrollbarRef.current) {
 				this.horizontalScrollbarRef.current.update(updatedBounds);
 			}
-			if (curVerticalScrollbarVisible && this.verticalScrollbarRef) {
+			if (curVerticalScrollbarVisible && this.verticalScrollbarRef.current) {
 				this.verticalScrollbarRef.current.update(updatedBounds);
 			}
 			return true;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -8,14 +8,14 @@
  * @private
  */
 
-import clamp from 'ramda/src/clamp';
 import classNames from 'classnames';
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
+import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
+import clamp from 'ramda/src/clamp';
 import React, {Component} from 'react';
-import Registry from '@enact/core/internal/Registry';
 
 import ForwardRef from '../ForwardRef';
 import {ResizeContext} from '../Resizable';

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -54,7 +54,7 @@ const TouchableDiv = Touchable('div');
  * @private
  */
 class ScrollableBaseNative extends Component {
-	static displayName = 'ui:ScrollableNativeBase'
+	static displayName = 'ui:ScrollableBaseNative'
 
 	static propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
 		/**

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -54,7 +54,7 @@ const TouchableDiv = Touchable('div');
  * @private
  */
 class ScrollableBaseNative extends Component {
-	static displayName = 'ui:ScrollableNative'
+	static displayName = 'ui:ScrollableNativeBase'
 
 	static propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
 		/**
@@ -1228,13 +1228,13 @@ class ScrollableBaseNative extends Component {
 	// ref
 
 	getScrollBounds () {
-		if (typeof this.childRefCurrent.getScrollBounds === 'function') {
+		if (this.childRefCurrent && typeof this.childRefCurrent.getScrollBounds === 'function') {
 			return this.childRefCurrent.getScrollBounds();
 		}
 	}
 
 	getMoreInfo () {
-		if (typeof this.childRefCurrent.getMoreInfo === 'function') {
+		if (this.childRefCurrent && typeof this.childRefCurrent.getMoreInfo === 'function') {
 			return this.childRefCurrent.getMoreInfo();
 		}
 	}

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1,12 +1,12 @@
-import clamp from 'ramda/src/clamp';
 import classNames from 'classnames';
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
-import {Job} from '@enact/core/util';
 import {platform} from '@enact/core/platform';
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
 import Registry from '@enact/core/internal/Registry';
+import {Job} from '@enact/core/util';
+import PropTypes from 'prop-types';
+import clamp from 'ramda/src/clamp';
+import React, {Component} from 'react';
 
 import {ResizeContext} from '../Resizable';
 import ri from '../resolution';

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import {forward} from '@enact/core/handle';
 import equals from 'ramda/src/equals';
+import {forward} from '@enact/core/handle';
 import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import equals from 'ramda/src/equals';
 import {forward} from '@enact/core/handle';
 import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
+import equals from 'ramda/src/equals';
 import React, {Component} from 'react';
 
 import Scrollable from '../Scrollable';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

We need to cleanup VirtualList and Scroller because we missed some patches and applied uncompleted patches in them.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

* Remove unused `findSpottableItemWithPositionInExtent()`
* Apply the patch for `Scrollable` in ENYO-5957 to `ScrollableNative`
* Cleanup `onAcceleratedKeyDown` parameters
* Reduce calling `getNextIndex() in VirtualList once
* Focus an item immediately when an app mounted and called the `cbScrollTo` in `VirtualList`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

* Cleanup Scrollable and ScrollableNative code.
* Cleanup VirtualList code.

### Links
[//]: # (Related issues, references)

PLAT-80079

### Comments
