### PR TITLE
PLAT-78973: Updated Icon to support arbitrary strings as icon names

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,10 +3,14 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
- 
+
 ### Added
- 
+
 - `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` support for resizing a window
+
+### Fixed
+
+- `ui/Icon` to support arbitrary icon name strings, like in material icons
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -49,18 +49,16 @@ const mergeStyle = function (style, src) {
 };
 
 /**
- * Tests if a character is a single printable character
+ * Tests if a string appears to be a URI/URL.
  *
  * @function
  * @param	{String}	c	Character to test
  *
- * @returns	{Boolean}		`true` if c is a single character
+ * @returns	{Boolean}		`true` if c looks like a URL
  * @private
  */
-const isSingleCharacter = function (c) {
-	return	c.length === 1 ||
-			// check for 4-byte Unicode character
-			c.length === 2 && c.charCodeAt() !== c.codePointAt();
+const isUri = function (c) {
+	return (c.indexOf('/') > -1) || (c.indexOf('.') > -1);
 };
 
 /**
@@ -188,8 +186,8 @@ const Icon = kind({
 					} else if (iconProp.indexOf('0x') === 0) {
 						// Converts a hex reference in string form
 						icon = String.fromCodePoint(iconProp);
-					} else if (isSingleCharacter(iconProp)) {
-						// A single character is assumed to be an explicit icon string
+					} else if (!isUri(iconProp)) {
+						// A "simple" string is assumed to be an icon-name string
 						icon = iconProp;
 					} else {
 						// for a path or URI, add it to style

--- a/packages/ui/Icon/tests/Icon-specs.js
+++ b/packages/ui/Icon/tests/Icon-specs.js
@@ -16,6 +16,32 @@ describe('Icon Specs', () => {
 		expect(actual).toEqual(expected);
 	});
 
+	test('should allow single-byte characters to pass through', () => {
+		const iconName = '+';
+		const icon = shallow(
+			<Icon>
+				{iconName}
+			</Icon>
+		);
+
+		const expected = iconName;
+		const actual = icon.text();
+		expect(actual).toEqual(expected);
+	});
+
+	test('should allow multi-byte characters to pass through', () => {
+		const iconName = '󰂪';
+		const icon = shallow(
+			<Icon>
+				{iconName}
+			</Icon>
+		);
+
+		const expected = iconName;
+		const actual = icon.text();
+		expect(actual).toEqual(expected);
+	});
+
 	test('should allow pre-defined icon names as an icon', () => {
 		const iconName = 'factory';
 		const iconGlyph = 'F';

--- a/packages/ui/Icon/tests/Icon-specs.js
+++ b/packages/ui/Icon/tests/Icon-specs.js
@@ -3,7 +3,85 @@ import {shallow} from 'enzyme';
 import Icon from '../Icon';
 
 describe('Icon Specs', () => {
-	test('should merge author styles with src', () => {
+	test('should allow icon-name words to pass through', () => {
+		const iconName = 'hollow_star';
+		const icon = shallow(
+			<Icon>
+				{iconName}
+			</Icon>
+		);
+
+		const expected = iconName;
+		const actual = icon.text();
+		expect(actual).toEqual(expected);
+	});
+
+	test('should allow pre-defined icon names as an icon', () => {
+		const iconName = 'factory';
+		const iconGlyph = 'F';
+		const iconList = {
+			train: 'T',
+			factory: 'F'
+		};
+		const icon = shallow(
+			<Icon iconList={iconList}>
+				{iconName}
+			</Icon>
+		);
+
+		const expected = iconGlyph;
+		const actual = icon.text();
+		expect(actual).toEqual(expected);
+	});
+
+	test('should allow un-matched icon names to fall through, even when pre-defined icons exist', () => {
+		const iconName = 'custom-icon-word';
+		const iconList = {
+			train: 'T',
+			factory: 'F'
+		};
+		const icon = shallow(
+			<Icon iconList={iconList}>
+				{iconName}
+			</Icon>
+		);
+
+		const expected = iconName;
+		const actual = icon.text();
+		expect(actual).toEqual(expected);
+	});
+
+	test('should allow URIs to be used as an icon', () => {
+		const src = 'images/icon.png';
+		const icon = shallow(
+			<Icon>
+				{src}
+			</Icon>
+		);
+
+		const expected = {
+			backgroundImage: `url(${src})`
+		};
+		const actual = icon.prop('style');
+		expect(actual).toEqual(expected);
+	});
+
+	test('should allow URLs to be used as an icon', () => {
+		const src = 'http://enactjs.com/images/logo';
+		const icon = shallow(
+			<Icon>
+				{src}
+			</Icon>
+		);
+
+		const expected = {
+			backgroundImage: `url(${src})`
+		};
+		const actual = icon.prop('style');
+		expect(actual).toEqual(expected);
+	});
+
+	test('should merge author styles with image URLs', () => {
 		const src = 'images/icon.png';
 		const icon = shallow(
 			<Icon style={{color: 'green'}}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Icon names longer than one character that are outside of the iconsList were being treated as URLs.

### Resolution
Updated the checker code to look for URL-like symbols to determine "URL-ness" of a string.