### PR TITLE
PLAT-76949: Expose Scrollable public props to VirtualListBase and ScrollerBase JS Docs

### DIFF
--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -431,9 +431,7 @@ const Scroller = (props) => (
 );
 
 Scroller.propTypes = /** @lends moonstone/Scroller.Scroller.prototype */ {
-	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
-
-	id: PropTypes.string
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
 };
 
 Scroller.defaultProps = {
@@ -468,9 +466,7 @@ const ScrollerNative = (props) => (
 );
 
 ScrollerNative.propTypes = /** @lends moonstone/Scroller.ScrollerNative.prototype */ {
-	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
-
-	id: PropTypes.string
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
 };
 
 ScrollerNative.defaultProps = {

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -35,13 +35,14 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  *
  * @class ScrollerBase
  * @memberof moonstone/Scroller
+ * @extends ui/Scroller.ScrollerBase
  * @ui
  * @public
  */
 class ScrollerBase extends Component {
 	static displayName = 'ScrollerBase'
 
-	static propTypes = /** @lends moonstone/Scroller.Scroller.prototype */ {
+	static propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 		/**
 		 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.
 		 *
@@ -343,6 +344,70 @@ class ScrollerBase extends Component {
 }
 
 /**
+ * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+ * not move focus to the scrollbar controls.
+ *
+ * @name focusableScrollbar
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {Boolean}
+ * @default false
+ * @public
+ */
+
+/**
+ * Unique identifier for the component.
+ *
+ * When defined and when the `Scroller` is within a [Panel]{@link moonstone/Panels.Panel}, the
+ * `Scroller` will store its scroll position and restore that position when returning to the
+ * `Panel`.
+ *
+ * @name id
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the next button in the vertical scroll bar.
+ *
+ * @name scrollDownAriaLabel
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default $L('scroll down')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+ *
+ * @name scrollLeftAriaLabel
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default $L('scroll left')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the next button in the horizontal scroll bar.
+ *
+ * @name scrollRightAriaLabel
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default $L('scroll right')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the previous button in the vertical scroll bar.
+ *
+ * @name scrollUpAriaLabel
+ * @memberof moonstone/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default $L('scroll up')
+ * @public
+ */
+
+/**
  * A Moonstone-styled Scroller, Scrollable applied.
  *
  * Usage:
@@ -366,27 +431,8 @@ const Scroller = (props) => (
 );
 
 Scroller.propTypes = /** @lends moonstone/Scroller.Scroller.prototype */ {
-	/**
-	 * Direction of the scroller.
-	 *
-	 * * Values: `'both'`, `'horizontal'`, `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'both'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
-	/**
-	 * Unique identifier for the component.
-	 *
-	 * When defined and when the `Scroller` is within a [Panel]{@link moonstone/Panels.Panel}, the
-	 * `Scroller` will store its scroll position and restore that position when returning to the
-	 * `Panel`.
-	 *
-	 * @type {String}
-	 * @public
-	 */
 	id: PropTypes.string
 };
 
@@ -422,27 +468,8 @@ const ScrollerNative = (props) => (
 );
 
 ScrollerNative.propTypes = /** @lends moonstone/Scroller.ScrollerNative.prototype */ {
-	/**
-	 * Direction of the scroller.
-	 *
-	 * * Values: `'both'`, `'horizontal'`, `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'both'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
-	/**
-	 * Unique identifier for the component.
-	 *
-	 * When defined and when the `Scroller` is within a [Panel]{@link moonstone/Panels.Panel}, the
-	 * `Scroller` will store its scroll position and restore that position when returning to the
-	 * `Panel`.
-	 *
-	 * @type {String}
-	 * @public
-	 */
 	id: PropTypes.string
 };
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -130,7 +130,7 @@ const VirtualListBaseFactory = (type) => {
 			 *
 			 * @type {Number}
 			 * @default 0
-			 * @private
+			 * @public
 			 */
 			spacing: PropTypes.number,
 
@@ -837,9 +837,7 @@ const ScrollableVirtualList = (props) => ( // eslint-disable-line react/jsx-no-b
 );
 
 ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
-	direction: PropTypes.oneOf(['horizontal', 'vertical']),
-
-	id: PropTypes.string
+	direction: PropTypes.oneOf(['horizontal', 'vertical'])
 };
 
 ScrollableVirtualList.defaultProps = {
@@ -859,9 +857,7 @@ const ScrollableVirtualListNative = (props) => (
 );
 
 ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.VirtualListBaseNative.prototype */ {
-	direction: PropTypes.oneOf(['horizontal', 'vertical']),
-
-	id: PropTypes.string
+	direction: PropTypes.oneOf(['horizontal', 'vertical'])
 };
 
 ScrollableVirtualListNative.defaultProps = {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -36,7 +36,7 @@ const
  * @class VirtualListCore
  * @memberof moonstone/VirtualList
  * @ui
- * @public
+ * @private
  */
 const VirtualListBaseFactory = (type) => {
 	const UiBase = (type === JS) ? UiVirtualListBase : UiVirtualListBaseNative;
@@ -44,7 +44,7 @@ const VirtualListBaseFactory = (type) => {
 	return class VirtualListCore extends Component {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
-		static propTypes = /** @lends moonstone/VirtualList.VirtualListCore.prototype */ {
+		static propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
 			/**
 			 * The `render` function called for each item in the list.
 			 *
@@ -130,7 +130,7 @@ const VirtualListBaseFactory = (type) => {
 			 *
 			 * @type {Number}
 			 * @default 0
-			 * @public
+			 * @private
 			 */
 			spacing: PropTypes.number,
 
@@ -715,24 +715,6 @@ const VirtualListBase = VirtualListBaseFactory(JS);
 VirtualListBase.displayName = 'VirtualListBase';
 
 /**
- * Activates the component for voice control.
- *
- * @name data-webos-voice-focused
- * @memberof moonstone/VirtualList.VirtualListBase.prototype
- * @type {Boolean}
- * @public
- */
-
-/**
- * The voice control group label.
- *
- * @name data-webos-voice-group-label
- * @memberof moonstone/VirtualList.VirtualListBase.prototype
- * @type {String}
- * @public
- */
-
-/**
  * A Moonstone-styled base component for [VirtualListNative]{@link moonstone/VirtualList.VirtualListNative} and
  * [VirtualGridListNative]{@link moonstone/VirtualList.VirtualGridListNative}.
  *
@@ -744,6 +726,70 @@ VirtualListBase.displayName = 'VirtualListBase';
  */
 const VirtualListBaseNative = VirtualListBaseFactory(Native);
 VirtualListBaseNative.displayName = 'VirtualListBaseNative';
+
+/**
+ * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+ * not move focus to the scrollbar controls.
+ *
+ * @name focusableScrollbar
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {Boolean}
+ * @default false
+ * @public
+ */
+
+/**
+ * Unique identifier for the component.
+ *
+ * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
+ * the `VirtualList` will store its scroll position and restore that position when returning to
+ * the `Panel`.
+ *
+ * @name id
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the next button in the vertical scroll bar.
+ *
+ * @name scrollDownAriaLabel
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default $L('scroll down')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+ *
+ * @name scrollLeftAriaLabel
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default $L('scroll left')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the next button in the horizontal scroll bar.
+ *
+ * @name scrollRightAriaLabel
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default $L('scroll right')
+ * @public
+ */
+
+/**
+ * Sets the hint string read when focusing the previous button in the vertical scroll bar.
+ *
+ * @name scrollUpAriaLabel
+ * @memberof moonstone/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default $L('scroll up')
+ * @public
+ */
 
 /* eslint-disable enact/prop-types */
 const listItemsRenderer = (props) => {
@@ -791,29 +837,8 @@ const ScrollableVirtualList = (props) => ( // eslint-disable-line react/jsx-no-b
 );
 
 ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
-	/**
-	 * Direction of the list.
-	 *
-	 * Valid values are:
-	 * * `'horizontal'`, and
-	 * * `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'vertical'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 
-	/**
-	 * Unique identifier for the component.
-	 *
-	 * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
-	 * the `VirtualList` will store its scroll position and restore that position when returning to
-	 * the `Panel`.
-	 *
-	 * @type {String}
-	 * @public
-	 */
 	id: PropTypes.string
 };
 
@@ -834,29 +859,8 @@ const ScrollableVirtualListNative = (props) => (
 );
 
 ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.VirtualListBaseNative.prototype */ {
-	/**
-	 * Direction of the list.
-	 *
-	 * Valid values are:
-	 * * `'horizontal'`, and
-	 * * `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'vertical'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 
-	/**
-	 * Unique identifier for the component.
-	 *
-	 * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
-	 * the `VirtualList` will store its scroll position and restore that position when returning to
-	 * the `Panel`.
-	 *
-	 * @type {String}
-	 * @public
-	 */
 	id: PropTypes.string
 };
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -352,16 +352,6 @@ class ScrollableBase extends Component {
 		stop: PropTypes.func,
 
 		/**
-		 * Scrollable CSS style.
-		 *
-		 * Should be defined because we manipulate style prop in render().
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		style: PropTypes.object,
-
-		/**
 		 * Specifies how to show vertical scrollbar.
 		 *
 		 * Valid values are:

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -338,16 +338,6 @@ class ScrollableBaseNative extends Component {
 		start: PropTypes.func,
 
 		/**
-		 * ScrollableNative CSS style.
-		 *
-		 * Should be defined because we manipulate style prop in render().
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		style: PropTypes.object,
-
-		/**
 		 * Specifies how to show vertical scrollbar.
 		 *
 		 * Valid values are:

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -203,6 +203,154 @@ class ScrollerBase extends Component {
 }
 
 /**
+ * A callback function that receives a reference to the `scrollTo` feature.
+ *
+ * Once received, the `scrollTo` method can be called as an imperative interface.
+ *
+ * The `scrollTo` function accepts the following paramaters:
+ * - {position: {x, y}} - Pixel value for x and/or y position
+ * - {align} - Where the scroll area should be aligned. Values are:
+ *   `'left'`, `'right'`, `'top'`, `'bottom'`,
+ *   `'topleft'`, `'topright'`, `'bottomleft'`, and `'bottomright'`.
+ * - {node} - Node to scroll into view
+ * - {animate} - When `true`, scroll occurs with animation. When `false`, no
+ *   animation occurs.
+ * - {focus} - When `true`, attempts to focus item after scroll. Only valid when scrolling
+ *   by `index` or `node`.
+ * > Note: Only specify one of: `position`, `align`, `index` or `node`
+ *
+ * Example:
+ * ```
+ *	// If you set cbScrollTo prop like below;
+ *	cbScrollTo: (fn) => {this.scrollTo = fn;}
+ *	// You can simply call like below;
+ *	this.scrollTo({align: 'top'}); // scroll to the top
+ * ```
+ *
+ * @name cbScrollTo
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {Function}
+ * @public
+ */
+
+/**
+ * Specifies how to show horizontal scrollbar.
+ *
+ * Valid values are:
+ * * `'auto'`,
+ * * `'visible'`, and
+ * * `'hidden'`.
+ *
+ * @name horizontalScrollbar
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default 'auto'
+ * @public
+ */
+
+/**
+ * Prevents scroll by wheeling on the scroller.
+ *
+ * @name noScrollByWheel
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {Boolean}
+ * @default false
+ * @public
+ */
+
+/**
+ * Called when scrolling.
+ *
+ * Passes `scrollLeft` and `scrollTop`.
+ * It is not recommended to set this prop since it can cause performance degradation.
+ * Use `onScrollStart` or `onScrollStop` instead.
+ *
+ * @name onScroll
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Called when scroll starts.
+ *
+ * Passes `scrollLeft` and `scrollTop`.
+ *
+ * Example:
+ * ```
+ * onScrollStart = ({scrollLeft, scrollTop}) => {
+ *     // do something with scrollLeft and scrollTop
+ * }
+ *
+ * render = () => (
+ *     <Scroller
+ *         ...
+ *         onScrollStart={this.onScrollStart}
+ *         ...
+ *     />
+ * )
+ * ```
+ *
+ * @name onScrollStart
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Called when scroll stops.
+ *
+ * Passes `scrollLeft` and `scrollTop`.
+ *
+ * Example:
+ * ```
+ * onScrollStop = ({scrollLeft, scrollTop}) => {
+ *     // do something with scrollLeft and scrollTop
+ * }
+ *
+ * render = () => (
+ *     <Scroller
+ *         ...
+ *         onScrollStop={this.onScrollStop}
+ *         ...
+ *     />
+ * )
+ * ```
+ *
+ * @name onScrollStop
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Specifies how to show vertical scrollbar.
+ *
+ * Valid values are:
+ * * `'auto'`,
+ * * `'visible'`, and
+ * * `'hidden'`.
+ *
+ * @name verticalScrollbar
+ * @memberof ui/Scroller.ScrollerBase.prototype
+ * @type {String}
+ * @default 'auto'
+ * @public
+ */
+
+/**
  * An unstyled scroller.
  *
  * Example:
@@ -212,7 +360,6 @@ class ScrollerBase extends Component {
  *
  * @class Scroller
  * @memberof ui/Scroller
- * @extends ui/Scrollable.Scrollable
  * @extends ui/Scrollable.ScrollerBase
  * @ui
  * @public
@@ -227,18 +374,6 @@ const Scroller = (props) => (
 );
 
 Scroller.propTypes = /** @lends ui/Scroller.Scroller.prototype */ {
-	/**
-	 * Direction of the scroller.
-	 *
-	 * Valid values are:
-	 * * `'both'`,
-	 * * `'horizontal'`, and
-	 * * `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'both'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
 };
 
@@ -274,18 +409,6 @@ const ScrollerNative = (props) => (
 );
 
 ScrollerNative.propTypes = /** @lends ui/Scroller.ScrollerNative.prototype */ {
-	/**
-	 * Direction of the scroller.
-	 *
-	 * Valid values are:
-	 * * `'both'`,
-	 * * `'horizontal'`, and
-	 * * `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'both'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical'])
 };
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -33,10 +33,10 @@ const gridListItemSizeShape = PropTypes.shape({
 /**
  * The base version of the virtual list component.
  *
- * @class VirtualListBase
+ * @class VirtualListBaseFactory
  * @memberof ui/VirtualList
  * @ui
- * @public
+ * @private
  */
 const VirtualListBaseFactory = (type) => {
 	return class VirtualListCore extends Component {
@@ -127,7 +127,7 @@ const VirtualListBaseFactory = (type) => {
 			 * Activates the component for voice control.
 			 *
 			 * @type {Boolean}
-			 * @private
+			 * @public
 			 */
 			'data-webos-voice-focused': PropTypes.bool,
 
@@ -135,7 +135,7 @@ const VirtualListBaseFactory = (type) => {
 			 * The voice control group label.
 			 *
 			 * @type {String}
-			 * @private
+			 * @public
 			 */
 			'data-webos-voice-group-label': PropTypes.string,
 
@@ -840,7 +840,7 @@ const VirtualListBaseFactory = (type) => {
  * @class VirtualListBase
  * @memberof ui/VirtualList
  * @ui
- * @private
+ * @public
  */
 const VirtualListBase = VirtualListBaseFactory(JS);
 VirtualListBase.displayName = 'ui:VirtualListBase';
@@ -856,6 +856,160 @@ VirtualListBase.displayName = 'ui:VirtualListBase';
  */
 const VirtualListBaseNative = VirtualListBaseFactory(Native);
 VirtualListBaseNative.displayName = 'ui:VirtualListBaseNative';
+
+/**
+ * A callback function that receives a reference to the `scrollTo` feature.
+ *
+ * Once received, the `scrollTo` method can be called as an imperative interface.
+ *
+ * The `scrollTo` function accepts the following paramaters:
+ * - {position: {x, y}} - Pixel value for x and/or y position
+ * - {align} - Where the scroll area should be aligned. Values are:
+ *   `'left'`, `'right'`, `'top'`, `'bottom'`,
+ *   `'topleft'`, `'topright'`, `'bottomleft'`, and `'bottomright'`.
+ * - {index} - Index of specific item. (`0` or positive integer)
+ *   This option is available for only `VirtualList` kind.
+ * - {node} - Node to scroll into view
+ * - {animate} - When `true`, scroll occurs with animation. When `false`, no
+ *   animation occurs.
+ * - {focus} - When `true`, attempts to focus item after scroll. Only valid when scrolling
+ *   by `index` or `node`.
+ * > Note: Only specify one of: `position`, `align`, `index` or `node`
+ *
+ * Example:
+ * ```
+ *	// If you set cbScrollTo prop like below;
+ *	cbScrollTo: (fn) => {this.scrollTo = fn;}
+ *	// You can simply call like below;
+ *	this.scrollTo({align: 'top'}); // scroll to the top
+ * ```
+ *
+ * @name cbScrollTo
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {Function}
+ * @public
+ */
+
+/**
+ * Specifies how to show horizontal scrollbar.
+ *
+ * Valid values are:
+ * * `'auto'`,
+ * * `'visible'`, and
+ * * `'hidden'`.
+ *
+ * @name horizontalScrollbar
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default 'auto'
+ * @public
+ */
+
+/**
+ * Prevents scroll by wheeling on the list.
+ *
+ * @name noScrollByWheel
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {Boolean}
+ * @default false
+ * @public
+ */
+
+/**
+ * Called when scrolling.
+ *
+ * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+ * It is not recommended to set this prop since it can cause performance degradation.
+ * Use `onScrollStart` or `onScrollStop` instead.
+ *
+ * @name onScroll
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Called when scroll starts.
+ *
+ * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+ * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
+ *
+ * Example:
+ * ```
+ * onScrollStart = ({scrollLeft, scrollTop, moreInfo}) => {
+ *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
+ *     // do something with firstVisibleIndex and lastVisibleIndex
+ * }
+ *
+ * render = () => (
+ *     <VirtualList
+ *         ...
+ *         onScrollStart={this.onScrollStart}
+ *         ...
+ *     />
+ * )
+ * ```
+ *
+ * @name onScrollStart
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Called when scroll stops.
+ *
+ * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+ * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
+ *
+ * Example:
+ * ```
+ * onScrollStop = ({scrollLeft, scrollTop, moreInfo}) => {
+ *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
+ *     // do something with firstVisibleIndex and lastVisibleIndex
+ * }
+ *
+ * render = () => (
+ *     <VirtualList
+ *         ...
+ *         onScrollStop={this.onScrollStop}
+ *         ...
+ *     />
+ * )
+ * ```
+ *
+ * @name onScrollStop
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {Function}
+ * @param {Object} event
+ * @param {Number} event.scrollLeft Scroll left value.
+ * @param {Number} event.scrollTop Scroll top value.
+ * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+ * @public
+ */
+
+/**
+ * Specifies how to show vertical scrollbar.
+ *
+ * Valid values are:
+ * * `'auto'`,
+ * * `'visible'`, and
+ * * `'hidden'`.
+ *
+ * @name verticalScrollbar
+ * @memberof ui/VirtualList.VirtualListBase.prototype
+ * @type {String}
+ * @default 'auto'
+ * @public
+ */
 
 const ScrollableVirtualList = (props) => (
 	<Scrollable
@@ -896,17 +1050,6 @@ const ScrollableVirtualListNative = (props) => (
 );
 
 ScrollableVirtualListNative.propTypes = /** @lends ui/VirtualList.VirtualListBaseNative.prototype */ {
-	/**
-	 * The layout direction of the list.
-	 *
-	 * Valid values are:
-	 * * `'horizontal'`, and
-	 * * `'vertical'`.
-	 *
-	 * @type {String}
-	 * @default 'vertical'
-	 * @public
-	 */
 	direction: PropTypes.oneOf(['horizontal', 'vertical'])
 };
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -33,7 +33,7 @@ const gridListItemSizeShape = PropTypes.shape({
 /**
  * The base version of the virtual list component.
  *
- * @class VirtualListBaseFactory
+ * @class VirtualListCore
  * @memberof ui/VirtualList
  * @ui
  * @private


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Some public props for VirtualList do not show in JSDoc.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Major fix
- Expose `ui/Scrollable` public props to `ui/VirtualList.VirtualListBase` and `ui/Scroller.ScrollerBase` JS Docs.
- Expose `moonstone/Scrollable` public props to `ui/VirtualList.VirtualListBase` and `moonstone/Scroller.ScrollerBase` JS Docs.
- Fix to show `id` prop in `moonstone/VirtualList.VirtualListBase` and `moonstone/Scroller.ScrollBase`.
- Fix to show `direction` prop in `ui/VirtualList.VirtualListBase` and `ui/Scroller.ScrollBase`.

Minor fix
- Fix to show `data-webos-voice-focused` and  `data-webos-voice-group-label` props in not `m oonstone/VirtualList.VirtualListBase` but `ui/VirtualList.VirtualListBase`.
- Make `spacing` prop in `moonstone/VirtualList.VirtualListBase` private because  `spacing` prop in `ui/VirtualList.VirtualListBase` already describes in JSDoc.
- Remove `* @extends ui/Scrollable.Scrollable` in `ui/Scroller` because `ui/Scrollable.Scrollable` is the private component.
- Replace the JSDoc for `ui/VirtualList.VirtualListBase` with the JSDoc for `ui/VirtualList.VirtualListCore` because the JSDoc for `ui/VirtualList.VirtualListBase` was defined twice.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

* Remove `style` props in Scrollable and ScrollableNative because we don't need them.

### Links
[//]: # (Related issues, references)

PLAT-76949