### PR TITLE
PLAT-81341: Fix ProgressBar and Slider to match current designs

### DIFF
--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -76,11 +76,6 @@ files, you may need to address these changes.
 * `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
 * `@moon-radio-item-selected-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-selected-focus-indicator-bg-color`
 * `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
-* `@moon-slider-nofocus-bg-color` has been renamed to `@moon-slider-bar-bg-color`
-* `@moon-slider-focus-bg-color` has been renamed to `@moon-slider-focus-bar-bg-color`
-* `@moon-slider-spotlight-bar-color` has been renamed to `@moon-slider-focus-bar-bg-color`
-* `@moon-slider-spotlight-knob-color` has been renamed to `@moon-slider-focus-knob-bg-color`
-* `@moon-slider-knob-active-bg-color` has been renamed to `@moon-slider-active-knob-bg-color`
 
 #### variables
 * `@moon-button-large-font-size` has been renamed to `@moon-button-font-size`

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -76,6 +76,11 @@ files, you may need to address these changes.
 * `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
 * `@moon-radio-item-selected-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-selected-focus-indicator-bg-color`
 * `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
+* `@moon-slider-nofocus-bg-color` has been renamed to `@moon-slider-bar-bg-color`
+* `@moon-slider-focus-bg-color` has been renamed to `@moon-slider-focus-bar-bg-color`
+* `@moon-slider-spotlight-bar-color` has been renamed to `@moon-slider-focus-bar-bg-color`
+* `@moon-slider-spotlight-knob-color` has been renamed to `@moon-slider-focus-knob-bg-color`
+* `@moon-slider-knob-active-bg-color` has been renamed to `@moon-slider-active-knob-bg-color`
 
 #### variables
 * `@moon-button-large-font-size` has been renamed to `@moon-button-font-size`

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
 - `moonstone/Panels.Header` type "dense" for "AlwaysViewing" Panels types
-- `moonstone/ProgressBar` public class name `bar` to support customizing the background of the bar
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors
-
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -15,7 +15,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Dropdown` button to not animate
 - `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
 - `moonstone/Heading` to have a bit more space between the text and the line, when the line is present
-- `moonstone/IncrementSlider`, `moonstone/ProgressBar`, and `moonstone/Slider` to use the latest set of design colors
 - `moonstone/LabeledItem` to pass `marqueeOn` prop to its contents
 - `moonstone/Picker` accessibility read out when a button becomes disabled
 - `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,13 +4,11 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors
 ### Added
 
 - `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
 - `moonstone/Panels.Header` type "dense" for "AlwaysViewing" Panels types
+- `moonstone/ProgressBar` public class name `bar` to support customizing the background of the bar
 
 ### Fixed
 
@@ -19,6 +17,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Heading` to have a bit more space between the text and the line, when the line is present
 - `moonstone/LabeledItem` to pass `marqueeOn` prop to its contents
 - `moonstone/Picker` accessibility read out when a button becomes disabled
+- `moonstone/ProgressBar`, `moonstone/Slider`, and `moonstone/IncrementSlider` to use the latest set of design colors
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses

--- a/packages/moonstone/ProgressBar/ProgressBar.module.less
+++ b/packages/moonstone/ProgressBar/ProgressBar.module.less
@@ -14,9 +14,7 @@
 
 	// Skin colors
 	.applySkins({
-		.bar {
-			background-color: @moon-progress-bar-bg-color;
-		}
+		background-color: @moon-progress-bar-bg-color;
 
 		.fill {
 			background-color: @moon-progress-bar-fill-bg-color;

--- a/packages/moonstone/ProgressBar/ProgressBar.module.less
+++ b/packages/moonstone/ProgressBar/ProgressBar.module.less
@@ -14,7 +14,9 @@
 
 	// Skin colors
 	.applySkins({
-		background-color: @moon-progress-bar-bg-color;
+		.bar {
+			background-color: @moon-progress-bar-bg-color;
+		}
 
 		.fill {
 			background-color: @moon-progress-bar-fill-bg-color;

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -132,50 +132,111 @@
 	});
 
 	.applySkins({
-		.progressBar {
-			background-color: @moon-progress-bar-bg-color;
+		.bar {
+			background-color: @moon-slider-bar-bg-color;
 		}
 
 		.fill {
-			background-color: @moon-progress-bar-fill-bg-color;
+			background-color: @moon-slider-fill-bg-color;
 		}
 
 		.load {
-			background-color: @moon-progress-bar-loaded-bg-color;
+			background-color: @moon-slider-load-bg-color;
 		}
 
 		.knob::before {
 			background-color: @moon-slider-knob-bg-color;
+			border-color: @moon-slider-knob-border-color;
+			box-shadow: @moon-slider-knob-shadow;
 		}
 
 		.spottable({
 			&:focus.activateOnFocus,
 			&.active,
 			&.pressed {
+				.bar {
+					background-color: @moon-slider-active-bar-bg-color;
+				}
+
 				.fill {
-					background-color: @moon-slider-spotlight-bar-color;
+					background-color: @moon-slider-active-fill-bg-color;
+				}
+
+				.load {
+					background-color: @moon-slider-active-load-bg-color;
+				}
+
+				.knob::before {
+					background-color: @moon-slider-active-knob-bg-color;
+					border-color: @moon-slider-active-knob-border-color;
 				}
 			}
 
 			.focus({
 				background-color: transparent;
 
+				.bar {
+					background-color: @moon-slider-focus-bar-bg-color;
+				}
+
+				.fill {
+					background-color: @moon-slider-focus-fill-bg-color;
+				}
+
+				.load {
+					background-color: @moon-slider-focus-load-bg-color;
+				}
+
 				.knob::before {
-					background-color: @moon-slider-spotlight-knob-color;
+					background-color: @moon-slider-focus-knob-bg-color;
+					border-color: @moon-slider-focus-knob-border-color;
 				}
 
 				&.active {
+					.bar {
+						background-color: @moon-slider-active-bar-bg-color;
+					}
+
+					.fill {
+						background-color: @moon-slider-active-fill-bg-color;
+					}
+
+					.load {
+						background-color: @moon-slider-active-load-bg-color;
+					}
+
 					.knob::before {
-						background-color: @moon-slider-knob-active-bg-color;
-						border-color: @moon-slider-spotlight-knob-color;
+						background-color: @moon-slider-active-knob-bg-color;
+						border-color: @moon-slider-active-knob-border-color;
 					}
 				}
 
 				.disabled({
-					opacity: @moon-disabled-opacity;
+					.bar {
+						opacity: @moon-slider-disabled-bar-opacity;
+					}
+
+					.knob::before {
+						background-color: @moon-slider-disabled-focus-knob-bg-color;
+						border-color: @moon-slider-focus-knob-border-color;
+					}
 				});
 			});
 		});
+
+		.disabled({
+			opacity: 1;
+
+			.bar {
+				opacity: @moon-slider-disabled-bar-opacity;
+			}
+
+			.knob::before {
+				background-color: @moon-slider-disabled-knob-bg-color;
+				border-color: @moon-slider-knob-border-color;
+			}
+		});
+
 
 		&.noFill {
 			.fill {

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -111,24 +111,6 @@
 				display: block;
 			}
 		}
-
-		&.pressed,
-		&:focus.activateOnFocus,
-		&:focus.active {
-			.knob::before {
-				transform: @knob-transform-active;
-			}
-		}
-
-		.disabled({
-			&.pressed,
-			&:focus.activateOnFocus,
-			&:focus.active {
-				.knob::before {
-					transform: @knob-transform-resting;
-				}
-			}
-		});
 	});
 
 	.applySkins({
@@ -150,10 +132,37 @@
 			box-shadow: @moon-slider-knob-shadow;
 		}
 
-		.spottable({
-			&:focus.activateOnFocus,
+		.focus({
+			background-color: transparent;
+
+			.bar {
+				background-color: @moon-slider-focus-bar-bg-color;
+			}
+
+			.fill {
+				background-color: @moon-slider-focus-fill-bg-color;
+			}
+
+			.load {
+				background-color: @moon-slider-focus-load-bg-color;
+			}
+
+			.knob::before {
+				background-color: @moon-slider-focus-knob-bg-color;
+				border-color: @moon-slider-focus-knob-border-color;
+			}
+
 			&.active,
+			&.activateOnFocus,
 			&.pressed {
+				.knob::before {
+					background-color: @moon-slider-active-knob-bg-color;
+					border-color: @moon-slider-active-knob-border-color;
+					transform: @knob-transform-active;
+				}
+			}
+
+			&.active {
 				.bar {
 					background-color: @moon-slider-active-bar-bg-color;
 				}
@@ -165,62 +174,25 @@
 				.load {
 					background-color: @moon-slider-active-load-bg-color;
 				}
-
-				.knob::before {
-					background-color: @moon-slider-active-knob-bg-color;
-					border-color: @moon-slider-active-knob-border-color;
-				}
 			}
 
-			.focus({
-				background-color: transparent;
-
+			.disabled({
 				.bar {
-					background-color: @moon-slider-focus-bar-bg-color;
-				}
-
-				.fill {
-					background-color: @moon-slider-focus-fill-bg-color;
-				}
-
-				.load {
-					background-color: @moon-slider-focus-load-bg-color;
+					opacity: @moon-slider-disabled-bar-opacity;
 				}
 
 				.knob::before {
-					background-color: @moon-slider-focus-knob-bg-color;
+					background-color: @moon-slider-disabled-focus-knob-bg-color;
 					border-color: @moon-slider-focus-knob-border-color;
 				}
 
-				&.active {
-					.bar {
-						background-color: @moon-slider-active-bar-bg-color;
-					}
-
-					.fill {
-						background-color: @moon-slider-active-fill-bg-color;
-					}
-
-					.load {
-						background-color: @moon-slider-active-load-bg-color;
-					}
-
+				&.active,
+				&.activateOnFocus,
+				&.pressed {
 					.knob::before {
-						background-color: @moon-slider-active-knob-bg-color;
-						border-color: @moon-slider-active-knob-border-color;
+						transform: @knob-transform-resting;
 					}
 				}
-
-				.disabled({
-					.bar {
-						opacity: @moon-slider-disabled-bar-opacity;
-					}
-
-					.knob::before {
-						background-color: @moon-slider-disabled-focus-knob-bg-color;
-						border-color: @moon-slider-focus-knob-border-color;
-					}
-				});
 			});
 		});
 

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -132,111 +132,50 @@
 	});
 
 	.applySkins({
-		.bar {
-			background-color: @moon-slider-bar-bg-color;
+		.progressBar {
+			background-color: @moon-progress-bar-bg-color;
 		}
 
 		.fill {
-			background-color: @moon-slider-fill-bg-color;
+			background-color: @moon-progress-bar-fill-bg-color;
 		}
 
 		.load {
-			background-color: @moon-slider-load-bg-color;
+			background-color: @moon-progress-bar-loaded-bg-color;
 		}
 
 		.knob::before {
 			background-color: @moon-slider-knob-bg-color;
-			border-color: @moon-slider-knob-border-color;
-			box-shadow: @moon-slider-knob-shadow;
 		}
 
 		.spottable({
 			&:focus.activateOnFocus,
 			&.active,
 			&.pressed {
-				.bar {
-					background-color: @moon-slider-active-bar-bg-color;
-				}
-
 				.fill {
-					background-color: @moon-slider-active-fill-bg-color;
-				}
-
-				.load {
-					background-color: @moon-slider-active-load-bg-color;
-				}
-
-				.knob::before {
-					background-color: @moon-slider-active-knob-bg-color;
-					border-color: @moon-slider-active-knob-border-color;
+					background-color: @moon-slider-spotlight-bar-color;
 				}
 			}
 
 			.focus({
 				background-color: transparent;
 
-				.bar {
-					background-color: @moon-slider-focus-bar-bg-color;
-				}
-
-				.fill {
-					background-color: @moon-slider-focus-fill-bg-color;
-				}
-
-				.load {
-					background-color: @moon-slider-focus-load-bg-color;
-				}
-
 				.knob::before {
-					background-color: @moon-slider-focus-knob-bg-color;
-					border-color: @moon-slider-focus-knob-border-color;
+					background-color: @moon-slider-spotlight-knob-color;
 				}
 
 				&.active {
-					.bar {
-						background-color: @moon-slider-active-bar-bg-color;
-					}
-
-					.fill {
-						background-color: @moon-slider-active-fill-bg-color;
-					}
-
-					.load {
-						background-color: @moon-slider-active-load-bg-color;
-					}
-
 					.knob::before {
-						background-color: @moon-slider-active-knob-bg-color;
-						border-color: @moon-slider-active-knob-border-color;
+						background-color: @moon-slider-knob-active-bg-color;
+						border-color: @moon-slider-spotlight-knob-color;
 					}
 				}
 
 				.disabled({
-					.bar {
-						opacity: @moon-slider-disabled-bar-opacity;
-					}
-
-					.knob::before {
-						background-color: @moon-slider-disabled-focus-knob-bg-color;
-						border-color: @moon-slider-focus-knob-border-color;
-					}
+					opacity: @moon-disabled-opacity;
 				});
 			});
 		});
-
-		.disabled({
-			opacity: 1;
-
-			.bar {
-				opacity: @moon-slider-disabled-bar-opacity;
-			}
-
-			.knob::before {
-				background-color: @moon-slider-disabled-knob-bg-color;
-				border-color: @moon-slider-knob-border-color;
-			}
-		});
-
 
 		&.noFill {
 			.fill {

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -197,8 +197,8 @@
 
 // Progress Bar
 // ---------------------------------------
-@moon-progress-bar-bg-color: fade(@moon-darker-gray, 30%);
-@moon-progress-bar-loaded-bg-color: fade(@moon-darker-gray, 50%);
+@moon-progress-bar-bg-color: fade(#333, 20%);
+@moon-progress-bar-loaded-bg-color: fade(#333, 30%);
 @moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
 @moon-progress-bar-tooltip-text-color: @moon-progress-bar-fill-bg-color;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
@@ -223,7 +223,7 @@
 @moon-slider-bar-bg-color: @moon-progress-bar-bg-color;
 @moon-slider-fill-bg-color: @moon-progress-bar-fill-bg-color;
 @moon-slider-load-bg-color: @moon-progress-bar-loaded-bg-color;
-@moon-slider-knob-bg-color: @moon-dark-gray;
+@moon-slider-knob-bg-color: @moon-white;
 @moon-slider-knob-border-color: transparent;
 @moon-slider-focus-bar-bg-color: @moon-slider-bar-bg-color;
 @moon-slider-focus-fill-bg-color: @moon-slider-fill-bg-color;
@@ -242,7 +242,7 @@
 @moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
 @moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
 @moon-slider-disabled-focus-knob-border-color: transparent;
-@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
+@moon-slider-knob-shadow: 0 3px 6px fade(black, 50%);
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -199,7 +199,7 @@
 // ---------------------------------------
 @moon-progress-bar-bg-color: fade(@moon-darker-gray, 30%);
 @moon-progress-bar-loaded-bg-color: fade(@moon-darker-gray, 50%);
-@moon-progress-bar-fill-bg-color: @moon-white;
+@moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
 @moon-progress-bar-tooltip-text-color: @moon-progress-bar-fill-bg-color;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
@@ -220,11 +220,29 @@
 
 // Slider
 // ---------------------------------------
-@moon-slider-nofocus-bg-color: @moon-white;
-@moon-slider-focus-bg-color: @moon-spotlight-color;
-@moon-slider-spotlight-knob-color: @moon-spotlight-color;
-@moon-slider-spotlight-bar-color: @moon-spotlight-color;
+@moon-slider-bar-bg-color: @moon-progress-bar-bg-color;
+@moon-slider-fill-bg-color: @moon-progress-bar-fill-bg-color;
+@moon-slider-load-bg-color: @moon-progress-bar-loaded-bg-color;
 @moon-slider-knob-bg-color: @moon-dark-gray;
+@moon-slider-knob-border-color: transparent;
+@moon-slider-focus-bar-bg-color: @moon-slider-bar-bg-color;
+@moon-slider-focus-fill-bg-color: @moon-slider-fill-bg-color;
+@moon-slider-focus-load-bg-color: @moon-slider-load-bg-color;
+@moon-slider-focus-knob-bg-color: @moon-spotlight-bg-color;
+@moon-slider-focus-knob-border-color: transparent;
+@moon-slider-active-bar-bg-color: @moon-slider-bar-bg-color;
+@moon-slider-active-fill-bg-color: @moon-slider-fill-bg-color;
+@moon-slider-active-load-bg-color: @moon-slider-load-bg-color;
+@moon-slider-active-knob-bg-color: @moon-white;
+@moon-slider-active-knob-border-color: @moon-spotlight-color;
+@moon-slider-disabled-bar-opacity: 0.4;
+@moon-slider-disabled-bar-bg-color: fadeout(@moon-slider-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
+@moon-slider-disabled-knob-bg-color: #666;
+@moon-slider-disabled-knob-border-color: transparent;
+@moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
+@moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
+@moon-slider-disabled-focus-knob-border-color: transparent;
+@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -199,7 +199,7 @@
 // ---------------------------------------
 @moon-progress-bar-bg-color: fade(@moon-darker-gray, 30%);
 @moon-progress-bar-loaded-bg-color: fade(@moon-darker-gray, 50%);
-@moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
+@moon-progress-bar-fill-bg-color: @moon-white;
 @moon-progress-bar-tooltip-text-color: @moon-progress-bar-fill-bg-color;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
@@ -220,29 +220,11 @@
 
 // Slider
 // ---------------------------------------
-@moon-slider-bar-bg-color: @moon-progress-bar-bg-color;
-@moon-slider-fill-bg-color: @moon-progress-bar-fill-bg-color;
-@moon-slider-load-bg-color: @moon-progress-bar-loaded-bg-color;
+@moon-slider-nofocus-bg-color: @moon-white;
+@moon-slider-focus-bg-color: @moon-spotlight-color;
+@moon-slider-spotlight-knob-color: @moon-spotlight-color;
+@moon-slider-spotlight-bar-color: @moon-spotlight-color;
 @moon-slider-knob-bg-color: @moon-dark-gray;
-@moon-slider-knob-border-color: transparent;
-@moon-slider-focus-bar-bg-color: @moon-slider-bar-bg-color;
-@moon-slider-focus-fill-bg-color: @moon-slider-fill-bg-color;
-@moon-slider-focus-load-bg-color: @moon-slider-load-bg-color;
-@moon-slider-focus-knob-bg-color: @moon-spotlight-bg-color;
-@moon-slider-focus-knob-border-color: transparent;
-@moon-slider-active-bar-bg-color: @moon-slider-bar-bg-color;
-@moon-slider-active-fill-bg-color: @moon-slider-fill-bg-color;
-@moon-slider-active-load-bg-color: @moon-slider-load-bg-color;
-@moon-slider-active-knob-bg-color: @moon-white;
-@moon-slider-active-knob-border-color: @moon-spotlight-color;
-@moon-slider-disabled-bar-opacity: 0.4;
-@moon-slider-disabled-bar-bg-color: fadeout(@moon-slider-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
-@moon-slider-disabled-knob-bg-color: #666;
-@moon-slider-disabled-knob-border-color: transparent;
-@moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
-@moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
-@moon-slider-disabled-focus-knob-border-color: transparent;
-@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -219,8 +219,8 @@
 
 // Progress Bar
 // ---------------------------------------
-@moon-progress-bar-bg-color: fade(@moon-gray, 19%);
-@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 23%);
+@moon-progress-bar-bg-color: fade(@moon-gray, 20%);
+@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 20%);
 @moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
 @moon-progress-bar-tooltip-text-color: @moon-white;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
@@ -269,7 +269,7 @@
 @moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
 @moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
 @moon-slider-disabled-focus-knob-border-color: transparent;
-@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
+@moon-slider-knob-shadow: 0 3px 6px fade(black, 50%);
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -219,9 +219,9 @@
 
 // Progress Bar
 // ---------------------------------------
-@moon-progress-bar-bg-color: fade(@moon-gray, 30%);
-@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 50%);
-@moon-progress-bar-fill-bg-color: @moon-white;
+@moon-progress-bar-bg-color: fade(@moon-gray, 19%);
+@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 23%);
+@moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
 @moon-progress-bar-tooltip-text-color: @moon-white;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
@@ -247,12 +247,29 @@
 
 // Slider
 // ---------------------------------------
-@moon-slider-nofocus-bg-color: @moon-white;
-@moon-slider-focus-bg-color: @moon-spotlight-color;
-@moon-slider-spotlight-knob-color: @moon-spotlight-color;
-@moon-slider-spotlight-bar-color: @moon-spotlight-color;
-@moon-slider-knob-bg-color: @moon-dark-gray;
-@moon-slider-knob-active-bg-color: @moon-slider-knob-bg-color;
+@moon-slider-bar-bg-color: @moon-progress-bar-bg-color;
+@moon-slider-fill-bg-color: @moon-progress-bar-fill-bg-color;
+@moon-slider-load-bg-color: @moon-progress-bar-loaded-bg-color;
+@moon-slider-knob-bg-color: @moon-white;
+@moon-slider-knob-border-color: transparent;
+@moon-slider-focus-bar-bg-color: @moon-slider-bar-bg-color;
+@moon-slider-focus-fill-bg-color: @moon-slider-fill-bg-color;
+@moon-slider-focus-load-bg-color: @moon-slider-load-bg-color;
+@moon-slider-focus-knob-bg-color: @moon-spotlight-bg-color;
+@moon-slider-focus-knob-border-color: transparent;
+@moon-slider-active-bar-bg-color: @moon-slider-bar-bg-color;
+@moon-slider-active-fill-bg-color: @moon-slider-fill-bg-color;
+@moon-slider-active-load-bg-color: @moon-slider-load-bg-color;
+@moon-slider-active-knob-bg-color: @moon-slider-knob-bg-color;
+@moon-slider-active-knob-border-color: @moon-spotlight-color;
+@moon-slider-disabled-bar-opacity: 0.4;
+@moon-slider-disabled-bar-bg-color: fadeout(@moon-slider-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
+@moon-slider-disabled-knob-bg-color: #666;
+@moon-slider-disabled-knob-border-color: transparent;
+@moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
+@moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
+@moon-slider-disabled-focus-knob-border-color: transparent;
+@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -219,9 +219,9 @@
 
 // Progress Bar
 // ---------------------------------------
-@moon-progress-bar-bg-color: fade(@moon-gray, 19%);
-@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 23%);
-@moon-progress-bar-fill-bg-color: @moon-spotlight-bg-color;
+@moon-progress-bar-bg-color: fade(@moon-gray, 30%);
+@moon-progress-bar-loaded-bg-color: fade(@moon-light-gray, 50%);
+@moon-progress-bar-fill-bg-color: @moon-white;
 @moon-progress-bar-tooltip-text-color: @moon-white;
 @moon-progress-bar-highlighted-fill-bg-color: @moon-spotlight-bg-color;
 
@@ -247,29 +247,12 @@
 
 // Slider
 // ---------------------------------------
-@moon-slider-bar-bg-color: @moon-progress-bar-bg-color;
-@moon-slider-fill-bg-color: @moon-progress-bar-fill-bg-color;
-@moon-slider-load-bg-color: @moon-progress-bar-loaded-bg-color;
-@moon-slider-knob-bg-color: @moon-white;
-@moon-slider-knob-border-color: transparent;
-@moon-slider-focus-bar-bg-color: @moon-slider-bar-bg-color;
-@moon-slider-focus-fill-bg-color: @moon-slider-fill-bg-color;
-@moon-slider-focus-load-bg-color: @moon-slider-load-bg-color;
-@moon-slider-focus-knob-bg-color: @moon-spotlight-bg-color;
-@moon-slider-focus-knob-border-color: transparent;
-@moon-slider-active-bar-bg-color: @moon-slider-bar-bg-color;
-@moon-slider-active-fill-bg-color: @moon-slider-fill-bg-color;
-@moon-slider-active-load-bg-color: @moon-slider-load-bg-color;
-@moon-slider-active-knob-bg-color: @moon-slider-knob-bg-color;
-@moon-slider-active-knob-border-color: @moon-spotlight-color;
-@moon-slider-disabled-bar-opacity: 0.4;
-@moon-slider-disabled-bar-bg-color: fadeout(@moon-slider-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
-@moon-slider-disabled-knob-bg-color: #666;
-@moon-slider-disabled-knob-border-color: transparent;
-@moon-slider-disabled-focus-bar-bg-color: fadeout(@moon-slider-focus-bar-bg-color, percentage(@moon-slider-disabled-bar-opacity), relative);
-@moon-slider-disabled-focus-knob-bg-color: @moon-spotlight-bg-color;
-@moon-slider-disabled-focus-knob-border-color: transparent;
-@moon-slider-knob-shadow: 0 3px 6px fade(black, 30%);
+@moon-slider-nofocus-bg-color: @moon-white;
+@moon-slider-focus-bg-color: @moon-spotlight-color;
+@moon-slider-spotlight-knob-color: @moon-spotlight-color;
+@moon-slider-spotlight-bar-color: @moon-spotlight-color;
+@moon-slider-knob-bg-color: @moon-dark-gray;
+@moon-slider-knob-active-bg-color: @moon-slider-knob-bg-color;
 
 // Spinner
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -396,7 +396,7 @@
 @moon-slider-knob-height: @moon-button-small-height;
 @moon-slider-knob-height-large: @moon-button-small-height-large;
 @moon-slider-tooltip-offset: (@moon-slider-knob-height / 2);
-@moon-slider-knob-resting-state-scale: 0.8;
+@moon-slider-knob-resting-state-scale: 0.75;
 
 // IntegerPicker
 // ---------------------------------------

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/ProgressBar` public class name `bar` to support customizing the background of the bar
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Added

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -72,9 +72,8 @@ const ProgressBar = kind({
 		 * The following classes are supported:
 		 *
 		 * * `progressBar` - The root component class
-		 * * `bar`         - The background node (the empty part of the progressBar)
-		 * * `fill`        - The foreground of the progress bar (`progress`)
-		 * * `load`        - The `backgroundProgress` node
+		 * * `fill`        - The foreground node of the progress bar
+		 * * `load`        - The background node of the progress bar
 		 * * `horizontal`  - Applied when `orientation` is `'horizontal'`
 		 * * `vertical`    - Applied when `orientation` is `'vertical'`
 		 *
@@ -168,10 +167,8 @@ const ProgressBar = kind({
 
 		return (
 			<div role="progressbar" {...rest}>
-				<div className={css.bar}>
-					<div className={css.load} />
-					<div className={css.fill} />
-				</div>
+				<div className={css.load} />
+				<div className={css.fill} />
 				{children}
 			</div>
 		);

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -72,8 +72,9 @@ const ProgressBar = kind({
 		 * The following classes are supported:
 		 *
 		 * * `progressBar` - The root component class
-		 * * `fill`        - The foreground node of the progress bar
-		 * * `load`        - The background node of the progress bar
+		 * * `bar`         - The background node (the empty part of the progressBar)
+		 * * `fill`        - The foreground of the progress bar (`progress`)
+		 * * `load`        - The `backgroundProgress` node
 		 * * `horizontal`  - Applied when `orientation` is `'horizontal'`
 		 * * `vertical`    - Applied when `orientation` is `'vertical'`
 		 *
@@ -167,8 +168,10 @@ const ProgressBar = kind({
 
 		return (
 			<div role="progressbar" {...rest}>
-				<div className={css.load} />
-				<div className={css.fill} />
+				<div className={css.bar}>
+					<div className={css.load} />
+					<div className={css.fill} />
+				</div>
 				{children}
 			</div>
 		);

--- a/packages/ui/ProgressBar/ProgressBar.module.less
+++ b/packages/ui/ProgressBar/ProgressBar.module.less
@@ -9,7 +9,6 @@
 	position: relative;
 	direction: ltr;
 
-	.bar,
 	.fill,
 	.load {
 		position: absolute;
@@ -18,7 +17,6 @@
 	&.vertical {
 		display: inline-block;
 
-		.bar,
 		.fill,
 		.load {
 			height: 100%;
@@ -38,14 +36,9 @@
 	}
 
 	&.horizontal {
-		.bar,
 		.fill,
 		.load {
 			height: 100%;
-		}
-
-		.bar {
-			width: 100%;
 		}
 
 		.fill {

--- a/packages/ui/ProgressBar/ProgressBar.module.less
+++ b/packages/ui/ProgressBar/ProgressBar.module.less
@@ -9,6 +9,7 @@
 	position: relative;
 	direction: ltr;
 
+	.bar,
 	.fill,
 	.load {
 		position: absolute;
@@ -17,6 +18,7 @@
 	&.vertical {
 		display: inline-block;
 
+		.bar,
 		.fill,
 		.load {
 			height: 100%;
@@ -36,9 +38,14 @@
 	}
 
 	&.horizontal {
+		.bar,
 		.fill,
 		.load {
 			height: 100%;
+		}
+
+		.bar {
+			width: 100%;
 		}
 
 		.fill {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
ProgressBar, Slider, and IncrementSlider need new colors.


### Resolution
New colors applied and cleaned up variables, abandoning old ones that didn't follow consistent naming conventions and removing unused variables. (Noted in the migration guide.)


### Additional Considerations
This includes a change to `ui/ProgressBar` which inserts a new DOM node in the stack, which decouples the styling of the bars from the knob. This allows the bars to be "grayed out" when disabled and leave the knob at full opacity, per the designs. I did experiment with several approaches that didn't necessitate adding a new node, but ultimately this seemed to be the cleanest.