### PR TITLE
ENYO-6099: VirtualList to set focus correctly after an update

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Popup` to properly handle closing in mid-transition
 - `moonstone/Scroller` to properly move focus out of the container
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after an update
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -559,6 +559,12 @@ const VirtualListBaseFactory = (type) => {
 			this.focusOnNode(item);
 			this.nodeIndexToBeFocused = null;
 			this.isScrolledByJump = false;
+
+			if (!item && index >= 0 && index < this.props.dataSize) {
+				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
+				this.preservedIndex = index;
+				this.restoreLastFocused = true;
+			}
 		}
 
 		initItemRef = (ref, index) => {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -550,20 +550,20 @@ const VirtualListBaseFactory = (type) => {
 		focusByIndex = (index) => {
 			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}'].spottable`);
 
-			if (this.isWrappedBy5way) {
-				SpotlightAccelerator.reset();
-				this.isWrappedBy5way = false;
-			}
-
-			this.pause.resume();
-			this.focusOnNode(item);
-			this.nodeIndexToBeFocused = null;
-			this.isScrolledByJump = false;
-
 			if (!item && index >= 0 && index < this.props.dataSize) {
 				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
 				this.preservedIndex = index;
 				this.restoreLastFocused = true;
+			} else {
+				if (this.isWrappedBy5way) {
+					SpotlightAccelerator.reset();
+					this.isWrappedBy5way = false;
+				}
+
+				this.pause.resume();
+				this.focusOnNode(item);
+				this.nodeIndexToBeFocused = null;
+				this.isScrolledByJump = false;
 			}
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When you call `.scrollTo({index, focus: true})` on a `VirtualList` after it has updated (after `componentDidUpdate`), the children may not have re-rendered yet, meaning the dom is not available and focus will not be set on the specified `index`, once the children are rendered and scrolled into view.


### Resolution
We can utilize the `this.handleUpdateItems` method of `VirtualList` in order to set focus after the list has been updated and the dom is available. We simply set the value of the index to be focused in the previous call to `this.focusByIndex`.
