### PR TITLE
PLAT-81278: Add Long Content to VirtualList Sample

### DIFF
--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -21,7 +21,7 @@ const
 	},
 	items = [],
 	defaultDataSize = 1000,
-	longContent = 'Loooooooooooooooooog Content',
+	longContent = 'Lorem ipsum dolor sit amet',
 	shouldAddLongContent = ({index, modIndex}) => (
 		index % modIndex === 0 ? ` ${longContent}` : ''
 	),

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -21,6 +21,10 @@ const
 	},
 	items = [],
 	defaultDataSize = 1000,
+	longContent = 'Loooooooooooooooooog Content',
+	shouldAddLongContent = ({index, modIndex}) => (
+		index % modIndex === 0 ? ` ${longContent}` : ''
+	),
 	// eslint-disable-next-line enact/prop-types
 	uiRenderItem = ({index, ...rest}) => {
 		const {text, subText, source} = items[index];
@@ -58,8 +62,8 @@ const updateDataSize = (dataSize) => {
 	for (let i = 0; i < dataSize; i++) {
 		const
 			count = (headingZeros + i).slice(-itemNumberDigits),
-			text = `Item ${count}`,
-			subText = `SubItem ${count}`,
+			text = `Item ${count}${shouldAddLongContent({index: i, modIndex: 2})}`,
+			subText = `SubItem ${count}${shouldAddLongContent({index: i, modIndex: 3})}`,
 			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
 			source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Recent changes to font size (and/or spacing & minWidth prop sizing or ri) caused the `GridListImageItem` components to fully display the `title` and `subtitle` content, making them not able to marquee - which was required for TCs and internal testing. 


### Resolution
Create long content that is applied to the `title` and `subtitle`, based on a {{%}} mod operator (every 2nd index for title, every 3rd index for subtitle). This way, there are:
- some `GridListImageItem` components that have no marquee-able content
- some can only marquee `title`
- some can only marquee `subtitle`
- some can marquee both `title` and `subtitle`

