### PR TITLE
ENYO-6120: Req: hides border-bottom of the Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Fixed
 
 - Non-Latin locale font assignments to match the new font family support in `LG Smart UI`
-- `moonstone/Checkbox`, `moonstone/FormCheckbox`, `moonstone/Header`, `moonstone/RadioItem`, `moonstone/Slider`, and `moonstone/Switch` to render correctly in high contrast
+- `moonstone/Checkbox`, `moonstone/FormCheckbox`, `moonstone/Panels.Header`, `moonstone/RadioItem`, `moonstone/Slider`, and `moonstone/Switch` to render correctly in high contrast
 - `moonstone/VideoPlayer` to hide scrim for high contrast if bottom controls are hidden
 
 ## [3.0.0-alpha.3] - 2019-05-29
@@ -90,7 +90,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 - `moonstone/Panels` support for managing share state of contained components
 - `moonstone/Scroller` and `moonstone/VirtualList` support for restoring scroll position when within a `moonstone/Panels.Panel`
-- `moonstone/Header` sample
+- `moonstone/Panels.Header` sample
 
 ### Changed
 
@@ -117,7 +117,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/DaySelector` item text size in large-text mode
 - `moonstone/Dropdown` popup scroller arrows showing in non-latin locales and added large-text mode support
 - `moonstone/FormCheckboxItem` to match the designs
-- `moonstone/Header` with `Input` to not have a distracting white background color
+- `moonstone/Panels.Header` with `Input` to not have a distracting white background color
 - `moonstone/Input` caret color to match the designs (black bar on white background, white bar on black background, standard inversion)
 - `moonstone/Item` height in non-latin locales
 - `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
@@ -139,7 +139,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/Button` prop `iconPosition`
 - `moonstone/ContextualPopup` config `noArrow`
 - `moonstone/Dropdown` component
-- `moonstone/Header` prop `centered` to support immersive apps with a completely centered design
+- `moonstone/Panels.Header` prop `centered` to support immersive apps with a completely centered design
 - `moonstone/Heading` component, an improved version of `moonstone/Divider` with additional features
 - `moonstone/Panels` slot `<controls>` to easily add custom controls next to the Panels' "close" button
 - `moonstone/Spinner` prop `size` to support a new "small" size for use inside `SlotItem` components
@@ -152,7 +152,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Changed
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
-- `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
+- `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Panels.Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
 - `moonstone/Button`, `moonstone/Dropdown`, `moonstone/Icon`, `moonstone/IconButton`, `moonstone/Input`, and `moonstone/ToggleButton` default size to "small", which unifies their initial heights
 - `moonstone/DaySelector` to have squared check boxes to match the rest of the checkmark components
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
@@ -1166,7 +1166,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/VirtualList` to scroll correctly using page down key with disabled items
 - `moonstone/Scrollable` to not cause a script error when scrollbar is not rendered
 - `moonstone/Picker` incrementer and decrementer to not change size when focused
-- `moonstone/Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai, as well as latin locales
+- `moonstone/Panels.Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai, as well as latin locales
 - `moonstone/Scroller` and `moonstone/VirtualList` to keep spotlight when pressing a 5-way control while scrolling
 - `moonstone/Panels` to prevent user interaction with panel contents during transition
 - `moonstone/Slider` and related components to correctly position knob for `detachedKnob` on mouse down and fire value where mouse was positioned on mouse up
@@ -1189,8 +1189,8 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/Divider` to pass `marqueeOn` prop
 - `moonstone/Slider` to fire `onChange` on mouse up and key up
 - `moonstone/VideoPlayer` to show knob when pressed
-- `moonstone/Header` to layout `titleBelow` and `subTitleBelow` correctly
-- `moonstone/Header` to use correct font-weight for `subTitleBelow`
+- `moonstone/Panels.Header` to layout `titleBelow` and `subTitleBelow` correctly
+- `moonstone/Panels.Header` to use correct font-weight for `subTitleBelow`
 - `ui/Transition` support for all `clip` transition-type directions and made rendering optimizations
 
 ## [1.12.0] - 2017-10-27
@@ -1239,9 +1239,9 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/Scrollable` and `moonstone/Scroller` to scroll via page up/down when focus is inside a Spotlight container
 - `moonstone/VirtualList` and `moonstone/VirtualGridList` to scroll by 5-way keys right after wheeling
 - `moonstone/VirtualList` not to move focus when a current item and the last item are located at the same line and pressing a page down key
-- `moonstone/Header` to layout header row correctly in `standard` type
+- `moonstone/Panels.Header` to layout header row correctly in `standard` type
 - `moonstone/Input` to not dismiss on-screen keyboard when dragging cursor out of input box
-- `moonstone/Header` RTL `line-height` issue
+- `moonstone/Panels.Header` RTL `line-height` issue
 - `moonstone/Panels` to render children on idle
 - `moonstone/Scroller.Scrollable` to limit its muted spotlight container scrim to its bounds
 - `moonstone/Input` to always forward `onKeyUp` event
@@ -1478,7 +1478,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `moonstone/VideoPlayer` to focus on hover over play/pause button when video is loading
 - `moonstone/VideoPlayer` to update and display proper time while moving knob when video is paused
 - `moonstone/VideoPlayer` long title overlap issues
-- `moonstone/Header` to apply `marqueeOn` prop to `subTitleBelow` and `titleBelow`
+- `moonstone/Panels.Header` to apply `marqueeOn` prop to `subTitleBelow` and `titleBelow`
 - `moonstone/Picker` wheeling in `moonstone/Scroller`
 - `moonstone/IncrementSlider` and `moonstone/Picker` to read value changes when selecting buttons
 - `spotlight` to not blur and re-focus an element that is already focused
@@ -1539,7 +1539,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 - `moonstone/ContextualPopupDecorator` close button to account for large text size
 - `moonstone/ContextualPopupDecorator` to not spot controls other than its activator when navigating out via 5-way
-- `moonstone/Header` to set the value of `marqueeOn` for all types of headers
+- `moonstone/Panels.Header` to set the value of `marqueeOn` for all types of headers
 
 ## [1.4.0] - 2017-06-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## unreleased
+## [unreleased]
 
 ### Added
 
-- `moonstone/Header` prop `hideLine` to hide `border-bottom`
+- `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
 
 ## [3.0.0-beta.1] - 2019-07-15
 
@@ -60,7 +60,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Header` to center text when `centered` is used and additional controls are included by `moonstone/Panels`
+- `moonstone/Panels.Header` to center text when `centered` is used and additional controls are included by `moonstone/Panels`
 - Fonts for non-Latin to not intermix font weights for bold when using a combination of Latin and non-Latin glyphs
 - `moonstone/VirtualList` to restore focus to an item when scrollbars are visible
 
@@ -74,7 +74,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - Non-Latin locale font assignments to match the new font family support in `LG Smart UI`
-- `moonstone/Checkbox`, `moonstone/FormCheckbox`, `moonstone/Header`, `moonstone/RadioItem`, `moonstone/Slider`, and `moonstone/Switch` to render correctly in high contrast
+- `moonstone/Checkbox`, `moonstone/FormCheckbox`, `moonstone/Panels.Header`, `moonstone/RadioItem`, `moonstone/Slider`, and `moonstone/Switch` to render correctly in high contrast
 - `moonstone/VideoPlayer` to hide scrim for high contrast if bottom controls are hidden
 
 ## [3.0.0-alpha.3] - 2019-05-29
@@ -108,7 +108,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/DaySelector` item text size in large-text mode
 - `moonstone/Dropdown` popup scroller arrows showing in non-latin locales and added large-text mode support
 - `moonstone/FormCheckboxItem` to match the designs
-- `moonstone/Header` with `Input` to not have a distracting white background color
+- `moonstone/Panels.Header` with `Input` to not have a distracting white background color
 - `moonstone/Input` caret color to match the designs (black bar on white background, white bar on black background, standard inversion)
 - `moonstone/Item` height in non-latin locales
 - `moonstone/RadioItem` and `moonstone/SelectableItem` icon size in large-text mode
@@ -127,7 +127,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Button` prop `iconPosition`
 - `moonstone/ContextualPopup` config `noArrow`
 - `moonstone/Dropdown` component
-- `moonstone/Header` prop `centered` to support immersive apps with a completely centered design
+- `moonstone/Panels.Header` prop `centered` to support immersive apps with a completely centered design
 - `moonstone/Heading` component, an improved version of `moonstone/Divider` with additional features
 - `moonstone/Panels` slot `<controls>` to easily add custom controls next to the Panels' "close" button
 - `moonstone/Spinner` prop `size` to support a new "small" size for use inside `SlotItem` components
@@ -136,7 +136,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Changed
 
 - `moonstone/Button.ButtonDecorator` to remove `i18n/Uppercase` HOC
-- `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
+- `moonstone/Button`, `moonstone/Checkbox`, `moonstone/CheckboxItem`, `moonstone/ContextualPopupDecorator`, `moonstone/FormCheckbox`, `moonstone/FormCheckboxItem`, `moonstone/Panels.Header`, `moonstone/Notification`, `moonstone/RadioItem`, and `moonstone/Tooltip` appearance to match the latest designs
 - `moonstone/Button`, `moonstone/Dropdown`, `moonstone/Icon`, `moonstone/IconButton`, `moonstone/Input`, and `moonstone/ToggleButton` default size to "small", which unifies their initial heights
 - `moonstone/DaySelector` to have squared check boxes to match the rest of the checkmark components
 - `moonstone/LabeledIcon` and `moonstone/LabeledIconButton` text size to be smaller
@@ -951,7 +951,7 @@ No significant changes.
 - `moonstone/VirtualList` to scroll correctly using page down key with disabled items
 - `moonstone/Scroller` and other scrolling components to not cause a script error when scrollbar is not rendered
 - `moonstone/Picker` incrementer and decrementer to not change size when focused
-- `moonstone/Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai, as well as latin locales
+- `moonstone/Panels.Header` to use a slightly smaller font size for `title` in non-latin locales and a line-height for `titleBelow` and `subTitleBelow` that better meets the needs of tall-glyph languages like Tamil and Thai, as well as latin locales
 - `moonstone/Scroller` and `moonstone/VirtualList` to keep spotlight when pressing a 5-way control while scrolling
 - `moonstone/Panels` to prevent user interaction with panel contents during transition
 - `moonstone/Slider` and related components to correctly position knob for `detachedKnob` on mouse down and fire value where mouse was positioned on mouse up
@@ -970,8 +970,8 @@ No significant changes.
 - `moonstone/Divider` to pass `marqueeOn` prop
 - `moonstone/Slider` to fire `onChange` on mouse up and key up
 - `moonstone/VideoPlayer` to show knob when pressed
-- `moonstone/Header` to layout `titleBelow` and `subTitleBelow` correctly
-- `moonstone/Header` to use correct font-weight for `subTitleBelow`
+- `moonstone/Panels.Header` to layout `titleBelow` and `subTitleBelow` correctly
+- `moonstone/Panels.Header` to use correct font-weight for `subTitleBelow`
 - `moonstone/VirtualList` to restore focus correctly for lists only slightly larger than the viewport
 
 ## [1.12.0] - 2017-10-27
@@ -1013,9 +1013,9 @@ No significant changes.
 - `moonstone/VirtualList` and `moonstone/VirtualGridList` to scroll by 5-way keys right after wheeling
 - `moonstone/VirtualList` not to move focus when a current item and the last item are located at the same line and pressing a page down key
 - `moonstone/Slider` knob to follow while dragging for detached knob
-- `moonstone/Header` to layout header row correctly in `standard` type
+- `moonstone/Panels.Header` to layout header row correctly in `standard` type
 - `moonstone/Input` to not dismiss on-screen keyboard when dragging cursor out of input box
-- `moonstone/Header` RTL `line-height` issue
+- `moonstone/Panels.Header` RTL `line-height` issue
 - `moonstone/Panels` to render children on idle
 - `moonstone/Scroller` and other scrolling components to limit muted spotlight container scrims to their bounds
 - `moonstone/Input` to always forward `onKeyUp` event
@@ -1237,7 +1237,7 @@ No significant changes.
 - `moonstone/VideoPlayer` to focus on hover over play/pause button when video is loading
 - `moonstone/VideoPlayer` to update and display proper time while moving knob when video is paused
 - `moonstone/VideoPlayer` long title overlap issues
-- `moonstone/Header` to apply `marqueeOn` prop to `subTitleBelow` and `titleBelow`
+- `moonstone/Panels.Header` to apply `marqueeOn` prop to `subTitleBelow` and `titleBelow`
 - `moonstone/Picker` wheeling in `moonstone/Scroller`
 - `moonstone/IncrementSlider` and `moonstone/Picker` to read value changes when selecting buttons
 
@@ -1292,7 +1292,7 @@ No significant changes.
 
 - `moonstone/ContextualPopupDecorator` close button to account for large text size
 - `moonstone/ContextualPopupDecorator` to not spot controls other than its activator when navigating out via 5-way
-- `moonstone/Header` to set the value of `marqueeOn` for all types of headers
+- `moonstone/Panels.Header` to set the value of `marqueeOn` for all types of headers
 
 ## [1.4.0] - 2017-06-29
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## unreleased
+
+### Added
+
+- `moonstone/Header` prop `hideLine` to hide `border-bottom`
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -100,7 +100,7 @@ const HeaderBase = kind({
 		headerInput: PropTypes.node,
 
 		/**
-		 * Hides a horizontal-rule (line) under the component
+		 * Hides the horizontal-rule (line) under the component
 		 *
 		 * @type {Boolean}
 		 * @public

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -100,6 +100,14 @@ const HeaderBase = kind({
 		headerInput: PropTypes.node,
 
 		/**
+		 * Hides a horizontal-rule (line) under the component
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		hideLine: PropTypes.bool,
+
+		/**
 		 * Determines what triggers the header content to start its animation.
 		 *
 		 * * Values: `'focus'`, `'hover'` and `'render'`.
@@ -173,7 +181,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, fullBleed, type, styler}) => styler.append({centered, fullBleed}, type),
+		className: ({centered, fullBleed, hideLine, type, styler}) => styler.append({centered, fullBleed, hideLine}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {
@@ -211,6 +219,7 @@ const HeaderBase = kind({
 		delete rest.centered;
 		delete rest.fullBleed;
 		delete rest.headerInput;
+		delete rest.hideLine;
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -115,6 +115,10 @@
 		border-top-width: 0;
 	}
 
+	&.hideLine {
+		border-bottom: none;
+	}
+
 	// Skin colors
 	.applySkins({
 		color: @moon-header-text-color;

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -115,14 +115,14 @@
 		border-top-width: 0;
 	}
 
-	&.hideLine {
-		border-bottom: none;
-	}
-
 	// Skin colors
 	.applySkins({
 		color: @moon-header-text-color;
 		border-bottom-color: @moon-header-bottom-border-color;
+
+		&.hideLine {
+			border-bottom-color: transparent;
+		}
 
 		&.standard {
 			.decorator {

--- a/packages/sampler/stories/default/Header.js
+++ b/packages/sampler/stories/default/Header.js
@@ -47,6 +47,7 @@ storiesOf('Moonstone', module)
 					centered={boolean('centered', Config)}
 					fullBleed={boolean('fullBleed', Config)}
 					headerInput={headerInput}
+					hideLine={boolean('hideLine', Config)}
 					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
 				>
 					{children}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There're some cases that cannot use Header because of under line of that component.
Actually, GUI of some applications want to use Header without underline.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added prop `hideLine` to hide `border-bottom` in the Header component.

### Links
[//]: # (Related issues, references)
ENYO-6120
