### PR TITLE
ENYO-6130: Pass spotlightDisabled prop from list or scroller to scroll buttons

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses
+- `moonstone/Scroller.Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` scrollbar buttons not to get focus when spotlight deactivates
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -116,6 +116,15 @@ class ScrollButtons extends Component {
 		rtl: PropTypes.bool,
 
 		/**
+		 * When `true`, the component cannot be navigated using spotlight.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		spotlightDisabled: PropTypes.bool,
+
+		/**
 		 * The scrollbar will be oriented vertically.
 		 *
 		 * @type {Boolean}
@@ -128,7 +137,8 @@ class ScrollButtons extends Component {
 	static defaultProps = {
 		focusableScrollButtons: false,
 		onNextScroll: nop,
-		onPrevScroll: nop
+		onPrevScroll: nop,
+		spotlightDisabled: false
 	}
 
 	constructor (props) {
@@ -319,6 +329,7 @@ class ScrollButtons extends Component {
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
 				ref={this.prevButtonRef}
+				spotlightDisabled={this.props.spotlightDisabled}
 			>
 				{prevIcon}
 			</ScrollButton>,
@@ -337,6 +348,7 @@ class ScrollButtons extends Component {
 				onSpotlightRight={this.onSpotlight}
 				onSpotlightUp={this.onSpotlight}
 				ref={this.nextButtonRef}
+				spotlightDisabled={this.props.spotlightDisabled}
 			>
 				{nextIcon}
 			</ScrollButton>,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -963,6 +963,7 @@ class ScrollableBase extends Component {
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
+									spotlightDisabled={spotlightContainerDisabled}
 								/> :
 								null
 							}
@@ -977,6 +978,7 @@ class ScrollableBase extends Component {
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}
+								spotlightDisabled={spotlightContainerDisabled}
 							/> :
 							null
 						}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -1027,6 +1027,7 @@ class ScrollableBaseNative extends Component {
 									nextButtonAriaLabel={downButtonAriaLabel}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
+									spotlightDisabled={spotlightContainerDisabled}
 								/> :
 								null
 							}
@@ -1041,6 +1042,7 @@ class ScrollableBaseNative extends Component {
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								previousButtonAriaLabel={leftButtonAriaLabel}
 								rtl={rtl}
+								spotlightDisabled={spotlightContainerDisabled}
 							/> :
 							null
 						}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Even though a list or a scroller has a `spotlightDisabled` prop, the scroll buttons in it has spotlight when holding them.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Pass spotlightDisabled prop from a list or a scroller to scroll buttons

### Links
[//]: # (Related issues, references)

ENYO-6130