### PR TITLE
PLAT-80081: Scroll and Move Spotlight to the paging control properly via 5-way Down if the current item sticking to the top is only spottable

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/GridListImageItem` to support overriding the `image` CSS class name
+- `moonstone/Scroller` to scroll and to move focus to the paging control properly if the current item sticking to the top is only spottable
 
 ## [3.0.0-alpha.6] - 2019-06-17
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -312,7 +312,7 @@ class ScrollerBase extends Component {
 				pos = isVerticalDirection ? top : left,
 				max = isVerticalDirection ? maxTop : maxLeft;
 
-			if (pos > 0 && pos < max) {
+			if (pos >= 0 && pos < max) {
 				this.props.scrollAndFocusScrollbarButton(direction);
 			}
 		}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -312,7 +312,7 @@ class ScrollerBase extends Component {
 				pos = isVerticalDirection ? top : left,
 				max = isVerticalDirection ? maxTop : maxLeft;
 
-			if (pos >= 0 && pos < max) {
+			if (pos >= 0 && pos <= max) {
 				this.props.scrollAndFocusScrollbarButton(direction);
 			}
 		}

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -344,9 +344,9 @@ storiesOf('Scroller', module)
 		() => (
 			<Scroller focusableScrollbar>
 				<div style={{height: '3000px'}}>
- 					<Item style={{height: '2000px'}}>Long Hieght Item</Item>
+					<Item style={{height: '2000px'}}>Long Hieght Item</Item>
 	 			</div>
- 			</Scroller>
+			</Scroller>
 		)
 	)
 	.add(

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -345,7 +345,7 @@ storiesOf('Scroller', module)
 			<Scroller focusableScrollbar>
 				<div style={{height: '3000px'}}>
 					<Item style={{height: '2000px'}}>Long Hieght Item</Item>
-	 			</div>
+				</div>
 			</Scroller>
 		)
 	)

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -343,8 +343,8 @@ storiesOf('Scroller', module)
 		'With One Long Hieght Item',
 		() => (
 			<Scroller focusableScrollbar>
-				<div style={{height: '3000px'}}>
-					<Item style={{height: '2000px'}}>Long Hieght Item</Item>
+				<div style={{height: '1220px'}}>
+					<Item style={{height: '1200px'}}>Long Hieght Item</Item>
 				</div>
 			</Scroller>
 		)

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -340,6 +340,16 @@ storiesOf('Scroller', module)
 		)
 	)
 	.add(
+		'With One Long Hieght Item',
+		() => (
+			<Scroller focusableScrollbar>
+				<div style={{height: '3000px'}}>
+ 					<Item style={{height: '2000px'}}>Long Hieght Item</Item>
+	 			</div>
+ 			</Scroller>
+		)
+	)
+	.add(
 		'With Nested Scroller',
 		() => {
 			let noScrollByWheel = boolean('noScrollByWheel', Scroller, false);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When
* only the first item is spottable in Scroller,
* the item gets spot,
* the item locates at (0,0), 
* the item height is larger than the list height,
* paging controls can be spottable, and
* pressing a Down key,

Scroller does not scroll and Spotlight stays on the first item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

This was the edge case for the requirement. I fixed the condition, then it worked.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I added the qa Scroller sampler for the TC.

### Links
[//]: # (Related issues, references)

PLAT-80081
