### PR TITLE
PLAT-81551: Fix wrong item container Ref in VirtualList

### DIFF
--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -863,7 +863,7 @@ const listItemsRenderer = (props) => {
 	const {
 		cc,
 		handlePlaceholderFocus,
-		initItemContainerRef: initUiItemContainerRef,
+		itemContainerRef: initUiItemContainerRef,
 		needsScrollingPlaceholder,
 		primary
 	} = props;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The item container Ref (`this.itemContainerRef`) was not properly passed to DOM element.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Wrong variable name for the item container Ref was passed to DOM element.
So I renamed `initItemContainerRef` as `itemContainerRef`.

### Links
[//]: # (Related issues, references)

PLAT-81551