### PR TITLE
PLAT-83432: Add missing knobs of Scroller, VirtualList and VirtualGridList saimples

### DIFF
--- a/packages/sampler/stories/default/Scroller.js
+++ b/packages/sampler/stories/default/Scroller.js
@@ -1,32 +1,35 @@
-import {Scroller as UiScroller} from '@enact/ui/Scroller';
+import {ScrollableBase} from '@enact/moonstone/Scrollable';
 import Scroller from '@enact/moonstone/Scroller';
 import ri from '@enact/ui/resolution';
-import React from 'react';
-import {storiesOf} from '@storybook/react';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
+import {Scroller as UiScroller, ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import {action} from '@storybook/addon-actions';
+import {storiesOf} from '@storybook/react';
+import React from 'react';
 
 import {boolean, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 
-const Config = mergeComponentMetadata('Scroller', Scroller, UiScroller);
-
 const
 	prop = {
 		direction: ['both', 'horizontal', 'vertical'],
-		horizontalScrollbar: ['auto', 'hidden', 'visible'],
-		verticalScrollbar: ['auto', 'hidden', 'visible']
+		scrollbarOption: ['auto', 'hidden', 'visible']
 	};
+
+const UiScrollerConfig = mergeComponentMetadata('UiScroller', UiScrollerBase, UiScrollableBase, UiScroller);
+const ScrollerConfig = mergeComponentMetadata('Scroller', UiScrollableBase, ScrollableBase, Scroller);
 
 storiesOf('UI', module)
 	.add(
 		'Scroller',
 		() => (
 			<UiScroller
-				direction={select('direction', prop.direction, Config, 'both')}
-				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Config, 'auto')}
+				direction={select('direction', prop.direction, UiScrollerConfig)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, UiScrollerConfig)}
+				noScrollByWheel={boolean('noScrollByWheel', UiScrollerConfig)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				verticalScrollbar={select('verticalScrollbar', prop.verticalScrollbar, Config, 'auto')}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, UiScrollerConfig)}
 			>
 				<div
 					style={{
@@ -58,12 +61,14 @@ storiesOf('Moonstone', module)
 		'Scroller',
 		() => (
 			<Scroller
-				direction={select('direction', prop.direction, Config, 'both')}
-				focusableScrollbar={boolean('focusableScrollbar', Config)}
-				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Config, 'auto')}
+				direction={select('direction', prop.direction, ScrollerConfig)}
+				focusableScrollbar={boolean('focusableScrollbar', ScrollerConfig)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, ScrollerConfig)}
+				noScrollByWheel={boolean('noScrollByWheel', ScrollerConfig)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				verticalScrollbar={select('verticalScrollbar', prop.verticalScrollbar, Config, 'auto')}
+				spotlightDisabled={boolean('spotlightDisabled', ScrollerConfig, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 			>
 				<div
 					style={{

--- a/packages/sampler/stories/default/Scroller.js
+++ b/packages/sampler/stories/default/Scroller.js
@@ -16,7 +16,7 @@ const
 		scrollbarOption: ['auto', 'hidden', 'visible']
 	};
 
-const UiScrollerConfig = mergeComponentMetadata('UiScroller', UiScrollerBase, UiScrollableBase, UiScroller);
+const UiScrollerConfig = mergeComponentMetadata('Scroller', UiScrollerBase, UiScrollableBase, UiScroller);
 const ScrollerConfig = mergeComponentMetadata('Scroller', UiScrollableBase, ScrollableBase, Scroller);
 
 storiesOf('UI', module)

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -1,11 +1,12 @@
-import {VirtualGridList as UiVirtualGridList} from '@enact/ui/VirtualList';
-import {VirtualGridList} from '@enact/moonstone/VirtualList';
-import {GridListImageItem as UiGridListImageItem} from '@enact/ui/GridListImageItem';
 import {GridListImageItem} from '@enact/moonstone/GridListImageItem';
+import {VirtualGridList, VirtualListBase} from '@enact/moonstone/VirtualList';
+import {GridListImageItem as UiGridListImageItem} from '@enact/ui/GridListImageItem';
 import ri from '@enact/ui/resolution';
-import React from 'react';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
+import {VirtualGridList as UiVirtualGridList, VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
+import React from 'react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
@@ -17,7 +18,8 @@ const
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	prop = {
-		direction: {'horizontal': 'horizontal', 'vertical': 'vertical'}
+		direction: {'horizontal': 'horizontal', 'vertical': 'vertical'},
+		scrollbarOption: ['auto', 'hidden', 'visible']
 	},
 	items = [],
 	defaultDataSize = 1000,
@@ -75,25 +77,27 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-
-const Config = mergeComponentMetadata('VirtualGridList', UiVirtualGridList, VirtualGridList);
-UiVirtualGridList.displayName = 'VirtualGridList';
+const UiVirtualGridListConfig = mergeComponentMetadata('UiVirtualGridList', UiVirtualListBase, UiScrollableBase);
+const VirtualGridListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 storiesOf('UI', module)
 	.add(
 		'VirtualList.VirtualGridList',
 		() => (
 			<UiVirtualGridList
-				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-				direction={select('direction', prop.direction, Config, 'vertical')}
+				dataSize={updateDataSize(number('dataSize', UiVirtualGridListConfig, defaultDataSize))}
+				direction={select('direction', prop.direction, UiVirtualGridListConfig)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, UiVirtualGridListConfig)}
 				itemRenderer={uiRenderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', Config, 180)),
-					minHeight: ri.scale(number('minHeight', Config, 270))
+					minWidth: ri.scale(number('minWidth', UiVirtualGridListConfig, 180)),
+					minHeight: ri.scale(number('minHeight', UiVirtualGridListConfig, 270))
 				}}
+				noScrollByWheel={boolean('noScrollByWheel', UiVirtualGridListConfig)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				spacing={ri.scale(number('spacing', Config, 20))}
+				spacing={ri.scale(number('spacing', UiVirtualGridListConfig, 20))}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, UiVirtualGridListConfig)}
 			/>
 		),
 		{
@@ -108,20 +112,22 @@ storiesOf('Moonstone', module)
 		'VirtualList.VirtualGridList',
 		() => (
 			<VirtualGridList
-				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-				direction={select('direction', prop.direction, Config, 'vertical')}
-				focusableScrollbar={boolean('focusableScrollbar', Config)}
-				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
+				dataSize={updateDataSize(number('dataSize', VirtualGridListConfig, defaultDataSize))}
+				direction={select('direction', prop.direction, VirtualGridListConfig)}
+				focusableScrollbar={boolean('focusableScrollbar', VirtualGridListConfig)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualGridListConfig)}
 				itemRenderer={renderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', Config, 180)),
-					minHeight: ri.scale(number('minHeight', Config, 270))
+					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 180)),
+					minHeight: ri.scale(number('minHeight', VirtualGridListConfig, 270))
 				}}
+				noScrollByWheel={boolean('noScrollByWheel', VirtualGridListConfig)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
-				spacing={ri.scale(number('spacing', Config, 20))}
-				verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
-				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+				spacing={ri.scale(number('spacing', VirtualGridListConfig, 20))}
+				spotlightDisabled={boolean('spotlightDisabled', VirtualGridListConfig, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, VirtualGridListConfig)}
+				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], VirtualGridListConfig)]}
 			/>
 		),
 		{

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -13,12 +13,12 @@ import {mergeComponentMetadata} from '../../src/utils';
 
 const
 	wrapOption = {
-		'false': false,
-		'true': true,
+		false: false,
+		true: true,
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	prop = {
-		direction: {'horizontal': 'horizontal', 'vertical': 'vertical'},
+		direction: {horizontal: 'horizontal', vertical: 'vertical'},
 		scrollbarOption: ['auto', 'hidden', 'visible']
 	},
 	items = [],

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -77,8 +77,8 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const UiVirtualGridListConfig = mergeComponentMetadata('UiVirtualGridList', UiVirtualListBase, UiScrollableBase);
-const VirtualGridListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const UiVirtualGridListConfig = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiScrollableBase);
+const VirtualGridListConfig = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 storiesOf('UI', module)
 	.add(

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -77,6 +77,7 @@ storiesOf('UI', module)
 			return (
 				<UiVirtualList
 					dataSize={updateDataSize(number('dataSize', UiVirtualListConfig, defaultDataSize))}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, UiVirtualListConfig)}
 					itemRenderer={uiRenderItem(ri.scale(number('itemSize', UiVirtualListConfig, 72)))}
 					itemSize={ri.scale(number('itemSize', UiVirtualListConfig, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', UiVirtualListConfig)}
@@ -103,6 +104,7 @@ storiesOf('Moonstone', module)
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', VirtualListConfig)}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualListConfig)}
 					itemRenderer={renderItem(ri.scale(number('itemSize', VirtualListConfig, 72)))}
 					itemSize={ri.scale(number('itemSize', VirtualListConfig, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', VirtualListConfig)}

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -13,8 +13,8 @@ import {mergeComponentMetadata} from '../../src/utils';
 
 const
 	wrapOption = {
-		'false': false,
-		'true': true,
+		false: false,
+		true: true,
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	prop = {

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -1,11 +1,12 @@
-import {Item as UiItem} from '@enact/ui/Item';
 import Item from '@enact/moonstone/Item';
-import {VirtualList as UiVirtualList} from '@enact/ui/VirtualList';
-import VirtualList from '@enact/moonstone/VirtualList';
+import VirtualList, {VirtualListBase} from '@enact/moonstone/VirtualList';
+import {Item as UiItem} from '@enact/ui/Item';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
+import {VirtualList as UiVirtualList, VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import ri from '@enact/ui/resolution';
-import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
+import React from 'react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
@@ -15,6 +16,9 @@ const
 		'false': false,
 		'true': true,
 		'&quot;noAnimation&quot;': 'noAnimation'
+	},
+	prop = {
+		scrollbarOption: ['auto', 'hidden', 'visible']
 	},
 	items = [],
 	defaultDataSize = 1000,
@@ -63,8 +67,8 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const Config = mergeComponentMetadata('VirtualList', UiVirtualList, VirtualList);
-UiVirtualList.displayName = 'VirtualList';
+const UiVirtualListConfig = mergeComponentMetadata('UiVirtualList', UiVirtualListBase, UiScrollableBase);
+const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 storiesOf('UI', module)
 	.add(
@@ -72,12 +76,14 @@ storiesOf('UI', module)
 		() => {
 			return (
 				<UiVirtualList
-					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					itemRenderer={uiRenderItem(ri.scale(number('itemSize', Config, 72)))}
-					itemSize={ri.scale(number('itemSize', Config, 72))}
+					dataSize={updateDataSize(number('dataSize', UiVirtualListConfig, defaultDataSize))}
+					itemRenderer={uiRenderItem(ri.scale(number('itemSize', UiVirtualListConfig, 72)))}
+					itemSize={ri.scale(number('itemSize', UiVirtualListConfig, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', UiVirtualListConfig)}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config, 0))}
+					spacing={ri.scale(number('spacing', UiVirtualListConfig))}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, UiVirtualListConfig)}
 				/>
 			);
 		},
@@ -88,21 +94,24 @@ storiesOf('UI', module)
 		}
 	);
 
+
 storiesOf('Moonstone', module)
 	.add(
 		'VirtualList',
 		() => {
 			return (
 				<VirtualList
-					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					focusableScrollbar={boolean('focusableScrollbar', Config)}
-					itemRenderer={renderItem(ri.scale(number('itemSize', Config, 72)))}
-					itemSize={ri.scale(number('itemSize', Config, 72))}
+					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
+					focusableScrollbar={boolean('focusableScrollbar', VirtualListConfig)}
+					itemRenderer={renderItem(ri.scale(number('itemSize', VirtualListConfig, 72)))}
+					itemSize={ri.scale(number('itemSize', VirtualListConfig, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', VirtualListConfig)}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config, 0))}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
-					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+					spacing={ri.scale(number('spacing', VirtualListConfig))}
+					spotlightDisabled={boolean('spotlightDisabled', VirtualListConfig, false)}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, VirtualListConfig)}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], VirtualListConfig)]}
 				/>
 			);
 		},

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -67,7 +67,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const UiVirtualListConfig = mergeComponentMetadata('UiVirtualList', UiVirtualListBase, UiScrollableBase);
+const UiVirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase);
 const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 storiesOf('UI', module)

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -174,6 +174,7 @@ storiesOf('Scroller', module)
 		'Horizontal scroll',
 		() => (
 			<Scroller
+				direction={select('direction', prop.direction, Scroller, 'horizontal')}
 				focusableScrollbar={boolean('focusableScrollbar', Config)}
 				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 				noScrollByWheel={boolean('noScrollByWheel', Config)}
@@ -235,7 +236,6 @@ storiesOf('Scroller', module)
 				noScrollByWheel={boolean('noScrollByWheel', Config)}
 				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
 				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
-
 			>
 				<Heading showLine>Nothing selected</Heading>
 				<ExpandableList

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -68,7 +68,6 @@ class ScrollerWithResizable extends React.Component {
 	render () {
 		return (
 			<Scroller
-				focusableScrollbar={boolean('focusableScrollbar', Config)}
 				verticalScrollbar="visible"
 			>
 				<Item>Item</Item>
@@ -174,7 +173,7 @@ storiesOf('Scroller', module)
 		'Horizontal scroll',
 		() => (
 			<Scroller
-				direction={select('direction', prop.direction, Scroller, 'horizontal')}
+				direction={select('direction', prop.direction, Config, 'horizontal')}
 				focusableScrollbar={boolean('focusableScrollbar', Config)}
 				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 				noScrollByWheel={boolean('noScrollByWheel', Config)}
@@ -202,12 +201,14 @@ storiesOf('Scroller', module)
 		'With Spottable Components',
 		() => (
 			<Scroller
-				direction={select('direction', prop.direction, Scroller, 'both')}
-				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
-				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Scroller, 'auto')}
-				verticalScrollbar={select('verticalScrollbar', prop.verticalScrollbar, Scroller, 'auto')}
+				direction={select('direction', prop.direction, Config)}
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 			>
 				<div
 					style={{

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -6,17 +6,20 @@ import Item from '@enact/moonstone/Item';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ri from '@enact/ui/resolution';
+import {ScrollableBase} from '@enact/moonstone/Scrollable';
 import Scroller from '@enact/moonstone/Scroller';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import UiScroller from '@enact/ui/Scroller';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 
 import {action} from '@storybook/addon-actions';
 import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils/propTables';
 
-Scroller.displayName = 'Scroller';
+const Config = mergeComponentMetadata('Scroller', UiScrollableBase, ScrollableBase, Scroller);
 
 const itemData = [];
 for (let i = 0; i < 100; i++) {
@@ -26,8 +29,7 @@ for (let i = 0; i < 100; i++) {
 const
 	prop = {
 		direction: ['both', 'horizontal', 'vertical'],
-		horizontalScrollbar: ['auto', 'hidden', 'visible'],
-		verticalScrollbar: ['auto', 'hidden', 'visible']
+		scrollbarOption: ['auto', 'hidden', 'visible']
 	};
 
 class ScrollerResizableItem extends React.Component {
@@ -65,7 +67,10 @@ class ScrollerWithResizable extends React.Component {
 
 	render () {
 		return (
-			<Scroller verticalScrollbar="visible">
+			<Scroller
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				verticalScrollbar="visible"
+			>
 				<Item>Item</Item>
 				<Item>Item</Item>
 				<ScrollerResizableItem more={this.state.more} toggleMore={this.handleClick} />
@@ -76,6 +81,7 @@ class ScrollerWithResizable extends React.Component {
 
 class ScrollerWithTwoExpandableList extends React.Component {
 	render () {
+
 		return (
 			<div>
 				<Scroller
@@ -132,8 +138,11 @@ storiesOf('Scroller', module)
 		'List of things',
 		() => (
 			<Scroller
-				spotlightDisabled={boolean('spotlightDisabled', Scroller, false)}
-				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 			>
 				<Group childComponent={Item}>
 					{itemData}
@@ -144,7 +153,14 @@ storiesOf('Scroller', module)
 	.add(
 		'With ExpandableList',
 		() => (
-			<Scroller focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}>
+			<Scroller
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
+			>
+
 				<ExpandableList
 					closeOnSelect
 					title="Expandable List in Scroller"
@@ -158,11 +174,13 @@ storiesOf('Scroller', module)
 		'Horizontal scroll',
 		() => (
 			<Scroller
-				direction={select('direction', prop.direction, Scroller, 'horizontal')}
-				focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}
-				horizontalScrollbar={select('horizontalScrollbar', prop.horizontalScrollbar, Scroller, 'auto')}
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 			>
 				<div
 					style={{
@@ -211,7 +229,14 @@ storiesOf('Scroller', module)
 	.add(
 		'With Many ExpandableList',
 		() => (
-			<Scroller focusableScrollbar={boolean('focusableScrollbar', Scroller, false)}>
+			<Scroller
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
+
+			>
 				<Heading showLine>Nothing selected</Heading>
 				<ExpandableList
 					closeOnSelect
@@ -352,7 +377,7 @@ storiesOf('Scroller', module)
 			return (
 				<Scroller
 					style={{height: ri.scaleToRem(200)}}
-					focusableScrollbar={boolean('focusableScrollbar', Scroller, true)}
+					focusableScrollbar={boolean('focusableScrollbar', Config, true)}
 				>
 					<div style={{height: ri.scaleToRem(size), paddingLeft: ri.scaleToRem(40)}}>{size}px Spacer</div>
 					<Item>1</Item>
@@ -402,7 +427,7 @@ storiesOf('Scroller', module)
 	.add(
 		'With Nested Scroller',
 		() => {
-			let noScrollByWheel = boolean('noScrollByWheel', Scroller, false);
+			let noScrollByWheel = boolean('noScrollByWheel', Config);
 			return (
 				<Scroller
 					direction="vertical"

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -2,6 +2,7 @@ import {VirtualGridList, VirtualListBase} from '@enact/moonstone/VirtualList';
 import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList/VirtualListBase';
 import GridListImageItem from '@enact/moonstone/GridListImageItem';
 import ri from '@enact/ui/resolution';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
@@ -9,10 +10,15 @@ import {action} from '@storybook/addon-actions';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
-const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
+const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 const
 	defaultDataSize = 1000,
+	wrapOption = {
+		'false': false,
+		'true': true,
+		'&quot;noAnimation&quot;': 'noAnimation'
+	},
 	items = [],
 	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
@@ -58,17 +64,20 @@ storiesOf('VirtualGridList', module)
 			<VirtualGridList
 				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 				direction="horizontal"
-				focusableScrollbar={boolean('focusableScrollbar', Config, false)}
-				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
+				focusableScrollbar={boolean('focusableScrollbar', Config)}
+				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config)}
 				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', Config, 180)),
 					minHeight: ri.scale(number('minHeight', Config, 270))
 				}}
+				noScrollByWheel={boolean('noScrollByWheel', Config)}
 				onKeyDown={action('onKeyDown')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 18))}
+				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 			/>
 		),
 		{propTables: [Config]}

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -15,8 +15,8 @@ const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScroll
 const
 	defaultDataSize = 1000,
 	wrapOption = {
-		'false': false,
-		'true': true,
+		false: false,
+		true: true,
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	items = [],

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -14,6 +14,9 @@ const Config = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiSc
 
 const
 	defaultDataSize = 1000,
+	prop = {
+		scrollbarOption: ['auto', 'hidden', 'visible']
+	},
 	wrapOption = {
 		false: false,
 		true: true,
@@ -65,7 +68,7 @@ storiesOf('VirtualGridList', module)
 				dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 				direction="horizontal"
 				focusableScrollbar={boolean('focusableScrollbar', Config)}
-				horizontalScrollbar={select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config)}
+				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 				itemRenderer={renderItem}
 				itemSize={{
 					minWidth: ri.scale(number('minWidth', Config, 180)),
@@ -77,6 +80,7 @@ storiesOf('VirtualGridList', module)
 				onScrollStop={action('onScrollStop')}
 				spacing={ri.scale(number('spacing', Config, 18))}
 				spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+				verticalScrollbar={select('verticaltalScrollbar', prop.scrollbarOption, Config)}
 				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 			/>
 		),

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -10,7 +10,7 @@ import {action} from '@storybook/addon-actions';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
-const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const Config = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 const
 	defaultDataSize = 1000,

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -4,6 +4,7 @@ import Scroller from '@enact/moonstone/Scroller';
 import SwitchItem from '@enact/moonstone/SwitchItem';
 import VirtualList, {VirtualListBase} from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -13,7 +14,7 @@ import {action} from '@storybook/addon-actions';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
-const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBase, UiVirtualListBase);
+const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
 
 const
 	itemStyle = {
@@ -175,14 +176,17 @@ storiesOf('VirtualList', module)
 			return (
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
 					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', Config)}
 					onKeyDown={action('onKeyDown')}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config, 0))}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
+					spacing={ri.scale(number('spacing', Config))}
+					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config)}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
 		},
@@ -197,12 +201,16 @@ storiesOf('VirtualList', module)
 				<InPanels
 					title={title}
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					focusableScrollbar={boolean('focusableScrollbar', Config, false)}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', Config)}
+					onKeyDown={action('onKeyDown')}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config, 0))}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto')}
+					spacing={ri.scale(number('spacing', Config))}
+					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config)}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
 		}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -27,9 +27,12 @@ const
 	borderStyle = ri.unit(3, 'rem') + ' solid #202328',
 	items = [],
 	defaultDataSize = 1000,
+	prop = {
+		scrollbarOption: ['auto', 'hidden', 'visible']
+	},
 	wrapOption = {
-		'false': false,
-		'true': true,
+		false: false,
+		true: true,
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	// eslint-disable-next-line enact/prop-types, enact/display-name
@@ -146,17 +149,17 @@ storiesOf('VirtualList', module)
 			const listProps = {
 				dataSize: updateDataSize(number('dataSize', Config, defaultDataSize)),
 				direction: 'horizontal',
-				focusableScrollbar: boolean('focusableScrollbar', Config, false),
-				horizontalScrollbar: select('horizontalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto'),
+				focusableScrollbar: boolean('focusableScrollbar', Config),
+				horizontalScrollbar: select('horizontalScrollbar', prop.scrollbarOption, Config),
 				itemRenderer: renderItem(Item, ri.scale(number('itemSize', Config, 72)), false),
 				itemSize: ri.scale(number('itemSize', Config, 72)),
-				noScrollByWheel: boolean('noScrollByWheel', Config, false),
+				noScrollByWheel: boolean('noScrollByWheel', Config),
 				onKeyDown: action('onKeyDown'),
 				onScrollStart: action('onScrollStart'),
 				onScrollStop: action('onScrollStop'),
-				spacing: ri.scale(number('spacing', Config, 0)),
+				spacing: ri.scale(number('spacing', Config)),
 				style: listStyle,
-				verticalScrollbar: select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config, 'auto'),
+				verticalScrollbar: select('verticalScrollbar', prop.scrollbarOption, Config),
 				wrap: wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]
 			};
 
@@ -177,6 +180,7 @@ storiesOf('VirtualList', module)
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', Config)}
@@ -185,7 +189,7 @@ storiesOf('VirtualList', module)
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config))}
 					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config)}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
@@ -202,6 +206,7 @@ storiesOf('VirtualList', module)
 					title={title}
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', Config)}
 					onKeyDown={action('onKeyDown')}
@@ -209,7 +214,7 @@ storiesOf('VirtualList', module)
 					onScrollStop={action('onScrollStop')}
 					spacing={ri.scale(number('spacing', Config))}
 					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
-					verticalScrollbar={select('verticalScrollbar', ['auto', 'hidden', 'visible'], Config)}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Lack of knobs to test props in Scroller, VirtualList, and VirtualGridList samples

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added knobs to edit the different type of props provided in Scroller, VirtualList, and VirtualGridList components dynamically in samplers.

### Links
[//]: # (Related issues, references)
PLAT-83432