### PR TITLE
ENYO-6139: Update LG dingbat font name

### DIFF
--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -19,7 +19,7 @@
 @font-system-src-non-latin-700:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold");
 
 @font-system-src-moonstone-icons:  local("Moonstone"), url("../../fonts/Moonstone.ttf") format("truetype");
-@font-system-src-lg-icons:         local("LG Display_Dingbat");
+@font-system-src-lg-icons:         local("LG Smart UI Dingbat");
 
 // Fonts are ready now, but we can't distribute them in the package.
 // When should font changes go into moonstone?


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
LG dingbat font name is changed

### Resolution
Change to `LG Smart UI Dingbat`

### Links
ENYO-6139