### PR TITLE
ENYO-6169: Remove redundant disabled CSS rules

### DIFF
--- a/packages/moonstone/ExpandableItem/ExpandableItem.js
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.js
@@ -26,7 +26,6 @@ import last from 'ramda/src/last';
 import React from 'react';
 
 import LabeledItem from '../LabeledItem';
-import Skinnable from '../Skinnable';
 import {extractVoiceProps} from '../internal/util';
 
 import Expandable from './Expandable';
@@ -392,7 +391,6 @@ const ExpandableItemBase = kind({
 			<ContainerDiv
 				{...rest}
 				aria-disabled={disabled}
-				disabled={disabled}
 				ref={setContainerNode}
 				spotlightDisabled={spotlightDisabled}
 			>
@@ -451,9 +449,7 @@ const ExpandableItemBase = kind({
  * @public
  */
 const ExpandableItem = Expandable(
-	Skinnable(
-		ExpandableItemBase
-	)
+	ExpandableItemBase
 );
 
 export default ExpandableItem;

--- a/packages/moonstone/ExpandableItem/ExpandableItem.module.less
+++ b/packages/moonstone/ExpandableItem/ExpandableItem.module.less
@@ -2,7 +2,6 @@
 //
 @import "../styles/variables.less";
 @import "../styles/mixins.less";
-@import "../styles/skin.less";
 
 .expandableItem {
 	&.autoLabel {
@@ -45,10 +44,4 @@
 			}
 		}
 	}
-
-	.applySkins({
-		.disabled({
-			opacity: 1;
-		});
-	});
 }

--- a/packages/moonstone/LabeledItem/LabeledItem.module.less
+++ b/packages/moonstone/LabeledItem/LabeledItem.module.less
@@ -80,9 +80,5 @@
 				color: inherit;
 			}
 		});
-
-		.disabled({
-			opacity: @moon-disabled-opacity;
-		});
 	});
 }


### PR DESCRIPTION
### Checklist

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There were a lot of disabled overriding caused by applying `disabled` on the container div. Removed `disabled` on that root node and removed the redundant disabled rules in `ExpandableItem`.
We don't need disabled to be applied on the container because we want to keep its opacity when spotted and we can let the child components handle disabled styling.

Also cleaned up `LabeledItem` disabled rule because moonstone disabled rules will handle it.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Not sure if `disabled` does anything else on the `ContainerDiv` of `ExpandableItem`. My guess is accessibility but that's already handled by `aria-disabled`.

This change affects `LabeledItem`, `ExpandableItem`, and all the components that uses `ExpandableItem` like `DatePicker`, `TimePicker`, `ExpandableInput`, etc.
Tested `LabeledItem`, `ExpandableItem` and also spot checked a few expandable components (the ones mentioned) disabled in dark/light skins and also high contrast modes for dark/light. 

### Links
[//]: # (Related issues, references)
ENYO-6169
