### PR TITLE
ENYO-6096: Fix VirtualList to retain proper scroll position after upd…

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to retain the proper scroll position when updating the `itemSize` or `spacing` props
+
 ## [3.0.0-rc.1] - 2019-07-31
 
 ### Added

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -306,23 +306,28 @@ const VirtualListBaseFactory = (type) => {
 				prevProps.spacing !== this.props.spacing ||
 				!equals(prevProps.itemSize, this.props.itemSize)
 			) {
+				const {x, y} = this.getXY(this.scrollPosition, 0);
+
 				this.calculateMetrics(this.props);
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(this.getStatesAndUpdateBounds(this.props));
 				this.setContainerSize();
+
+				const {clientHeight, clientWidth, scrollHeight, scrollWidth} = this.scrollBounds;
+				const xMax = scrollWidth - clientWidth;
+				const yMax = scrollHeight - clientHeight;
+
+				this.updateScrollPosition({
+					x: xMax > x ? x : xMax,
+					y: yMax > y ? y : yMax
+				});
 			} else if (this.hasDataSizeChanged) {
 				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState(newState);
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
-				const {x, y} = this.getXY(this.scrollPosition, 0);
-
-				if (type === Native) {
-					this.scrollToPosition(x, y, this.props.rtl);
-				} else {
-					this.setScrollPosition(x, y, this.props.rtl);
-				}
+				this.updateScrollPosition(this.getXY(this.scrollPosition, 0));
 			}
 		}
 
@@ -353,6 +358,14 @@ const VirtualListBaseFactory = (type) => {
 		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
+
+		updateScrollPosition = ({x, y}, rtl = this.props.rtl) => {
+			if (type === Native) {
+				this.scrollToPosition(x, y, rtl);
+			} else {
+				this.setScrollPosition(x, y, rtl);
+			}
+		}
 
 		isVertical = () => this.isPrimaryDirectionVertical
 


### PR DESCRIPTION
…ating item size-spacing

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
After updating the item layout of a `VirtualList` (or `VirtualGridList`) via the `spacing` and/or `itemSize` props (where the amount of items are the same), the scroll position can appear to be incorrect, depending on where the scroller position was prior to the update. It will then "sync" back to its correct position once you begin to scroll the list contents. This can result in an instant and unexpected "jump" from item 0 to wherever the scroll position should be.

The scroll position is actually correct (as the scroll buttons and thumb reflect the correct position). It's the viewport that appears incorrect.


### Resolution
We can update the viewport to scroll to the scroll position after such an update, where the list content sizes have changed.

