### PR TITLE
PLAT-80194: Fix Scroller and VirtualList duplicate scrolling by page up/down

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - Fonts to use the updated names of global fonts available in the system
 - `moonstone/LabeledItem` to not clip the bottom of descender glyphs in large text mode
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after an update
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll too far by page up/down keys
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -579,6 +579,7 @@ class ScrollableBase extends Component {
 		forward('onKeyDown', ev, this.props);
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
+			ev.stopPropagation();
 			ev.preventDefault();
 		}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -640,6 +640,7 @@ class ScrollableBaseNative extends Component {
 		forward('onKeyDown', ev, this.props);
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
+			ev.stopPropagation();
 			ev.preventDefault();
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualList scrolls one more time on page up/down keys when an item is focused in pointer mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Since the focus disappears after scrolling by page keys, another handling logic for non-focused case in pointer mode performs once more. This makes a list scrolls twice far.
Basically, this happens `keydown` event is not consumed by the event handler which handles scroll by page. So, this PR adds simply `stopPropagation`.

### Links
[//]: # (Related issues, references)
PLAT-80194

### Comments
