### PR TITLE
PLAT-79873: Updated Global font to 3-languages font name(s)

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` to properly move focus out of the container
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 - `moonstone/IncrementSlider` to support aria-label when disabled
-- `Fonts` to use the updated names of global fonts available in the system
+- Fonts to use the updated names of global fonts available in the system
 
 ## [3.0.0-alpha.7] - 2019-06-24
 
@@ -42,7 +42,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Header` to center text when `centered` is used and additional controls are included by `moonstone/Panels`
-- `Fonts` for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
+- Fonts for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
 - `moonstone/VirtualList` to restore focus to an item when scrollbars are visible
 
 ## [3.0.0-alpha.4] - 2019-06-03

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Scroller` to properly move focus out of the container
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 - `moonstone/IncrementSlider` to support aria-label when disabled
+- `Fonts` to use the updated names of global fonts available in the system
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -12,8 +12,8 @@ const fontName = 'Moonstone Global';
 const fonts = {
 	'NonLatin': {
 		// Hacky solution to add support for full-name and postscript names of the same font (support for multiple different operating systems font handling)
-		regular: 'LG Smart UI Global-Light"), local("LGSmartUIGlobal-Light',
-		bold:    'LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular'
+		regular: 'LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular',
+		bold:    'LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold'
 	},
 	'am': {
 		regular: 'LG Display_Amharic'

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -14,9 +14,9 @@
 @font-system-src-moonstone-900:    local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
 @font-system-src-moonstone-900-i:  local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
 
-@font-system-src-non-latin-300:  local("LG Smart UI Global-Light"), local("LGSmartUIGlobal-Light");
-@font-system-src-non-latin-400:  local("LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular");
-@font-system-src-non-latin-700:  local("LG Smart UI Global-Regular"), local("LGSmartUIGlobal-Regular");
+@font-system-src-non-latin-300:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular");
+@font-system-src-non-latin-400:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular");
+@font-system-src-non-latin-700:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold");
 
 @font-system-src-moonstone-icons:  local("Moonstone"), url("../../fonts/Moonstone.ttf") format("truetype");
 @font-system-src-lg-icons:         local("LG Display_Dingbat");


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The `LG Smart UI Global` collection of fonts has been removed (renamed) and replaced by `LG Smart UI AR HE TH` family of fonts.


### Resolution
These fonts have been updated to the new names.


### Additional Considerations
There is a change in font-weight definition. Previously we had `LG Smart UI-Light` and `LG Smart UI-Regular` yet we support at least 3 different weights: light, regular, and bold. These new fonts come in non-matching weights: `LG Smart UI AR HE TH Regular` and `LG Smart UI AR HE TH SemiBold`. Previously, we'd mapped light to light, regular to regular, and regular to bold. (regular and bold would look the same). Now, these new fonts are being mapped to regular to light, regular to regular, and semibold to bold. (light and regular will use the same font-weight, and bold will stand out as different, as light did in the past). This means that some text will change in apparent weight visually, even though no change has happened in the code.

I believe this change was intentional and we now are simply using the appropriate weight metadata for the thickness of the glyphs in each of the font files.

*Note:* I'm not sure the changelog entry is ideal. If someone could verify it or correct it, that would be super.