### PR TITLE
Fix LabeledItem to pass marqueeOn prop

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/LabeledItem` to pass `marqueeOn` prop to its contents
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/LabeledItem/LabeledItem.js
+++ b/packages/moonstone/LabeledItem/LabeledItem.js
@@ -90,6 +90,15 @@ const LabeledItemBase = kind({
 		label: PropTypes.node,
 
 		/**
+		 * Determines what triggers the `LabelItem`'s marquee to start its animation.
+		 *
+		 * @type {('focus'|'hover'|'render')}
+		 * @default 'focus'
+		 * @public
+		 */
+		marqueeOn: PropTypes.oneOf(['focus', 'hover', 'render']),
+
+		/**
 		 * Icon to be displayed next to the title text.
 		 *
 		 * @type {String|Object}
@@ -104,13 +113,13 @@ const LabeledItemBase = kind({
 		publicClassNames: ['labeledItem', 'icon', 'label']
 	},
 
-	render: ({children, css, disabled, label, titleIcon, ...rest}) => (
+	render: ({children, css, disabled, label, marqueeOn, titleIcon, ...rest}) => (
 		<Controller disabled={disabled} {...rest} css={css}>
 			<div className={css.text}>
-				<Marquee disabled={disabled} className={css.title}>{children}</Marquee>
+				<Marquee disabled={disabled} className={css.title} marqueeOn={marqueeOn}>{children}</Marquee>
 				{(titleIcon != null) ? <Icon size="small" className={css.icon}>{titleIcon}</Icon> : null}
 			</div>
-			{(label != null) ? <Marquee disabled={disabled} className={css.label}>{label}</Marquee> : null}
+			{(label != null) ? <Marquee disabled={disabled} className={css.label} marqueeOn={marqueeOn}>{label}</Marquee> : null}
 		</Controller>
 	)
 });

--- a/packages/sampler/stories/default/LabeledItem.js
+++ b/packages/sampler/stories/default/LabeledItem.js
@@ -2,7 +2,7 @@ import LabeledItem from '@enact/moonstone/LabeledItem';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
-import {boolean, text} from '../../src/enact-knobs';
+import {boolean, select, text} from '../../src/enact-knobs';
 LabeledItem.displayName = 'LabeledItem';
 
 storiesOf('Moonstone', module)
@@ -12,6 +12,7 @@ storiesOf('Moonstone', module)
 			<LabeledItem
 				label={text('label', LabeledItem, 'Label')}
 				disabled={boolean('disabled', LabeledItem)}
+				marqueeOn={select('marqueeOn', ['focus', 'hover', 'render'], LabeledItem, 'focus')}
 			>
 				{text('children', LabeledItem, 'Hello LabeledItem')}
 			</LabeledItem>

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -226,9 +226,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Determines what triggers the marquee to start its animation.
 			 *
-			 * Valid values are `'focus'`, `'hover'` and `'render'`. The default is `'focus'`.
-			 *
-			 * @type {String}
+			 * @type {('focus'|'hover'|'render')}
 			 * @default 'focus'
 			 * @public
 			 */


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`LabeledItem` had no way to adjust when it would marquee. A use case existed where
it was used as a non-focusable component, so the default `marqueeOn` of `"focus"`
prevented it from being able to marquee.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Pass `marqueeOn` prop to label and contents.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Another possible solution is to modify the component to detect `spotlightDisabled` and automatically set `marqueeOn` for the items.  This seemed a bit too magical and we'd need to make a similar change to all focusable components for consistency. This solution makes a very small change and gives developers the tools they need to accomplish the use case desired.

I decided to not pass along any additional marquee properties as they were not relevant to this request.

### Links
[//]: # (Related issues, references)
ENYO-6100

### Comments
