### PR TITLE
Additional webOS platform detection, including a generic LG webOS fallback

### DIFF
--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -55,6 +55,9 @@ const platforms = [
 	{platform: 'webos', regex: /Web0S;.*Safari\/538.2/, forceVersion: 2},
 	{platform: 'webos', regex: /Web0S;.*Chrome\/38/, forceVersion: 3},
 	{platform: 'webos', regex: /Web0S;.*Chrome\/53/, forceVersion: 4},
+	{platform: 'webos', regex: /Web0S;.*Chrome\/68/, forceVersion: 5},
+	// LG webOS of indeterminate version
+	{platform: 'webos', regex: /Web0S;/, forceVersion: -1},
 	// LuneOS
 	{platform: 'webos', regex: /LuneOS/, forceVersion: 0, extra: {luneos: 1}},
 	// Palm/HP/Open webOS

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -59,12 +59,12 @@ const platforms = [
 	// LG webOS of indeterminate version
 	{platform: 'webos', regex: /Web0S;/, forceVersion: -1},
 	// LuneOS
-	{platform: 'webos', regex: /LuneOS/, forceVersion: 0, extra: {luneos: 1}},
+	{platform: 'webos', regex: /LuneOS/, forceVersion: -1, extra: {luneos: 1}},
 	// Palm/HP/Open webOS
-	{platform: 'webos', regex: /WebAppManager|Isis|webOS\./, forceVersion: 0, extra: {legacy: 4}},
-	{platform: 'webos', regex: /(?:web|hpw)OS\/1/, forceVersion: 0, extra: {legacy: 1}},
-	{platform: 'webos', regex: /(?:web|hpw)OS\/2/, forceVersion: 0, extra: {legacy: 2}},
-	{platform: 'webos', regex: /(?:web|hpw)OS\/3/, forceVersion: 0, extra: {legacy: 3}},
+	{platform: 'webos', regex: /WebAppManager|Isis|webOS\./, forceVersion: -1, extra: {legacy: 4}},
+	{platform: 'webos', regex: /(?:web|hpw)OS\/1/, forceVersion: -1, extra: {legacy: 1}},
+	{platform: 'webos', regex: /(?:web|hpw)OS\/2/, forceVersion: -1, extra: {legacy: 2}},
+	{platform: 'webos', regex: /(?:web|hpw)OS\/3/, forceVersion: -1, extra: {legacy: 3}},
 	// desktop Safari
 	{platform: 'safari', regex: /Version\/(\d+)[.\d]+\s+Safari/},
 	// desktop Chrome

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -64,15 +64,15 @@ describe('platform', () => {
 			expect(actual).toMatchObject(expected);
 		});
 
-		test('should return webOS 0 + LuneOS 1', () => {
-			const expected = {webos: 0, luneos: 1};
+		test('should return webOS -1 + LuneOS 1', () => {
+			const expected = {webos: -1, luneos: 1};
 
 			expect(parseUserAgent(LuneOS1)).toMatchObject(expected);
 			expect(parseUserAgent(LuneOS2)).toMatchObject(expected);
 		});
 
-		test('should return webOS 0 + legacy 1', () => {
-			const expected = {webos: 0, legacy: 1};
+		test('should return webOS -1 + legacy 1', () => {
+			const expected = {webos: -1, legacy: 1};
 
 			expect(parseUserAgent(webOS10)).toMatchObject(expected);
 			expect(parseUserAgent(webOS11)).toMatchObject(expected);
@@ -81,8 +81,8 @@ describe('platform', () => {
 			expect(parseUserAgent(webOS1351)).toMatchObject(expected);
 		});
 
-		test('should return webOS 0 + legacy 2', () => {
-			const expected = {webos: 0, legacy: 2};
+		test('should return webOS -1 + legacy 2', () => {
+			const expected = {webos: -1, legacy: 2};
 
 			expect(parseUserAgent(webOS2)).toMatchObject(expected);
 		});

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -4,6 +4,7 @@ describe('platform', () => {
 
 	describe('webOS', () => {
 		// From http://webostv.developer.lge.com/discover/specifications/web-engine/
+		const webOSTV5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.1785.34 Safari/537.36 WebAppManager';
 		const webOSTV3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.1.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
 		const webOSTV2 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/538.2 (KHTML, like Gecko) Large Screen WebAppManager Safari/538.2';
@@ -18,6 +19,8 @@ describe('platform', () => {
 		const webOS13 = 'Mozilla/5.0 (webOS/1.3.1; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.0';
 		const webOS1351 = 'Mozilla/5.0 (webOS/1.3.5.1; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.1';
 		const webOS2 = 'Mozilla/5.0 (webOS/2.0.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.2';
+
+		const webOSOther = 'Mozilla/5.0 (Web0S; Linux) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3440.106 Safari/537.36 WebAppManager';
 
 		test('should return webOS 1', () => {
 			const expected = {webos: 1};
@@ -43,6 +46,20 @@ describe('platform', () => {
 		test('should return webOS 4', () => {
 			const expected = {webos: 4};
 			const actual = parseUserAgent(webOSTV4);
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		test('should return webOS 5', () => {
+			const expected = {webos: 5};
+			const actual = parseUserAgent(webOSTV5);
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		test('should return webOS -1', () => {
+			const expected = {webos: -1};
+			const actual = parseUserAgent(webOSOther);
 
 			expect(actual).toMatchObject(expected);
 		});


### PR DESCRIPTION
Addendum to https://github.com/enactjs/enact/pull/2397

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- webOS 5 and indeterminate versions of webOS would be ommitted as "webos" in platform detection

### Resolution
* Adds a webOS 5 detection entry as well as a generalized LG webOS catchall for indeterminate versions and versions with unexpected corresponding Chrome releases.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>