### PR TITLE
ENYO-6066: Fix GridListImageItem to add 'image' css class

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/GridListImageItem` to support overriding the `image` CSS class name
+
 ## [3.0.0-alpha.6] - 2019-06-17
 
 ### Removed

--- a/packages/moonstone/GridListImageItem/GridListImageItem.module.less
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.module.less
@@ -36,6 +36,10 @@
 		padding-top: @moon-gridlist-item-caption-padding-top;
 	}
 
+	.image {
+		/* Public Class Names */
+	}
+
 	// Skin colors
 	.applySkins({
 		border-color: transparent;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There is no `image` css class in `GridListImageItem.module.less` of moonstone.
`GridListImageItem` supports css overriding for image according to the specification of css prop

### Resolution
Add just `image` class

### Additional Considerations

### Links
ENYO-6066


### Comments
