### PR TITLE
PLAT-83422: Fix VirtualList to scroll via channel up and down keys on vertical paging controls in pointer mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys on any paging controls in pointer mode
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys on any vertical paging controls in pointer mode
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys on any vertical paging controls in pointer mode
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys when focus is on any vertical paging control while in pointer mode
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys on any paging controls in pointer mode
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via channel up or down keys when focus is on any vertical paging control while in pointer mode
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via a page up or down key when focus is on any vertical paging control while in pointer mode
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -277,7 +277,7 @@ class ScrollButtons extends Component {
 			{keyCode} = ev;
 
 		if (isPageDown(keyCode)) {
-			if (focusableScrollButtons) {
+			if (focusableScrollButtons && !Spotlight.getPointerMode()) {
 				preventDefault(ev);
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(ReactDOM.findDOMNode(this.nextButtonRef.current)); // eslint-disable-line react/no-find-dom-node
@@ -300,7 +300,7 @@ class ScrollButtons extends Component {
 			{keyCode} = ev;
 
 		if (isPageUp(keyCode)) {
-			if (focusableScrollButtons) {
+			if (focusableScrollButtons && !Spotlight.getPointerMode()) {
 				preventDefault(ev);
 				Spotlight.setPointerMode(false);
 				Spotlight.focus(ReactDOM.findDOMNode(this.prevButtonRef.current)); // eslint-disable-line react/no-find-dom-node


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing a Channel Up or Down key on Scroll Buttons In pointer mode, VirtuaList or Scroller did not scroll and Spotlight is on the other Scroll Button if there is the Scroll Button to the direction.

For example,
1. Hover the Up Paging Control at the top of the VirtualList with focusableScrollbar prop of `true`
2. Channel Down

Expected Result: The VirtualList scrolls and Spotlight is still on the Up Paging Control
Actual Result: The VirtualList does not scroll and Spotlight is the other Scroll Button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If it is pointer mode, then VirtualList and Scroller just scrolls. I added the condition to make a decision to move focus or to scroll.

### Links
[//]: # (Related issues, references)

PLAT-83422
