### PR TITLE
ENYO-6090: Change Scroller to support page up/down when scrollbars are hidden

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Panels.Header` prop `hideLine` to hide the bottom separator line
 
+### Changed
+
+- `moonstone/Scroller` and other scrolling components to scroll via remote page up/down buttons when the scrollbar is hidden
+
 ### Fixed
 
 - `moonstone/Dropdown` button to not animate

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -489,12 +489,6 @@ class ScrollableBase extends Component {
 	}
 
 	scrollByPage = (direction) => {
-		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
-		// scroller as a plain container
-		if (!this.uiRef.current.state.isVerticalScrollbarVisible) {
-			return false;
-		}
-
 		const
 			{childRefCurrent, scrollTop} = this.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
@@ -531,8 +525,6 @@ class ScrollableBase extends Component {
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
 		}
-
-		return true;
 	}
 
 	hasFocus () {
@@ -568,8 +560,10 @@ class ScrollableBase extends Component {
 		this.animateOnFocus = true;
 
 		if (!repeat && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-			let direction = isPageUp(keyCode) ? 'up' : 'down';
-			if (this.scrollByPage(direction) && this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+			const direction = isPageUp(keyCode) ? 'up' : 'down';
+
+			this.scrollByPage(direction);
+			if (this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
 				this.checkAndApplyOverscrollEffectByDirection(direction);
 			}
 		}
@@ -594,7 +588,8 @@ class ScrollableBase extends Component {
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
-					if (this.scrollByPage(direction) && overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+					this.scrollByPage(direction);
+					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -554,12 +554,6 @@ class ScrollableBaseNative extends Component {
 	}
 
 	scrollByPage = (direction) => {
-		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
-		// scroller as a plain container
-		if (!this.uiRef.current.state.isVerticalScrollbarVisible) {
-			return false;
-		}
-
 		const
 			{childRefCurrent, scrollTop} = this.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
@@ -596,8 +590,6 @@ class ScrollableBaseNative extends Component {
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
 		}
-
-		return true;
 	}
 
 	hasFocus () {
@@ -633,8 +625,10 @@ class ScrollableBaseNative extends Component {
 		this.animateOnFocus = true;
 
 		if (!repeat && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-			let direction = isPageUp(keyCode) ? 'up' : 'down';
-			if (this.scrollByPage(direction) && this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+			const direction = isPageUp(keyCode) ? 'up' : 'down';
+
+			this.scrollByPage(direction);
+			if (this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
 				this.checkAndApplyOverscrollEffectByDirection(direction);
 			}
 		}
@@ -659,7 +653,8 @@ class ScrollableBaseNative extends Component {
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
-					if (this.scrollByPage(direction) && overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+					this.scrollByPage(direction);
+					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -111,6 +111,7 @@ storiesOf('Moonstone', module)
 				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 				direction={select('direction', prop.direction, Config, 'vertical')}
 				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', Config, 180)),
@@ -119,6 +120,7 @@ storiesOf('Moonstone', module)
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 20))}
+				verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 			/>
 		),

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -101,6 +101,7 @@ storiesOf('Moonstone', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -6,7 +6,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
-import {boolean, number} from '../../src/enact-knobs';
+import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
@@ -59,6 +59,7 @@ storiesOf('VirtualGridList', module)
 				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 				direction="horizontal"
 				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
+				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', Config, 180)),

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -9,7 +9,7 @@ import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 
-import {boolean, number} from '../../src/enact-knobs';
+import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
 const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBase, UiVirtualListBase);
@@ -136,6 +136,7 @@ storiesOf('VirtualList', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 				/>
 			);
 		},
@@ -155,6 +156,7 @@ storiesOf('VirtualList', module)
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config, 0))}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
 				/>
 			);
 		}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -702,10 +702,6 @@ class ScrollableBase extends Component {
 	}
 
 	scrollByPage = (keyCode) => {
-		// Only scroll by page when the vertical scrollbar is visible. Otherwise, treat the
-		// scroller as a plain container
-		if (!this.state.isVerticalScrollbarVisible) return;
-
 		const
 			bounds = this.getScrollBounds(),
 			canScrollVertically = this.canScrollVertically(bounds),


### PR DESCRIPTION
…r is hidden

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
A behavior change in needed for scrolling components (`Scroller`, `VirtualList`, etc) so that they can respond to and scroll when a remote paging key (channel up/down) is pressed when the scrollbar is hidden. Currently no action is taken.


### Resolution
We had specific guards against performing the requested scrolling action when scrollbars were hidden. We can remove this guard now. It should be noted that the existing behavior only affects vertical scrolling when a paging key is pressed.

