### PR TITLE
PLAT-81126: Fix VirtualList wrap knob configuration

### DIFF
--- a/packages/sampler/src/configure.js
+++ b/packages/sampler/src/configure.js
@@ -17,7 +17,6 @@ function config (stories, mod) {
 	// Set addon-knobs defaults
 	addDecorator(withKnobs({
 		// debounce: {wait: 500}, // Same as lodash debounce.
-		escapeHTML: false,
 		timestamps: true // Doesn't emit events while user is typing.
 	}));
 

--- a/packages/sampler/src/configure.js
+++ b/packages/sampler/src/configure.js
@@ -17,6 +17,7 @@ function config (stories, mod) {
 	// Set addon-knobs defaults
 	addDecorator(withKnobs({
 		// debounce: {wait: 500}, // Same as lodash debounce.
+		escapeHTML: false,
 		timestamps: true // Doesn't emit events while user is typing.
 	}));
 

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -14,7 +14,7 @@ const
 	wrapOption = {
 		'false': false,
 		'true': true,
-		"'noAnimation'": 'noAnimation'
+		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	prop = {
 		direction: {'horizontal': 'horizontal', 'vertical': 'vertical'}
@@ -115,7 +115,7 @@ storiesOf('Moonstone', module)
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 20))}
-				wrap={wrapOption[select('wrap', ['false', 'true', "'noAnimation'"], Config)]}
+				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 			/>
 		),
 		{

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -14,7 +14,7 @@ const
 	wrapOption = {
 		'false': false,
 		'true': true,
-		"'noAnimation'": 'noAnimation'
+		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	items = [],
 	defaultDataSize = 1000,
@@ -103,7 +103,7 @@ storiesOf('Moonstone', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
-					wrap={wrapOption[select('wrap', ['false', 'true', "'noAnimation'"], Config)]}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
 		},


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Since the storybook 5 update, addon knobs will convert string characters to html entities. This is causing problems in our `VirtualList` samples, where the value of the `wrap` prop set as `'noAnimation'` would be seen as `&#39;noAnimation&#39;`

This will ultimately lead to the `wrap` prop being passed an `undefined` value, causing seemingly incorrect component behavior.

### Resolution
Update the knob config to ensure the right value is passed to the component
