### PR TITLE
PLAT-78618: Update disabled colors

### DIFF
--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -343,6 +343,12 @@
 					background-color: @moon-button-selected-focus-bg-color;
 					border-color: @moon-button-selected-focus-border-color;
 				}
+
+				.disabled({
+					.bg {
+						border-color: @moon-button-selected-disabled-focus-border-color;
+					}
+				});
 			});
 		}
 	});

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,12 +4,9 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Changed
-
-- disabled focus colors and opacity to match the latest designs
-
 ### Fixed
 
+- `moonstone` disabled focus appearance to match the latest designs
 - `moonstone/Picker` to avoid overlapping items on render
 - `moonstone/Scroller` and other scrolling components to properly scroll via remote page up/down buttons when nested within another scrolling component
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to scroll via a page up or down key when focus is on any vertical paging control while in pointer mode

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- disabled focus colors and opacity to match the latest designs
+
 ### Fixed
 
 - `moonstone/Picker` to avoid overlapping items on render

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
@@ -14,7 +14,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import FormCheckbox from '../FormCheckbox';
-import ToggleItem from '../ToggleItem';
+import {ToggleItemBase, ToggleItemDecorator} from '../ToggleItem';
 
 import componentCss from './FormCheckboxItem.module.less';
 
@@ -52,18 +52,22 @@ const FormCheckboxItemBase = kind({
 		publicClassNames: ['formCheckboxItem']
 	},
 
-	render: (props) => (
-		<ToggleItem
+	render: ({children, css, ...props}) => (
+		<ToggleItemBase
 			data-webos-voice-intent="SelectCheckItem"
 			{...props}
-			css={props.css}
+			css={css}
 			iconComponent={FormCheckbox}
-		/>
+		>
+			<span className={componentCss.content}>{children}</span>
+		</ToggleItemBase>
 	)
 });
 
-export default FormCheckboxItemBase;
+const FormCheckboxItem = ToggleItemDecorator(FormCheckboxItemBase);
+
+export default FormCheckboxItem;
 export {
-	FormCheckboxItemBase as FormCheckboxItem,
+	FormCheckboxItem,
 	FormCheckboxItemBase
 };

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -27,7 +27,11 @@
 			background-color: @moon-formcheckboxitem-focus-bg-color;
 
 			.disabled({
-				opacity: @moon-disabled-opacity;
+				opacity: 1;
+
+				.content {
+					opacity: @moon-disabled-opacity;
+				}
 			});
 		});
 	});

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -33,17 +33,12 @@
 		text-overflow: ellipsis;
 	}
 
-	.input-placeholder({
-		.vendor-opacity(@moon-input-placeholder-opacity);
-	});
-
 	.focus({
 		cursor: text;
 	});
 
 	.disabled({
 		cursor: default;
-		.vendor-opacity(@moon-input-disabled-opacity);
 	});
 
 	:global(.enact-locale-right-to-left) & {
@@ -151,6 +146,7 @@
 			color: inherit;
 
 			.input-placeholder({
+				.vendor-opacity(@moon-input-placeholder-opacity);
 				color: @moon-input-placeholder-color;
 			});
 
@@ -201,12 +197,28 @@
 			.vendor-opacity(@moon-input-disabled-opacity);
 
 			.focus({
-				.vendor-opacity(@moon-input-disabled-opacity);
+				background-color: @moon-input-decorator-disabled-focus-bg-color;
+
+				.input,
+				.decoratorIcon {
+					.vendor-opacity(1);
+					.input-placeholder({
+						.vendor-opacity(@moon-input-disabled-opacity);
+					});
+				}
 			});
 
 			.input,
 			.decoratorIcon {
+				.vendor-opacity(@moon-input-disabled-opacity);
 				color: @moon-input-disabled-text-color;
+			}
+
+			.input {
+				.input-placeholder({
+					.vendor-opacity(1);
+					color: @moon-input-placeholder-disabled-color;
+				});
 			}
 		});
 	});

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -202,6 +202,8 @@
 				.input,
 				.decoratorIcon {
 					.vendor-opacity(1);
+					color: @moon-input-disabled-focus-text-color;
+
 					.input-placeholder({
 						.vendor-opacity(@moon-input-disabled-opacity);
 					});

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -101,7 +101,7 @@
 
 // FormCheckbox
 // ---------------------------------------
-@moon-formcheckbox-bg-color: #686868;
+@moon-formcheckbox-bg-color: @moon-white;
 @moon-formcheckbox-text-color: @moon-white;
 @moon-formcheckbox-border-color: @moon-dark-gray;
 @moon-formcheckbox-focus-bg-color: @moon-spotlight-color;
@@ -143,18 +143,19 @@
 
 // Input
 // ---------------------------------------
-@moon-input-text-color:               @moon-white;
 @moon-input-border-color:             #eaeaea;
 @moon-input-textarea-color:           @moon-dark-gray;
 @moon-input-placeholder-color:        @moon-white;
 @moon-input-placeholder-focus-color:  @moon-input-decorator-bg-color;
 @moon-input-placeholder-active-color: @moon-input-placeholder-focus-color;
 @moon-input-focus-text-color:         @moon-dark-gray;
+@moon-input-disabled-focus-text-color: fade(@moon-input-text-color, @moon-disabled-opacity-percentage);
 @moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;
 @moon-input-decorator-active-bg-color: @moon-input-decorator-focus-bg-color;
+@moon-input-decorator-disabled-focus-bg-color: fade(@moon-input-decorator-bg-color, @moon-disabled-opacity-percentage);
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-border-active-border-color: transparent;
 @moon-input-border-active-shadow: 0 0 0 3px @moon-input-border-focus-border-color;

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -101,7 +101,7 @@
 
 // FormCheckbox
 // ---------------------------------------
-@moon-formcheckbox-bg-color: @moon-white;
+@moon-formcheckbox-bg-color: #686868;
 @moon-formcheckbox-text-color: @moon-white;
 @moon-formcheckbox-border-color: @moon-dark-gray;
 @moon-formcheckbox-focus-bg-color: @moon-spotlight-color;

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -30,7 +30,7 @@
 
 // Disabled Opacity
 // ---------------------------------------
-@moon-disabled-opacity: 0.3;
+@moon-disabled-opacity: 0.4;
 @moon-disabled-translucent-opacity: 0.4;
 
 // Spotlight and State

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -72,6 +72,7 @@
 @moon-button-selected-focus-text-color: @moon-spotlight-text-color;
 @moon-button-selected-focus-bg-color: @moon-spotlight-bg-color;
 @moon-button-selected-focus-border-color: @moon-active-spotlight-border-color;
+@moon-button-selected-disabled-focus-border-color: lighten(@moon-spotlight-border-color, 20%);
 
 // ContextualPopup
 // ---------------------------------------
@@ -173,10 +174,10 @@
 @moon-input-focus-text-color:         @moon-dark-gray;
 @moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
-@moon-input-decorator-disabled-focus-bg-color: #666;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;
 @moon-input-decorator-active-bg-color: @moon-input-decorator-focus-bg-color;
+@moon-input-decorator-disabled-focus-bg-color: darken(@moon-input-decorator-focus-bg-color, 60%);
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-border-active-border-color: transparent;
 @moon-input-border-active-shadow: 0 0 0 3px @moon-input-border-focus-border-color;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -29,6 +29,7 @@
 // Disabled Opacity
 // ---------------------------------------
 @moon-disabled-opacity: 0.4;
+@moon-disabled-opacity-percentage: 40%;
 @moon-disabled-translucent-opacity: 0.4;
 
 // Spotlight and State
@@ -172,12 +173,13 @@
 @moon-input-placeholder-active-color: @moon-input-placeholder-focus-color;
 @moon-input-placeholder-disabled-color:  @moon-white;
 @moon-input-focus-text-color:         @moon-dark-gray;
+@moon-input-disabled-focus-text-color: fade(@moon-input-text-color, @moon-disabled-opacity-percentage);
 @moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;
 @moon-input-decorator-active-bg-color: @moon-input-decorator-focus-bg-color;
-@moon-input-decorator-disabled-focus-bg-color: darken(@moon-input-decorator-focus-bg-color, 60%);
+@moon-input-decorator-disabled-focus-bg-color: fade(@moon-input-decorator-focus-bg-color, @moon-disabled-opacity-percentage);
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-border-active-border-color: transparent;
 @moon-input-border-active-shadow: 0 0 0 3px @moon-input-border-focus-border-color;

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -183,8 +183,6 @@
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-border-active-border-color: transparent;
 @moon-input-border-active-shadow: 0 0 0 3px @moon-input-border-focus-border-color;
-@moon-input-disabled-opacity: @moon-disabled-opacity;
-@moon-input-placeholder-opacity: 0.5;
 
 // LabeledItem
 // ---------------------------------------

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -28,7 +28,7 @@
 
 // Disabled Opacity
 // ---------------------------------------
-@moon-disabled-opacity: 0.3;
+@moon-disabled-opacity: 0.4;
 @moon-disabled-translucent-opacity: 0.4;
 
 // Spotlight and State
@@ -169,15 +169,19 @@
 @moon-input-placeholder-color:        @moon-white;
 @moon-input-placeholder-focus-color:  @moon-input-decorator-bg-color;
 @moon-input-placeholder-active-color: @moon-input-placeholder-focus-color;
+@moon-input-placeholder-disabled-color:  @moon-white;
 @moon-input-focus-text-color:         @moon-dark-gray;
 @moon-input-disabled-text-color:      inherit;
 @moon-input-decorator-bg-color:       #aaa;
+@moon-input-decorator-disabled-focus-bg-color: #666;
 @moon-input-decorator-border-color:   @moon-light-gray;
 @moon-input-decorator-focus-bg-color: @moon-white;
 @moon-input-decorator-active-bg-color: @moon-input-decorator-focus-bg-color;
 @moon-input-border-focus-border-color: @moon-spotlight-border-color;
 @moon-input-border-active-border-color: transparent;
 @moon-input-border-active-shadow: 0 0 0 3px @moon-input-border-focus-border-color;
+@moon-input-disabled-opacity: @moon-disabled-opacity;
+@moon-input-placeholder-opacity: 0.5;
 
 // LabeledItem
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -256,6 +256,8 @@
 @moon-input-padding: 0 @moon-input-icon-spacing;
 @moon-input-font-weight: 600;
 @moon-input-text-indent: 0.2em;
+@moon-input-disabled-opacity: 0.4;
+@moon-input-placeholder-opacity: 0.5;
 @moon-input-border-radius: @moon-input-border-width;
 @moon-input-border-width: 3px;
 @moon-input-border-outline-width: @moon-input-border-width;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -256,8 +256,6 @@
 @moon-input-padding: 0 @moon-input-icon-spacing;
 @moon-input-font-weight: 600;
 @moon-input-text-indent: 0.2em;
-@moon-input-disabled-opacity: 0.3;
-@moon-input-placeholder-opacity: @moon-input-disabled-opacity;
 @moon-input-border-radius: @moon-input-border-width;
 @moon-input-border-width: 3px;
 @moon-input-border-outline-width: @moon-input-border-width;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updated disabled focus and disabled opacity. 
Overall disabled opacity is changed from 30% to 40%.

Components that have some additional disabled focus changes:
- `Button` (disabled focus selected border color)
- `FormCheckboxItem` (disabled focus icon full opacity / content 40% opacity)
- `Input` (disabled focus ring full opacity)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
-  Added some `Input` disabled focus colors for the focus ring to be full opacity and also be consistent in light skin.
- `<input>` placeholder opacity cannot be separated from`<input>` text opacity afaik.
- Fixed `FormCheckboxItem` light skin normal icon bg color.

### Links
[//]: # (Related issues, references)
PLAT-78618
