### PR TITLE
ENYO-6107: Fix Panels clip path to only apply during transition

### DIFF
--- a/packages/moonstone/Panels/Arrangers.js
+++ b/packages/moonstone/Panels/Arrangers.js
@@ -55,19 +55,6 @@ const offsetForBreadcrumbs = (node) => {
 	return `translateX(${isFirst ? 0 : unit(scale(breadcrumbWidth), 'rem')})`;
 };
 
-// Adds the data-clip attribute to allow clipping when transitioning between non-zero panels
-// CSS is enforced by Panels.module.less
-const clipForBreadcrumbs = (node, to, from) => {
-	const viewport = node.parentNode;
-
-	if (to === 0 || from === 0) {
-		// remove clip when moving to or from the first panel and when a transition is completing
-		delete viewport.dataset.clip;
-	} else {
-		viewport.dataset.clip = 'true';
-	}
-};
-
 /**
  * Arranger that slides panels in from the right and out to the left allowing space for the single
  * breadcrumb when `to` index is greater than zero.
@@ -79,8 +66,6 @@ export const ActivityArranger = {
 	enter: (config) => {
 		const {node, reverse, to, from} = config;
 
-		clipForBreadcrumbs(node, to, from);
-
 		return arrange(config, [
 			{transform: `${offsetForBreadcrumbs(node)} translateX(100%)`, offset: 0},
 			reverse ?
@@ -91,8 +76,6 @@ export const ActivityArranger = {
 	},
 	leave: (config) => {
 		const {node, reverse, to, from} = config;
-
-		clipForBreadcrumbs(node, to, from);
 
 		return arrange(config, [
 			{transform: offsetForBreadcrumbs(node), offset: 0},

--- a/packages/moonstone/Panels/Panels.module.less
+++ b/packages/moonstone/Panels/Panels.module.less
@@ -87,7 +87,7 @@
 	}
 
 	.viewport {
-		&[data-clip] {
+		&.transitioning {
 			-webkit-clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
 			clip-path: polygon(@moon-breadcrumb-width 0, 100% 0, 100% 100%, @moon-breadcrumb-width 100%);
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
CSS `clip-path` was no longer removed post-transition on Panels' Viewport

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use the `.transitioning` class instead of the `data-clip` attribute

I left off a changelog since the fix is not author-facing in any material way.

### Links
[//]: # (Related issues, references)
#2292 changed the arrangers to use Web Animations and introduced the regression.
#615 added the `data-clip` because we lacked an indicator for transitioning. 
#1297 added the `.transitioning` class but didn't address the `data-clip` usage.
