### PR TITLE
ENYO-6095: Fix VirtualGridList to not scroll unexpectedly when naviga…

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -36,9 +36,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VirtualList` to allow keydown events to bubble up when not handled by the component
 - `moonstone/IncrementSlider` to support aria-label when disabled
 - `moonstone/LabeledItem` to not clip the bottom of descender glyphs in large text mode
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after an update
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll too far by page up/down keys
-- `moonstone/VirtualList.VirtualGridList` to not scroll unexpectedly when navigating to an adjacent item
+- `moonstone/VirtualList.VirtualGridList` scrolling when navigating to an adjacent item
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after an update
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/LabeledItem` to not clip the bottom of descender glyphs in large text mode
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to focus an item properly after an update
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll too far by page up/down keys
+- `moonstone/VirtualList.VirtualGridList` to not scroll unexpectedly when navigating to an adjacent item
 
 ## [3.0.0-alpha.7] - 2019-06-24
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -406,13 +406,18 @@ const VirtualListBaseFactory = (type) => {
 			this.isScrolledByJump = false;
 
 			if (nextIndex >= 0) {
+				const {dataSize} = this.props;
+				const column = index % dimensionToExtent;
+				const row = (index - column) % dataSize / dimensionToExtent;
+				const nextColumn = nextIndex % dimensionToExtent;
+				const nextRow = (nextIndex - nextColumn) % dataSize / dimensionToExtent;
 				const numOfItemsInPage = Math.floor((clientSize + spacing) / gridSize) * dimensionToExtent;
 				const firstFullyVisibleIndex = Math.ceil(scrollPosition / gridSize) * dimensionToExtent;
 				const isNextItemInView = nextIndex >= firstFullyVisibleIndex && nextIndex < firstFullyVisibleIndex + numOfItemsInPage;
 
 				this.lastFocusedIndex = nextIndex;
 
-				if (isNextItemInView) {
+				if (isNextItemInView || row === nextRow) {
 					this.focusByIndex(nextIndex);
 				} else {
 					this.isScrolledBy5way = true;


### PR DESCRIPTION
…ting to adjacent items

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The scroller in a `VirtualGridList` can scroll unexpectedly when using 5way to navigate to an adjacent item while the previously focused item is still being scrolled into view.


### Resolution
When focus is being changed to the "next" item, we can check the row position of the current and next items and prevent programmatically initiating the scroll if they are the same. This applies for vertical and horizontal orientations.

