### PR TITLE
ENYO-6112: Fix Scrollable to only stop propagation when in contents

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -350,6 +350,15 @@ class ScrollableBase extends Component {
 		}
 	}
 
+	isScrollButtonFocused () {
+		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = this.uiRef.current;
+
+		return (
+			h.current && h.current.isOneOfScrollButtonsFocused() ||
+			v.current && v.current.isOneOfScrollButtonsFocused()
+		);
+	}
+
 	onFlick = ({direction}) => {
 		const bounds = this.uiRef.current.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
@@ -373,24 +382,17 @@ class ScrollableBase extends Component {
 	}
 
 	onTouchStart = () => {
-		const
-			focusedItem = Spotlight.getCurrent(),
-			{horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef.current,
-			isHorizontalScrollButtonFocused = horizontalScrollbarRef.current && horizontalScrollbarRef.current.isOneOfScrollButtonsFocused(),
-			isVerticalScrollButtonFocused = verticalScrollbarRef.current && verticalScrollbarRef.current.isOneOfScrollButtonsFocused();
+		const focusedItem = Spotlight.getCurrent();
 
-		if (!Spotlight.isPaused() && focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
+		if (!Spotlight.isPaused() && focusedItem && !this.isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 	}
 
-	onWheel = ({delta, horizontalScrollbarRef, verticalScrollbarRef}) => {
-		const
-			focusedItem = Spotlight.getCurrent(),
-			isHorizontalScrollButtonFocused = horizontalScrollbarRef.current && horizontalScrollbarRef.current.isOneOfScrollButtonsFocused(),
-			isVerticalScrollButtonFocused = verticalScrollbarRef.current && verticalScrollbarRef.current.isOneOfScrollButtonsFocused();
+	onWheel = ({delta}) => {
+		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
+		if (focusedItem && !this.isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 
@@ -578,7 +580,7 @@ class ScrollableBase extends Component {
 
 		forward('onKeyDown', ev, this.props);
 
-		if (isPageUp(keyCode) || isPageDown(keyCode)) {
+		if ((isPageUp(keyCode) || isPageDown(keyCode)) && !this.isScrollButtonFocused()) {
 			ev.stopPropagation();
 			ev.preventDefault();
 		}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -332,6 +332,16 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
+
+	isScrollButtonFocused () {
+		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = this.uiRef.current;
+
+		return (
+			h.current && h.current.isOneOfScrollButtonsFocused() ||
+			v.current && v.current.isOneOfScrollButtonsFocused()
+		);
+	}
+
 	onFlick = ({direction}) => {
 		const bounds = this.uiRef.current.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
@@ -357,13 +367,9 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onTouchStart = () => {
-		const
-			focusedItem = Spotlight.getCurrent(),
-			{horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef.current,
-			isHorizontalScrollButtonFocused = horizontalScrollbarRef.current && horizontalScrollbarRef.current.isOneOfScrollButtonsFocused(),
-			isVerticalScrollButtonFocused = verticalScrollbarRef.current && verticalScrollbarRef.current.isOneOfScrollButtonsFocused();
+		const focusedItem = Spotlight.getCurrent();
 
-		if (!Spotlight.isPaused() && focusedItem && !isHorizontalScrollButtonFocused && !isVerticalScrollButtonFocused) {
+		if (!Spotlight.isPaused() && focusedItem && !this.isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 	}
@@ -639,7 +645,7 @@ class ScrollableBaseNative extends Component {
 
 		forward('onKeyDown', ev, this.props);
 
-		if (isPageUp(keyCode) || isPageDown(keyCode)) {
+		if ((isPageUp(keyCode) || isPageDown(keyCode)) && !this.isScrollButtonFocused()) {
 			ev.stopPropagation();
 			ev.preventDefault();
 		}


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Pressing page up/down on a paging control of Scroller/VL would not scroll the viewport.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
#2418 added code to stop page up/down key events from propagating in order to avoid duplicate paging when in pointer mode. This was caused by the first handler blurring the focused item before scrolling causing the second to think that nothing was focused so _it_ should scroll.

However, when the paging controls are focused, the first handler doesn't blur the focused item _and_ doesn't trigger the scroll so _nothing_ scrolls the view. This is normally handled by an `onKeyDown` handler in ScrollButtons but it never receives the event because it was stopped by Scrollable.

Adding an check for scroll button focus in Scrollable seems to do the trick!

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* I did a little refactoring of duplicate code to fix this
* This bug seems to point to a possible design issue with so many methods to trigger paging. A subsequent refactoring ticket should be opened to address this.
