### PR TITLE
ENYO-6109: Not try to scroll horizontally if the scroller can scroll only vertically

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` not to jump to the top when right key is pressed in vertical scroller
+- `moonstone/Scroller` not to jump to the top when right key is pressed in the right most item of vertical scroller
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` not to jump to the top when right key is pressed in the right most item of vertical scroller
+
 ## [3.0.0-beta.2] - 2019-07-23
 
 ### Added
@@ -15,7 +21,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
 - `moonstone/Heading` to have a bit more space between the text and the line, when the line is present
 - `moonstone/LabeledItem` to pass `marqueeOn` prop to its contents
-- `moonstone/Scroller` not to jump to the top when right key is pressed in the right most item of vertical scroller
 - `moonstone/Panels.Header` to use the latest designs with better spacing between the titles below
 - `moonstone/Picker` accessibility read out when a button becomes disabled
 - `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` not to scroll at the bottom of the scroller
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` not to scroll at the bottom of the scroller
+- `moonstone/Scroller` not to jump to the top when right key is pressed in vertical scroller
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -632,32 +632,37 @@ class ScrollableBase extends Component {
 		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
 	}
 
+	focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
+		if (scrollbarRef.current) {
+			scrollbarRef.current.focusOnButton(isPreviousScrollButton);
+		}
+	}
+
 	scrollAndFocusScrollbarButton = (direction) => {
-		const
-			isRtl = this.uiRef.current.state.rtl,
-			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
-			isHorizontalDirection = direction === 'left' || direction === 'right',
-			isVerticalDirection = direction === 'up' || direction === 'down';
+		if (this.uiRef.current) {
+			const
+				uiRefCurrent = this.uiRef.current,
+				isRtl = uiRefCurrent.state.rtl,
+				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
+				isHorizontalDirection = direction === 'left' || direction === 'right',
+				isVerticalDirection = direction === 'up' || direction === 'down',
+				{focusableScrollbar, direction: directionProp} = this.props,
+				canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
+				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
-		const {focusableScrollbar, direction: directionProp} = this.props;
+			if (canScrollHorizontally || canScrollingVertically) {
+				this.onScrollbarButtonClick({
+					isPreviousScrollButton,
+					isVerticalScrollBar: canScrollingVertically
+				});
 
-		this.onScrollbarButtonClick({
-			isPreviousScrollButton,
-			isVerticalScrollBar:
-				isVerticalDirection &&
-				(directionProp === 'vertical' || directionProp === 'both')
-		});
-
-		if (focusableScrollbar) {
-			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
-				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {
-					const scrollbar = this.uiRef.current.verticalScrollbarRef;
-					scrollbar.current.focusOnButton(isPreviousScrollButton);
-				}
-			} else if (isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both')) {
-				if (this.uiRef.current && this.uiRef.current.horizontalScrollbarRef.current) {
-					const scrollbar = this.uiRef.current.horizontalScrollbarRef;
-					scrollbar.current.focusOnButton(isPreviousScrollButton);
+				if (focusableScrollbar) {
+					this.focusOnScrollButton(
+						canScrollingVertically ?
+							uiRefCurrent.verticalScrollbarRef :
+							uiRefCurrent.horizontalScrollbarRef,
+						isPreviousScrollButton
+					);
 				}
 			}
 		}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -641,12 +641,12 @@ class ScrollableBase extends Component {
 	scrollAndFocusScrollbarButton = (direction) => {
 		if (this.uiRef.current) {
 			const
+				{focusableScrollbar, direction: directionProp} = this.props,
 				uiRefCurrent = this.uiRef.current,
 				isRtl = uiRefCurrent.state.rtl,
 				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 				isHorizontalDirection = direction === 'left' || direction === 'right',
 				isVerticalDirection = direction === 'up' || direction === 'down',
-				{focusableScrollbar, direction: directionProp} = this.props,
 				canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
 				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
@@ -658,9 +658,7 @@ class ScrollableBase extends Component {
 
 				if (focusableScrollbar) {
 					this.focusOnScrollButton(
-						canScrollingVertically ?
-							uiRefCurrent.verticalScrollbarRef :
-							uiRefCurrent.horizontalScrollbarRef,
+						canScrollingVertically ? uiRefCurrent.verticalScrollbarRef : uiRefCurrent.horizontalScrollbarRef,
 						isPreviousScrollButton
 					);
 				}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -702,16 +702,18 @@ class ScrollableBaseNative extends Component {
 			isRtl = this.uiRef.current.state.rtl,
 			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 			isHorizontalDirection = direction === 'left' || direction === 'right',
-			isVerticalDirection = direction === 'up' || direction === 'down';
+			isVerticalDirection = direction === 'up' || direction === 'down',
+			canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
+			canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
 		const {focusableScrollbar, direction: directionProp} = this.props;
 
-		this.onScrollbarButtonClick({
-			isPreviousScrollButton,
-			isVerticalScrollBar:
-				isVerticalDirection &&
-				(directionProp === 'vertical' || directionProp === 'both')
-		});
+		if (canScrollHorizontally || canScrollingVertically) {
+			this.onScrollbarButtonClick({
+				isPreviousScrollButton,
+				isVerticalScrollBar: canScrollingVertically
+			});
+		}
 
 		if (focusableScrollbar) {
 			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -697,34 +697,37 @@ class ScrollableBaseNative extends Component {
 		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
 	}
 
-	scrollAndFocusScrollbarButton = (direction) => {
-		const
-			isRtl = this.uiRef.current.state.rtl,
-			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
-			isHorizontalDirection = direction === 'left' || direction === 'right',
-			isVerticalDirection = direction === 'up' || direction === 'down',
-			canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
-			canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
-
-		const {focusableScrollbar, direction: directionProp} = this.props;
-
-		if (canScrollHorizontally || canScrollingVertically) {
-			this.onScrollbarButtonClick({
-				isPreviousScrollButton,
-				isVerticalScrollBar: canScrollingVertically
-			});
+	focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
+		if (scrollbarRef.current) {
+			scrollbarRef.current.focusOnButton(isPreviousScrollButton);
 		}
+	}
 
-		if (focusableScrollbar) {
-			if (isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both')) {
-				if (this.uiRef.current && this.uiRef.current.verticalScrollbarRef.current) {
-					const scrollbar = this.uiRef.current.verticalScrollbarRef;
-					scrollbar.current.focusOnButton(isPreviousScrollButton);
-				}
-			} else if (isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both')) {
-				if (this.uiRef.current && this.uiRef.current.horizontalScrollbarRef.current) {
-					const scrollbar = this.uiRef.current.horizontalScrollbarRef;
-					scrollbar.current.focusOnButton(isPreviousScrollButton);
+	scrollAndFocusScrollbarButton = (direction) => {
+		if (this.uiRef.current) {
+			const
+				uiRefCurrent = this.uiRef.current,
+				isRtl = uiRefCurrent.state.rtl,
+				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
+				isHorizontalDirection = direction === 'left' || direction === 'right',
+				isVerticalDirection = direction === 'up' || direction === 'down',
+				{focusableScrollbar, direction: directionProp} = this.props,
+				canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
+				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
+
+			if (canScrollHorizontally || canScrollingVertically) {
+				this.onScrollbarButtonClick({
+					isPreviousScrollButton,
+					isVerticalScrollBar: canScrollingVertically
+				});
+
+				if (focusableScrollbar) {
+					this.focusOnScrollButton(
+						canScrollingVertically ?
+							uiRefCurrent.verticalScrollbarRef :
+							uiRefCurrent.horizontalScrollbarRef,
+						isPreviousScrollButton
+					);
 				}
 			}
 		}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -706,12 +706,12 @@ class ScrollableBaseNative extends Component {
 	scrollAndFocusScrollbarButton = (direction) => {
 		if (this.uiRef.current) {
 			const
+				{focusableScrollbar, direction: directionProp} = this.props,
 				uiRefCurrent = this.uiRef.current,
 				isRtl = uiRefCurrent.state.rtl,
 				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 				isHorizontalDirection = direction === 'left' || direction === 'right',
 				isVerticalDirection = direction === 'up' || direction === 'down',
-				{focusableScrollbar, direction: directionProp} = this.props,
 				canScrollHorizontally = isHorizontalDirection && (directionProp === 'horizontal' || directionProp === 'both'),
 				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
@@ -723,9 +723,7 @@ class ScrollableBaseNative extends Component {
 
 				if (focusableScrollbar) {
 					this.focusOnScrollButton(
-						canScrollingVertically ?
-							uiRefCurrent.verticalScrollbarRef :
-							uiRefCurrent.horizontalScrollbarRef,
+						canScrollingVertically ? uiRefCurrent.verticalScrollbarRef : uiRefCurrent.horizontalScrollbarRef,
 						isPreviousScrollButton
 					);
 				}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -313,7 +313,7 @@ class ScrollerBase extends Component {
 				pos = isVerticalDirection ? top : left,
 				max = isVerticalDirection ? maxTop : maxLeft;
 
-			if (pos >= 0 && pos <= max) {
+			if (pos >= 0 && pos < max) {
 				this.props.scrollAndFocusScrollbarButton(direction);
 			}
 		}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -313,7 +313,7 @@ class ScrollerBase extends Component {
 				pos = isVerticalDirection ? top : left,
 				max = isVerticalDirection ? maxTop : maxLeft;
 
-			if (pos >= 0 && pos < max) {
+			if (pos >= 0 && pos <= max) {
 				this.props.scrollAndFocusScrollbarButton(direction);
 			}
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

A Scroller jumped to the top when right key is pressed in the right most item of vertical scroller

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If 5-way right is pressed on the right most item in the scroller and the scroller can scroll only vertically, the scroller should not jump. But he scroller tried to scroll horizontally due to no condition. Then the scroller jumped to the top because the `native` scroller do jump with wrong scroll x position. So I fixed the condition.

### Links
[//]: # (Related issues, references)

ENYO-6109