### PR TITLE
ENYO-6050: Fix ViewManager to provide a default value for previousIndex

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/ViewManager` to correctly arrange views when initially rendering a non-zero index
+
 ## [3.0.0-alpha.5] - 2019-06-10
 
 ### Added

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -229,7 +229,7 @@ class View extends React.Component {
 	 * @private
 	 */
 	prepareTransition = (arranger, callback, noAnimation) => {
-		const {duration, index, previousIndex, reverseTransition} = this.props;
+		const {duration, index, previousIndex = index, reverseTransition} = this.props;
 
 		// Need to ensure that we have a valid node reference before we animation. Sometimes, React
 		// will replace the node after mount causing a reference cached there to be invalid.

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -127,7 +127,9 @@ class View extends React.Component {
 
 	static defaultProps = {
 		appearing: false,
-		enteringDelay: 0
+		enteringDelay: 0,
+		index: 0,
+		reverseTransition: false
 	}
 
 	constructor (props) {

--- a/packages/ui/ViewManager/tests/View-specs.js
+++ b/packages/ui/ViewManager/tests/View-specs.js
@@ -219,4 +219,33 @@ describe('View', () => {
 		);
 	});
 
+	describe('arranger API', () => {
+		const arrangerStruct = {
+			from: expect.any(Number),
+			reverse: expect.any(Boolean),
+			to: expect.any(Number),
+			duration: expect.any(Number),
+			fill: expect.any(String),
+			node: expect.any(Object)
+		};
+
+		test(
+			'should pass the expected object to the arranger',
+			() => {
+				const arranger = {
+					enter: jest.fn(() => ({}))
+				};
+
+				const subject = mount(
+					<View duration={1000} arranger={arranger}>
+						<span />
+					</View>
+				);
+
+				subject.instance().componentWillEnter();
+				expect(arranger.enter).toBeCalledWith(arrangerStruct);
+			}
+		);
+	});
+
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Arrangers that rely on `previousIndex` and `index` to position views could throw on first render.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Default `previousIndex` to `index` for arrangers to ensure there's a valid value

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Also added a test to verify the input API of arranger methods.
