### PR TITLE
PLAT-84120: Add support for zh-Hans Font

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone` to support custom font for zh-Hans locale
+- `moonstone` to support custom font for simplified Chinese
 - `moonstone` disabled focus appearance to match the latest designs
 - `moonstone/DatePicker`, `moonstone/DayPicker`, `moonstone/ExpandableList`, and `moonstone/TimePicker` disabled opacity in high contrast mode
 - `moonstone/Picker` to avoid overlapping items on render

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone` to support custom font for zh-Hans locale
 - `moonstone/Picker` to avoid overlapping items on render
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via a page up or down key when focus is on any vertical paging control while in pointer mode

--- a/packages/moonstone/MoonstoneDecorator/fontGenerator.js
+++ b/packages/moonstone/MoonstoneDecorator/fontGenerator.js
@@ -32,6 +32,9 @@ const fonts = {
 	'ja': {
 		regular: 'LG Smart UI JP',
 		bold: 'LG Display_JP_Bold'
+	},
+	'zh-Hans': {
+		regular: 'LG Smart UI SC'
 	}
 };
 

--- a/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
+++ b/packages/sampler/src/MoonstoneEnvironment/MoonstoneEnvironment.js
@@ -73,6 +73,7 @@ const locales = {
 	'th-TH - Thai, with tall characters':                   'th-TH',
 	'ar-SA - Arabic, RTL and standard font':                'ar-SA',
 	'ur-PK - Urdu, RTL and custom Urdu font':               'ur-PK',
+	'zh-Hans-HK - Simplified Chinese, custom Hans font':    'zh-Hans-HK',
 	'zh-Hant-HK - Traditional Chinese, custom Hant font':   'zh-Hant-HK',
 	'vi-VN - Vietnamese, Special non-latin font handling':  'vi-VN',
 	'ta-IN - Tamil, custom Indian font':                    'ta-IN',

--- a/packages/sampler/stories/qa/Text.js
+++ b/packages/sampler/stories/qa/Text.js
@@ -25,6 +25,7 @@ import {select} from '../../src/enact-knobs';
 const inputData = {
 	english: 'We name themes after gemstones',
 	arabic: 'نحن اسم المواضيع بعد الأحجار الكريمة',
+	chinese: '星期日 星期一 星期二 星期三 星期四 星期五 星期六',
 	greek: 'Ονομάζουμε θέματα μετά από πολύτιμους λίθους',
 	hebrew: 'אנו שם נושאים לאחר אבני חן',
 	japanese: '宝石にちなんでテーマに名前を付けます',

--- a/packages/ui/internal/localized-fonts/localized-fonts.js
+++ b/packages/ui/internal/localized-fonts/localized-fonts.js
@@ -66,7 +66,9 @@ const buildFontDefinitionCss = function (locale, buildOverrides) {
 	const
 		matchLang = locale.match(/\b([a-z]{2})\b/),
 		language = matchLang && matchLang[1],
-		matchReg = locale.match(/\b([A-Z]{2}|[0-9]{3}|[a-zA-Z]{4})\b/),
+		matchScript = locale.match(/\b([a-z]{4})\b/i),
+		script = matchScript && matchScript[1],
+		matchReg = locale.match(/\b([A-Z]{2}|[0-9]{3})\b/),
 		region = matchReg && matchReg[1];
 
 	let fontDefinitionCss = '';
@@ -80,12 +82,19 @@ const buildFontDefinitionCss = function (locale, buildOverrides) {
 				fontDefinitionCss += buildFontSet(fontName, fonts, lang);
 			} else {
 				// Set up the override for locale-specific font.
-				// la = language, re = region; `la-RE`
-				const [la, re] = lang.split('-');
-				if (la === language) {
-					if (!re || (re && re === region)) {
-						fontDefinitionCss += buildFontSet(fontName, fonts, lang, true);
-					}
+				// la = language, sc = script, re = region; `la-RE` or `zh-Hans-HK`
+				let [la, sc, re] = lang.split('-');
+
+				// if script is not specified, fall back to second part representing region
+				if (!re && sc && sc.length === 2) {
+					re = sc;
+					sc = null;
+				}
+
+				const matchesRegion = re ? re === region : true;
+				const matchesScript = sc ? sc === script : true;
+				if (la === language && matchesRegion && matchesScript) {
+					fontDefinitionCss += buildFontSet(fontName, fonts, lang, true);
 				}
 			}
 		}

--- a/packages/ui/internal/localized-fonts/localized-fonts.js
+++ b/packages/ui/internal/localized-fonts/localized-fonts.js
@@ -66,7 +66,7 @@ const buildFontDefinitionCss = function (locale, buildOverrides) {
 	const
 		matchLang = locale.match(/\b([a-z]{2})\b/),
 		language = matchLang && matchLang[1],
-		matchReg = locale.match(/\b([A-Z]{2}|[0-9]{3})\b/),
+		matchReg = locale.match(/\b([A-Z]{2}|[0-9]{3}|[a-zA-Z]{4})\b/),
 		region = matchReg && matchReg[1];
 
 	let fontDefinitionCss = '';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add support for zh-Hans font.
* Change the locale parser to handle the 4 character script code.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Hasn't been tested on TV but verified to work in Chrome with the font installed locally.

### Links
[//]: # (Related issues, references)
https://stackoverflow.com/questions/18902072/what-standard-do-language-codes-of-the-form-zh-hans-belong-to

### Comments
