### PR TITLE
ENYO-6062: BrowsersList failure on Enact Sampler

### DIFF
--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -44,6 +44,7 @@
     "@storybook/theming": "^5.1.8",
     "babel-loader": "^8.0.6",
     "babel-plugin-dev-expression": "^0.2.1",
+    "browserslist": "^4.6.2",
     "core-js": "^3.1.4",
     "less": "^3.9.0",
     "less-loader": "^5.0.0",

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -44,7 +44,7 @@
     "@storybook/theming": "^5.1.8",
     "babel-loader": "^8.0.6",
     "babel-plugin-dev-expression": "^0.2.1",
-    "browserslist": "^4.6.2",
+    "caniuse-lite": "1.0.30000974",
     "core-js": "^3.1.4",
     "less": "^3.9.0",
     "less-loader": "^5.0.0",


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* `browserslist` is broken currently with a bad release on NPM interacting incorrectly with current `caniuse-lite`

### Resolution
* Setting top-level dependency `caniuse-lite@1.0.30000974` fixes the issue.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>