### PR TITLE
PLAT-84242: Fix Picker item rendering when noAnimation is set

### DIFF
--- a/packages/moonstone/internal/Picker/Picker.js
+++ b/packages/moonstone/internal/Picker/Picker.js
@@ -787,7 +787,6 @@ const PickerBase = class extends React.Component {
 		const {active} = this.state;
 		const {
 			'aria-valuetext': ariaValueText,
-			noAnimation,
 			children,
 			disabled,
 			id,
@@ -823,6 +822,7 @@ const PickerBase = class extends React.Component {
 		delete rest.decrementIcon;
 		delete rest.incrementAriaLabel;
 		delete rest.incrementIcon;
+		delete rest.noAnimation;
 		delete rest.onChange;
 		delete rest.onSpotlightDown;
 		delete rest.onSpotlightLeft;
@@ -839,10 +839,8 @@ const PickerBase = class extends React.Component {
 		const incrementerDisabled = disabled || reachedEnd;
 		const classes = this.determineClasses(decrementerDisabled, incrementerDisabled);
 
-		let arranger;
-		if (!noAnimation && !disabled) {
-			arranger = orientation === 'vertical' ? SlideTopArranger : SlideLeftArranger;
-		}
+		let arranger = orientation === 'vertical' ? SlideTopArranger : SlideLeftArranger;
+		let noAnimation = this.props.noAnimation || disabled;
 
 		let sizingPlaceholder = null;
 		if (typeof width === 'number' && width > 0) {


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `noAnimation` is set on a Picker, items are often rendered out of the viewport caused by the changes in #2475.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix Picker to still set an `arranger` for `ViewManager` when `noAnimation` or `disabled` is set and rely on VM to short-circuit the animation (as it already did).
