### PR TITLE
ENYO-6064: Derive groupId from displayName, when one is not set

### DIFF
--- a/packages/sampler/.qa-storybook/config.js
+++ b/packages/sampler/.qa-storybook/config.js
@@ -3,7 +3,7 @@ import {addParameters} from '@storybook/react';
 import {create} from '@storybook/theming';
 import configure from '../src/configure';
 
-const stories = require.context('../stories/qa', true, /.js$/);
+const stories = require.context('../stories/qa', false, /.js$/);
 
 addParameters({
 	options: {

--- a/packages/sampler/.storybook/config.js
+++ b/packages/sampler/.storybook/config.js
@@ -1,9 +1,10 @@
 import 'core-js';
-import {addParameters} from '@storybook/react';
+import {addParameters, addDecorator} from '@storybook/react';
 import {create} from '@storybook/theming';
+import {withInfo} from '@storybook/addon-info';
 import configure from '../src/configure';
 
-const stories = require.context('../stories/default', true, /.js$/);
+const stories = require.context('../stories/default', false, /.js$/);
 
 addParameters({
 	options: {
@@ -19,5 +20,31 @@ addParameters({
 		panelPosition: 'bottom'
 	}
 });
+
+// Set addon-info defaults
+addDecorator(withInfo({
+	propTables: null, // Disable all propTables
+	// Custom styling to ensure content fits well and potential scrollbars aren't under the
+	// overlay close button
+	styles: {
+		info: {
+			overflow: 'hidden',
+			padding: '25px 0px 0px 0px'
+		},
+		infoPage: {
+			overflow: 'auto',
+			height: '100%',
+			padding: '0px 20px'
+		},
+		infoBody: {
+			marginTop: '0px'
+		},
+		children: {
+			// backgroundColor: 'purple',  // For easier debugging
+			width: '100%',
+			height: '100%'
+		}
+	}
+}));
 
 configure(stories, module);

--- a/packages/sampler/src/configure.js
+++ b/packages/sampler/src/configure.js
@@ -1,7 +1,6 @@
 import {configure, addDecorator} from '@storybook/react';
 import {configureActions} from '@storybook/addon-actions';
 import {withKnobs} from '@storybook/addon-knobs';
-import {withInfo} from '@storybook/addon-info';
 import {Component} from 'react';
 
 // Fix for @storybook/addon-info which always needs at least an empty object for defaultProps.
@@ -14,34 +13,6 @@ function config (stories, mod) {
 		// Limit the number of items logged into the actions panel
 		limit: 10
 	});
-
-	// Set addon-info defaults
-	addDecorator(withInfo({
-		propTables: null, // Disable all propTables
-		// header: false, // Global configuration for the info addon across all of your stories.
-		// inline: true,
-		// Custom styling to ensure content fits well and potential scrollbars aren't under the
-		// overlay close button
-		styles: {
-			info: {
-				overflow: 'hidden',
-				padding: '25px 0px 0px 0px'
-			},
-			infoPage: {
-				overflow: 'auto',
-				height: '100%',
-				padding: '0px 20px'
-			},
-			infoBody: {
-				marginTop: '0px'
-			},
-			children: {
-				// backgroundColor: 'purple',  // For easier debugging
-				width: '100%',
-				height: '100%'
-			}
-		}
-	}));
 
 	// Set addon-knobs defaults
 	addDecorator(withKnobs({

--- a/packages/sampler/src/enact-knobs/select.js
+++ b/packages/sampler/src/enact-knobs/select.js
@@ -33,6 +33,11 @@ const select = (name, items, Config, selectedValue) => {
 		Config.defaultProps = {};
 	}
 
+	// If there's no group ID but there is a display name, use that for the group ID
+	if (Config.displayName && !Config.groupId) {
+		Config.groupId = Config.displayName;
+	}
+
 	const defaultValue = (typeof selectedValue === 'undefined') ?
 		Config.defaultProps[name] :
 		selectedValue;

--- a/packages/sampler/stories/default/Button.js
+++ b/packages/sampler/stories/default/Button.js
@@ -29,7 +29,7 @@ storiesOf('Moonstone', module)
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
 				iconPosition={select('iconPosition', ['', 'before', 'after'], Config, '')}
-				minWidth={!!boolean('minWidth', Config)}
+				minWidth={boolean('minWidth', Config) ? void 0 : false}
 				selected={boolean('selected', Config)}
 				size={select('size', ['', 'small', 'large'], Config)}
 			>

--- a/packages/sampler/stories/default/DayPicker.js
+++ b/packages/sampler/stories/default/DayPicker.js
@@ -13,7 +13,7 @@ storiesOf('Moonstone', module)
 		() => (
 			<DayPicker
 				aria-label={text('aria-label', DayPicker)}
-				dayNameLength={select('dayNameLength', ['short', 'medium', 'long', 'full'], 'long')}
+				dayNameLength={select('dayNameLength', ['short', 'medium', 'long', 'full'], DayPicker, 'long')}
 				disabled={boolean('disabled', DayPicker)}
 				everyDayText={text('everyDayText', DayPicker)}
 				everyWeekdayText={text('everyWeekdayText', DayPicker)}

--- a/packages/sampler/stories/default/Icon.js
+++ b/packages/sampler/stories/default/Icon.js
@@ -1,28 +1,37 @@
-import Icon from '@enact/moonstone/Icon';
+import Icon, {IconBase} from '@enact/moonstone/Icon';
 import Heading from '@enact/moonstone/Heading';
+import UiIcon from '@enact/ui/Icon';
 import iconNames from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {select, text} from '../../src/enact-knobs';
-import emptify from '../../src/utils/emptify.js';
+import {mergeComponentMetadata} from '../../src/utils';
 
 // import icons
 import docs from '../../images/icon-enact-docs.png';
 import factory from '../../images/icon-enact-factory.svg';
 import logo from '../../images/icon-enact-logo.svg';
 
+Icon.displayName = 'Icon';
+const Config = mergeComponentMetadata('Icon', UiIcon, IconBase, Icon);
+
 storiesOf('Moonstone', module)
 	.add(
 		'Icon',
 		() => {
-			const size = select('size', ['small', 'large'], Icon, 'large');
+			const size = select('size', ['small', 'large'], Config, 'large');
+			const iconType = select('icon type', ['glyph', 'url src', 'custom'], Config, 'glyph');
+			let children;
+			switch (iconType) {
+				case 'glyph': children = select('icon', iconNames, Config, 'plus'); break;
+				case 'url src': children = select('src', [docs, factory, logo], Config, logo); break;
+				default: children = text('custom icon', Config);
+			}
 			return (
 				<div>
-					<Icon
-						size={size}
-					>
-						{emptify(select('src', ['', docs, factory, logo], Icon, '')) + emptify(select('icon', ['', ...iconNames], Icon, 'plus')) + emptify(text('custom icon', Icon, ''))}
+					<Icon size={size}>
+						{children}
 					</Icon>
 					<br />
 					<br />

--- a/packages/sampler/stories/default/IconButton.js
+++ b/packages/sampler/stories/default/IconButton.js
@@ -45,7 +45,7 @@ storiesOf('Moonstone', module)
 				>
 					{children}
 				</IconButton>
-			)
+			);
 		},
 		{
 			info: {

--- a/packages/sampler/stories/default/IconButton.js
+++ b/packages/sampler/stories/default/IconButton.js
@@ -8,7 +8,6 @@ import {action} from '@storybook/addon-actions';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
-import emptify from '../../src/utils/emptify.js';
 
 // import icons
 import docs from '../../images/icon-enact-docs.png';
@@ -26,19 +25,28 @@ const Config = mergeComponentMetadata('IconButton', Button, ButtonBase, UIButton
 storiesOf('Moonstone', module)
 	.add(
 		'IconButton',
-		() => (
-			<IconButton
-				onClick={action('onClick')}
-				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config, '')}
-				color={select('color', ['', 'red', 'green', 'yellow', 'blue'], Config, '')}
-				disabled={boolean('disabled', Config)}
-				selected={boolean('selected', Config)}
-				size={select('size', ['small', 'large'], Config)}
-				tooltipText={text('tooltipText', Config, '')}
-			>
-				{emptify(select('src', ['', docs, factory, logo], '')) + emptify(select('icon', ['', ...icons], 'plus')) + emptify(text('custom icon', ''))}
-			</IconButton>
-		),
+		() => {
+			const iconType = select('icon type', ['glyph', 'url src', 'custom'], Config, 'glyph');
+			let children;
+			switch (iconType) {
+				case 'glyph': children = select('icon', icons, Config, 'plus'); break;
+				case 'url src': children = select('src', [docs, factory, logo], Config, logo); break;
+				default: children = text('custom icon', Config);
+			}
+			return (
+				<IconButton
+					onClick={action('onClick')}
+					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config, '')}
+					color={select('color', ['', 'red', 'green', 'yellow', 'blue'], Config, '')}
+					disabled={boolean('disabled', Config)}
+					selected={boolean('selected', Config)}
+					size={select('size', ['small', 'large'], Config)}
+					tooltipText={text('tooltipText', Config, '')}
+				>
+					{children}
+				</IconButton>
+			)
+		},
 		{
 			info: {
 				text: 'The basic IconButton'

--- a/packages/sampler/stories/default/Layout.js
+++ b/packages/sampler/stories/default/Layout.js
@@ -8,6 +8,7 @@ import {storiesOf} from '@storybook/react';
 import {boolean, number, select} from '../../src/enact-knobs';
 
 Layout.displayName = 'Layout';
+Cell.displayName = 'Cell';
 
 storiesOf('UI', module)
 	.add(

--- a/packages/sampler/stories/default/VideoPlayer.js
+++ b/packages/sampler/stories/default/VideoPlayer.js
@@ -92,7 +92,7 @@ storiesOf('Moonstone', module)
 				<div
 					style={{
 						transformOrigin: 'top',
-						transform: 'scale(' + number('video scale', 1, {range: true, min: 0.05, max: 1, step: 0.01}) + ')',
+						transform: 'scale(' + number('video scale', Config, {range: true, min: 0.05, max: 1, step: 0.01}, 1) + ')',
 						outline: 'teal dashed 1px',
 						height: '70vh'
 					}}

--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -6,7 +6,6 @@ import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
-import {boolean as storybookBoolean} from '@storybook/addon-knobs';
 import css from './Button.module.less';
 
 import {boolean, select, text} from '../../src/enact-knobs';
@@ -34,7 +33,7 @@ storiesOf('Button', module)
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
-				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+				minWidth={boolean('minWidth', Config, true) ? void 0 : false}
 				selected={boolean('selected', Config)}
 				size={select('size', ['small', 'large'], Config)}
 			>
@@ -50,7 +49,7 @@ storiesOf('Button', module)
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
-				minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+				minWidth={boolean('minWidth', Config, true) ? void 0 : false}
 				selected={boolean('selected', Config)}
 				size={select('size', ['small', 'large'], Config)}
 			>
@@ -66,7 +65,7 @@ storiesOf('Button', module)
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 				disabled={boolean('disabled', Config)}
 				icon={select('icon', prop.icons, Config)}
-				minWidth={storybookBoolean('minWidth', false) ? void 0 : false}
+				minWidth={boolean('minWidth', Config, false) ? void 0 : false}
 				selected={boolean('selected', Config)}
 				size={select('size', ['small', 'large'], Config)}
 			>
@@ -83,7 +82,7 @@ storiesOf('Button', module)
 					backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
 					disabled={boolean('disabled', Config)}
 					icon={select('icon', prop.icons, Config)}
-					minWidth={storybookBoolean('minWidth', true) ? void 0 : false}
+					minWidth={boolean('minWidth', Config, true) ? void 0 : false}
 					selected={boolean('selected', Config)}
 					size={select('size', ['small', 'large'], Config)}
 				>

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -104,7 +104,7 @@ class IncrementSliderWithMinValue extends React.Component {
 					max={number('max', IncrementSliderConfig)}
 					min={number('min', IncrementSliderConfig)}
 					onChange={this.handleChange}
-					value={number('value', this.state.value)}
+					value={number('value', IncrementSliderConfig, this.state.value)}
 				/>
 			</div>
 		);

--- a/packages/sampler/stories/qa/Item.js
+++ b/packages/sampler/stories/qa/Item.js
@@ -70,22 +70,22 @@ storiesOf('Item', module)
 					{text('Disabled Text', Item, inputData.disabledText)}
 				</Item>
 				<Item>
-					<Icon size={select('size', ['small', 'large'], 'large')}>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>
 						{select('iconBefore', iconNames, Item, 'plus')}
 					</Icon>
 					{text('Text with iconBefore', Item, 'Item with text that is spottable with an icon (at the start of the string)')}
 				</Item>
 				<Item>
 					{text('Text with iconAfter', Item, 'Item with text that is spottable with an icon(at the end of the string)')}
-					<Icon size={select('size', ['small', 'large'], 'large')}>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>
 						{select('iconAfter', iconNames, Item, 'pauseforward')}
 					</Icon>
 				</Item>
 				<Item>
-					<Icon size={select('size', ['small', 'large'], 'large')}>gear</Icon>
-					<Icon size={select('size', ['small', 'large'], 'large')}>minus</Icon>
-					<Icon size={select('size', ['small', 'large'], 'large')}>trash</Icon>
-					<Icon size={select('size', ['small', 'large'], 'large')}>flag</Icon>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>gear</Icon>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>minus</Icon>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>trash</Icon>
+					<Icon size={select('size', ['small', 'large'], Item, 'large')}>flag</Icon>
 				</Item>
 			</div>
 		)

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -285,7 +285,7 @@ storiesOf('Scroller', module)
 	.add(
 		'Test scrolling to boundary with small overflow',
 		() => {
-			const size = number('Spacer size', 100, {max: 300, min: 0, range: true});
+			const size = number('Spacer size', Scroller, {max: 300, min: 0, range: true}, 100);
 			return (
 				<Scroller style={{height: ri.scaleToRem(200)}}>
 					<Item>1</Item>
@@ -298,11 +298,11 @@ storiesOf('Scroller', module)
 	.add(
 		'Test scrolling to boundary with long overflow',
 		() => {
-			const size = number('Spacer size', 200, {max: 300, min: 0, range: true});
+			const size = number('Spacer size', Scroller, {max: 300, min: 0, range: true}, 200);
 			return (
 				<Scroller
 					style={{height: ri.scaleToRem(200)}}
-					focusableScrollbar={boolean('focusableScrollbar', {}, true)}
+					focusableScrollbar={boolean('focusableScrollbar', Scroller, true)}
 				>
 					<div style={{height: ri.scaleToRem(size), paddingLeft: ri.scaleToRem(40)}}>{size}px Spacer</div>
 					<Item>1</Item>

--- a/packages/sampler/stories/qa/Slider.js
+++ b/packages/sampler/stories/qa/Slider.js
@@ -1,13 +1,14 @@
 import VirtualList from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import Item from '@enact/moonstone/Item';
-
 import Slider from '@enact/moonstone/Slider';
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import {storiesOf} from '@storybook/react';
-import {withKnobs, number} from '@storybook/addon-knobs';
+
+import {number} from '../../src/enact-knobs';
+
+Slider.displayName = 'Slider';
 
 class SliderList extends React.Component {
 	static propTypes = {
@@ -96,7 +97,6 @@ class SliderList extends React.Component {
 }
 
 storiesOf('Slider', module)
-	.addDecorator(withKnobs)
 	.add(
 		'Add and Remove ',
 		() => {

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -203,7 +203,6 @@ class DisableTest extends React.Component {
 }
 
 class PopupFocusTest extends React.Component {
-	static groupId = 'Popup'
 	static propTypes = {
 		noAnimation: PropTypes.bool,
 		noAutoDismiss: PropTypes.bool,
@@ -427,11 +426,11 @@ storiesOf('Spotlight', module)
 		'Popup Navigation',
 		() => (
 			<PopupFocusTest
-				noAnimation={boolean('noAnimation', PopupFocusTest, false)}
-				noAutoDismiss={boolean('noAutoDismiss', PopupFocusTest, false)}
-				scrimType={select('scrimType', ['none', 'transparent', 'translucent'], PopupFocusTest, 'translucent')}
-				showCloseButton={boolean('showCloseButton', PopupFocusTest, true)}
-				spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], PopupFocusTest, 'self-only')}
+				noAnimation={boolean('noAnimation', Popup, false)}
+				noAutoDismiss={boolean('noAutoDismiss', Popup, false)}
+				scrimType={select('scrimType', ['none', 'transparent', 'translucent'], Popup, 'translucent')}
+				showCloseButton={boolean('showCloseButton', Popup, true)}
+				spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Popup, 'self-only')}
 			/>
 		)
 	)

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -203,6 +203,7 @@ class DisableTest extends React.Component {
 }
 
 class PopupFocusTest extends React.Component {
+	static groupId = 'Popup'
 	static propTypes = {
 		noAnimation: PropTypes.bool,
 		noAutoDismiss: PropTypes.bool,

--- a/packages/sampler/stories/qa/Text.js
+++ b/packages/sampler/stories/qa/Text.js
@@ -49,7 +49,7 @@ storiesOf('Text', module)
 	.add(
 		'Tall Glyphs as Non-Latin components',
 		() => {
-			const children = select('children', prop.tallText, 'नरेंद्र मोदी');
+			const children = select('children', prop.tallText, {groupId: 'Text'}, 'नरेंद्र मोदी');
 
 			return (
 				<Scroller style={{height: '100%'}}>

--- a/packages/sampler/stories/qa/Touchable.js
+++ b/packages/sampler/stories/qa/Touchable.js
@@ -105,8 +105,8 @@ storiesOf('Touchable', module)
 	.add(
 		'that pauses the hold when moving beyond tolerance (16px)',
 		() => {
-			const moveTolerance = number('holdConfig.moveTolerance', Button, 16, {range: true, min: 8, max: 160, step: 8});
-			const cancelOnMove = boolean('holdConfig.cancelOnMove', Button, true);
+			const moveTolerance = number('holdConfig moveTolerance', Button, 16, {range: true, min: 8, max: 160, step: 8});
+			const cancelOnMove = boolean('holdConfig cancelOnMove', Button, true) || false;
 			return (
 				<TouchArea
 					holdConfig={{
@@ -156,8 +156,8 @@ storiesOf('Touchable', module)
 		() => (
 			<TouchableDiv
 				dragConfig={{
-					global: boolean('dragConfig.global', TouchableDiv, false),
-					moveTolerance: number('dragConfig.moveTolerance', TouchableDiv, 16)
+					global: boolean('dragConfig global', TouchableDiv, false) || false,
+					moveTolerance: number('dragConfig moveTolerance', TouchableDiv, 16)
 				}}
 				noResume={boolean('noResume', TouchableDiv, false)}
 				onDragStart={action('onDragStart')}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* The Sampler `select` knob doesn't assign a groupId when none if found. As a result, `select` knobs with no explicit group are appearing in an "Other" category. This can be observed in the Moonstone->Icon story.

### Resolution
* Add a fallback to use `displayName` as the default `groupId` value when not found. This is the technique already used on the other knob proxies.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>