### PR TITLE
PLAT-81214: Add limit to sampler action payloads

### DIFF
--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sampler` to limit the fields included in the Actions tab to improve serialization performance on low-powered hardware
+
 ## [3.0.0-rc.2] - 2019-08-08
 
 No significant changes.

--- a/packages/sampler/src/utils/action.js
+++ b/packages/sampler/src/utils/action.js
@@ -1,0 +1,22 @@
+import {action} from '@storybook/addon-actions';
+
+const safeAction = (name, include = ['type']) => {
+	const myAction = action(name);
+	return (ev) => {
+		// If it's a React synthetic event, extract the type member and drop the rest
+		if (ev.nativeEvent) {
+			ev = Object.keys(ev).filter(key => include.includes(key)).reduce((acc, key) => {
+				acc[key] = ev[key];
+
+				return acc;
+			}, {});
+		}
+
+		myAction(ev);
+	};
+};
+
+export default safeAction;
+export {
+	safeAction as action
+};

--- a/packages/sampler/src/utils/action.js
+++ b/packages/sampler/src/utils/action.js
@@ -1,7 +1,7 @@
 import {action} from '@storybook/addon-actions';
 
 const safeAction = (name, include = ['type']) => {
-	const myAction = action(name);
+	const handler = action(name);
 	return (ev) => {
 		// If it's a React synthetic event, extract the type member and drop the rest
 		if (ev.nativeEvent) {
@@ -12,7 +12,7 @@ const safeAction = (name, include = ['type']) => {
 			}, {});
 		}
 
-		myAction(ev);
+		handler(ev);
 	};
 };
 

--- a/packages/sampler/src/utils/action.js
+++ b/packages/sampler/src/utils/action.js
@@ -5,7 +5,7 @@ const safeAction = (name, include = ['type']) => {
 	return (ev) => {
 		// Ducktyping for React synthetic event to extract the specified members to improve
 		// serialization perf
-		if (ev.nativeEvent) {
+		if (ev && ev.nativeEvent) {
 			ev = Object.keys(ev).filter(key => include.includes(key)).reduce((acc, key) => {
 				acc[key] = ev[key];
 

--- a/packages/sampler/src/utils/action.js
+++ b/packages/sampler/src/utils/action.js
@@ -3,7 +3,8 @@ import {action} from '@storybook/addon-actions';
 const safeAction = (name, include = ['type']) => {
 	const handler = action(name);
 	return (ev) => {
-		// If it's a React synthetic event, extract the type member and drop the rest
+		// Ducktyping for React synthetic event to extract the specified members to improve
+		// serialization perf
 		if (ev.nativeEvent) {
 			ev = Object.keys(ev).filter(key => include.includes(key)).reduce((acc, key) => {
 				acc[key] = ev[key];

--- a/packages/sampler/src/utils/index.js
+++ b/packages/sampler/src/utils/index.js
@@ -7,3 +7,4 @@
 export * from './propTables.js';
 export * from './nullify.js';
 export * from './emptify.js';
+export * from './action.js';

--- a/packages/sampler/stories/default/About.js
+++ b/packages/sampler/stories/default/About.js
@@ -6,9 +6,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 import css from './About.module.less';
 

--- a/packages/sampler/stories/default/About.js
+++ b/packages/sampler/stories/default/About.js
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/default/Button.js
+++ b/packages/sampler/stories/default/Button.js
@@ -3,10 +3,9 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 // Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean knob and return `void 0` when `true`.
 Button.displayName = 'Button';

--- a/packages/sampler/stories/default/Button.js
+++ b/packages/sampler/stories/default/Button.js
@@ -3,7 +3,7 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/CheckboxItem.js
+++ b/packages/sampler/stories/default/CheckboxItem.js
@@ -7,7 +7,7 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata, nullify} from '../../src/utils';

--- a/packages/sampler/stories/default/CheckboxItem.js
+++ b/packages/sampler/stories/default/CheckboxItem.js
@@ -7,10 +7,9 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata, nullify} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 CheckboxItem.displayName = 'CheckboxItem';
 const Config = mergeComponentMetadata('CheckboxItem', UiItem, ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, CheckboxItem);

--- a/packages/sampler/stories/default/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/default/ContextualPopupDecorator.js
@@ -4,10 +4,9 @@ import Button from '@enact/moonstone/Button';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 
 const ContextualButton = ContextualPopupDecorator(Button);

--- a/packages/sampler/stories/default/ContextualPopupDecorator.js
+++ b/packages/sampler/stories/default/ContextualPopupDecorator.js
@@ -4,7 +4,7 @@ import Button from '@enact/moonstone/Button';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/DatePicker.js
+++ b/packages/sampler/stories/default/DatePicker.js
@@ -1,10 +1,9 @@
 import DatePicker, {DatePickerBase} from '@enact/moonstone/DatePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata, removeProps} from '../../src/utils';
+import {action, mergeComponentMetadata, removeProps} from '../../src/utils';
 
 const Config = mergeComponentMetadata('DatePicker', DatePickerBase, DatePicker);
 removeProps(Config, 'year defaultOpen day maxDays maxMonths month onChangeDate onChangeMonth onChangeYear order');

--- a/packages/sampler/stories/default/DatePicker.js
+++ b/packages/sampler/stories/default/DatePicker.js
@@ -1,7 +1,7 @@
 import DatePicker, {DatePickerBase} from '@enact/moonstone/DatePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata, removeProps} from '../../src/utils';

--- a/packages/sampler/stories/default/DayPicker.js
+++ b/packages/sampler/stories/default/DayPicker.js
@@ -1,9 +1,9 @@
 import DayPicker from '@enact/moonstone/DayPicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 DayPicker.displayName = 'DayPicker';
 

--- a/packages/sampler/stories/default/DayPicker.js
+++ b/packages/sampler/stories/default/DayPicker.js
@@ -1,7 +1,7 @@
 import DayPicker from '@enact/moonstone/DayPicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/default/DaySelector.js
+++ b/packages/sampler/stories/default/DaySelector.js
@@ -1,7 +1,7 @@
 import DaySelector, {DaySelectorBase} from '@enact/moonstone/DaySelector';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/DaySelector.js
+++ b/packages/sampler/stories/default/DaySelector.js
@@ -1,10 +1,9 @@
 import DaySelector, {DaySelectorBase} from '@enact/moonstone/DaySelector';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 DaySelector.displayName = 'DaySelector';
 const Config = mergeComponentMetadata('DaySelector', DaySelectorBase, DaySelector);

--- a/packages/sampler/stories/default/Dialog.js
+++ b/packages/sampler/stories/default/Dialog.js
@@ -4,10 +4,9 @@ import BodyText from '@enact/moonstone/BodyText';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Dialog', Popup, Dialog);
 Dialog.displayName = 'Dialog';

--- a/packages/sampler/stories/default/Dialog.js
+++ b/packages/sampler/stories/default/Dialog.js
@@ -4,7 +4,7 @@ import BodyText from '@enact/moonstone/BodyText';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -3,10 +3,9 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 Dropdown.displayName = 'Dropdown';
 const Config = mergeComponentMetadata('Dropdown', UIButtonBase, UIButton, ButtonBase, Button, DropdownBase, Dropdown);

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -3,7 +3,7 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/EditableIntegerPicker.js
+++ b/packages/sampler/stories/default/EditableIntegerPicker.js
@@ -2,10 +2,9 @@ import EditableIntegerPicker, {EditableIntegerPickerBase} from '@enact/moonstone
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('EditableIntegerPicker', EditableIntegerPickerBase, EditableIntegerPicker);
 EditableIntegerPicker.displayName = 'EditableIntegerPicker';

--- a/packages/sampler/stories/default/EditableIntegerPicker.js
+++ b/packages/sampler/stories/default/EditableIntegerPicker.js
@@ -2,7 +2,7 @@ import EditableIntegerPicker, {EditableIntegerPickerBase} from '@enact/moonstone
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/ExpandableInput.js
+++ b/packages/sampler/stories/default/ExpandableInput.js
@@ -2,7 +2,7 @@ import ExpandableInput, {ExpandableInputBase} from '@enact/moonstone/ExpandableI
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/ExpandableInput.js
+++ b/packages/sampler/stories/default/ExpandableInput.js
@@ -2,10 +2,9 @@ import ExpandableInput, {ExpandableInputBase} from '@enact/moonstone/ExpandableI
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const iconNames = ['', ...Object.keys(icons)];
 

--- a/packages/sampler/stories/default/ExpandableItem.js
+++ b/packages/sampler/stories/default/ExpandableItem.js
@@ -3,10 +3,9 @@ import Icon from '@enact/moonstone/Icon';
 import Item from '@enact/moonstone/Item';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ExpandableItem', Expandable, ExpandableItem, ExpandableItemBase);
 ExpandableItem.displayName = 'ExpandableItem';

--- a/packages/sampler/stories/default/ExpandableItem.js
+++ b/packages/sampler/stories/default/ExpandableItem.js
@@ -3,7 +3,7 @@ import Icon from '@enact/moonstone/Icon';
 import Item from '@enact/moonstone/Item';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/ExpandableList.js
+++ b/packages/sampler/stories/default/ExpandableList.js
@@ -1,7 +1,7 @@
 import ExpandableList, {ExpandableListBase} from '@enact/moonstone/ExpandableList';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/ExpandableList.js
+++ b/packages/sampler/stories/default/ExpandableList.js
@@ -1,10 +1,9 @@
 import ExpandableList, {ExpandableListBase} from '@enact/moonstone/ExpandableList';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ExpandableList', ExpandableList, ExpandableListBase);
 ExpandableList.displayName = 'ExpandableList';

--- a/packages/sampler/stories/default/ExpandablePicker.js
+++ b/packages/sampler/stories/default/ExpandablePicker.js
@@ -1,10 +1,9 @@
 import ExpandablePicker, {ExpandablePickerBase} from '@enact/moonstone/ExpandablePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ExpandablePicker', ExpandablePicker, ExpandablePickerBase);
 ExpandablePicker.displayName = 'ExpandablePicker';

--- a/packages/sampler/stories/default/ExpandablePicker.js
+++ b/packages/sampler/stories/default/ExpandablePicker.js
@@ -1,7 +1,7 @@
 import ExpandablePicker, {ExpandablePickerBase} from '@enact/moonstone/ExpandablePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/FormCheckboxItem.js
+++ b/packages/sampler/stories/default/FormCheckboxItem.js
@@ -6,7 +6,7 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata, nullify} from '../../src/utils';

--- a/packages/sampler/stories/default/FormCheckboxItem.js
+++ b/packages/sampler/stories/default/FormCheckboxItem.js
@@ -6,10 +6,9 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata, nullify} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 FormCheckboxItem.displayName = 'FormCheckboxItem';
 const Config = mergeComponentMetadata('FormCheckboxItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, FormCheckboxItem);

--- a/packages/sampler/stories/default/Group.js
+++ b/packages/sampler/stories/default/Group.js
@@ -7,7 +7,7 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/default/Group.js
+++ b/packages/sampler/stories/default/Group.js
@@ -7,9 +7,9 @@ import ToggleButton from '@enact/moonstone/ToggleButton';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 // Set up some defaults for info and knobs
 const prop = {

--- a/packages/sampler/stories/default/IconButton.js
+++ b/packages/sampler/stories/default/IconButton.js
@@ -4,7 +4,7 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/IconButton.js
+++ b/packages/sampler/stories/default/IconButton.js
@@ -4,10 +4,9 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 // import icons
 import docs from '../../images/icon-enact-docs.png';

--- a/packages/sampler/stories/default/Image.js
+++ b/packages/sampler/stories/default/Image.js
@@ -1,10 +1,9 @@
 import Image, {ImageBase, ImageDecorator} from '@enact/moonstone/Image';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {object, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const src = {
 	'hd':  'http://via.placeholder.com/200x200',

--- a/packages/sampler/stories/default/Image.js
+++ b/packages/sampler/stories/default/Image.js
@@ -1,7 +1,7 @@
 import Image, {ImageBase, ImageDecorator} from '@enact/moonstone/Image';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {object, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/IncrementSlider.js
+++ b/packages/sampler/stories/default/IncrementSlider.js
@@ -2,7 +2,7 @@ import IncrementSlider, {IncrementSliderBase, IncrementSliderTooltip} from '@ena
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/IncrementSlider.js
+++ b/packages/sampler/stories/default/IncrementSlider.js
@@ -2,10 +2,9 @@ import IncrementSlider, {IncrementSliderBase, IncrementSliderTooltip} from '@ena
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const IncrementSliderConfig = mergeComponentMetadata('IncrementSlider', IncrementSliderBase, IncrementSlider);
 const IncrementSliderTooltipConfig = mergeComponentMetadata('IncrementSliderTooltip', IncrementSliderTooltip);

--- a/packages/sampler/stories/default/Input.js
+++ b/packages/sampler/stories/default/Input.js
@@ -2,7 +2,7 @@ import Input, {InputBase} from '@enact/moonstone/Input';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Input.js
+++ b/packages/sampler/stories/default/Input.js
@@ -2,10 +2,9 @@ import Input, {InputBase} from '@enact/moonstone/Input';
 import icons from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const iconNames = ['', ...icons];
 

--- a/packages/sampler/stories/default/Notification.js
+++ b/packages/sampler/stories/default/Notification.js
@@ -3,10 +3,9 @@ import Popup from '@enact/moonstone/Popup';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Notification', Notification, Popup);
 

--- a/packages/sampler/stories/default/Notification.js
+++ b/packages/sampler/stories/default/Notification.js
@@ -3,7 +3,7 @@ import Popup from '@enact/moonstone/Popup';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Picker.js
+++ b/packages/sampler/stories/default/Picker.js
@@ -2,7 +2,7 @@ import Picker from '@enact/moonstone/Picker';
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/default/Picker.js
+++ b/packages/sampler/stories/default/Picker.js
@@ -2,9 +2,9 @@ import Picker from '@enact/moonstone/Picker';
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 // Set up some defaults for info and knobs
 const prop = {

--- a/packages/sampler/stories/default/Popup.js
+++ b/packages/sampler/stories/default/Popup.js
@@ -2,10 +2,9 @@ import Popup from '@enact/moonstone/Popup';
 import BodyText from '@enact/moonstone/BodyText';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Popup', Popup);
 

--- a/packages/sampler/stories/default/Popup.js
+++ b/packages/sampler/stories/default/Popup.js
@@ -2,7 +2,7 @@ import Popup from '@enact/moonstone/Popup';
 import BodyText from '@enact/moonstone/BodyText';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/RadioItem.js
+++ b/packages/sampler/stories/default/RadioItem.js
@@ -6,10 +6,9 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata, nullify} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 RadioItem.displayName = 'RadioItem';
 const Config = mergeComponentMetadata('RadioItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, RadioItem);

--- a/packages/sampler/stories/default/RadioItem.js
+++ b/packages/sampler/stories/default/RadioItem.js
@@ -6,7 +6,7 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata, nullify} from '../../src/utils';

--- a/packages/sampler/stories/default/RangePicker.js
+++ b/packages/sampler/stories/default/RangePicker.js
@@ -2,7 +2,7 @@ import RangePicker, {RangePickerBase} from '@enact/moonstone/RangePicker';
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/RangePicker.js
+++ b/packages/sampler/stories/default/RangePicker.js
@@ -2,11 +2,9 @@ import RangePicker, {RangePickerBase} from '@enact/moonstone/RangePicker';
 import {decrementIcons, incrementIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
-import nullify from '../../src/utils/nullify.js';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 const Config = mergeComponentMetadata('RangePicker', RangePickerBase, RangePicker);
 

--- a/packages/sampler/stories/default/Scroller.js
+++ b/packages/sampler/stories/default/Scroller.js
@@ -3,7 +3,7 @@ import Scroller from '@enact/moonstone/Scroller';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Scroller.js
+++ b/packages/sampler/stories/default/Scroller.js
@@ -3,10 +3,9 @@ import Scroller from '@enact/moonstone/Scroller';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Scroller', Scroller, UiScroller);
 

--- a/packages/sampler/stories/default/SelectableItem.js
+++ b/packages/sampler/stories/default/SelectableItem.js
@@ -6,7 +6,7 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata, nullify} from '../../src/utils';

--- a/packages/sampler/stories/default/SelectableItem.js
+++ b/packages/sampler/stories/default/SelectableItem.js
@@ -6,10 +6,9 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata, nullify} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 SelectableItem.displayName = 'SelectableItem';
 const Config = mergeComponentMetadata('SelectableItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, SelectableItem);

--- a/packages/sampler/stories/default/Slider.js
+++ b/packages/sampler/stories/default/Slider.js
@@ -1,7 +1,7 @@
 import Slider, {SliderTooltip} from '@enact/moonstone/Slider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Slider.js
+++ b/packages/sampler/stories/default/Slider.js
@@ -1,10 +1,9 @@
 import Slider, {SliderTooltip} from '@enact/moonstone/Slider';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const SliderConfig = mergeComponentMetadata('Slider', Slider);
 const SliderTooltipConfig = mergeComponentMetadata('SliderTooltip', SliderTooltip);

--- a/packages/sampler/stories/default/Spinner.js
+++ b/packages/sampler/stories/default/Spinner.js
@@ -3,7 +3,7 @@ import UiSpinner, {SpinnerBase as UiSpinnerBase} from '@enact/ui/Spinner';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/Spinner.js
+++ b/packages/sampler/stories/default/Spinner.js
@@ -3,10 +3,9 @@ import UiSpinner, {SpinnerBase as UiSpinnerBase} from '@enact/ui/Spinner';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 Spinner.displayName = 'Spinner';
 const Config = mergeComponentMetadata('Spinner', UiSpinnerBase, UiSpinner, SpinnerBase, Spinner);

--- a/packages/sampler/stories/default/SwitchItem.js
+++ b/packages/sampler/stories/default/SwitchItem.js
@@ -6,7 +6,7 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata, nullify} from '../../src/utils';

--- a/packages/sampler/stories/default/SwitchItem.js
+++ b/packages/sampler/stories/default/SwitchItem.js
@@ -6,10 +6,9 @@ import Icon from '@enact/moonstone/Icon';
 import {listIcons} from './icons';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata, nullify} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 SwitchItem.displayName = 'SwitchItem';
 const Config = mergeComponentMetadata('SwitchItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, SwitchItem);

--- a/packages/sampler/stories/default/TimePicker.js
+++ b/packages/sampler/stories/default/TimePicker.js
@@ -1,7 +1,7 @@
 import TimePicker from '@enact/moonstone/TimePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/TimePicker.js
+++ b/packages/sampler/stories/default/TimePicker.js
@@ -1,10 +1,9 @@
 import TimePicker from '@enact/moonstone/TimePicker';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('TimePicker', TimePicker);
 TimePicker.displayName = 'TimePicker';

--- a/packages/sampler/stories/default/ToggleButton.js
+++ b/packages/sampler/stories/default/ToggleButton.js
@@ -3,7 +3,7 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/ToggleButton.js
+++ b/packages/sampler/stories/default/ToggleButton.js
@@ -3,10 +3,9 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 // Set up some defaults for info and knobs
 const prop = {

--- a/packages/sampler/stories/default/VideoPlayer.js
+++ b/packages/sampler/stories/default/VideoPlayer.js
@@ -4,10 +4,9 @@ import IconButton from '@enact/moonstone/IconButton';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 // Set up some defaults for info and knobs
 const prop = {

--- a/packages/sampler/stories/default/VideoPlayer.js
+++ b/packages/sampler/stories/default/VideoPlayer.js
@@ -4,7 +4,7 @@ import IconButton from '@enact/moonstone/IconButton';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -5,7 +5,7 @@ import {GridListImageItem} from '@enact/moonstone/GridListImageItem';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -5,10 +5,9 @@ import {GridListImageItem} from '@enact/moonstone/GridListImageItem';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const
 	wrapOption = {

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -5,7 +5,7 @@ import VirtualList from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -5,10 +5,9 @@ import VirtualList from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const
 	wrapOption = {

--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -5,7 +5,7 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 import css from './Button.module.less';
 
 import {boolean, select, text} from '../../src/enact-knobs';

--- a/packages/sampler/stories/qa/Button.js
+++ b/packages/sampler/stories/qa/Button.js
@@ -5,11 +5,11 @@ import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
-import css from './Button.module.less';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
+
+import css from './Button.module.less';
 
 // Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean knob and return `void 0` when `true`.
 Button.displayName = 'Button';

--- a/packages/sampler/stories/qa/CheckboxItem.js
+++ b/packages/sampler/stories/qa/CheckboxItem.js
@@ -5,7 +5,7 @@ import Item, {ItemBase} from '@enact/moonstone/Item';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/qa/CheckboxItem.js
+++ b/packages/sampler/stories/qa/CheckboxItem.js
@@ -5,10 +5,9 @@ import Item, {ItemBase} from '@enact/moonstone/Item';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('CheckboxItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, CheckboxItem);
 

--- a/packages/sampler/stories/qa/Dropdown.js
+++ b/packages/sampler/stories/qa/Dropdown.js
@@ -3,9 +3,9 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
+
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Dropdown', UIButtonBase, UIButton, ButtonBase, Button, DropdownBase, Dropdown);
 const items = (itemCount, optionText = 'Option') => (new Array(itemCount)).fill().map((i, index) => `${optionText} ${index + 1}`);

--- a/packages/sampler/stories/qa/Dropdown.js
+++ b/packages/sampler/stories/qa/Dropdown.js
@@ -3,7 +3,7 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';
 

--- a/packages/sampler/stories/qa/ExpandableInput.js
+++ b/packages/sampler/stories/qa/ExpandableInput.js
@@ -2,7 +2,7 @@ import ExpandableInput from '@enact/moonstone/ExpandableInput';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/ExpandableInput.js
+++ b/packages/sampler/stories/qa/ExpandableInput.js
@@ -2,9 +2,9 @@ import ExpandableInput from '@enact/moonstone/ExpandableInput';
 import {icons} from '@enact/moonstone/Icon';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 const iconNames = ['', ...Object.keys(icons)];
 

--- a/packages/sampler/stories/qa/ExpandableList.js
+++ b/packages/sampler/stories/qa/ExpandableList.js
@@ -5,7 +5,7 @@ import Scroller from '@enact/moonstone/Scroller';
 import {RadioControllerDecorator} from '@enact/ui/RadioDecorator';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/qa/ExpandableList.js
+++ b/packages/sampler/stories/qa/ExpandableList.js
@@ -5,10 +5,9 @@ import Scroller from '@enact/moonstone/Scroller';
 import {RadioControllerDecorator} from '@enact/ui/RadioDecorator';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ExpandableList', ExpandableList, ExpandableListBase);
 

--- a/packages/sampler/stories/qa/Input.js
+++ b/packages/sampler/stories/qa/Input.js
@@ -3,9 +3,9 @@ import {Input, InputBase} from '@enact/moonstone/Input';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 Input.displayName = 'Input';
 

--- a/packages/sampler/stories/qa/Input.js
+++ b/packages/sampler/stories/qa/Input.js
@@ -3,7 +3,7 @@ import {Input, InputBase} from '@enact/moonstone/Input';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/Notification.js
+++ b/packages/sampler/stories/qa/Notification.js
@@ -3,10 +3,9 @@ import Popup from '@enact/moonstone/Popup';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('Notification', Notification, Popup);
 

--- a/packages/sampler/stories/qa/Notification.js
+++ b/packages/sampler/stories/qa/Notification.js
@@ -3,7 +3,7 @@ import Popup from '@enact/moonstone/Popup';
 import Button from '@enact/moonstone/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/qa/Picker.js
+++ b/packages/sampler/stories/qa/Picker.js
@@ -4,9 +4,9 @@ import PickerAddRemove from './components/PickerAddRemove';
 import PickerRTL from './components/PickerRTL';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 Picker.displayName = 'Picker';
 

--- a/packages/sampler/stories/qa/Picker.js
+++ b/packages/sampler/stories/qa/Picker.js
@@ -4,7 +4,7 @@ import PickerAddRemove from './components/PickerAddRemove';
 import PickerRTL from './components/PickerRTL';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/Popup.js
+++ b/packages/sampler/stories/qa/Popup.js
@@ -5,7 +5,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import Toggleable from '@enact/ui/Toggleable';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/Popup.js
+++ b/packages/sampler/stories/qa/Popup.js
@@ -5,9 +5,9 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import Toggleable from '@enact/ui/Toggleable';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 Popup.displayName = 'Popup';
 

--- a/packages/sampler/stories/qa/ProgressBar.js
+++ b/packages/sampler/stories/qa/ProgressBar.js
@@ -4,7 +4,7 @@ import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 
-import {mergeComponentMetadata} from '../../src/utils/propTables';
+import {mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('ProgressBar', ProgressBarBase, ProgressBar);
 

--- a/packages/sampler/stories/qa/RadioItem.js
+++ b/packages/sampler/stories/qa/RadioItem.js
@@ -4,10 +4,9 @@ import UiToggleItem, {ToggleItemBase as UiToggleItemBase} from '@enact/ui/Toggle
 import Item, {ItemBase} from '@enact/moonstone/Item';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
-import {mergeComponentMetadata} from '../../src/utils';
 import {boolean} from '../../src/enact-knobs';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 RadioItem.displayName = 'RaditoItem';
 const Config = mergeComponentMetadata('RadioItem', ItemBase, Item, UiToggleItemBase, UiToggleItem, ToggleItem, RadioItem);

--- a/packages/sampler/stories/qa/RadioItem.js
+++ b/packages/sampler/stories/qa/RadioItem.js
@@ -4,7 +4,7 @@ import UiToggleItem, {ToggleItemBase as UiToggleItemBase} from '@enact/ui/Toggle
 import Item, {ItemBase} from '@enact/moonstone/Item';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {mergeComponentMetadata} from '../../src/utils';
 import {boolean} from '../../src/enact-knobs';

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -10,11 +10,10 @@ import Scroller from '@enact/moonstone/Scroller';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import UiScroller from '@enact/ui/Scroller';
-
-import {action} from '../../src/utils/action';
 import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 Scroller.displayName = 'Scroller';
 

--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -11,7 +11,7 @@ import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import UiScroller from '@enact/ui/Scroller';
 
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';

--- a/packages/sampler/stories/qa/SelectableItem.js
+++ b/packages/sampler/stories/qa/SelectableItem.js
@@ -2,7 +2,7 @@ import SelectableItem from '@enact/moonstone/SelectableItem';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/SelectableItem.js
+++ b/packages/sampler/stories/qa/SelectableItem.js
@@ -2,9 +2,9 @@ import SelectableItem from '@enact/moonstone/SelectableItem';
 import Group from '@enact/ui/Group';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 SelectableItem.displayName = 'SelectableItem';
 

--- a/packages/sampler/stories/qa/Spinner.js
+++ b/packages/sampler/stories/qa/Spinner.js
@@ -3,9 +3,9 @@ import Button from '@enact/moonstone/Button';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 Spinner.displayName = 'Spinner';
 

--- a/packages/sampler/stories/qa/Spinner.js
+++ b/packages/sampler/stories/qa/Spinner.js
@@ -3,7 +3,7 @@ import Button from '@enact/moonstone/Button';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -31,7 +31,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import docs from '../../images/icon-enact-docs.png';
 import {boolean, select} from '../../src/enact-knobs';

--- a/packages/sampler/stories/qa/Spotlight.js
+++ b/packages/sampler/stories/qa/Spotlight.js
@@ -27,15 +27,15 @@ import Slider from '@enact/moonstone/Slider';
 import Spotlight from '@enact/spotlight';
 import {Row, Cell, Column} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
+import Pause from '@enact/spotlight/Pause';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import docs from '../../images/icon-enact-docs.png';
 import {boolean, select} from '../../src/enact-knobs';
-import Pause from '@enact/spotlight/Pause';
+import {action} from '../../src/utils';
 
 const Container = SpotlightContainerDecorator(
 	{enterTo: 'last-focused'},

--- a/packages/sampler/stories/qa/SwitchItem.js
+++ b/packages/sampler/stories/qa/SwitchItem.js
@@ -3,9 +3,9 @@ import Group from '@enact/ui/Group';
 import Heading from '@enact/moonstone/Heading';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 SwitchItem.displayName = 'SwitchItem';
 

--- a/packages/sampler/stories/qa/SwitchItem.js
+++ b/packages/sampler/stories/qa/SwitchItem.js
@@ -3,7 +3,7 @@ import Group from '@enact/ui/Group';
 import Heading from '@enact/moonstone/Heading';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, text} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/ToggleButton.js
+++ b/packages/sampler/stories/qa/ToggleButton.js
@@ -3,7 +3,7 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils';

--- a/packages/sampler/stories/qa/ToggleButton.js
+++ b/packages/sampler/stories/qa/ToggleButton.js
@@ -3,10 +3,9 @@ import Button, {ButtonBase} from '@enact/moonstone/Button';
 import UiButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, select, text} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 ToggleButton.displayName = 'ToggleButton';
 const Config = mergeComponentMetadata('ToggleButton', UIButtonBase, UiButton, ButtonBase, Button, ToggleButton);

--- a/packages/sampler/stories/qa/Touchable.js
+++ b/packages/sampler/stories/qa/Touchable.js
@@ -5,9 +5,9 @@ import React from 'react';
 import Touchable from '@enact/ui/Touchable';
 import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number} from '../../src/enact-knobs';
+import {action} from '../../src/utils';
 
 const TouchableDiv = Touchable('div');
 

--- a/packages/sampler/stories/qa/Touchable.js
+++ b/packages/sampler/stories/qa/Touchable.js
@@ -5,7 +5,7 @@ import React from 'react';
 import Touchable from '@enact/ui/Touchable';
 import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number} from '../../src/enact-knobs';
 

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -4,7 +4,7 @@ import GridListImageItem from '@enact/moonstone/GridListImageItem';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';

--- a/packages/sampler/stories/qa/VirtualGridList.js
+++ b/packages/sampler/stories/qa/VirtualGridList.js
@@ -4,10 +4,9 @@ import GridListImageItem from '@enact/moonstone/GridListImageItem';
 import ri from '@enact/ui/resolution';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils/propTables';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('VirtualGridList', VirtualGridList, VirtualListBase, UiVirtualListBase);
 

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -8,10 +8,9 @@ import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils/propTables';
+import {action, mergeComponentMetadata} from '../../src/utils';
 
 const Config = mergeComponentMetadata('VirtualList', VirtualList, VirtualListBase, UiVirtualListBase);
 

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -8,7 +8,7 @@ import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
+import {action} from '../../src/utils/action';
 
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On low-powered hardware, serializing event payloads passed to `action` was very slow, particularly for nativeEvents which have significant payloads.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a middleware function to limit the number of fields

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I defaulted to only `type` for native events in order to distinguish the source type. I don't think we often need more than that but we can revise later as needed.
