### PR TITLE
PLAT-83255: Corrected a non-sequitur variable association

### DIFF
--- a/packages/moonstone/styles/mixins.less
+++ b/packages/moonstone/styles/mixins.less
@@ -114,7 +114,7 @@
 .moon-text-base(@font-size: @moon-body-font-size; @target: normal) {
 	.moon-font({
 		font-weight: @moon-non-latin-font-weight;
-		font-size: @moon-non-latin-header-title-below-font-size;
+		font-size: @moon-non-latin-base-font-size;
 		line-height: @moon-non-latin-body-line-height;
 	}, @target);
 	font-weight: normal;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -51,7 +51,8 @@
 @moon-non-latin-pre-text-size:          24px;
 @moon-non-latin-popup-header-font-size: 66px;
 @moon-non-latin-header-font-size:       57px;
-@moon-non-latin-header-title-below-font-size: 24px;
+@moon-non-latin-header-title-below-font-size: (@moon-header-title-below-font-size - 3px);
+@moon-non-latin-base-font-size:         @moon-body-font-size;
 @moon-non-latin-body-font-size:         27px;
 @moon-non-latin-body-small-font-size:   24px;
 @moon-non-latin-button-large-font-size: 36px;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -46,13 +46,13 @@
 @moon-input-small-font-size:        36px;
 @moon-tooltip-label-font-size:      27px;
 
+@moon-non-latin-base-font-size:         33px;
 @moon-non-latin-superscript-text-size:  24px;
 @moon-non-latin-large-text-size:        48px;
 @moon-non-latin-pre-text-size:          24px;
 @moon-non-latin-popup-header-font-size: 66px;
 @moon-non-latin-header-font-size:       57px;
 @moon-non-latin-header-title-below-font-size: (@moon-header-title-below-font-size - 3px);
-@moon-non-latin-base-font-size:         @moon-body-font-size;
 @moon-non-latin-body-font-size:         27px;
 @moon-non-latin-body-small-font-size:   24px;
 @moon-non-latin-button-large-font-size: 36px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Items all over got their text set to be too small.

### Resolution
The font size for the commonly used mixin `.moon-text-base` was, for some legacy reason, using the Header titleBelow font size to set the non-Latin font size. When this changed, via normal GUI request to fix the header font size, the body text mixin, in turn, also got smaller for non-Latin.

The solution is to create a `base` variable for the mixin to use instead of depending on some unrelated value, since the two can diverge unexpectedly.