### PR TITLE
ENYO-6051: Fix VirtualList to scroll to focused item in next line

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+- `moonstone/VirtualList` to scroll to the focused item when navigating out of the viewport via 5-way
+
 ## [3.0.0-alpha.6] - 2019-06-17
 
 ### Removed

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -452,9 +452,13 @@ const VirtualListBaseFactory = (type) => {
 							isLeftMovement && column === 0 ||
 							isRightMovement && column === dimensionToExtent - 1;
 
-						if (repeat && isLeaving || !isLeaving && Spotlight.move(direction)) {
+						if (repeat && isLeaving) {
 							ev.preventDefault();
 							ev.stopPropagation();
+						} else if (!isLeaving && Spotlight.move(direction)) {
+							ev.preventDefault();
+							ev.stopPropagation();
+							this.onAcceleratedKeyDown({keyCode, nextIndex: getNumberValue(Spotlight.getCurrent().dataset.index), repeat, target});
 						}
 					}
 				}


### PR DESCRIPTION
…t line

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When pressing a 5way directional key in `VirtualList` - where the next target is a) out of the current viewable range and b) an oblique direction - focus is set on the control, but the control is not scrolled into view. This causes the appearance of "losing" spotlight focus.


### Resolution
Properly scroll the focused control into view.

