### PR TITLE
PLAT-80460: Fix change log titles from alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 ## Removed
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 No significant changes.
 

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 ## Removed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 ### Removed
 

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 No significant changes.
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 No significant changes.
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 ### Fixed
 

--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact webos module, newest changes on the top.
 
-## [3.0.0-alpha.5] - 2019-06-17
+## [3.0.0-alpha.6] - 2019-06-17
 
 No significant changes.
 


### PR DESCRIPTION
I missed/mistyped the change log headers in alpha.6 so let's fix that before we move ahead.