### PR TITLE
PLAT-79871: Fix spotlight support for Dropdown

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## unreleased
+## [unreleased]
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## unreleased
+
+### Fixed
+
+- `moonstone/Dropdown` to scroll to and focus the selected item when opened
+
 ## [3.0.0-alpha.6] - 2019-06-17
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,10 +6,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Dropdown` to scroll to and focus the selected item when opened
 - `moonstone/ExpandableItem.ExpandableItemBase` to not error if `onClose` or `onOpen` was not supplied
 - `moonstone/GridListImageItem` to support overriding the `image` CSS class name
 - `moonstone/VirtualList` to scroll to the focused item when navigating out of the viewport via 5-way
+- `moonstone/Dropdown` to scroll to and focus the selected item when opened
 
 ## [3.0.0-alpha.6] - 2019-06-17
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -417,12 +417,12 @@ const DropdownBase = kind({
  * @public
  */
 const DropdownDecorator = compose(
-	I18nContextDecorator(
-		{rtlProp: 'rtl'}
-	),
 	Pure({propComparators: {
 		children: compareChildren
 	}}),
+	I18nContextDecorator(
+		{rtlProp: 'rtl'}
+	),
 	Changeable({
 		change: 'onSelect',
 		prop: 'selected'

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -541,7 +541,7 @@ class ScrollableBase extends Component {
 			current = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 		}
 
-		return current && this.uiRef.current.containerRef.current.contains(current);
+		return current && this.uiRef.current && this.uiRef.current.containerRef.current.contains(current);
 	}
 
 	checkAndApplyOverscrollEffectByDirection = (direction) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Added/fixed focus management for `Dropdown`

### Resolution
- When dropdown opens, the previously-selected item (if available) will be scrolled to (vertically-centered) and focused
- Pressing 5way horizontally will close the popup and move focus to the next eligible horizontal target
- Pressing 5way vertically (when at the top/bottom bounds of the `Dropdown` list) will not allow focus to leave the list
- Pointer can be used to begin an interaction with other components while a `Dropdown` is opened, effectively closing the `Dropdown` (removing the scrim)
