### PR TITLE
PLAT-83423: Fix VirtualList not to scroll via channel up and down keys on horizontal paging controls

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll via channel up or down keys on horizontal paging controls
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll via channel up or down keys on horizontal paging controls
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to scroll via a page up or down key when focus is on any horizontal paging control
 
 ## [3.0.0-rc.1] - 2019-07-31
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -277,6 +277,7 @@ class ScrollButtons extends Component {
 			{keyCode} = ev;
 
 		if (!vertical) {
+			ev.preventDefault();
 			return;
 		}
 
@@ -304,6 +305,7 @@ class ScrollButtons extends Component {
 			{keyCode} = ev;
 
 		if (!vertical) {
+			ev.preventDefault();
 			return;
 		}
 

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -276,24 +276,26 @@ class ScrollButtons extends Component {
 			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (!vertical) {
-			ev.preventDefault();
-			return;
-		}
-
-		if (isPageDown(keyCode)) {
-			if (focusableScrollButtons && !Spotlight.getPointerMode()) {
-				preventDefault(ev);
-				Spotlight.setPointerMode(false);
-				Spotlight.focus(ReactDOM.findDOMNode(this.nextButtonRef.current)); // eslint-disable-line react/no-find-dom-node
-			} else if (!nextButtonDisabled) {
-				preventDefault(ev);
-				this.onClickNext(ev);
+		if (isPageDown(keyCode) || isPageUp(keyCode)) {
+			if (!vertical) {
+				ev.preventDefault();
+				return;
 			}
-		} else if (isPageUp(keyCode)) {
-			if (!prevButtonDisabled) {
-				preventDefault(ev);
-				this.onClickPrev(ev);
+
+			if (isPageDown(keyCode)) {
+				if (focusableScrollButtons && !Spotlight.getPointerMode()) {
+					preventDefault(ev);
+					Spotlight.setPointerMode(false);
+					Spotlight.focus(ReactDOM.findDOMNode(this.nextButtonRef.current)); // eslint-disable-line react/no-find-dom-node
+				} else if (!nextButtonDisabled) {
+					preventDefault(ev);
+					this.onClickNext(ev);
+				}
+			} else {
+				if (!prevButtonDisabled) {
+					preventDefault(ev);
+					this.onClickPrev(ev);
+				}
 			}
 		}
 	}
@@ -304,24 +306,26 @@ class ScrollButtons extends Component {
 			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
 
-		if (!vertical) {
-			ev.preventDefault();
-			return;
-		}
-
-		if (isPageUp(keyCode)) {
-			if (focusableScrollButtons && !Spotlight.getPointerMode()) {
-				preventDefault(ev);
-				Spotlight.setPointerMode(false);
-				Spotlight.focus(ReactDOM.findDOMNode(this.prevButtonRef.current)); // eslint-disable-line react/no-find-dom-node
-			} else if (!prevButtonDisabled) {
-				preventDefault(ev);
-				this.onClickPrev(ev);
+		if (isPageDown(keyCode) || isPageUp(keyCode)) {
+			if (!vertical) {
+				ev.preventDefault();
+				return;
 			}
-		} else if (isPageDown(keyCode)) {
-			if (!nextButtonDisabled) {
-				preventDefault(ev);
-				this.onClickNext(ev);
+
+			if (isPageUp(keyCode)) {
+				if (focusableScrollButtons && !Spotlight.getPointerMode()) {
+					preventDefault(ev);
+					Spotlight.setPointerMode(false);
+					Spotlight.focus(ReactDOM.findDOMNode(this.prevButtonRef.current)); // eslint-disable-line react/no-find-dom-node
+				} else if (!prevButtonDisabled) {
+					preventDefault(ev);
+					this.onClickPrev(ev);
+				}
+			} else {
+				if (!nextButtonDisabled) {
+					preventDefault(ev);
+					this.onClickNext(ev);
+				}
 			}
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -291,8 +291,7 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickNext(ev);
 				}
-			} else {
-				if (!prevButtonDisabled) {
+			} else if (!prevButtonDisabled) {
 					preventDefault(ev);
 					this.onClickPrev(ev);
 				}
@@ -321,8 +320,7 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickPrev(ev);
 				}
-			} else {
-				if (!nextButtonDisabled) {
+			} else if (!nextButtonDisabled) {
 					preventDefault(ev);
 					this.onClickNext(ev);
 				}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -291,11 +291,9 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickNext(ev);
 				}
-			} else {
-				if (!prevButtonDisabled) {
-					preventDefault(ev);
-					this.onClickPrev(ev);
-				}
+			} else if (!prevButtonDisabled) {
+				preventDefault(ev);
+				this.onClickPrev(ev);
 			}
 		}
 	}
@@ -321,11 +319,9 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickPrev(ev);
 				}
-			} else {
-				if (!nextButtonDisabled) {
-					preventDefault(ev);
-					this.onClickNext(ev);
-				}
+			} else if (!nextButtonDisabled) {
+				preventDefault(ev);
+				this.onClickNext(ev);
 			}
 		}
 	}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -291,7 +291,8 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickNext(ev);
 				}
-			} else if (!prevButtonDisabled) {
+			} else {
+				if (!prevButtonDisabled) {
 					preventDefault(ev);
 					this.onClickPrev(ev);
 				}
@@ -320,7 +321,8 @@ class ScrollButtons extends Component {
 					preventDefault(ev);
 					this.onClickPrev(ev);
 				}
-			} else if (!nextButtonDisabled) {
+			} else {
+				if (!nextButtonDisabled) {
 					preventDefault(ev);
 					this.onClickNext(ev);
 				}

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -272,9 +272,13 @@ class ScrollButtons extends Component {
 
 	onKeyDownPrev = (ev) => {
 		const
-			{focusableScrollButtons} = this.props,
+			{focusableScrollButtons, vertical} = this.props,
 			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
+
+		if (!vertical) {
+			return;
+		}
 
 		if (isPageDown(keyCode)) {
 			if (focusableScrollButtons) {
@@ -295,9 +299,13 @@ class ScrollButtons extends Component {
 
 	onKeyDownNext = (ev) => {
 		const
-			{focusableScrollButtons} = this.props,
+			{focusableScrollButtons, vertical} = this.props,
 			{nextButtonDisabled, prevButtonDisabled} = this.state,
 			{keyCode} = ev;
+
+		if (!vertical) {
+			return;
+		}
 
 		if (isPageUp(keyCode)) {
 			if (focusableScrollButtons) {

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -16,15 +16,22 @@ const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBas
 
 const
 	itemStyle = {
-		borderBottom: ri.unit(3, 'rem') + ' solid #202328',
 		boxSizing: 'border-box',
 		display: 'flex'
 	},
+	borderStyle = ri.unit(3, 'rem') + ' solid #202328',
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
-	renderItem = (ItemComponent, size, onClick) => ({index, ...rest}) => {
-		const style = {height: size + 'px', ...itemStyle};
+	renderItem = (ItemComponent, size, vertical, onClick) => ({index, ...rest}) => {
+		const style = {
+			...(
+				vertical ?
+					{borderBottom: borderStyle, height: size + 'px'} :
+					{borderRight: borderStyle, height: '100%', width: size + 'px', writingMode: 'vertical-lr'}
+			),
+			...itemStyle
+		};
 		return (
 			<ItemComponent index={index} style={style} onClick={onClick} {...rest}>
 				{items[index].item}
@@ -109,7 +116,7 @@ const InPanels = ({className, title, ...rest}) => {
 				<VirtualList
 					id="spotlight-list"
 					// eslint-disable-next-line enact/prop-types
-					itemRenderer={renderItem(Item, rest.itemSize, handleSelectItem)}
+					itemRenderer={renderItem(Item, rest.itemSize, true, handleSelectItem)}
 					spotlightId="virtual-list"
 					{...rest}
 				/>
@@ -124,13 +131,33 @@ const InPanels = ({className, title, ...rest}) => {
 
 storiesOf('VirtualList', module)
 	.add(
+		'horizontal scroll',
+		() => {
+			return (
+				<VirtualList
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					direction="horizontal"
+					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
+					itemRenderer={renderItem(Item, ri.scale(number('itemSize', Config, 72)), false)}
+					itemSize={ri.scale(number('itemSize', Config, 72))}
+					onKeyDown={action('onKeyDown')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					spacing={ri.scale(number('spacing', Config, 0))}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
+				/>
+			);
+		},
+		{propTables: [Config]}
+	)
+	.add(
 		'with more items',
 		() => {
 			return (
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
-					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)))}
+					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
 					onKeyDown={action('onKeyDown')}
 					onScrollStart={action('onScrollStart')}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -1,6 +1,7 @@
 import Item from '@enact/moonstone/Item';
-import SwitchItem from '@enact/moonstone/SwitchItem';
 import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
+import Scroller from '@enact/moonstone/Scroller';
+import SwitchItem from '@enact/moonstone/SwitchItem';
 import VirtualList, {VirtualListBase} from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
@@ -19,9 +20,17 @@ const
 		boxSizing: 'border-box',
 		display: 'flex'
 	},
+	listStyle = {
+		height: '200px'
+	},
 	borderStyle = ri.unit(3, 'rem') + ' solid #202328',
 	items = [],
 	defaultDataSize = 1000,
+	wrapOption = {
+		'false': false,
+		'true': true,
+		'&quot;noAnimation&quot;': 'noAnimation'
+	},
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	renderItem = (ItemComponent, size, vertical, onClick) => ({index, ...rest}) => {
 		const style = {
@@ -131,21 +140,31 @@ const InPanels = ({className, title, ...rest}) => {
 
 storiesOf('VirtualList', module)
 	.add(
-		'horizontal scroll',
+		'horizontal scroll in Scroller',
 		() => {
+			const listProps = {
+				dataSize: updateDataSize(number('dataSize', Config, defaultDataSize)),
+				direction: 'horizontal',
+				focusableScrollbar: boolean('focusableScrollbar', Config, false),
+				horizontalScrollbar: select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto'),
+				itemRenderer: renderItem(Item, ri.scale(number('itemSize', Config, 72)), false),
+				itemSize: ri.scale(number('itemSize', Config, 72)),
+				noScrollByWheel: boolean('noScrollByWheel', Config, false),
+				onKeyDown: action('onKeyDown'),
+				onScrollStart: action('onScrollStart'),
+				onScrollStop: action('onScrollStop'),
+				spacing: ri.scale(number('spacing', Config, 0)),
+				style: listStyle,
+				verticalScrollbar: select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto'),
+				wrap: wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]
+			};
+
 			return (
-				<VirtualList
-					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					direction="horizontal"
-					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
-					itemRenderer={renderItem(Item, ri.scale(number('itemSize', Config, 72)), false)}
-					itemSize={ri.scale(number('itemSize', Config, 72))}
-					onKeyDown={action('onKeyDown')}
-					onScrollStart={action('onScrollStart')}
-					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config, 0))}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
-				/>
+				<Scroller >
+					<VirtualList {...listProps} key="1" />
+					<VirtualList {...listProps} key="2" />
+					<VirtualList {...listProps} key="3" />
+				</Scroller>
 			);
 		},
 		{propTables: [Config]}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

VirtualList should not scroll via channel up or down keys on horizontal paging controls.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If scrollbar is vertical, then skip to scroll via channel up and down keys.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I added horizontal VirtualList qa-sampler to verify this issue.

### Links
[//]: # (Related issues, references)

PLAT-83423