### PR TITLE
ENYO-6128: Fix Input disabled focus color

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Input` disabled focus text color
+
 ## [3.0.0-beta.2] - 2019-07-23
 
 ### Added

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -157,7 +157,7 @@
 @moon-input-placeholder-focus-color:  @moon-input-decorator-bg-color;
 @moon-input-placeholder-active-color: @moon-input-placeholder-focus-color;
 @moon-input-focus-text-color:         @moon-dark-gray;
-@moon-input-disabled-text-color:      fade(@moon-white, 60%);
+@moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -177,7 +177,7 @@
 @moon-input-placeholder-focus-color:  @moon-input-decorator-bg-color;
 @moon-input-placeholder-active-color: @moon-input-placeholder-focus-color;
 @moon-input-focus-text-color:         @moon-dark-gray;
-@moon-input-disabled-text-color:      @moon-white;
+@moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `Input` disabled focus color so that it's not the same as the background color.
We could remove `@moon-input-disabled-text-color` all together, but decided to keep it for future references in case we do need to use disabled text color again.



### Links
[//]: # (Related issues, references)
ENYO-6128
