### PR TITLE
PLAT-79069: Update Header with Input focus

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -247,7 +247,7 @@ const InputBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'decorator',
-		publicClassNames: ['decorator', 'input']
+		publicClassNames: ['decorator', 'input', 'inputHighlight']
 	},
 
 	handlers: {
@@ -292,6 +292,7 @@ const InputBase = kind({
 		return (
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" size={size}>{iconBefore}</InputDecoratorIcon>
+				<span className={css.inputHighlight}>{value}</span>
 				<input
 					{...inputProps}
 					{...voiceProps}

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -292,7 +292,7 @@ const InputBase = kind({
 		return (
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" size={size}>{iconBefore}</InputDecoratorIcon>
-				<span className={css.inputHighlight}>{value}</span>
+				<span className={css.inputHighlight}>{value ? value : placeholder}</span>
 				<input
 					{...inputProps}
 					{...voiceProps}

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -14,7 +14,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	flex-grow: 1;
-	text-indent: 0.2em;
+	text-indent: @moon-input-text-indent;
 
 	&[type=number] {
 		-moz-appearance: textfield;
@@ -77,11 +77,13 @@
 
 	.inputHighlight {
 		position: absolute;
-		pointer-events: none;
-		max-width: 379px;
+		top: 6px;
+		height: @moon-input-highlight-height;
+		max-width: @moon-input-highlight-max-width;
 		overflow: hidden;
-		text-indent: 0.2em;
+		text-indent: @moon-input-text-indent;
 		letter-spacing: 0.1px;
+		pointer-events: none;
 		opacity: 0;
 		z-index: -1;
 	}
@@ -101,9 +103,9 @@
 		}
 
 		.inputHighlight {
-			max-width: 357px;
 			line-height: @moon-input-small-height;
 			height: @moon-input-decorator-small-height;
+			max-width: @moon-input-highlight-small-max-width;
 		}
 	}
 
@@ -167,7 +169,10 @@
 
 		.inputHighlight {
 			color: transparent;
-			background-color: @moon-spotlight-color;
+			background-color: transparent;
+			// Set `.inputHighlight` background color to make it appear that the text is highlighted
+			// when `.input` has transparent background and when `.decorator` has focus, but not `.input`.
+			// background-color: @moon-spotlight-color;
 		}
 
 		.focus({
@@ -181,9 +186,11 @@
 				});
 			}
 
-			.inputHighlight {
-				opacity: 1;
-			}
+			// Set `.inputHighlight` opacity to make it appear that the text is highlighted
+			// when `.input` has transparent background and when `.decorator` has focus, but not `.input`.
+			// .inputHighlight {
+			// 	opacity: 1;
+			// }
 		});
 
 		&:focus-within {

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -60,17 +60,30 @@
 	box-sizing: border-box;
 	vertical-align: middle;
 
-	.input {
+	.input,
+	.inputHighlight {
 		font-size: @moon-input-font-size;
 		font-weight: @moon-input-font-weight;
 	}
 
 	.input,
+	.inputHighlight,
 	.iconBefore,
 	.iconAfter {
 		line-height: @moon-input-height;
 		height: @moon-input-height;
 		vertical-align: middle;
+	}
+
+	.inputHighlight {
+		position: absolute;
+		pointer-events: none;
+		max-width: 379px;
+		overflow: hidden;
+		text-indent: 0.2em;
+		letter-spacing: 0.1px;
+		opacity: 0;
+		z-index: -1;
 	}
 
 	&.small {
@@ -85,6 +98,12 @@
 		.input {
 			font-size: @moon-input-small-font-size;
 			height: @moon-input-small-height;
+		}
+
+		.inputHighlight {
+			max-width: 357px;
+			line-height: @moon-input-small-height;
+			height: @moon-input-decorator-small-height;
 		}
 	}
 
@@ -146,6 +165,11 @@
 			color: @moon-red;
 		}
 
+		.inputHighlight {
+			color: transparent;
+			background-color: @moon-spotlight-color;
+		}
+
 		.focus({
 			background-color: @moon-input-decorator-focus-bg-color;
 			color: @moon-input-focus-text-color;
@@ -155,6 +179,10 @@
 				.input-placeholder({
 					color: @moon-input-placeholder-focus-color;
 				});
+			}
+
+			.inputHighlight {
+				opacity: 1;
 			}
 		});
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -22,6 +22,7 @@
 	// Remove the built-in h1 and h2 margins
 	.decorator,
 	.decorator .input,
+	.decorator .inputHighlight,
 	.title,
 	.titleBelow,
 	.subTitleBelow {
@@ -29,6 +30,7 @@
 	}
 
 	.decorator .input,
+	.decorator .inputHighlight,
 	.title {
 		.moon-header-text();
 		text-indent: 0.05em;  // Fix for characters like `j` being left-truncated because of being too close to the edge
@@ -37,6 +39,10 @@
 	.decorator {
 		padding: 0;
 		margin: -2px 3px 0 -3px; // Negative 3px here to allow the decorator title text to horizontally align with the rest of the header text
+
+		.inputHighlight {
+			max-width: none;
+		}
 	}
 
 	.titleBelow,
@@ -76,6 +82,11 @@
 			width: 100%;
 		}
 
+
+		.inputHighlight {
+			max-width: 100%;
+		}
+
 		.titleBelow,
 		.subTitleBelow {
 			line-height: 1.4em;
@@ -91,6 +102,7 @@
 		}
 
 		.input,
+		.inputHighlight,
 		.title {
 			font-size: @moon-small-header-font-size;
 			display: inline;
@@ -119,6 +131,7 @@
 
 				.focus({
 					background-color: transparent;
+					box-shadow: none;
 				});
 
 				.input {

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -39,10 +39,6 @@
 	.decorator {
 		padding: 0;
 		margin: -2px 3px 0 -3px; // Negative 3px here to allow the decorator title text to horizontally align with the rest of the header text
-
-		.inputHighlight {
-			max-width: none;
-		}
 	}
 
 	.titleBelow,
@@ -81,7 +77,6 @@
 			height: 100%;
 			width: 100%;
 		}
-
 
 		.inputHighlight {
 			max-width: 100%;

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -132,6 +132,14 @@
 				.focus({
 					background-color: transparent;
 					box-shadow: none;
+
+					.input {
+						color: @moon-header-input-focus-text-color;
+					}
+
+					.inputHighlight {
+						opacity: 1;
+					}
 				});
 
 				.input {
@@ -140,6 +148,10 @@
 					.input-placeholder({
 						color: @moon-header-text-color;
 					});
+				}
+
+				.inputHighlight {
+					background-color: @moon-header-input-focus-background-color;
 				}
 			}
 

--- a/packages/moonstone/styles/colors-highcontrast.less
+++ b/packages/moonstone/styles/colors-highcontrast.less
@@ -44,10 +44,6 @@
 @moon-gridlist-item-selected-icon-border-color: @high-contrast-black;
 @moon-gridlist-item-selected-icon-color: @moon-gridlist-item-selected-icon-border-color;
 
-// Header
-// ---------------------------------------
-@moon-header-input-focus-text-color: @moon-spotlight-text-color;
-
 // Input
 // ---------------------------------------
 @moon-input-border-active-shadow: 0px 0px 0px 6px @moon-input-border-focus-border-color;

--- a/packages/moonstone/styles/colors-highcontrast.less
+++ b/packages/moonstone/styles/colors-highcontrast.less
@@ -44,6 +44,10 @@
 @moon-gridlist-item-selected-icon-border-color: @high-contrast-black;
 @moon-gridlist-item-selected-icon-color: @moon-gridlist-item-selected-icon-border-color;
 
+// Header
+// ---------------------------------------
+@moon-header-input-focus-text-color: @moon-spotlight-text-color;
+
 // Input
 // ---------------------------------------
 @moon-input-border-active-shadow: 0px 0px 0px 6px @moon-input-border-focus-border-color;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -151,7 +151,7 @@
 @moon-header-title-below-full-bleed-text-color: @moon-light-gray;
 @moon-header-full-bleed-border-color: fade(@moon-white, 25%);
 @moon-header-controls-border-color:   #383838;
-@moon-header-input-focus-text-color:   @moon-white;
+@moon-header-input-focus-text-color:  @moon-spotlight-text-color;
 @moon-header-input-focus-background-color:   @moon-spotlight-color;
 
 // Heading

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -151,6 +151,8 @@
 @moon-header-title-below-full-bleed-text-color: @moon-light-gray;
 @moon-header-full-bleed-border-color: fade(@moon-white, 25%);
 @moon-header-controls-border-color:   #383838;
+@moon-header-input-focus-text-color:   @moon-white;
+@moon-header-input-focus-background-color:   @moon-spotlight-color;
 
 // Heading
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -268,7 +268,7 @@
 @moon-input-decorator-small-height: @moon-input-small-height;
 @moon-expandableinput-input-margin: 6px @moon-spotlight-outset;
 @moon-input-highlight-height: (@moon-input-height - 3px);
-@moon-input-highlight-max-width: 379px;
+@moon-input-highlight-max-width: 378px;
 @moon-input-highlight-small-max-width: 357px;
 
 // Items

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -255,6 +255,7 @@
 @moon-input-margin: 0 @moon-spotlight-outset;
 @moon-input-padding: 0 @moon-input-icon-spacing;
 @moon-input-font-weight: 600;
+@moon-input-text-indent: 0.2em;
 @moon-input-disabled-opacity: 0.3;
 @moon-input-placeholder-opacity: @moon-input-disabled-opacity;
 @moon-input-border-radius: @moon-input-border-width;
@@ -266,6 +267,9 @@
 @moon-input-small-height: @moon-button-small-height;
 @moon-input-decorator-small-height: @moon-input-small-height;
 @moon-expandableinput-input-margin: 6px @moon-spotlight-outset;
+@moon-input-highlight-height: (@moon-input-height - 3px);
+@moon-input-highlight-max-width: 379px;
+@moon-input-highlight-small-max-width: 357px;
 
 // Items
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update Header with Input to match new designs. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a span, `.inputHighlight`, with the input value and background color to mimic highlighted text when the `InputDecorator` receives focus.
`.inputHighlight`'s opacity and background color are left up to `Header` to handle otherwise they are transparent in normal input because in normal input, they are not needed.

### Links
[//]: # (Related issues, references)
PLAT-79069
