### PR TITLE
ENYO-6051: Allow go next line even thought no item below the current item in VirtualGridList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -355,7 +355,7 @@ const VirtualListBaseFactory = (type) => {
 			const isNextItemMovement = isNextAdjacent && (isPDV && isRightMovement || !isPDV && isDownKey);
 			const isBackward = (isPDV && isUpKey || !isPDV && isLeftMovement || null);
 			const isForward = (isPDV && isDownKey || !isPDV && isRightMovement || null);
-			
+
 			let isWrapped = false;
 			let nextIndex = -1;
 			let targetIndex = -1;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing a 5-way Down key when there is no item below the current item but there is the next line in VirtualGridList, Spotlight was gone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If there is no item below the current item and there is the next line in VirtualGridList when pressing 5-way Down, Spotlight moves to the last item in it.

### Links
[//]: # (Related issues, references)

ENYO-6051