### PR TITLE
ENYO-6076: Updated largeText mode label size/position in LabeledItem

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 - `moonstone/IncrementSlider` to support aria-label when disabled
 - Fonts to use the updated names of global fonts available in the system
-- `LabeledItem` in largeText mode to not clip the bottom of descender glyphs
+- `moonstone/LabeledItem` to not clip the bottom of descender glyphs in large text mode
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 - `moonstone/IncrementSlider` to support aria-label when disabled
 - Fonts to use the updated names of global fonts available in the system
+- `LabeledItem` in largeText mode to not clip the bottom of descender glyphs
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/LabeledItem/LabeledItem.module.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.module.less
@@ -7,7 +7,7 @@
 .labeledItem {
 	//// Locally scoped LESS variables ////
 	// Vertically shift the text element to position it closer to the header than the line-height naturally allows
-	@text-vertical-offset: 6px;
+	@text-vertical-offset: 9px;
 
 	flex-wrap: wrap;	// Allow the label to fall on the next line
 
@@ -44,7 +44,7 @@
 		text-transform: none;
 		// The following two margin values must cancel each other out, so there is zero layout impact when `text` is empty.
 		margin-top: -@text-vertical-offset;
-		margin-bottom: @text-vertical-offset;
+		padding-bottom: @text-vertical-offset;
 		// Force the label to fill the next line in the flexbox container
 		width: 100%;
 
@@ -63,6 +63,8 @@
 	.moon-custom-text({
 		.label {
 			font-size: @moon-expandable-value-font-size-large;
+			line-height: @moon-body-line-height-large;
+			padding-bottom: (@text-vertical-offset - 6px);
 		}
 	});
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -24,7 +24,7 @@
 @moon-popup-sub-header-font-size:   27px;
 @moon-popup-content-font-size:      30px;
 @moon-expandable-value-font-size:   27px;
-@moon-expandable-value-font-size-large:   33px;
+@moon-expandable-value-font-size-large:   30px;
 @moon-expandable-client-item-font-size:   27px;
 @moon-expandable-client-item-font-size-large:   33px;
 @moon-divider-font-size:            24px; // Deprecated?
@@ -116,6 +116,7 @@
 @moon-body-font-style: normal;
 // Body text line heights must be speified in px, since moon.ExpandableText requires precise line measurement
 @moon-body-line-height: @moon-body-font-size + 6;
+@moon-body-line-height-large: @moon-body-line-height + 6; // The fact that this 6 is the same number as the above 6 is coincidental. LargeText is typically 6px larger than normal.
 @moon-non-latin-body-line-height: 1.7em;
 
 @moon-divider-font-family: @moon-font-family;
@@ -199,7 +200,7 @@
 @moon-button-colordot-width: 27px;
 @moon-button-colordot-height: 9px;
 @moon-button-small-colordot-width: 21px;
-@moon-button-small-colordot-height: @moon-button-colordot-height;
+@moon-button-small-colordot-height: 6px;
 @moon-button-to-button-large-h-margin: 30px;
 
 // Divider


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`g` characters and other "tall"(?) descenders extend too far down in LabeledItem's label and are clipped.


### Resolution
This slightly reduces the font size for largeText mode of the label, and adjusts the line-height and paddings to keep the text is basically the same position but have more clearance below itself before getting clipped off.