### PR TITLE
PLAT-61546: Configure table of contents for docs

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: Enact Best Practices
+toc: 2
 ---
 
 ## Overview

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+toc: false
 ---
 
 ## Terms

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-toc: false
+toc: 0
 ---
 
 ## Terms

--- a/docs/migration/enact/migrating-to-enact-2.md
+++ b/docs/migration/enact/migrating-to-enact-2.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating to Enact 2.0
+toc: 2
 ---
 
 ## Overview

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating to Enact 3.0
+toc: 2
 ---
 
 ## Overview

--- a/docs/testing-components/unit-testing/index.md
+++ b/docs/testing-components/unit-testing/index.md
@@ -1,5 +1,6 @@
 ---
 title: Unit Testing
+toc: 2
 ---
 
 ## Prerequisites

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,5 +1,6 @@
 ---
 title: Theming
+toc: 2
 ---
 
 ## Introduction

--- a/packages/i18n/docs/index.md
+++ b/packages/i18n/docs/index.md
@@ -2,14 +2,6 @@
 title: i18n (Internationalization)
 ---
 
-* [Overview](#overview)
-* [Using I18nDecorator](#using-i18ndecorator)
-* [Locale-Specific CSS](#locale-specific-css)
-* [Translating Strings using $L()](#translating-strings-using-l)
-* [Updating Locale](#updating-locale)
-* [iLib](#ilib)
-* [Sample i18n App](#sample)
-
 ## Overview
 
 This guide details how to use some of i18n library's features. For an overview of the modules supplied with the library please see [I18nDecorator](../../modules/i18n/I18nDecorator/) and [Text](../../modules/i18n/Text/). This library incorporates the [iLib](https://github.com/iLib-js/iLib) internationalization library.

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -1,19 +1,8 @@
 ---
 title: Spotlight
+toc: 2
 ---
 
-
-1. [What Is Spotlight?](#what-is-spotlight)
-2. [Modes](#modes)
-3. [Navigation](#navigation)
-4. [Selectors](#selectors)
-5. [SpotlightRootDecorator](#spotlightrootdecorator)
-6. [Spottable](#spottable)
-7. [Containers](#containers)
-8. [Events](#events)
-9. [Spotlight API](#spotlight-api)
-10. [HOC Parameters and Properties](#hoc-parameters-and-properties)
-11. [Examples](#examples)
 
 ## What Is Spotlight?
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
enactjs/docs#109 adds support for a `toc` field in the front matter of our static docs. This PR configures it for some of them based on my review of their length and utility.