### PR TITLE
ENYO-6116: Fix Tooltip Layering Order

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/TooltipDecorator/Tooltip.module.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.module.less
@@ -16,6 +16,7 @@
 
 .tooltip {
 	position: absolute;
+	z-index: 1;
 
 	// You'll notice tiny adjustments to the position: 0.5px, 1px, 4px, etc. in the following code.
 	// These are to account for sub-pixel rendering on scaled or "imperfect" rendering scenarios


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The inherited layer order of a Tooltip inside a ContextualPopup and conflict, so they visually layer incorrectly (stack and look wrong).


### Resolution
Added a finite `z-index` to tooltip to promote it to its own layer-space, rather than its inherited space, which relies on DOM ordering.