### PR TITLE
ENYO-6099: Focus an item asynchronous after VirtualList jumps

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Popup` to properly handle closing in mid-transition
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after jumping.
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -492,17 +492,20 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		focusByIndex = (index) => {
-			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}'].spottable`);
+			// We have to focus node asynchronous since `numOfItems` state will be updated asynchronous later and VirtualList will render items after then.
+			setTimeout(() => {
+				const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}'].spottable`);
 
-			if (this.isWrappedBy5way) {
-				SpotlightAccelerator.reset();
-				this.isWrappedBy5way = false;
-			}
+				if (this.isWrappedBy5way) {
+					SpotlightAccelerator.reset();
+					this.isWrappedBy5way = false;
+				}
 
-			this.pause.resume();
-			this.focusOnNode(item);
-			this.nodeIndexToBeFocused = null;
-			this.isScrolledByJump = false;
+				this.pause.resume();
+				this.focusOnNode(item);
+				this.nodeIndexToBeFocused = null;
+				this.isScrolledByJump = false;
+			}, 0);
 		}
 
 		initItemRef = (ref, index) => {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Spotlight was not on any item in `VirtualList` after the list item size increases and the list jumps.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We changed to focus an item **synchronous** because all item DOM elements were rendered in `componentDidUpdate` phase in `VirtuaList` and App when launching the list with data size.

But this issue was generated when changing the data size of the `VirtualList` after launching the list related with the adaptation of new React lifecycle methods.

* In the first `componentDidUpdate` phase in `VirtuaList`, `numOfItems` was requested to be updated asynchronous with `setState`, `numOfItems` was still 0, and no items were rendered.
* In the first `componentDidUpdate` phase in app, `cbScrollTo` prop was called, but there was no item DOM element yet to be focused.
* In the second `componentDidUpdate` phase in `VirtualList`, the items were rendered properly.
* So we needed to focus an item after all items were rendered.

It is hard to choose the right timing to focus an item now. So as we did, I would like to focus an item asynchronous again to cover all edge cases.

### Links
[//]: # (Related issues, references)

ENYO-6099