### PR TITLE
ENYO-6135: Not scroll horizontally via 5-way down in horizontal scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Scroller` not to scroll horizontally via 5-way down in horizontal scroller
+
 ## [3.0.0-beta.2] - 2019-07-23
 
 ### Added

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -313,7 +313,8 @@ class ScrollerBase extends Component {
 				pos = isVerticalDirection ? top : left,
 				max = isVerticalDirection ? maxTop : maxLeft;
 
-			if (pos >= 0 && pos <= max) {
+			// If max is equal to 0, it means scroller can not scroll to the direction.
+			if (pos >= 0 && pos <= max && max !== 0) {
 				this.props.scrollAndFocusScrollbarButton(direction);
 			}
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When 5-way Down on the first item in a horizontal scroller, the scroller scrolls horizontally.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If 5-way down is pressed and there is no more spottable items to the direction in a vertical scroller, the scroller scrolls vertically. But if it is a horizontal scroller, we don't have to scroll. So I guard this action with a condition not to scroll.

### Links
[//]: # (Related issues, references)

ENYO-6135