### PR TITLE
PLAT-83172: Space added for Heading with line, cleanup of divider cruft

### DIFF
--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -91,6 +91,12 @@ files, you may need to address these changes.
 * `@moon-button-icon-position-after-end-margin` has been renamed to `@moon-button-icon-position-after-margin-end`
 * `@moon-button-icon-position-after-small-start-margin` has been renamed to `@moon-button-icon-position-after-small-margin-start`
 * `@moon-button-icon-position-after-small-end-margin` has been renamed to `@moon-button-icon-position-after-small-margin-end`
+* `@moon-divider-font-family` has been removed
+* `@moon-non-latin-divider-font-size` has been removed
+* `@moon-divider-font-size` has been removed
+* `@moon-divider-font-weight` has been removed
+* `@moon-divider-font-style` has been removed
+* `@moon-divider-letter-spacing` has been removed
 * `@moon-header-border-top-width` has been removed
 * `@moon-icon-button-size` has been removed
 * `@moon-icon-button-size-large` has been removed
@@ -99,6 +105,9 @@ files, you may need to address these changes.
 * `@moon-notification-out-border-radius` has been removed
 * `@moon-notification-button-gap` has been removed
 * `@moon-tooltip-h-padding` has been replaced by `@moon-tooltip-padding`
+
+### mixins
+* `.moon-divider-text` has been removed
 
 ### `Button`
 The `casing` prop has been removed.

--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -66,47 +66,50 @@ files, you may need to address these changes.
 * `@moon-checkbox-check-color` has been renamed to `@moon-checkbox-text-color`
 * `@moon-checkbox-spotlight-bg-color` (`@moon-checkbox-bg-spotlight-color` in `colors-light.less`) has been renamed to `@moon-checkbox-focus-bg-color`
 * `@moon-checkbox-spotlight-color` has been renamed to `@moon-checkbox-focus-text-color`
+* `@moon-divider-border-color` has been removed
+* `@moon-divider-text-color` has been removed
 * `@moon-header-input-bg-color` has been removed
 * `@moon-header-input-text-color` has been removed
 * `@moon-input-border-active-outline-color` has been renamed to `@moon-input-border-active-shadow`
 * `@moon-radio-item-indicator-border-color` has been removed
-* `@moon-radio-item-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-focus-indicator-bg-color`
-* `@moon-radio-item-spotlight-indicator-border-color` has been removed
 * `@moon-radio-item-selected-indicator-border-color` has been removed
-* `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
 * `@moon-radio-item-selected-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-selected-focus-indicator-bg-color`
 * `@moon-radio-item-selected-spotlight-indicator-border-color` has been removed
+* `@moon-radio-item-selected-spotlight-indicator-color` has been renamed to `@moon-radio-item-selected-focus-indicator-color`
+* `@moon-radio-item-spotlight-indicator-bg-color` has been renamed to `@moon-radio-item-focus-indicator-bg-color`
+* `@moon-radio-item-spotlight-indicator-border-color` has been removed
 
 #### variables
 * `@moon-breadcrumb-text-size` has been replaced by `@moon-panels-breadcrumb-text-size`
 * `@moon-breadcrumb-width` has been replaced by `@moon-panels-breadcrumb-width`
 * `@moon-button-icon-end-margin` has been renamed to `@moon-button-icon-margin-end`
+* `@moon-button-icon-end-margin` has been renamed to `@moon-button-icon-margin-end`
+* `@moon-button-icon-position-after-end-margin` has been renamed to `@moon-button-icon-position-after-margin-end`
 * `@moon-button-icon-position-after-end-margin` has been renamed to `@moon-button-icon-position-after-margin-end`
 * `@moon-button-icon-position-after-small-end-margin` has been renamed to `@moon-button-icon-position-after-small-margin-end`
+* `@moon-button-icon-position-after-small-end-margin` has been renamed to `@moon-button-icon-position-after-small-margin-end`
+* `@moon-button-icon-position-after-small-start-margin` has been renamed to `@moon-button-icon-position-after-small-margin-start`
 * `@moon-button-icon-position-after-small-start-margin` has been renamed to `@moon-button-icon-position-after-small-margin-start`
 * `@moon-button-icon-position-after-start-margin` has been renamed to `@moon-button-icon-position-after-margin-start`
+* `@moon-button-icon-position-after-start-margin` has been renamed to `@moon-button-icon-position-after-margin-start`
+* `@moon-button-icon-small-end-margin` has been renamed to `@moon-button-icon-small-margin-end`
 * `@moon-button-icon-small-end-margin` has been renamed to `@moon-button-icon-small-margin-end`
 * `@moon-button-icon-small-start-margin` has been renamed to `@moon-button-icon-small-margin-start`
+* `@moon-button-icon-small-start-margin` has been renamed to `@moon-button-icon-small-margin-start`
+* `@moon-button-icon-start-margin` has been renamed to `@moon-button-icon-margin-start`
 * `@moon-button-icon-start-margin` has been renamed to `@moon-button-icon-margin-start`
 * `@moon-button-large-font-size-large` has been renamed to `@moon-button-font-size-large`
 * `@moon-button-large-font-size` has been renamed to `@moon-button-font-size`
 * `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
+* `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
 * `@moon-button-large-text-size` has been removed
 * `@moon-button-small-text-size` has been removed
-* `@moon-button-large-min-width` has been renamed to `@moon-button-min-width`
-* `@moon-button-icon-start-margin` has been renamed to `@moon-button-icon-margin-start`
-* `@moon-button-icon-end-margin` has been renamed to `@moon-button-icon-margin-end`
-* `@moon-button-icon-small-start-margin` has been renamed to `@moon-button-icon-small-margin-start`
-* `@moon-button-icon-small-end-margin` has been renamed to `@moon-button-icon-small-margin-end`
-* `@moon-button-icon-position-after-start-margin` has been renamed to `@moon-button-icon-position-after-margin-start`
-* `@moon-button-icon-position-after-end-margin` has been renamed to `@moon-button-icon-position-after-margin-end`
-* `@moon-button-icon-position-after-small-start-margin` has been renamed to `@moon-button-icon-position-after-small-margin-start`
-* `@moon-button-icon-position-after-small-end-margin` has been renamed to `@moon-button-icon-position-after-small-margin-end`
+* `@moon-divider-border-width` has been removed
 * `@moon-divider-font-family` has been removed
-* `@moon-non-latin-divider-font-size` has been removed
 * `@moon-divider-font-size` has been removed
-* `@moon-divider-font-weight` has been removed
 * `@moon-divider-font-style` has been removed
+* `@moon-divider-font-weight` has been removed
+* `@moon-divider-height` has been removed
 * `@moon-divider-letter-spacing` has been removed
 * `@moon-header-border-top-width` has been removed
 * `@moon-header-height-large` has been removed
@@ -118,6 +121,7 @@ files, you may need to address these changes.
 * `@moon-icon-button-small-size-large` has been removed
 * `@moon-icon-button-small-size` has been removed
 * `@moon-medium-header-line-height` has been replaced by `@moon-header-standard-title-line-height`
+* `@moon-non-latin-divider-font-size` has been removed
 * `@moon-non-latin-header-text-line-height` has been replaced by `@moon-non-latin-header-line-height`
 * `@moon-non-latin-medium-header-line-height` has been replaced by `@moon-non-latin-header-standard-title-line-height`
 * `@moon-non-latin-small-header-line-height` has been replaced by `@moon-non-latin-header-compact-title-line-height`

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Dropdown` button to not animate
 - `moonstone/FormCheckboxItem` so it doesn't change size between normal and large text mode
+- `moonstone/Heading` to have a bit more space between the text and the line, when the line is present
 - `moonstone/LabeledItem` to pass `marqueeOn` prop to its contents
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`

--- a/packages/moonstone/Heading/Heading.module.less
+++ b/packages/moonstone/Heading/Heading.module.less
@@ -7,12 +7,17 @@
 .heading {
 	border-bottom: @moon-heading-border-width solid transparent;
 	margin: 0 @moon-spotlight-outset (1.5 * @moon-spotlight-outset) @moon-spotlight-outset;
+	padding: @moon-heading-padding;
 	min-height: (1.5 * @moon-spotlight-outset);
 	letter-spacing: @moon-heading-letter-spacing;
 	line-height: @moon-heading-line-height;
 	.moon-font(@moon-heading-large-font-family, @moon-heading-non-latin-font-family, {
 		line-height: @moon-heading-non-latin-line-height;
 	});
+
+	&.showLine {
+		padding: @moon-heading-showline-padding;
+	}
 
 	&.large {
 		font-family: @moon-heading-large-font-family;
@@ -59,7 +64,6 @@
 
 		&.showLine {
 			border-bottom-color: @moon-heading-border-color;
-			padding-bottom: 9px;
 		}
 	});
 }

--- a/packages/moonstone/Heading/Heading.module.less
+++ b/packages/moonstone/Heading/Heading.module.less
@@ -59,6 +59,7 @@
 
 		&.showLine {
 			border-bottom-color: @moon-heading-border-color;
+			padding-bottom: 9px;
 		}
 	});
 }

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -95,11 +95,6 @@
 @moon-day-selector-checkbox-bg-color: @moon-formcheckbox-bg-color;
 @moon-day-selector-checkbox-text-color: @moon-formcheckbox-text-color;
 
-// Divider
-// ---------------------------------------
-@moon-divider-text-color: @moon-heading-text-color;  // Deprecated
-@moon-divider-border-color: @moon-heading-border-color;  // Deprecated
-
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-selected-text-color: @moon-spotlight-color;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -93,11 +93,6 @@
 @moon-day-selector-checkbox-bg-color: @moon-formcheckbox-bg-color;
 @moon-day-selector-checkbox-text-color: @moon-formcheckbox-text-color;
 
-// Divider
-// ---------------------------------------
-@moon-divider-text-color: @moon-heading-text-color;  // Deprecated
-@moon-divider-border-color: @moon-heading-border-color;  // Deprecated
-
 // Dropdown
 // ---------------------------------------
 @moon-dropdown-selected-text-color: @moon-spotlight-color;

--- a/packages/moonstone/styles/mixins.less
+++ b/packages/moonstone/styles/mixins.less
@@ -391,20 +391,3 @@
 	font-size: @moon-button-small-font-size;
 	.font-kerning;
 }
-
-// NOTE: Consider deprecation in 3.0.0
-.moon-divider-text() {
-	.moon-font(@moon-divider-font-family, @moon-non-latin-font-family-bold, {
-		font-weight: @moon-non-latin-font-weight-bold;
-		font-size: @moon-non-latin-divider-font-size;
-		font-style: normal;
-	});
-	font-size: @moon-divider-font-size;
-	font-weight: @moon-divider-font-weight;
-	font-style: @moon-divider-font-style;
-	letter-spacing: @moon-divider-letter-spacing;
-
-	:global(.enact-locale-non-italic) & {
-		font-style: normal;
-	}
-}

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -54,7 +54,6 @@
 @moon-non-latin-header-title-below-font-size: 33px;
 @moon-non-latin-body-font-size:         27px;
 @moon-non-latin-body-small-font-size:   24px;
-@moon-non-latin-divider-font-size:      27px;
 @moon-non-latin-button-large-font-size: 36px;
 @moon-non-latin-button-small-font-size: 27px;
 @moon-non-latin-expandable-client-item-font-size: 27px;
@@ -187,11 +186,6 @@
 @moon-button-small-colordot-width: 21px;
 @moon-button-small-colordot-height: 6px;
 @moon-button-to-button-large-h-margin: 30px;
-
-// Divider
-// ---------------------------------------
-@moon-divider-border-width: 3px;
-@moon-divider-height: 39px;
 
 // Dropdown
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -222,6 +222,8 @@
 @moon-heading-spacing-large: 39px;
 @moon-heading-spacing-medium: 21px;
 @moon-heading-spacing-small: 9px;
+@moon-heading-padding: 0;
+@moon-heading-showline-padding: 0 0 9px 0;
 
 // Icon Button
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -27,7 +27,6 @@
 @moon-expandable-value-font-size-large:   30px;
 @moon-expandable-client-item-font-size:   27px;
 @moon-expandable-client-item-font-size-large:   33px;
-@moon-divider-font-size:            24px; // Deprecated?
 @moon-heading-large-font-size:      36px;
 @moon-heading-medium-font-size:     33px;
 @moon-heading-small-font-size:      27px;
@@ -118,13 +117,6 @@
 @moon-body-line-height: @moon-body-font-size + 6;
 @moon-body-line-height-large: @moon-body-line-height + 6; // The fact that this 6 is the same number as the above 6 is coincidental. LargeText is typically 6px larger than normal.
 @moon-non-latin-body-line-height: 1.7em;
-
-@moon-divider-font-family: @moon-font-family;
-@moon-divider-font-weight: bold;
-@moon-divider-font-style: italic;
-@moon-divider-letter-spacing: 0;
-@moon-divider-line-height: @moon-medium-header-line-height;
-@moon-divider-non-latin-line-height: @moon-non-latin-medium-header-line-height;
 
 @moon-heading-large-font-family: @moon-font-family;
 @moon-heading-large-font-weight: 600;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Heading text is too close to the line. It gives people anxiety; like driving really close to the cement barrier on the highway.


### Resolution
Added some space (according to the spec) between the text and the line, when the line is present. The design doc indicates that the space should be `12px`, however, the 12px spacing is based on the bottom of Korean characters, which don't include descenders or a taller-than-what's-visible line-height. Therefore this PR sets a `9px` padding, which accounts for a roughly `3px` inherent gap added by the line-height rule respecting taller glyphs and descenders. The net visual effect should be 12px total.


### Additional Considerations
Finally doing house-keeping on the ancient divider mixin, which should no longer be necessary with the built-in customizability of the newer `Heading` component.