### PR TITLE
ENYO-6153: Fix Picker to avoid overlapping items on render

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Picker` to avoid overlapping items on render
+
 ## [3.0.0-rc.1] - 2019-07-31
 
 ### Added

--- a/packages/moonstone/internal/Picker/Picker.module.less
+++ b/packages/moonstone/internal/Picker/Picker.module.less
@@ -161,15 +161,18 @@
 		width: 300px;
 	}
 
-	&.small,
-	&.medium,
-	&.large {
-		.valueWrapper {
-			position: relative;
+	&.horizontal {
+		&.small,
+		&.medium,
+		&.large {
+			.valueWrapper {
+				position: relative;
 
-			.item {
-				position: absolute;
-				.position(0);
+				.item {
+					position: absolute;
+					.position(0);
+					transform: translateX(100%);
+				}
 			}
 		}
 	}
@@ -186,6 +189,7 @@
 		.item {
 			position: absolute;
 			.position(0);
+			transform: translateY(100%);
 		}
 	}
 

--- a/packages/ui/ViewManager/Arranger.js
+++ b/packages/ui/ViewManager/Arranger.js
@@ -81,6 +81,10 @@ export const SlideArranger = ({amount = 100, direction}) => ({
 	leave: (config) => arrange(config, [
 		{transform: slideInOut('out', 0, direction)},
 		{transform: slideInOut('out', amount, direction)}
+	]),
+	stay: (config) => arrange(config, [
+		{transform: slideInOut('in', 0, direction)},
+		{transform: slideInOut('in', 0, direction)}
 	])
 });
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Picker currently renders all picker items visible and relies on the ViewManager arranger to position them correctly. Normally, this isn't visible but can be seen on lower powered hardware.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Render the picker items out of the viewport by default and then move them into view.
* Add a "stay" animation to the SlideArrangers to correctly position the items on render


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The "stay" animation is a no-op under typical ViewManager uses where the view was already at no translation. In VM, it's called when a view is first rendered ("appears") without animation. The effect in Picker is that the view is initially rendered out of view but immediately moved into view on mount.
