### PR TITLE
Updated sample to remove Panels-in-Panels problem

### DIFF
--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -48,7 +48,7 @@ const PanelsBase = kind({
 					</Column>] : children
 				}
 			</Panel> : children}
-		</Panels> : children
+		</Panels> : <div {...rest}>{children}</div>
 	)
 });
 

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -1,6 +1,6 @@
 import Item from '@enact/moonstone/Item';
 import SwitchItem from '@enact/moonstone/SwitchItem';
-import {ActivityPanels, Panel} from '@enact/moonstone/Panels';
+import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
 import VirtualList, {VirtualListBase} from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
@@ -17,7 +17,8 @@ const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBas
 const
 	itemStyle = {
 		borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-		boxSizing: 'border-box'
+		boxSizing: 'border-box',
+		display: 'flex'
 	},
 	items = [],
 	defaultDataSize = 1000,
@@ -90,7 +91,8 @@ class StatefulSwitchItem extends React.Component {
 	}
 }
 
-const InPanels = (props) => {
+// eslint-disable-next-line enact/prop-types
+const InPanels = ({className, title, ...rest}) => {
 	const [index, setIndex] = useState(0);
 	function handleSelectBreadcrumb (ev) {
 		setIndex(ev.index);
@@ -101,17 +103,19 @@ const InPanels = (props) => {
 	}
 
 	return (
-		<ActivityPanels index={index} onSelectBreadcrumb={handleSelectBreadcrumb} noCloseButton>
+		<ActivityPanels className={className} index={index} onSelectBreadcrumb={handleSelectBreadcrumb} noCloseButton>
 			<Panel>
+				<Header type="compact" title={`${title} Panel 0`} key="header" />
 				<VirtualList
 					id="spotlight-list"
 					// eslint-disable-next-line enact/prop-types
-					itemRenderer={renderItem(Item, props.itemSize, handleSelectItem)}
+					itemRenderer={renderItem(Item, rest.itemSize, handleSelectItem)}
 					spotlightId="virtual-list"
-					{...props}
+					{...rest}
 				/>
 			</Panel>
-			<Panel>
+			<Panel title={`${title} Panel 1`}>
+				<Header type="compact" title={`${title} Panel 1`} key="header" />
 				<Item onClick={handleSelectItem}>Go Back</Item>
 			</Panel>
 		</ActivityPanels>
@@ -139,14 +143,19 @@ storiesOf('VirtualList', module)
 	)
 	.add(
 		'in Panels',
-		() => (
-			<InPanels
-				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
-				itemSize={ri.scale(number('itemSize', Config, 72))}
-				onScrollStart={action('onScrollStart')}
-				onScrollStop={action('onScrollStop')}
-				spacing={ri.scale(number('spacing', Config, 0))}
-			/>
-		)
+		context => {
+			context.noPanels = true;
+			const title = `${context.kind} ${context.story}`.trim();
+			return (
+				<InPanels
+					title={title}
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
+					itemSize={ri.scale(number('itemSize', Config, 72))}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					spacing={ri.scale(number('spacing', Config, 0))}
+				/>
+			);
+		}
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The existing new sample nests Panels, which isn't ideal.


### Resolution
This change leverages the existing system for disabling the auto-inserted Panels element in favor of our own (defined in the sample). It now syncs-up with other samples and positions elements correctly on the page.

Also updated MoonstoneEnvironment to have better support for the (never before used) `noPanels` option.