### PR TITLE
ENYO-6142: Fix tooltip arrow gap

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/VideoPlayer` feedback tooltip to overlap in non-latin locale
 - `moonstone/Scroller` to no scroll horizontally via 5-way down in horizontal scroller
 - `moonstone/Scroller` to not jump to the top when right key is pressed in the right most item of a vertical scroller
+- `moonstone/Tooltip` arrow gap
 
 ## [3.0.0-beta.2] - 2019-07-23
 

--- a/packages/moonstone/TooltipDecorator/Tooltip.module.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.module.less
@@ -45,12 +45,12 @@
 		}
 	}
 	&.centerArrow .tooltipArrow {
-		width: ((@moon-tooltip-point-height / 2) + 2px);
+		width: ((@moon-tooltip-point-height / 2) + 3px);
 		height: @moon-tooltip-point-width;
 		left: 50%;
 
 		&::after {
-			right: 81%;
+			right: ((@moon-tooltip-point-height / 2) + 1px);
 		}
 	}
 	&.middleArrow .tooltipArrow {

--- a/packages/moonstone/TooltipDecorator/Tooltip.module.less
+++ b/packages/moonstone/TooltipDecorator/Tooltip.module.less
@@ -50,7 +50,7 @@
 		left: 50%;
 
 		&::after {
-			right: ((@moon-tooltip-point-height / 2) + 1px);
+			right: 81%;
 		}
 	}
 	&.middleArrow .tooltipArrow {


### PR DESCRIPTION
### Checklist


### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix tooltip arrow gap with an updated width for `.tooltipArrow`

### Links
[//]: # (Related issues, references)
Fix tooltip arrow gap

