### PR TITLE
ENYO-6131: Fix VirtualList to properly prevent keydown events from sc…

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Spinner` to use the latest designs
 - `moonstone/Tooltip` layer order so it doesn't interfere with other positioned elements, like `ContextualPopup`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly respond to 5way directional key presses
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly navigate from paging controls to controls out of the list
 
 ## [3.0.0-beta.1] - 2019-07-15
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -2,7 +2,7 @@ import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import Accelerator from '@enact/spotlight/Accelerator';
 import Pause from '@enact/spotlight/Pause';
-import Spottable from '@enact/spotlight/Spottable';
+import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
@@ -27,7 +27,8 @@ const
 	Native = 'Native',
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0,
-	nop = () => {};
+	nop = () => {},
+	spottableSelector = `.${spottableClass}`;
 
 /**
  * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
@@ -403,6 +404,19 @@ const VirtualListBaseFactory = (type) => {
 			return {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex};
 		}
 
+		getScrollButtons = () => {
+			const {spotlightId} = this.props;
+			const {containerRef: {current}} = this.uiRefCurrent;
+
+			return [...document.querySelectorAll(`[data-spotlight-id="${spotlightId}"] ${spottableSelector}`)]
+				.reduce((result, item, index, spottables) => {
+					if (!current.contains(item)) {
+						result[index === spottables.length - 1 ? 'last' : 'first'] = item;
+					}
+					return result;
+				}, {});
+		}
+
 		/**
 		 * Handle `onKeyDown` event
 		 */
@@ -434,7 +448,7 @@ const VirtualListBaseFactory = (type) => {
 					this.isWrappedBy5way = isWrapped;
 
 					if (isWrapped && (
-						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}'].spottable`) == null
+						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
 					)) {
 						if (wrap === true) {
 							this.pause.pause();
@@ -471,7 +485,7 @@ const VirtualListBaseFactory = (type) => {
 					ev.stopPropagation();
 				} else {
 					const {repeat} = ev;
-					const {isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
+					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
 					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
 					const targetIndex = target.dataset.index;
 					const isScrollButton = (
@@ -506,7 +520,7 @@ const VirtualListBaseFactory = (type) => {
 							ev.stopPropagation();
 							this.onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
 						} else {
-							const {dataSize, focusableScrollbar} = this.props;
+							const {dataSize} = this.props;
 							const column = index % dimensionToExtent;
 							const row = (index - column) % dataSize / dimensionToExtent;
 							isLeaving = directions.up && row === 0 ||
@@ -530,18 +544,15 @@ const VirtualListBaseFactory = (type) => {
 
 						}
 					} else {
-						const spottables = Spotlight.getSpottableDescendants(spotlightId);
-						const spottablesTotal = spottables.length;
-						const firstScrollButton = spottables[spottablesTotal - 2];
-						const lastScrollButton = spottables[spottablesTotal - 1];
-						const isLastScrollButton = target === lastScrollButton;
+						const {first, last} = this.getScrollButtons();
+						const isLastScrollButton = target === last;
 
 						if (
 							directions.right && repeat ||
 							directions.left && Spotlight.move(direction) ||
 							(directions.up && !isLastScrollButton || directions.down && isLastScrollButton) && repeat ||
-							directions.down && !isLastScrollButton && Spotlight.focus(lastScrollButton) ||
-							directions.up && isLastScrollButton && Spotlight.focus(firstScrollButton)
+							directions.down && !isLastScrollButton && (focusableScrollbar && Spotlight.focus(last) || Spotlight.move(direction)) ||
+							directions.up && isLastScrollButton && (focusableScrollbar && Spotlight.focus(first) || Spotlight.move(direction))
 						) {
 							ev.preventDefault();
 							ev.stopPropagation();
@@ -584,7 +595,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		focusByIndex = (index) => {
-			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}'].spottable`);
+			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}']${spottableSelector}`);
 
 			if (!item && index >= 0 && index < this.props.dataSize) {
 				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -27,13 +27,7 @@ const
 	Native = 'Native',
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0,
-	nop = () => {},
-	moveFocusStraight = ({direction, id}) => {
-		Spotlight.set(id, {straightOnly: true});
-		const moved = Spotlight.move(direction);
-		Spotlight.set(id, {straightOnly: false});
-		return moved;
-	};
+	nop = () => {};
 
 /**
  * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
@@ -467,7 +461,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		onKeyDown = (ev) => {
-			const {currentTarget, keyCode, target} = ev;
+			const {keyCode, target} = ev;
 			const direction = getDirection(keyCode);
 
 			if (direction) {
@@ -537,14 +531,17 @@ const VirtualListBaseFactory = (type) => {
 						}
 					} else {
 						const spottables = Spotlight.getSpottableDescendants(spotlightId);
-						const lastSpottable = spottables[spottables.length - 1];
-						const isBottomScrollButton = target === lastSpottable;
+						const spottablesTotal = spottables.length;
+						const firstScrollButton = spottables[spottablesTotal - 2];
+						const lastScrollButton = spottables[spottablesTotal - 1];
+						const isLastScrollButton = target === lastScrollButton;
 
 						if (
 							directions.right && repeat ||
 							directions.left && Spotlight.move(direction) ||
-							(directions.up && !isBottomScrollButton || directions.down && isBottomScrollButton) && repeat ||
-							(directions.down && !isBottomScrollButton || directions.up && isBottomScrollButton) && moveFocusStraight({id: spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent())
+							(directions.up && !isLastScrollButton || directions.down && isLastScrollButton) && repeat ||
+							directions.down && !isLastScrollButton && Spotlight.focus(lastScrollButton) ||
+							directions.up && isLastScrollButton && Spotlight.focus(firstScrollButton)
 						) {
 							ev.preventDefault();
 							ev.stopPropagation();

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -28,7 +28,7 @@ const
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0,
 	nop = () => {},
-	moveFocusStraight = ({direction, id}) => {
+	moveFocusStraight = ({direction, ev, id}) => {
 		Spotlight.set(id, {straightOnly: true});
 		const moved = Spotlight.move(direction);
 		Spotlight.set(id, {straightOnly: false});
@@ -535,15 +535,22 @@ const VirtualListBaseFactory = (type) => {
 							}
 
 						}
-					} else if (
-						directions.right && repeat ||
-						directions.left && Spotlight.move(direction) ||
-						(directions.up || directions.down) && (repeat || moveFocusStraight({id: this.props.spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent()))
-					) {
-						ev.preventDefault();
-						ev.stopPropagation();
-					} else if (!repeat) {
-						isLeaving = true;
+					} else {
+						const spottables = Spotlight.getSpottableDescendants(spotlightId);
+						const lastSpottable = spottables[spottables.length - 1];
+						const isBottomScrollButton = target === lastSpottable;
+
+						if (
+							directions.right && repeat ||
+							directions.left && Spotlight.move(direction) ||
+							(directions.up && !isBottomScrollButton || directions.down && isBottomScrollButton) && repeat ||
+							(directions.down && !isBottomScrollButton || directions.up && isBottomScrollButton) && moveFocusStraight({id: spotlightId, direction}) && currentTarget.contains(Spotlight.getCurrent())
+						) {
+							ev.preventDefault();
+							ev.stopPropagation();
+						} else if (!repeat) {
+							isLeaving = true;
+						}
 					}
 
 					if (isLeaving) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -28,7 +28,7 @@ const
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0,
 	nop = () => {},
-	moveFocusStraight = ({direction, ev, id}) => {
+	moveFocusStraight = ({direction, id}) => {
 		Spotlight.set(id, {straightOnly: true});
 		const moved = Spotlight.move(direction);
 		Spotlight.set(id, {straightOnly: false});


### PR DESCRIPTION
…roll buttons

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When attempting to use 5way to leave a `VirtualList` while focus is on the scroll button, `onKeyDown` event bubbling is not prevented and/or allowed properly, causing a condition where focus can change twice for a single key press.


### Resolution
We can identify which scroll button has focus and depending on the 5way direction pressed (and whether the event is repeating), we can properly manage which events are bubbled - which will allow spotlight to handle the focus change rather than `VirtualList`.

We've been hesitant to import the `ScrollBar.module.less` into `VirtualListBase`, since we do not want to create more dependencies. So in order to identify which scroll button has focus, I opted to use `Spotlight.getSpottableDescendants(spotlightId);`, where the last spottable element returned is the last scroll button (bottom button in a vertical list, right button in a horizontal list, left button in a RTL horizontal list). The logic used applies to all these scenarios, so this change appears safe. I'l like to hear any thoughts or concerns.
