### PR TITLE
PLAT-83146: Navigate from paging controls to items properly via 5way keys without focusableScrollbar

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to navigate from paging controls to items properly via 5way directional key presses
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -240,7 +240,8 @@ class ScrollButtons extends Component {
 		} else {
 			// If it is vertical `Scrollable`, move focus to the left for ltr or to the right for rtl
 			// If is is horizontal `Scrollable`, move focus to the up
-			const direction = !vertical && 'up' || rtl && 'right' || 'left';
+			const spotDirection = !vertical && 'up' || rtl && 'right' || 'left';
+			const keyDirection = getDirection(ev.keyCode);
 
 			if (Spotlight.getPointerMode()) {
 				// When changing from "pointer" mode to "5way key" mode,
@@ -248,11 +249,22 @@ class ScrollButtons extends Component {
 				// To make sure the content in `VirtualList` or `Scroller` to be focused after that, we used 50ms.
 				setTimeout(() => {
 					if (Spotlight.getCurrent() === target) {
-						Spotlight.move(direction);
+						Spotlight.move(spotDirection);
 					}
 				}, 50);
 			} else if (Spotlight.getCurrent() === target) {
-				Spotlight.move(direction);
+				Spotlight.move(spotDirection);
+
+				// If 5-way up on next button or 5-way down on previous button is pressed,
+				// Spotlight moves to that direction more.
+				// So preventDefault() and stopPropagation should not be called.
+				if (!(
+					target === this.nextButtonRef.current && (vertical && keyDirection === 'up' || !vertical && keyDirection === 'left') ||
+					target === this.prevButtonRef.current && (vertical && keyDirection === 'down' || !vertical && keyDirection === 'right')
+				)) {
+					ev.preventDefault();
+					ev.stopPropagation();
+				}
 			}
 		}
 	}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -477,7 +477,7 @@ const VirtualListBaseFactory = (type) => {
 					ev.stopPropagation();
 				} else {
 					const {repeat} = ev;
-					const {isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
+					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
 					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
 					const targetIndex = target.dataset.index;
 					const isScrollButton = (
@@ -538,7 +538,7 @@ const VirtualListBaseFactory = (type) => {
 					} else if (
 						directions.right && repeat ||
 						directions.left && Spotlight.move(direction) ||
-						(directions.up || directions.down) && (repeat || moveFocusStraight({id: this.props.spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent()))
+						(directions.up || directions.down) && focusableScrollbar && (repeat || moveFocusStraight({id: this.props.spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent()))
 					) {
 						ev.preventDefault();
 						ev.stopPropagation();

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -512,7 +512,7 @@ const VirtualListBaseFactory = (type) => {
 							ev.stopPropagation();
 							this.onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
 						} else {
-							const {dataSize, focusableScrollbar} = this.props;
+							const {dataSize} = this.props;
 							const column = index % dimensionToExtent;
 							const row = (index - column) % dataSize / dimensionToExtent;
 							isLeaving = directions.up && row === 0 ||


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When pressing 5-way direction keys on scroll buttons without focus option (focusableScrollbar), Spotlight moves to incorrect item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When pressing 5-way Up on next scroll button, 
1) Spotlight moves to out of VirtualList and 
2) Spotlight moves to the 5-way key direction.

For 1) case, it happened because scroll buttons could not get focus without focusableScrollbar prop. So I add the condition to skip manipulating spotlight by calling `moveFocusStraight`.

For 2) case, sometimes Spotlight should be just on the item next to the scroll button no matter which key is pressed. In this case, I called `preventDefault()` and `stopPropagation()`.

### Links
[//]: # (Related issues, references)

PLAT-83146