### PR TITLE
PLAT-81283: Not to read out previous or next item when the decrementer or incrementer icon is disabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Popup` to properly handle closing in mid-transition
+- `moonstone/Picker` not to read out previous or next item when the decrementer or incrementer icon is disabled
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -751,7 +751,7 @@ const PickerBase = class extends React.Component {
 			return label;
 		}
 
-		return `${valueText} ${!disabled ? (next ? $L('next item') : $L('previous item')) : ''}`;
+		return `${valueText} ${!disabled && (next ? $L('next item') : $L('previous item')) || ''}`;
 	}
 
 	calcDecrementLabel (valueText, decrementerDisabled) {

--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -743,7 +743,7 @@ const PickerBase = class extends React.Component {
 		return valueText;
 	}
 
-	calcButtonLabel (next, valueText) {
+	calcButtonLabel (next, valueText, disabled) {
 		const {decrementAriaLabel, incrementAriaLabel} = this.props;
 		let label = next ? incrementAriaLabel : decrementAriaLabel;
 
@@ -751,15 +751,15 @@ const PickerBase = class extends React.Component {
 			return label;
 		}
 
-		return `${valueText} ${next ? $L('next item') : $L('previous item')}`;
+		return `${valueText} ${!disabled ? (next ? $L('next item') : $L('previous item')) : ''}`;
 	}
 
-	calcDecrementLabel (valueText) {
-		return !this.props.joined ? this.calcButtonLabel(this.props.reverse, valueText) : null;
+	calcDecrementLabel (valueText, decrementerDisabled) {
+		return !this.props.joined ? this.calcButtonLabel(this.props.reverse, valueText, decrementerDisabled) : null;
 	}
 
-	calcIncrementLabel (valueText) {
-		return !this.props.joined ? this.calcButtonLabel(!this.props.reverse, valueText) : null;
+	calcIncrementLabel (valueText, incrementerDisabled) {
+		return !this.props.joined ? this.calcButtonLabel(!this.props.reverse, valueText, incrementerDisabled) : null;
 	}
 
 	calcAriaLabel (valueText) {
@@ -890,9 +890,9 @@ const PickerBase = class extends React.Component {
 				<PickerButton
 					{...voiceProps}
 					aria-controls={!joined ? incrementerAriaControls : null}
-					aria-label={this.calcIncrementLabel(valueText)}
+					aria-label={this.calcIncrementLabel(valueText, incrementerDisabled)}
 					className={css.incrementer}
-					data-webos-voice-label={joined ? this.calcButtonLabel(!reverse, valueText) : null}
+					data-webos-voice-label={joined ? this.calcButtonLabel(!reverse, valueText, incrementerDisabled) : null}
 					disabled={incrementerDisabled}
 					hidden={reachedEnd}
 					holdConfig={holdConfig}
@@ -927,9 +927,9 @@ const PickerBase = class extends React.Component {
 				<PickerButton
 					{...voiceProps}
 					aria-controls={!joined ? decrementerAriaControls : null}
-					aria-label={this.calcDecrementLabel(valueText)}
+					aria-label={this.calcDecrementLabel(valueText, decrementerDisabled)}
 					className={css.decrementer}
-					data-webos-voice-label={joined ? this.calcButtonLabel(reverse, valueText) : null}
+					data-webos-voice-label={joined ? this.calcButtonLabel(reverse, valueText, decrementerDisabled) : null}
 					disabled={decrementerDisabled}
 					hidden={reachedStart}
 					holdConfig={holdConfig}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though the decrementer or incrementer icon is disabled, "previous item" or "next item" was read out in Picker.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

"previous item" or "next item" was read out properly in Picker depending on the activation of the decrementer or incrementer button.

### Links
[//]: # (Related issues, references)

PLAT-81283

### Comments
