### PR TITLE
PLAT-80732: Fix Spotlight qa sample to add space between buttons

### DIFF
--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -25,7 +25,7 @@ import ToggleItem from '@enact/moonstone/ToggleItem';
 import Scroller from '@enact/moonstone/Scroller';
 import Slider from '@enact/moonstone/Slider';
 import Spotlight from '@enact/spotlight';
-import {Row} from '@enact/ui/Layout';
+import {Row, Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import React from 'react';
@@ -317,17 +317,23 @@ storiesOf('Spotlight', module)
 	.add(
 		'Multiple Buttons',
 		() => (
-			<div>
-				<Button onClick={action('onClick')}>
-					One
-				</Button>
-				<Button onClick={action('onClick')}>
-					Two
-				</Button>
-				<Button onClick={action('onClick')}>
-					Three
-				</Button>
-			</div>
+			<Row>
+				<Cell>
+					<Button onClick={action('onClick')}>
+						One
+					</Button>
+				</Cell>
+				<Cell>
+					<Button onClick={action('onClick')}>
+						Two
+					</Button>
+				</Cell>
+				<Cell>
+					<Button onClick={action('onClick')}>
+						Three
+					</Button>
+				</Cell>
+			</Row>
 		)
 	)
 	.add(

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -297,7 +297,7 @@ class FocusedAndDisabled extends React.Component {
 				</ol>
 				<Button onClick={this.handleClear}>Enable All</Button>
 				{this.tests.map((comp, index) => (
-					<Row key={`row-${index}`}>
+					<div key={`row-${index}`}>
 						{/* eslint-disable-next-line react/jsx-no-bind */}
 						<IconButton onTap={() => this.select(index)}>
 							arrowlargeright
@@ -306,7 +306,7 @@ class FocusedAndDisabled extends React.Component {
 							disabled: this.state.index === index,
 							spotlightId: `component-${index}`
 						})}
-					</Row>
+					</div>
 				))}
 			</Scroller>
 		);

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -317,18 +317,18 @@ storiesOf('Spotlight', module)
 	.add(
 		'Multiple Buttons',
 		() => (
-			<Row>
-				<Cell>
+			<Row align="center space-evenly">
+				<Cell shrink>
 					<Button onClick={action('onClick')}>
 						One
 					</Button>
 				</Cell>
-				<Cell>
+				<Cell shrink>
 					<Button onClick={action('onClick')}>
 						Two
 					</Button>
 				</Cell>
-				<Cell>
+				<Cell shrink>
 					<Button onClick={action('onClick')}>
 						Three
 					</Button>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Default size of buttons changed causing the sample to lack space between them which made it impossible to place the pointer in the middle without focusing either.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Space the buttons out independent of their size
