### PR TITLE
ENYO-6082: Navigate items properly in VirtualList in RTL languages

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to navigate items properly in RTL languages
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -554,7 +554,7 @@ class ScrollableBase extends Component {
 
 		if (scrollability) {
 			const
-				isRtl = this.uiRef.current.state.rtl,
+				isRtl = this.uiRef.current.props.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
 			this.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
@@ -634,7 +634,7 @@ class ScrollableBase extends Component {
 
 	scrollAndFocusScrollbarButton = (direction) => {
 		const
-			isRtl = this.uiRef.current.state.rtl,
+			isRtl = this.uiRef.current.props.rtl,
 			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 			isHorizontalDirection = direction === 'left' || direction === 'right',
 			isVerticalDirection = direction === 'up' || direction === 'down';
@@ -823,7 +823,7 @@ class ScrollableBase extends Component {
 	onVoice = (e) => {
 		const
 			isHorizontal = this.props.direction === 'horizontal',
-			isRtl = this.uiRef.current.state.rtl,
+			isRtl = this.uiRef.current.props.rtl,
 			{scrollTop, scrollLeft} = this.uiRef.current,
 			{maxLeft, maxTop} = this.uiRef.current.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -619,7 +619,7 @@ class ScrollableBaseNative extends Component {
 
 		if (scrollability) {
 			const
-				isRtl = this.uiRef.current.state.rtl,
+				isRtl = this.uiRef.current.props.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
 			this.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
@@ -699,7 +699,7 @@ class ScrollableBaseNative extends Component {
 
 	scrollAndFocusScrollbarButton = (direction) => {
 		const
-			isRtl = this.uiRef.current.state.rtl,
+			isRtl = this.uiRef.current.props.rtl,
 			isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 			isHorizontalDirection = direction === 'left' || direction === 'right',
 			isVerticalDirection = direction === 'up' || direction === 'down';
@@ -888,7 +888,7 @@ class ScrollableBaseNative extends Component {
 	onVoice = (e) => {
 		const
 			isHorizontal = this.props.direction === 'horizontal',
-			isRtl = this.uiRef.current.state.rtl,
+			isRtl = this.uiRef.current.props.rtl,
 			{scrollTop, scrollLeft} = this.uiRef.current,
 			{maxLeft, maxTop} = this.uiRef.current.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

VirtualList scrolls to the incorrect direction in RTL languages.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`ui/Scrollable` had `RTL` information as not `state` but `props` from https://github.com/enactjs/enact/pull/2035. But `moonstone/Scrollable` tried to get the RTL information in `ui/Scrollable`'s `state` incorrectly. So I fixed to get it from the `props`.

### Links
[//]: # (Related issues, references)

ENYO-6082