### PR TITLE
ENYO-6074: Fix FloatingLayer to be closed after transition ends

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Popup` to properly handle closing in mid-transition
+
 ## [3.0.0-alpha.7] - 2019-06-24
 
 ### Fixed

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -411,7 +411,7 @@ class Popup extends React.Component {
 			} else {
 				return {
 					popupOpen: OpenState.CLOSED,
-					floatLayerOpen: state.popupOpen === OpenState.OPEN ? !props.noAnimation : false,
+					floatLayerOpen: state.popupOpen !== OpenState.CLOSED ? !props.noAnimation : false,
 					activator: props.noAnimation ? null : state.activator,
 					prevOpen: props.open
 				};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `Popup`'s `open` state is changed while in transition, the floating layer closes before the transition is finished. One of the side effects of this is spotlight pause will not properly resume as it depends on transitionEnd event.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix setting `floatLayerOpen` state to check for both OPEN and OPENING `popupOpen` state.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
