### PR TITLE
PLAT-80395: Apply focusless spatial navigation called "interest"

### DIFF
--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -478,6 +478,13 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getContainerNode = (node) => {
 			this.containerNode = node;
+			if (this.containerNode) {
+				this.containerNode.parentElement.addEventListener('navnotarget', (ev) => {
+					forward('onClose', ev, this.props);
+					ev.preventDefault();
+					ev.stopPropagation();
+				});
+			}
 		}
 
 		getClientNode = (node) => {
@@ -547,8 +554,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		// handle key event from contextual popup and closes the popup
 		handleContainerBlur = (ev) => {
+			let nextItem = Spotlight.getNext() || Spotlight.getCurrent();
 			// if focus moves outside the popup's container, issue the `onClose` event
-			if (!this.containerNode.contains(Spotlight.getCurrent())) {
+			if (!this.containerNode.contains(nextItem)) {
 				forward('onClose', ev, this.props);
 			}
 		}

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -110,7 +110,7 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 		getInputNode = (node) => {
 			if (node) {
 				this.inputNode = node;
-				this.inputNode.focus();
+				Spotlight.focus(this.inputNode);
 			}
 		}
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -144,6 +144,12 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 		updateFocus = (prevState) => {
 			if (this.state.node) {
 				if (Spotlight.getCurrent() !== this.state.node) {
+					// Remove interest.
+					if (window.__spatialNavigation__ && window.__spatialNavigation__.interest) {
+						window.__spatialNavigation__.interest();
+					}
+
+					// Set focus to input element.
 					this.state.node.focus();
 				}
 			}

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -484,14 +484,16 @@ class Popup extends React.Component {
 
 	handleOnNavNoTarget = (ev) => {
 		const {onClose} = this.props;
-		if (onClose && this.pressUpKey) {
+		if (ev.target === getContainerNode(this.state.containerId)) {
 			// preventDefault to prevent spatial navigation next behavior.
 			// Do not search next target which is outside of this container.
 			ev.preventDefault();
 			// Stop propagation to prevent handle this event on spotlight.js
 			ev.stopPropagation();
 
-			onClose(ev);
+			if (onClose && this.pressUpKey) {
+				onClose(ev);
+			}
 		}
 	}
 
@@ -552,14 +554,10 @@ class Popup extends React.Component {
 		on('navnotarget', this.handleOnNavNoTarget);
 
 		if (!Spotlight.focus(containerId)) {
-			const current = Spotlight.getCurrent();
-
 			// In cases where the container contains no spottable controls or we're in pointer-mode, focus
 			// cannot inherently set the active container or blur the active control, so we must do that
 			// here.
-			if (current) {
-				current.blur();
-			}
+			Spotlight.blur();
 			Spotlight.setActiveContainer(containerId);
 		}
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -432,9 +432,9 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	calculateAndScrollTo = () => {
+	calculateAndScrollTo = (nextItem) => {
 		const
-			spotItem = Spotlight.getCurrent(),
+			spotItem = nextItem || Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
 			{containerRef} = this.uiRef.current.childRefCurrent;
 
@@ -462,6 +462,25 @@ class ScrollableBase extends Component {
 
 			// update `scrollHeight`
 			this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+		}
+	}
+
+	onNavBeforeFocus = (ev) => {
+		const shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
+			this.childRef.current.shouldPreventScrollByFocus() :
+			false;
+
+		if (this.isWheeling) {
+			this.uiRef.current.stop();
+			this.animateOnFocus = false;
+		}
+
+		this.alertThumb();
+
+		if (!shouldPreventScrollByFocus) {
+			this.calculateAndScrollTo(ev.target);
+		} else if (this.childRef.current.setLastFocusedNode) {
+			this.childRef.current.setLastFocusedNode(ev.target);
 		}
 	}
 
@@ -775,6 +794,7 @@ class ScrollableBase extends Component {
 	addEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.addEventListener) {
 			childContainerRef.current.addEventListener('focusin', this.onFocus);
+			childContainerRef.current.addEventListener('navbeforefocus', this.onNavBeforeFocus);
 			if (platform.webos) {
 				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
 				childContainerRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
@@ -786,6 +806,7 @@ class ScrollableBase extends Component {
 	removeEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
 			childContainerRef.current.removeEventListener('focusin', this.onFocus);
+			childContainerRef.current.removeEventListener('navbeforefocus', this.onNavBeforeFocus);
 			if (platform.webos) {
 				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);
 				childContainerRef.current.removeAttribute('data-webos-voice-intent');

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -498,9 +498,9 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	calculateAndScrollTo = () => {
+	calculateAndScrollTo = (nextItem) => {
 		const
-			spotItem = Spotlight.getCurrent(),
+			spotItem = nextItem || Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
 			{containerRef} = this.uiRef.current.childRefCurrent;
 
@@ -528,6 +528,20 @@ class ScrollableBaseNative extends Component {
 
 			// update `scrollHeight`
 			this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+		}
+	}
+
+	onNavBeforeFocus = (ev) => {
+		const shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
+			this.childRef.current.shouldPreventScrollByFocus() :
+			false;
+
+		this.alertThumb();
+
+		if (!shouldPreventScrollByFocus) {
+			this.calculateAndScrollTo(ev.target);
+		} else if (this.childRef.current.setLastFocusedNode) {
+			this.childRef.current.setLastFocusedNode(ev.target);
 		}
 	}
 
@@ -836,6 +850,7 @@ class ScrollableBaseNative extends Component {
 	addEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.addEventListener) {
 			childContainerRef.current.addEventListener('focusin', this.onFocus);
+			childContainerRef.current.addEventListener('navbeforefocus', this.onNavBeforeFocus);
 			if (platform.webos) {
 				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
 				childContainerRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
@@ -847,6 +862,7 @@ class ScrollableBaseNative extends Component {
 	removeEventListeners = (childContainerRef) => {
 		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
 			childContainerRef.current.removeEventListener('focusin', this.onFocus);
+			childContainerRef.current.removeEventListener('navbeforefocus', this.onNavBeforeFocus);
 			if (platform.webos) {
 				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);
 				childContainerRef.current.removeAttribute('data-webos-voice-intent');

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -5,6 +5,7 @@ import Pause from '@enact/spotlight/Pause';
 import PropTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import React from 'react';
+import Spotlight from '@enact/spotlight';
 
 import $L from '../internal/$L';
 
@@ -100,7 +101,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (platform.touch && this.state.dragging && !prevState.dragging) {
 				const thisNode = findDOMNode(this); // eslint-disable-line react/no-find-dom-node
 				const sliderNode = thisNode.getAttribute('role') === 'slider' ? thisNode : thisNode.querySelector('[role="slider"]');
-				sliderNode.focus();
+				Spotlight.focus(sliderNode);
 			}
 		}
 

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -203,6 +203,11 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		componentDidMount () {
 			// eslint-disable-next-line react/no-find-dom-node
 			this.node = ReactDOM.findDOMNode(this);
+
+			if (this.node) {
+				this.node.addEventListener('interest', this.handleFocus);
+				this.node.addEventListener('interestblur', this.handleInterestBlur);
+			}
 		}
 
 		componentDidUpdate (prevProps) {
@@ -233,6 +238,11 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
+			if (this.node) {
+				this.node.removeEventListener('interest', this.handleFocus);
+				this.node.removeEventListener('interestblur', this.handleBlur);
+			}
+
 			if (this.isFocused) {
 				forward('onSpotlightDisappear', null, this.props);
 			}
@@ -338,6 +348,26 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			forward('onClick')
 		)
 
+		handleInterestBlur = (ev) => {
+			if (this.shouldPreventBlur) return;
+			if (ev.currentTarget === ev.target) {
+				this.isFocused = false;
+				if (this.focusedWhenDisabled) {
+					this.focusedWhenDisabled = false;
+					// We only need to trigger a rerender if a focused item becomes disabled and still needs its focus.
+					// Once it blurs we need to rerender to remove the spottable class so it will not spot again.
+					// The reason we don't use state is for performance reasons to avoid updates.
+					this.forceUpdate();
+				}
+			}
+
+			if (Spotlight.isMuted(ev.target)) {
+				ev.stopPropagation();
+			} else {
+				forward('onInterestBlur', ev, this.props);
+			}
+		}
+
 		handleBlur = (ev) => {
 			if (this.shouldPreventBlur) return;
 			if (ev.currentTarget === ev.target) {
@@ -356,6 +386,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			} else {
 				forward('onBlur', ev, this.props);
 			}
+			Spotlight.notifyBlur(ev.target);
 		}
 
 		handleFocus = (ev) => {

--- a/packages/spotlight/src/spatial-navigation-polyfill.js
+++ b/packages/spotlight/src/spatial-navigation-polyfill.js
@@ -12,8 +12,15 @@
 
 (function () {
   // Turn on/off interest
-  const focuslessSpatialNavigation = false;
+  const focuslessSpatialNavigation = true;
   let _interestElement = null;
+
+  const createInterestEvents = function (eventType, target) {
+    if(target && ['interestblur', 'interest'].includes(eventType)) {
+      const triggeredEvent = new CustomEvent(eventType, {bubbles: false, cancelable: false});
+      return target.dispatchEvent(triggeredEvent);
+    }
+  };
 
   const currentInterest = function () {
     // get current interest element.
@@ -25,6 +32,7 @@
     const prevInterest = currentInterest();
     if (prevInterest) {
       prevInterest.classList.remove('interest');
+      createInterestEvents('interestblur', prevInterest);
     }
 
     _interestElement = element;
@@ -32,6 +40,7 @@
     if (element) {
       document.activeElement.blur();
       _interestElement.classList.add('interest');
+      createInterestEvents('interest', _interestElement);
     }
   };
 
@@ -114,6 +123,8 @@
       const dir = ARROW_KEY_CODE[e.keyCode];
       const interestKey = INTEREST_KEY_CODE[e.keyCode];
 
+      if (!e.isTrusted)
+        return;
       if (e.keyCode === TAB_KEY_CODE) {
         if (focuslessSpatialNavigation) {
           interest(null); // remove interest
@@ -1661,14 +1672,22 @@
    * @function getInitialAPIs
    */
   function getInitialAPIs() {
-    return {
-      enableExperimentalAPIs,
-      get keyMode() { return this._keymode ? this._keymode : 'ARROW'; },
-      set keyMode(mode) { this._keymode = (['SHIFTARROW', 'ARROW', 'NONE'].includes(mode)) ? mode : 'ARROW'; },
-      currentInterest,
-      interest,
-      setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null}
-    };
+    if (focuslessSpatialNavigation)
+      return {
+        enableExperimentalAPIs,
+        get keyMode() { return this._keymode ? this._keymode : 'ARROW'; },
+        set keyMode(mode) { this._keymode = (['SHIFTARROW', 'ARROW', 'NONE'].includes(mode)) ? mode : 'ARROW'; },
+        currentInterest,
+        interest,
+        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null}
+      };
+    else
+      return {
+        enableExperimentalAPIs,
+        get keyMode() { return this._keymode ? this._keymode : 'ARROW'; },
+        set keyMode(mode) { this._keymode = (['SHIFTARROW', 'ARROW', 'NONE'].includes(mode)) ? mode : 'ARROW'; },
+        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null}
+      };
   }
 
   window.addEventListener('load', () => {

--- a/packages/spotlight/styles/debug.less
+++ b/packages/spotlight/styles/debug.less
@@ -3,6 +3,11 @@
 //
 
 :global {
+	.spottable.interest {
+    	border-color: yellow !important;
+    	background-color: yellow !important;
+	}
+
 	.debug.spotlight {
 		@debug-color-up: hsla(0, 100%, 72%, 1);
 		@debug-color-right: hsla(90, 100%, 72%, 1);


### PR DESCRIPTION
- Adapt the component to focusless mode. (Use spatnav or interest event instead of focus event)
- Send fake key event to componenet, because all key event is occured on document in focusless mode.
- Use Spotlight.focus() instead element.focus()

Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)


### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The standardization of spatial navigation is progressing for the lightweight spotlight.
(https://drafts.csswg.org/css-nav-1/)

We need to check up the standard is appropriate to implement lightweight spotlight.
In the POC, We aim to apply the latest standard to spotlight and replace the spotlight code to spatial-navigation-polyfill.

There is "interest" concept, which is progressed by google, and it navigate elements without focus. 
(Detail : https://docs.google.com/document/d/1-ASYIuPpBm2cFxy_KUagakLGPc1mdF--rC9-EliqYRU)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

As the third step of this POC, In this ticket, apply interest concept for light weight spotlight.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

All key event is occured on document in focusless mode. So, each component event handler cannot receive any key event. 

It's very critical issue, but currently we don't have any solution yet. 

In this commit, I sent fake key event to element which has interest. It is tricky solution, but it is temporary measure.

We will continue to discuss with Google, who suggested Interest, how to resolve this issue from a web-standard point of view.

### Links
[//]: # (Related issues, references)
PLAT-80395

### Comments

