### PR TITLE
PLAT-80385: Utilize spatial-navigation event

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -63,8 +63,7 @@ const RootContainer = SpotlightContainerDecorator(
 
 const ControlsContainer = SpotlightContainerDecorator(
 	{
-		enterTo: '',
-		straightOnly: true
+		enterTo: ''
 	},
 	'div'
 );
@@ -1875,6 +1874,7 @@ const VideoPlayerBase = class extends React.Component {
 						<ControlsContainer
 							className={css.bottom + (this.state.mediaControlsVisible ? '' : ' ' + css.hidden)}
 							spotlightDisabled={spotlightDisabled || !this.state.mediaControlsVisible}
+							spotlightRule="grid"
 						>
 							{/*
 								Info Section: Title, Description, Times

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -71,9 +71,6 @@ let GlobalConfig = {
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
 	selector: '',           // can be a valid <extSelector> except "@" syntax.
 	selectorDisabled: false,
-	straightMultiplier: 1,
-	straightOnly: false,
-	straightOverlapThreshold: 0.5,
 	tabIndexIgnoreList: 'a, input, select, textarea, button, iframe, [contentEditable=true]'
 };
 
@@ -582,18 +579,7 @@ const isNavigable = (node, containerId, verify) => {
  * @private
  */
 const getAllContainerIds = () => {
-	const ids = [];
-	const keys = containerConfigs.keys();
-
-	// PhantomJS-friendly iterator->array conversion
-	let id;
-	while ((id = keys.next()) && !id.done) {
-		if (isActiveContainer(id.value)) {
-			ids.push(id.value);
-		}
-	}
-
-	return ids;
+	return [...containerConfigs.keys()].filter(id => isActiveContainer(id));
 };
 
 /**

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -300,26 +300,19 @@ const Spotlight = (function () {
 	}
 
 	function spotNextFromPoint (direction, position) {
-		const containerId = Spotlight.getActiveContainer();
-
+		// Set StartingPoint
 		if (window.__spatialNavigation__) {
 			window.__spatialNavigation__.setStartingPoint(position.x, position.y);
 		}
-		Spotlight.move(direction);
-		const next = Spotlight.getCurrent();
 
-		if (next) {
-			setContainerPreviousTarget(
-				containerId,
-				direction,
-				next,
-				getContainerLastFocusedElement(containerId)
-			);
+		const result = Spotlight.move(direction);
 
-			return focusElement(next, getContainersForNode(next));
+		// Reset StartingPoint
+		if (window.__spatialNavigation__) {
+			window.__spatialNavigation__.setStartingPoint();
 		}
 
-		return false;
+		return result;
 	}
 
 	function focusMovePrepare (direction, currentFocusedElement, nextElement) {
@@ -528,8 +521,8 @@ const Spotlight = (function () {
 
 
 	function onNavnotarget (evt) {
-		//console.log('onNavnotarget');
-		//console.log(evt);
+		// console.log('onNavnotarget');
+		// console.log(evt);
 
 		const targetContainer = evt.target;
 		const targetContinerId = getContainerId(targetContainer);
@@ -566,12 +559,13 @@ const Spotlight = (function () {
 	}
 
 	function onNavBeforeFocus (evt) {
-		//console.log('onNavBeforeFocus');
-		//console.log(evt);
-		//console.log(document.activeElement);
+		// console.log('onNavBeforeFocus');
+		// console.log(evt);
+		// console.log(document.activeElement);
+		// console.log(getCurrent());
 
 		const direction = evt.detail.dir;
-		const currentFocusedElement = document.activeElement;
+		const currentFocusedElement = getCurrent();
 		const currentContainerIds = getContainersForNode(currentFocusedElement);
 		let nextElement = evt.target;
 		const nextContainerIds = getContainersForNode(nextElement);
@@ -999,7 +993,9 @@ const Spotlight = (function () {
 			}
 
 			return getSpottableDescendants(containerId);
-		}
+		},
+
+		isAccelerating: SpotlightAccelerator.isAccelerating
 	};
 
 	return exports;

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -8,7 +8,8 @@ import {
 	getDefaultContainer,
 	getLastContainer,
 	isContainer,
-	isNavigable
+	isNavigable,
+	isRestrictedContainer
 } from './container';
 import {
 	parseSelector
@@ -93,7 +94,7 @@ function getLeaveForTarget (containerId, direction) {
 	const config = getContainerConfig(containerId);
 
 	if (config) {
-		const target = config.restrict !== 'self-only' && config.leaveFor && config.leaveFor[direction];
+		const target = !isRestrictedContainer(containerId) && config.leaveFor && config.leaveFor[direction];
 		if (typeof target === 'string') {
 			if (target === '') {
 				return false;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The standardization of spatial navigation is progressing for the lightweight spotlight.
(https://drafts.csswg.org/css-nav-1/)

We need to check up the standard is appropriate to implement lightweight spotlight.
In the POC, We aim to apply the latest standard to spotlight and replace the spotlight code to spatial-navigation-polyfill.

There are two kind of spatial navigation event, `navnotarget` and `navbeforefocus` which is helpful for lightweight spotlight.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

As the second step of this POC,  simplify some enact code with spatial navigation event.
In more details, the following are implemented:
1) Transfer handling of direction-key down to spatial-navigation from virtualList. Use `navnotarget`, `navbeforefocus` event for case.
2) Remove unsuport configuration in container (`straitOnly`, `straightMultiplier`, `straightOverlapThreshold`).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-80385

### Comments
