### PR TITLE
ENYO-6061: Warn only once for validation

### DIFF
--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -218,7 +218,7 @@ const PickerBase = kind({
 		value: ({value, children}) => {
 			const max = children && children.length ? children.length - 1 : 0;
 			if (__DEV__) {
-				validateRange(value, 0, max, 'Picker', '"value"', 'min', 'max index');
+				validateRange(value, 0, max, 'Picker', 'value', 'min', 'max index');
 			}
 			return clamp(0, max, value);
 		},

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -33,7 +33,7 @@ import React from 'react';
 
 import {ProgressBarTooltip} from '../ProgressBar';
 import Skinnable from '../Skinnable';
-import {validateStepped} from '../internal/validators';
+import {validateSteppedOnce} from '../internal/validators';
 
 import SliderBehaviorDecorator from './SliderBehaviorDecorator';
 import {
@@ -266,6 +266,15 @@ const SliderBase = kind({
 			activateOnFocus,
 			active
 		}),
+		knobStep: validateSteppedOnce(props => props.knobStep, {
+			component: 'Slider',
+			stepName: 'knobStep',
+			valueName: 'max'
+		}),
+		step: validateSteppedOnce(props => props.step, {
+			component: 'Slider',
+			valueName: 'max'
+		}),
 		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
 	},
 
@@ -273,10 +282,6 @@ const SliderBase = kind({
 		delete rest.activateOnFocus;
 		delete rest.active;
 		delete rest.onActivate;
-
-		if (__DEV__) {
-			validateStepped(rest.max, rest.min, rest.knobStep, 'Slider', '"max"', '"knobStep"');
-		}
 		delete rest.knobStep;
 
 		return (

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -814,7 +814,7 @@ const PickerBase = class extends React.Component {
 		if (__DEV__) {
 			validateRange(value, min, max, PickerBase.displayName);
 			validateStepped(value, min, step, PickerBase.displayName);
-			validateStepped(max, min, step, PickerBase.displayName, '"max"');
+			validateStepped(max, min, step, PickerBase.displayName, 'max');
 		}
 
 		delete rest['aria-label'];

--- a/packages/moonstone/internal/validators/validators.js
+++ b/packages/moonstone/internal/validators/validators.js
@@ -41,7 +41,7 @@ export const warn = (msg) => {
  * @memberof moonstone/internal/validators
  * @private
  */
-export const validateRange = (value, min, max, component, valueName = '"value"', minName = '"min"', maxName = '"max"') => {
+export const validateRange = (value, min, max, component, valueName = 'value', minName = 'min', maxName = 'max') => {
 	if (__DEV__) {
 		let warned = false;
 		if (value < min) {
@@ -59,7 +59,7 @@ export const validateRange = (value, min, max, component, valueName = '"value"',
 	}
 };
 
-export const validateRangeOnce = (thing, {component, valueName = '"value"', minName = '"min"', maxName = '"max"'}) => {
+export const validateRangeOnce = (thing, {component, valueName = 'value', minName = 'min', maxName = 'max'}) => {
 	if (__DEV__) {
 		let displayed;
 		return (props) => {
@@ -89,7 +89,7 @@ export const validateRangeOnce = (thing, {component, valueName = '"value"', minN
  * @memberof moonstone/internal/validators
  * @private
  */
-export const validateStepped = (value, min, step, component, valueName = '"value"', stepName = '"step"') => {
+export const validateStepped = (value, min, step, component, valueName = 'value', stepName = 'step') => {
 	if (__DEV__) {
 		// Ignore fractional steps as floating point math can give inconsistent results (1 % 0.1 != 0)
 		if (step && step === Math.floor(step) && (value - min) % step !== 0) {

--- a/packages/moonstone/internal/validators/validators.js
+++ b/packages/moonstone/internal/validators/validators.js
@@ -43,14 +43,33 @@ export const warn = (msg) => {
  */
 export const validateRange = (value, min, max, component, valueName = '"value"', minName = '"min"', maxName = '"max"') => {
 	if (__DEV__) {
+		let warned = false;
 		if (value < min) {
 			warn(`Warning: ${component} ${valueName} (${value}) less than ${minName} (${min})`);
+			warned = true;
 		} else if (value > max) {
 			warn(`Warning: ${component} ${valueName} (${value}) greater than ${maxName} (${max})`);
+			warned = true;
 		}
 		if (min > max) {
 			warn(`Warning: ${component} ${minName} (${min}) greater than ${maxName} (${max})`);
+			warned = true;
 		}
+		return warned;
+	}
+};
+
+export const validateRangeOnce = (thing, {component, valueName = '"value"', minName = '"min"', maxName = '"max"'}) => {
+	if (__DEV__) {
+		let displayed;
+		return (props) => {
+			if (!displayed) {
+				displayed = validateRange(props[valueName], props[minName], props[maxName], component, valueName, minName, maxName);
+			}
+			return thing(props);
+		};
+	} else {
+		return thing;
 	}
 };
 
@@ -66,7 +85,7 @@ export const validateRange = (value, min, max, component, valueName = '"value"',
  * @param {String} [valueName='value'] The name of the value property
  * @param {String} [stepName='step'] The name of the step property
  *
- * @returns {undefined}
+ * @returns {Boolean} `true` if warned
  * @memberof moonstone/internal/validators
  * @private
  */
@@ -87,7 +106,7 @@ export const validateSteppedOnce = (thing, {component, minName = 'min', stepName
 		return (props) => {
 			if (!displayed) {
 				displayed = validateStepped(props[valueName], props[minName], props[stepName], component, valueName, stepName);
-		}
+			}
 			return thing(props);
 		};
 	} else {

--- a/packages/moonstone/internal/validators/validators.js
+++ b/packages/moonstone/internal/validators/validators.js
@@ -75,6 +75,22 @@ export const validateStepped = (value, min, step, component, valueName = '"value
 		// Ignore fractional steps as floating point math can give inconsistent results (1 % 0.1 != 0)
 		if (step && step === Math.floor(step) && (value - min) % step !== 0) {
 			warn(`Warning: ${component} ${valueName} (${value}) must be evenly divisible by ${stepName} (${step})`);
+			return true;
 		}
+	}
+	return false;
+};
+
+export const validateSteppedOnce = (thing, {component, minName = 'min', stepName = 'step', valueName = 'value'}) => {
+	if (__DEV__) {
+		let displayed;
+		return (props) => {
+			if (!displayed) {
+				displayed = validateStepped(props[valueName], props[minName], props[stepName], component, valueName, stepName);
+		}
+			return thing(props);
+		};
+	} else {
+		return thing;
 	}
 };

--- a/packages/ui/Slider/PositionDecorator.js
+++ b/packages/ui/Slider/PositionDecorator.js
@@ -3,11 +3,16 @@ import {forward} from '@enact/core/handle';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {validateRange, validateStepped} from '../internal/validators';
+import {validateRangeOnce, validateSteppedOnce} from '../internal/validators';
 
 import {calcProportion} from './utils';
 
 import css from './Slider.module.less';
+
+
+const validateRange = validateRangeOnce((props) => props, {'component': 'PositionDecorator'});
+const validateStepValue = validateSteppedOnce((props) => props, {'component': 'PositionDecorator'});
+const validateStepMax = validateSteppedOnce((props) => props, {'component': 'PositionDecorator', valueName: 'max'});
 
 const PositionDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
 	return class extends React.Component {
@@ -134,10 +139,11 @@ const PositionDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-u
 		render () {
 			if (__DEV__) {
 				const {min, value = min, max, step} = this.props;
+				const props = {min, value: value || min, max, step};
 
-				validateRange(value, min, max, 'Slider');
-				validateStepped(value, min, step, 'Slider');
-				validateStepped(max, min, step, 'Slider', '"max"');
+				validateRange(props);
+				validateStepValue(props);
+				validateStepMax(props);
 			}
 
 			return (

--- a/packages/ui/Slider/PositionDecorator.js
+++ b/packages/ui/Slider/PositionDecorator.js
@@ -9,7 +9,6 @@ import {calcProportion} from './utils';
 
 import css from './Slider.module.less';
 
-
 const validateRange = validateRangeOnce((props) => props, {'component': 'PositionDecorator'});
 const validateStepValue = validateSteppedOnce((props) => props, {'component': 'PositionDecorator'});
 const validateStepMax = validateSteppedOnce((props) => props, {'component': 'PositionDecorator', valueName: 'max'});

--- a/packages/ui/internal/validators/validators.js
+++ b/packages/ui/internal/validators/validators.js
@@ -41,7 +41,7 @@ export const warn = (msg) => {
  * @memberof ui/internal/validators
  * @private
  */
-export const validateRange = (value, min, max, component, valueName = '"value"', minName = '"min"', maxName = '"max"') => {
+export const validateRange = (value, min, max, component, valueName = 'value', minName = 'min', maxName = 'max') => {
 	if (__DEV__) {
 		let warned = false;
 		if (value < min) {
@@ -59,7 +59,7 @@ export const validateRange = (value, min, max, component, valueName = '"value"',
 	}
 };
 
-export const validateRangeOnce = (thing, {component, valueName = '"value"', minName = '"min"', maxName = '"max"'}) => {
+export const validateRangeOnce = (thing, {component, valueName = 'value', minName = 'min', maxName = 'max'}) => {
 	if (__DEV__) {
 		let displayed;
 		return (props) => {
@@ -89,7 +89,7 @@ export const validateRangeOnce = (thing, {component, valueName = '"value"', minN
  * @memberof ui/internal/validators
  * @private
  */
-export const validateStepped = (value, min, step, component, valueName = '"value"', stepName = '"step"') => {
+export const validateStepped = (value, min, step, component, valueName = 'value', stepName = 'step') => {
 	if (__DEV__) {
 		// Ignore fractional steps as floating point math can give inconsistent results (1 % 0.1 != 0)
 		if (step && step === Math.floor(step) && (value - min) % step !== 0) {

--- a/packages/ui/internal/validators/validators.js
+++ b/packages/ui/internal/validators/validators.js
@@ -43,14 +43,33 @@ export const warn = (msg) => {
  */
 export const validateRange = (value, min, max, component, valueName = '"value"', minName = '"min"', maxName = '"max"') => {
 	if (__DEV__) {
+		let warned = false;
 		if (value < min) {
 			warn(`Warning: ${component} ${valueName} (${value}) less than ${minName} (${min})`);
+			warned = true;
 		} else if (value > max) {
 			warn(`Warning: ${component} ${valueName} (${value}) greater than ${maxName} (${max})`);
+			warned = true;
 		}
 		if (min > max) {
 			warn(`Warning: ${component} ${minName} (${min}) greater than ${maxName} (${max})`);
+			warned = true;
 		}
+		return warned;
+	}
+};
+
+export const validateRangeOnce = (thing, {component, valueName = '"value"', minName = '"min"', maxName = '"max"'}) => {
+	if (__DEV__) {
+		let displayed;
+		return (props) => {
+			if (!displayed) {
+				displayed = validateRange(props[valueName], props[minName], props[maxName], component, valueName, minName, maxName);
+			}
+			return thing(props);
+		};
+	} else {
+		return thing;
 	}
 };
 
@@ -66,7 +85,7 @@ export const validateRange = (value, min, max, component, valueName = '"value"',
  * @param {String} [valueName='value'] The name of the value property
  * @param {String} [stepName='step'] The name of the step property
  *
- * @returns {undefined}
+ * @returns {Boolean} `true` if warned
  * @memberof ui/internal/validators
  * @private
  */
@@ -75,6 +94,22 @@ export const validateStepped = (value, min, step, component, valueName = '"value
 		// Ignore fractional steps as floating point math can give inconsistent results (1 % 0.1 != 0)
 		if (step && step === Math.floor(step) && (value - min) % step !== 0) {
 			warn(`Warning: ${component} ${valueName} (${value}) must be evenly divisible by ${stepName} (${step})`);
+			return true;
 		}
+	}
+	return false;
+};
+
+export const validateSteppedOnce = (thing, {component, minName = 'min', stepName = 'step', valueName = 'value'}) => {
+	if (__DEV__) {
+		let displayed;
+		return (args) => {
+			if (!displayed) {
+				displayed = validateStepped(args[valueName], args[minName], args[stepName], component, valueName, stepName);
+			}
+			return thing(args);
+		};
+	} else {
+		return thing;
 	}
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Slider` warns on every render if values/max are not divisible by steps.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add functions in `validators` to display only once per validation.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
