### PR TITLE
ENYO-6041: Add onKeyDown action/prop to VirtualList QA samples

### DIFF
--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -64,6 +64,7 @@ storiesOf('VirtualList.VirtualGridList', module)
 					minWidth: ri.scale(number('minWidth', Config, 180)),
 					minHeight: ri.scale(number('minHeight', Config, 270))
 				}}
+				onKeyDown={action('onKeyDown')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 18))}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -99,6 +99,7 @@ storiesOf('VirtualList', module)
 					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
 					itemRenderer={renderItem(itemSize)}
 					itemSize={itemSize}
+					onKeyDown={action('onKeyDown')}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There was no way to test when `VirtualList` prevented the `keydown` event to bubble, as is done internally in order to strictly regulate how focus is handled within the component.


### Resolution
We have existing QA samples for both `VirtualList` and `VirtualGridList`, so we can simply add the onKeyDown action/prop to those samples.

