### PR TITLE
ENYO-6131: Fix not to handle 5-way key twice on paging control in VirtualList

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to navigate from paging controls to controls out of the list
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -538,7 +538,7 @@ const VirtualListBaseFactory = (type) => {
 					} else if (
 						directions.right && repeat ||
 						directions.left && Spotlight.move(direction) ||
-						(directions.up || directions.down) && (repeat || moveFocusStraight({id: this.props.spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent()))
+						(directions.up || directions.down) && (repeat && currentTarget.contains(Spotlight.getCurrent()) || moveFocusStraight({id: this.props.spotlightId, direction}))
 					) {
 						ev.preventDefault();
 						ev.stopPropagation();


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

5-way key on paging control was handled twice in VirtualList and Spotlight. So Spotlight moved to incorrect item. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Even though 5-way key was handled in VirtualList, `preventDefault()` and `stopPropagation() were not called when Spotlight moved out of the list. So those functions are forced to be called when the key is handled in VirtualList.

### Links
[//]: # (Related issues, references)

ENYO-6131