### PR TITLE
PLAT-81339: FormCheckboxItem no longer responds to `largeText` mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,12 +4,13 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
 ### Added
 
 - `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
+
+### Fixed
+
+- `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/FormCheckbox/FormCheckbox.module.less
+++ b/packages/moonstone/FormCheckbox/FormCheckbox.module.less
@@ -10,19 +10,6 @@
 	height: @moon-formcheckbox-size;
 	border-radius: @moon-formcheckbox-border-radius;
 
-	.moon-custom-text({
-		width: @moon-formcheckbox-size-large;
-		height: @moon-formcheckbox-size-large;
-		border-radius: (@moon-formcheckbox-size-large / 2);
-
-		.icon {
-			width: @moon-formcheckbox-size-large;
-			height: @moon-formcheckbox-size-large;
-			line-height: @moon-formcheckbox-size-large;
-			font-size: @moon-formcheckbox-check-icon-size-large;
-		}
-	});
-
 	.icon {
 		width: @moon-formcheckbox-size;
 		height: @moon-formcheckbox-size;
@@ -37,6 +24,15 @@
 			visibility: visible;
 		}
 	}
+
+	.moon-custom-text({
+		.icon {
+			width: @moon-formcheckbox-size;
+			height: @moon-formcheckbox-size;
+			line-height: @moon-formcheckbox-size;
+			font-size: @moon-formcheckbox-check-icon-size;
+		}
+	});
 
 	// Skin colors
 	.applySkins({

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -6,6 +6,16 @@
 // Public
 .formCheckboxItem {
 	/* Available for customization */
+
+	// FormCheckboxItem should not increase in size when in `largeText` mode
+	.moon-custom-text({
+		font-size: @moon-item-font-size;
+		line-height: @moon-item-line-height;
+
+		.moon-locale-non-latin({
+			line-height: @moon-item-line-height;
+		});
+	});
 }
 
 // Interally theme our implementation using published classes from ToggleItem and ToggleIcon


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`FormCheckboxItem` is too large when in large-text mode.


### Resolution
Manually reset the size of `FormCheckboxItem` and the associated checkmark component when in large-text mode so there is no "net change" in the size, according to the specs.