### PR TITLE
ENYO-6051: Go next line via 5-way Down even though there is no item below the current item

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Dropdown` to support voice readout
 - `moonstone/Dropdown` remaining open after it becomes `disabled`
+- `moonstone/VirtualGridList` to go next line via 5-way Down even though there is no item below the current item
 
 ## [3.0.0-alpha.5] - 2019-06-10
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -366,8 +366,14 @@ const VirtualListBaseFactory = (type) => {
 			if (isPrimaryDirectionVertical) {
 				if (isUpKey && row) {
 					targetIndex = index - dimensionToExtent;
-				} else if (isDownKey && isNextRow) {
-					targetIndex = index + dimensionToExtent;
+				} else if (isDownKey) {
+					if (isNextRow) {
+						targetIndex = index + dimensionToExtent;
+					} else if ( // if the next line is the last line and there is no item below the current item
+						Math.floor((index + dimensionToExtent ) / dimensionToExtent) === Math.floor((dataSize - 1) / dimensionToExtent)
+					) {
+						targetIndex = dataSize - 1;
+					}
 				} else if (isLeftMovement && column) {
 					targetIndex = index - 1;
 				} else if (isRightMovement && isNextAdjacent) {
@@ -375,8 +381,14 @@ const VirtualListBaseFactory = (type) => {
 				}
 			} else if (isLeftMovement && row) {
 				targetIndex = index - dimensionToExtent;
-			} else if (isRightMovement && isNextRow) {
-				targetIndex = index + dimensionToExtent;
+			} else if (isRightMovement) {
+				if (isNextRow) {
+					targetIndex = index + dimensionToExtent;
+				} else if ( // if the next line is the last line and there is no item below the current item
+					Math.floor((index + dimensionToExtent ) / dimensionToExtent) === Math.floor((dataSize - 1) / dimensionToExtent)
+				) {
+					targetIndex = dataSize - 1;
+				}
 			} else if (isUpKey && column) {
 				targetIndex = index - 1;
 			} else if (isDownKey && isNextAdjacent) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing a 5-way Down key when there is no item below the current item but there is the next line in VirtualGridList, Spotlight was gone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If there is no item below the current item and there is the next line in VirtualGridList when pressing 5-way Down, Spotlight moves to the last item in it.

### Links
[//]: # (Related issues, references)

ENYO-6051