### PR TITLE
ENYO-6101: Set the aria-label of IconButton in IncrementSlider

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Popup` to properly handle closing in mid-transition
+- `moonstone/IncrementSlider` to support aria-label when disabled
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -466,18 +466,14 @@ const IncrementSliderBase = kind({
 				decrementAriaLabel = $L('press ok button to decrease the value');
 			}
 
-			return !(disabled || value <= min) ?
-				`${valueText != null ? valueText : value} ${decrementAriaLabel}` :
-				null;
+			return `${valueText != null ? valueText : value} ${decrementAriaLabel}`;
 		},
 		incrementAriaLabel: ({'aria-valuetext': valueText, incrementAriaLabel, disabled, min, max, value = min}) => {
 			if (incrementAriaLabel == null) {
 				incrementAriaLabel = $L('press ok button to increase the value');
 			}
 
-			return !(disabled || value >= max) ?
-				`${valueText != null ? valueText : value} ${incrementAriaLabel}` :
-				null;
+			return `${valueText != null ? valueText : value} ${incrementAriaLabel}`;
 		}
 	},
 

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -461,14 +461,14 @@ const IncrementSliderBase = kind({
 		incrementDisabled: ({disabled, max, min, value = min}) => disabled || value >= max,
 		decrementIcon: ({decrementIcon, orientation}) => (decrementIcon || ((orientation === 'vertical') ? 'arrowlargedown' : 'arrowlargeleft')),
 		incrementIcon: ({incrementIcon, orientation}) => (incrementIcon || ((orientation === 'vertical') ? 'arrowlargeup' : 'arrowlargeright')),
-		decrementAriaLabel: ({'aria-valuetext': valueText, decrementAriaLabel, disabled, min, value = min}) => {
+		decrementAriaLabel: ({'aria-valuetext': valueText, decrementAriaLabel, min, value = min}) => {
 			if (decrementAriaLabel == null) {
 				decrementAriaLabel = $L('press ok button to decrease the value');
 			}
 
 			return `${valueText != null ? valueText : value} ${decrementAriaLabel}`;
 		},
-		incrementAriaLabel: ({'aria-valuetext': valueText, incrementAriaLabel, disabled, min, max, value = min}) => {
+		incrementAriaLabel: ({'aria-valuetext': valueText, incrementAriaLabel, min, value = min}) => {
 			if (incrementAriaLabel == null) {
 				incrementAriaLabel = $L('press ok button to increase the value');
 			}

--- a/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
+++ b/packages/moonstone/IncrementSlider/tests/IncrementSlider-specs.js
@@ -182,13 +182,13 @@ describe('IncrementSlider Specs', () => {
 	);
 
 	test(
-		'should not set decrementButton "aria-label" when decrementButton is disabled',
+		'should set decrementButton "aria-label" when decrementButton is disabled',
 		() => {
 			const incrementSlider = mount(
 				<IncrementSlider disabled value={10} />
 			);
 
-			const expected = null;
+			const expected = '10 press ok button to decrease the value';
 			const actual = incrementSlider.find(`IconButton.${css.decrementButton}`).prop('aria-label');
 
 			expect(actual).toBe(expected);
@@ -225,13 +225,13 @@ describe('IncrementSlider Specs', () => {
 	);
 
 	test(
-		'should not set incrementButton "aria-label" when incrementButton is disabled',
+		'should set incrementButton "aria-label" when incrementButton is disabled',
 		() => {
 			const incrementSlider = mount(
 				<IncrementSlider disabled value={10} />
 			);
 
-			const expected = null;
+			const expected = '10 press ok button to increase the value';
 			const actual = incrementSlider.find(`IconButton.${css.incrementButton}`).prop('aria-label');
 
 			expect(actual).toBe(expected);


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is no aria-label when the value is min or max in IncrementSlider

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Because we support focus to disabled item, aria-label of IconButton in IncrementSlider should be set even the value is min or max.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6101

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>