### PR TITLE
ENYO-6079: Fix LS2Request to return an error for null messages

### DIFF
--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact webos module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `webos/LS2Request` to return an error for a null response from a service
+
 ## [3.0.0-beta.1] - 2019-07-15
 
 No significant changes.

--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -126,14 +126,23 @@ export default class LS2Request {
 		this.timeoutJob.stop();
 
 		let parsedMsg;
-		try {
-			parsedMsg = JSON.parse(msg);
-		} catch (e) {
+
+		if (msg == null) {
 			parsedMsg = {
 				errorCode: -1,
-				errorText: msg,
+				errorText: 'No message returned',
 				returnValue: false
 			};
+		} else {
+			try {
+				parsedMsg = JSON.parse(msg);
+			} catch (e) {
+				parsedMsg = {
+					errorCode: -1,
+					errorText: msg,
+					returnValue: false
+				};
+			}
 		}
 
 		if ((parsedMsg.errorCode || parsedMsg.returnValue === false)) {

--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -130,7 +130,7 @@ export default class LS2Request {
 		if (msg == null) {
 			parsedMsg = {
 				errorCode: -1,
-				errorText: 'No message returned',
+				errorText: `Invalid response: ${msg}`,
 				returnValue: false
 			};
 		} else {

--- a/packages/webos/LS2Request/tests/LS2Request-specs.js
+++ b/packages/webos/LS2Request/tests/LS2Request-specs.js
@@ -1,0 +1,19 @@
+import LS2Request from "../LS2Request";
+
+describe('LS2Request', () => {
+	const nop = () => {};
+
+	describe('callback', () => {
+		it ('should return an error for a null msg', () => {
+			const request = new LS2Request();
+			const onError = jest.fn();
+
+			request.callback(nop, onError, nop, null);
+
+			const expected = {errorCode: -1};
+			const actual = onError.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+	});
+});

--- a/packages/webos/LS2Request/tests/LS2Request-specs.js
+++ b/packages/webos/LS2Request/tests/LS2Request-specs.js
@@ -1,4 +1,4 @@
-import LS2Request from "../LS2Request";
+import LS2Request from '../LS2Request';
 
 describe('LS2Request', () => {
 	const nop = () => {};

--- a/packages/webos/LS2Request/tests/LS2Request-specs.js
+++ b/packages/webos/LS2Request/tests/LS2Request-specs.js
@@ -4,14 +4,90 @@ describe('LS2Request', () => {
 	const nop = () => {};
 
 	describe('callback', () => {
+		const invalidResponse = '{invalid: json';
+		const failedResponse = '{"errorCode": 101}';
+		const successfulResponse = '{"returnValue": true}';
+
 		it ('should return an error for a null msg', () => {
 			const request = new LS2Request();
-			const onError = jest.fn();
+			const onFailure = jest.fn();
 
-			request.callback(nop, onError, nop, null);
+			request.callback(nop, onFailure, nop, null);
 
 			const expected = {errorCode: -1};
-			const actual = onError.mock.calls[0][0];
+			const actual = onFailure.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should return an error for invalid JSON', () => {
+			const request = new LS2Request();
+			const onFailure = jest.fn();
+
+			request.callback(nop, onFailure, nop, );
+
+			const expected = {errorCode: -1};
+			const actual = onFailure.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should invoke onFailure for a valid, failed request', () => {
+			const request = new LS2Request();
+			const onFailure = jest.fn();
+
+			request.callback(nop, onFailure, nop, failedResponse);
+
+			const expected = {errorCode: 101};
+			const actual = onFailure.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should invoke onSuccess for a valid request', () => {
+			const request = new LS2Request();
+			const onSuccess = jest.fn();
+
+			request.callback(onSuccess, nop, nop, successfulResponse);
+
+			const expected = {returnValue: true};
+			const actual = onSuccess.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should invoke onComplete for a valid request', () => {
+			const request = new LS2Request();
+			const onComplete = jest.fn();
+
+			request.callback(nop, nop, onComplete, successfulResponse);
+
+			const expected = {returnValue: true};
+			const actual = onComplete.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should invoke onComplete for an invalid request', () => {
+			const request = new LS2Request();
+			const onComplete = jest.fn();
+
+			request.callback(nop, nop, onComplete, invalidResponse);
+
+			const expected = {errorCode: -1};
+			const actual = onComplete.mock.calls[0][0];
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		it ('should invoke onComplete for a valid, failed request', () => {
+			const request = new LS2Request();
+			const onComplete = jest.fn();
+
+			request.callback(nop, nop, onComplete, failedResponse);
+
+			const expected = {errorCode: 101};
+			const actual = onComplete.mock.calls[0][0];
 
 			expect(actual).toMatchObject(expected);
 		});

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "clean": "enact clean",
     "lint": "enact lint --strict",
-    "test": "echo \"No test suite\" && exit 0",
+    "test": "enact test",
+    "test-json": "enact test --json",
+    "test-watch": "enact test --watch",
     "transpile": "enact transpile"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If an LS2 service returns `null` as the message, it will be treated as a success even though it isn't.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update the failure logic to account for null and undefined messages.
