### PR TITLE
ENYO-6103: Fix SpotlightContainerDecorator focus and blur event forwarding

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightContainerDecorator` to correctly forward `onFocusCapture` and `onBlurCapture` events
+
 ## [3.0.0-alpha.7] - 2019-06-24
 
 No significant changes.

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -7,7 +7,7 @@
  * @module spotlight/SpotlightContainerDecorator
  */
 
-import {forProp, forward, handle, stop} from '@enact/core/handle';
+import {call, forProp, forward, handle, oneOf, returnsTrue, stop} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -246,16 +246,18 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handle = handle.bind(this)
 
-		handleBlur = this.handle(
-			() => this.shouldPreventBlur,
-			stop
-		)
+		handleBlur = oneOf(
+			[() => this.shouldPreventBlur, stop],
+			[returnsTrue, forward('onBlurCapture')]
+		).bindAs(this, 'handleBlur')
 
-		handleFocus = this.handle(
-			forProp('spotlightDisabled', true),
-			stop,
-			this.silentBlur
-		)
+		handleFocus = oneOf(
+			[forProp('spotlightDisabled', true), handle(
+				stop,
+				call('silentBlur')
+			)],
+			[returnsTrue, forward('onFocusCapture')]
+		).bindAs(this, 'handleFocus')
 
 		handleMouseEnter = this.handle(
 			forward('onMouseEnter'),

--- a/packages/spotlight/SpotlightContainerDecorator/tests/SpotlightContainerDecorator-specs.js
+++ b/packages/spotlight/SpotlightContainerDecorator/tests/SpotlightContainerDecorator-specs.js
@@ -104,4 +104,108 @@ describe('SpotlightContainerDecorator', () => {
 			expect(actual).toBe(expected);
 		}
 	);
+
+	test(
+		'should forward onFocusCapture events',
+		() => {
+			const spy = jest.fn();
+			let focus;
+
+			const Component = SpotlightContainerDecorator(({onFocusCapture}) => {
+				focus = onFocusCapture;
+				return <div />;
+			});
+			mount(<Component onFocusCapture={spy} />);
+
+			focus({});
+
+			const expected = 1;
+			const actual = spy.mock.calls.length;
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should suppress onFocusCapture events when spotlightDisabled',
+		() => {
+			const spy = jest.fn();
+			let focus;
+
+			const Component = SpotlightContainerDecorator(({onFocusCapture}) => {
+				focus = onFocusCapture;
+				return <div />;
+			});
+			mount(<Component onFocusCapture={spy} spotlightDisabled />);
+
+			// building out the api called on the event object + target
+			focus({
+				stopPropagation: () => true,
+				target: {
+					blur: () => true
+				}
+			});
+
+			const expected = 0;
+			const actual = spy.mock.calls.length;
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should forward onBlurCapture events',
+		() => {
+			const spy = jest.fn();
+			let blur;
+
+			const Component = SpotlightContainerDecorator(({onBlurCapture}) => {
+				blur = onBlurCapture;
+				return <div />;
+			});
+			mount(<Component onBlurCapture={spy} spotlightDisabled />);
+
+			// building out the api called on the event object + target
+			blur({
+				stopPropagation: () => true,
+				target: {
+					blur: () => blur({})
+				}
+			});
+
+			const expected = 1;
+			const actual = spy.mock.calls.length;
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should suppress onBlurCapture events when focus was suppressed',
+		() => {
+			const spy = jest.fn();
+			let focus;
+			let blur;
+
+			const Component = SpotlightContainerDecorator(({onBlurCapture, onFocusCapture}) => {
+				blur = onBlurCapture;
+				focus = onFocusCapture;
+				return <div />;
+			});
+			mount(<Component onBlurCapture={spy} spotlightDisabled />);
+
+			// building out the api called on the event object + target
+			focus({
+				stopPropagation: () => true,
+				target: {
+					// the focus handler calls blur() on the target so we're simulating that here by
+					// wiring our onBlurCapture handler directly to the invocation. This isn't a
+					// perfect modeling of the system but serves to validate the callback
+					// suppression logic.
+					blur: () => blur({})
+				}
+			});
+
+			const expected = 0;
+			const actual = spy.mock.calls.length;
+			expect(actual).toBe(expected);
+		}
+	);
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
SpotlightContainerDecorator consumed `onFocusCapture` and `onBlurCapture` events preventing authors from handling those events as well.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed it to forward except when spotlight has suppressed a focus event due to `spotlightDisabled`
