### PR TITLE
PLAT-81157: Move VirtualGridList to the component directory in qa-sampler

### DIFF
--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -51,7 +51,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-storiesOf('VirtualList.VirtualGridList', module)
+storiesOf('VirtualGridList', module)
 	.add(
 		'Horizontal VirtualGridList',
 		() => (


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualGridList and VirtualList become located in the same hierarchy.

### Links
[//]: # (Related issues, references)
PLAT-81157

### Comments
`.` is a hierarchy separator for the title when calling 'storiesOf' method. If the title is "VirtualList.VirtualGridList", VirtualGridList show up underneath VirtualList.