### PR TITLE
PLAT-79985: Fix VirtualList event bubbling

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Popup` to properly handle closing in mid-transition
 - `moonstone/Scroller` to properly move focus out of the container
+- `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -916,7 +916,6 @@ class ScrollableBase extends Component {
 									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
-									focusableScrollbar,
 									initUiChildRef,
 									isVerticalScrollbarVisible,
 									onScroll: handleScroll,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -916,6 +916,7 @@ class ScrollableBase extends Component {
 									...childComponentProps,
 									cbScrollTo: scrollTo,
 									className: componentCss.scrollableFill,
+									focusableScrollbar,
 									initUiChildRef,
 									isVerticalScrollbarVisible,
 									onScroll: handleScroll,

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -11,8 +11,6 @@ import React, {Component} from 'react';
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
 
-import scrollbarCss from '../Scrollable/Scrollbar.module.less';
-
 const SpotlightAccelerator = new Accelerator();
 const SpotlightPlaceholder = Spottable('div');
 
@@ -459,8 +457,13 @@ const VirtualListBaseFactory = (type) => {
 				} else {
 					const {repeat} = ev;
 					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
-					const isScrollButton = target.classList.contains(scrollbarCss.scrollButton);
 					const targetIndex = target.dataset.index;
+					const isScrollButton = (
+						// if target has an index, it must be an item so can't be a scroll button
+						!targetIndex &&
+						// if it lacks an index and is inside the scroller, it must be a button
+						target.matches(`[data-spotlight-id="${this.props.spotlightId}"] *`)
+					);
 					const index = !isScrollButton ? getNumberValue(targetIndex) : -1;
 					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
 					const directions = {};

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -29,7 +29,13 @@ const
 	Native = 'Native',
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0,
-	nop = () => {};
+	nop = () => {},
+	moveFocusStraight = ({direction, id}) => {
+		Spotlight.set(id, {straightOnly: true});
+		const moved = Spotlight.move(direction);
+		Spotlight.set(id, {straightOnly: false});
+		return moved;
+	};
 
 /**
  * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
@@ -503,7 +509,7 @@ const VirtualListBaseFactory = (type) => {
 					} else if (
 						directions.right && repeat ||
 						directions.left && Spotlight.move(direction) ||
-						(directions.up || directions.down) && (repeat || Spotlight.move(direction) && currentTarget.contains(Spotlight.getCurrent()))
+						(directions.up || directions.down) && (repeat || moveFocusStraight({id: this.props.spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent()))
 					) {
 						ev.preventDefault();
 						ev.stopPropagation();

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -515,13 +515,8 @@ const VirtualListBaseFactory = (type) => {
 						ev.stopPropagation();
 					}
 				}
-			} else {
-				ev.preventDefault();
-				ev.stopPropagation();
-
-				if (isPageUp(keyCode) || isPageDown(keyCode)) {
-					this.isScrolledBy5way = false;
-				}
+			} else if (isPageUp(keyCode) || isPageDown(keyCode)) {
+				this.isScrolledBy5way = false;
 			}
 		}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -515,8 +515,13 @@ const VirtualListBaseFactory = (type) => {
 						ev.stopPropagation();
 					}
 				}
-			} else if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				this.isScrolledBy5way = false;
+			} else {
+				ev.preventDefault();
+				ev.stopPropagation();
+
+				if (isPageUp(keyCode) || isPageDown(keyCode)) {
+					this.isScrolledBy5way = false;
+				}
 			}
 		}
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -830,17 +830,22 @@ const listItemsRenderer = (props) => {
 };
 /* eslint-enable enact/prop-types */
 
-const ScrollableVirtualList = (props) => ( // eslint-disable-line react/jsx-no-bind
-	<Scrollable
-		{...props}
-		childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
-			<VirtualListBase
-				{...childProps}
-				itemsRenderer={listItemsRenderer}
-			/>
-		)}
-	/>
-);
+const ScrollableVirtualList = (props) => { // eslint-disable-line react/jsx-no-bind
+	const {focusableScrollbar} = props;
+
+	return (
+		<Scrollable
+			{...props}
+			childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
+				<VirtualListBase
+					{...childProps}
+					focusableScrollbar={focusableScrollbar}
+					itemsRenderer={listItemsRenderer}
+				/>
+			)}
+		/>
+	);
+};
 
 ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
 	/**
@@ -857,6 +862,16 @@ ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBa
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 
 	/**
+	 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+	 * not move focus to the scrollbar controls.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	focusableScrollbar: PropTypes.bool,
+
+	/**
 	 * Unique identifier for the component.
 	 *
 	 * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
@@ -870,20 +885,26 @@ ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBa
 };
 
 ScrollableVirtualList.defaultProps = {
-	direction: 'vertical'
+	direction: 'vertical',
+	focusableScrollbar: false
 };
 
-const ScrollableVirtualListNative = (props) => (
-	<ScrollableNative
-		{...props}
-		childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
-			<VirtualListBaseNative
-				{...childProps}
-				itemsRenderer={listItemsRenderer}
-			/>
-		)}
-	/>
-);
+const ScrollableVirtualListNative = (props) => {
+	const {focusableScrollbar} = props;
+
+	return (
+		<ScrollableNative
+			{...props}
+			childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
+				<VirtualListBaseNative
+					{...childProps}
+					focusableScrollbar={focusableScrollbar}
+					itemsRenderer={listItemsRenderer}
+				/>
+			)}
+		/>
+	);
+};
 
 ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.VirtualListBaseNative.prototype */ {
 	/**
@@ -900,6 +921,16 @@ ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.Virtual
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 
 	/**
+	 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+	 * not move focus to the scrollbar controls.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	focusableScrollbar: PropTypes.bool,
+
+	/**
 	 * Unique identifier for the component.
 	 *
 	 * When defined and when the `VirtualList` is within a [Panel]{@link moonstone/Panels.Panel},
@@ -913,7 +944,8 @@ ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.Virtual
 };
 
 ScrollableVirtualListNative.defaultProps = {
-	direction: 'vertical'
+	direction: 'vertical',
+	focusableScrollbar: false
 };
 
 export default VirtualListBase;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Keydown events in `VirtualList` do not bubble expectedly.


### Resolution
Fix `keydown` event bubbling when pressing 5way directional keys from either a list item or scroll buttons.

The changes in this PR have the potential to affect a number of 5way behaviors (all for the better hopefully 🤞 ). Since we need to be aware of `keydown` events on the scroll buttons, we need to change the dom where we are listening for events - from the wrapper to the spotlight container. This change means we need to act on the capture phase of the event in order to prevent an application from being able to act on the event when attached to the `VirtualList`, as was the intent behind the existing behavior. We should spend time thoroughly testing this change.