### PR TITLE
ENYO-6073: Fix Scrollable to focus outside the container

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Popup` to properly handle closing in mid-transition
+- `moonstone/Scroller` to properly move focus out of the container
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -636,9 +636,15 @@ class ScrollableBase extends Component {
 			isHorizontalDirection = direction === 'left' || direction === 'right',
 			isVerticalDirection = direction === 'up' || direction === 'down';
 
-		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalDirection});
-
 		const {focusableScrollbar, direction: directionProp} = this.props;
+
+		this.onScrollbarButtonClick({
+			isPreviousScrollButton,
+			isVerticalScrollBar:
+				isVerticalDirection &&
+				(directionProp === 'vertical' || directionProp === 'both')
+		});
+
 		if (focusableScrollbar) {
 			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
 				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -633,15 +633,24 @@ class ScrollableBase extends Component {
 		const
 			isRtl = this.uiRef.current.state.rtl,
 			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
-			isVerticalScrollBar = direction === 'up' || direction === 'down';
+			isHorizontalDirection = direction === 'left' || direction === 'right',
+			isVerticalDirection = direction === 'up' || direction === 'down';
 
-		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar});
+		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalDirection});
 
-		if (this.props.focusableScrollbar) {
-			const scrollbar = this.uiRef.current[
-				(isVerticalScrollBar ? 'vertical' : 'horizontal') + 'ScrollbarRef'
-			];
-			scrollbar.current.focusOnButton(isPreviousScrollButton);
+		const {focusableScrollbar, direction: directionProp} = this.props;
+		if (focusableScrollbar) {
+			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
+				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {
+					const scrollbar = this.uiRef.current.verticalScrollbarRef;
+					scrollbar.current.focusOnButton(isPreviousScrollButton);
+				}
+			} else if (isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both')) {
+				if (this.uiRef.current && this.uiRef.current.horizontalScrollbarRef.current) {
+					const scrollbar = this.uiRef.current.horizontalScrollbarRef;
+					scrollbar.current.focusOnButton(isPreviousScrollButton);
+				}
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -694,15 +694,24 @@ class ScrollableBaseNative extends Component {
 		const
 			isRtl = this.uiRef.current.state.rtl,
 			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
-			isVerticalScrollBar = direction === 'up' || direction === 'down';
+			isHorizontalDirection = direction === 'left' || direction === 'right',
+			isVerticalDirection = direction === 'up' || direction === 'down';
 
-		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar});
+		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalDirection});
 
-		if (this.props.focusableScrollbar) {
-			const scrollbar = this.uiRef.current[
-				(isVerticalScrollBar ? 'vertical' : 'horizontal') + 'ScrollbarRef'
-			];
-			scrollbar.current.focusOnButton(isPreviousScrollButton);
+		const {focusableScrollbar, direction: directionProp} = this.props;
+		if (focusableScrollbar) {
+			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
+				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {
+					const scrollbar = this.uiRef.current.verticalScrollbarRef;
+					scrollbar.current.focusOnButton(isPreviousScrollButton);
+				}
+			} else if (isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both')) {
+				if (this.uiRef.current && this.uiRef.current.horizontalScrollbarRef.current) {
+					const scrollbar = this.uiRef.current.horizontalScrollbarRef;
+					scrollbar.current.focusOnButton(isPreviousScrollButton);
+				}
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -697,9 +697,15 @@ class ScrollableBaseNative extends Component {
 			isHorizontalDirection = direction === 'left' || direction === 'right',
 			isVerticalDirection = direction === 'up' || direction === 'down';
 
-		this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalDirection});
-
 		const {focusableScrollbar, direction: directionProp} = this.props;
+
+		this.onScrollbarButtonClick({
+			isPreviousScrollButton,
+			isVerticalScrollBar:
+				isVerticalDirection &&
+				(directionProp === 'vertical' || directionProp === 'both')
+		});
+
 		if (focusableScrollbar) {
 			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
 				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`scrollAndFocusScrollbarButton` function only accounts for vertical direction spotlight leave to focus to the closest scroller button. This results in an error where focus moving out horizontally from the container fails to find scroller to focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Checks both the vertical and horizontal direction and check if the scroller exists in the direction. A simple condition check whether scroller exists or not would probably be enough, but it's probably better to get the logic down correctly.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>
