### PR TITLE
ENYO-6080: Fix VideoPlayer feedback tooltip overlap

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-[unreleased]
+## [unreleased]
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,9 +6,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VideoPlayer` feedback tooltip non-latin overlap
-- `moonstone/Scroller` not to scroll horizontally via 5-way down in horizontal scroller
-- `moonstone/Scroller` not to jump to the top when right key is pressed in the right most item of vertical scroller
+- `moonstone/VideoPlayer` feedback tooltip to overlap in non-latin locale
+- `moonstone/Scroller` to no scroll horizontally via 5-way down in horizontal scroller
+- `moonstone/Scroller` to not jump to the top when right key is pressed in the right most item of a vertical scroller
 
 ## [3.0.0-beta.2] - 2019-07-23
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+[unreleased]
+
+### Fixed
+
+- `moonstone/VideoPlayer` feedback tooltip non-latin overlap
+
 ## [3.0.0-beta.2] - 2019-07-23
 
 ### Added

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.module.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.module.less
@@ -49,6 +49,10 @@
 		.content {
 			transform: translateX(-100%) translateX(0);
 		}
+
+		.content {
+			text-align: right;
+		}
 	}
 
 	.applySkins({

--- a/packages/moonstone/VideoPlayer/FeedbackTooltip.module.less
+++ b/packages/moonstone/VideoPlayer/FeedbackTooltip.module.less
@@ -5,6 +5,9 @@
 @import "../styles/skin.less";
 
 .feedbackTooltip {
+	position: absolute;
+	bottom: @moon-video-slider-tooltip-position-bottom;
+
 	&.hidden {
 		display: none;
 	}
@@ -16,8 +19,6 @@
 	}
 
 	.thumbnail {
-		position: absolute;
-		bottom: (@moon-video-slider-tooltip-line-height + @moon-spotlight-outset);
 		border-width: @moon-video-slider-tooltip-thumbnail-border-width;
 		border-style: solid;
 		border-radius: 0;
@@ -41,8 +42,6 @@
 		.moon-text-base(@moon-video-slider-tooltip-font-size);
 		line-height: @moon-video-slider-tooltip-line-height;
 		white-space: nowrap;
-		position: absolute;
-		bottom: @moon-spotlight-outset;
 	}
 
 	&.afterMidpoint {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -461,6 +461,7 @@
 
 // Video
 // ---------------------------------------
+@moon-video-slider-tooltip-position-bottom:        @moon-spotlight-outset;
 @moon-video-slider-tooltip-font-size:              24px;
 @moon-video-slider-tooltip-line-height:            36px;
 @moon-video-slider-tooltip-gutter-width:           12px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Moved positioning rules to `. feedbackTooltip`  from `.content` and `.thumbnail` so the elements within `.feedbackTooltip` has default non overlapping layout.

### Links
[//]: # (Related issues, references)
ENYO-6080
