### PR TITLE
PLAT-83114: Fix Picker read out of disabled buttons

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
 
+### Fixed
+
+- `moonstone/Picker` accessibility read out when a button becomes disabled
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 ### Removed

--- a/packages/moonstone/internal/Picker/PickerButton.js
+++ b/packages/moonstone/internal/Picker/PickerButton.js
@@ -76,8 +76,9 @@ const PickerButtonBase = kind({
 	},
 
 	render: ({disabled, icon, joined, ...rest}) => {
+		delete rest.hidden;
+
 		if (joined) {
-			delete rest.hidden;
 			delete rest.onSpotlightDisappear;
 			delete rest.spotlightDisabled;
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Picker buttons that became disabled were refocused by React causing a duplicate read out.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the `hidden` prop which was cascading into the DOM causing the unintentional side effect.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I couldn't find anything that specified that a hidden element _should_ be blurred but it was nonetheless. It occurred as a result of setting the attribute on the node so it must be a decision made by chrome and presumably new since v53.

![image](https://user-images.githubusercontent.com/788456/61474057-9f76b680-a93c-11e9-8590-95717fff5906.png)


### Links
[//]: # (Related issues, references)
Sort of a regression of #740 which introduced the bug by not removing the prop correctly but seemingly only manifested by the chromium update.