### PR TITLE
ENYO-6154: Fix HeaderInput highlight positioning

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Header` input highlight positioning
+
 ## [3.0.0-rc.2] - 2019-08-08
 
 ### Added

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -267,7 +267,9 @@ const InputBase = kind({
 		return (
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" size={size}>{iconBefore}</InputDecoratorIcon>
-				<span className={css.inputHighlight}>{value ? value : placeholder}</span>
+				<div className={`${css.input} ${css.inputHighlightContainer}`}>
+					<span className={css.inputHighlight}>{value ? value : placeholder}</span>
+				</div>
 				<input
 					{...inputProps}
 					{...voiceProps}

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -267,9 +267,7 @@ const InputBase = kind({
 		return (
 			<div {...rest} disabled={disabled}>
 				<InputDecoratorIcon position="before" size={size}>{iconBefore}</InputDecoratorIcon>
-				<div className={`${css.input} ${css.inputHighlightContainer}`}>
-					<span className={css.inputHighlight}>{value ? value : placeholder}</span>
-				</div>
+				<span className={css.inputHighlight}>{value ? value : placeholder}</span>
 				<input
 					{...inputProps}
 					{...voiceProps}

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -80,6 +80,7 @@
 		letter-spacing: 0.1px;
 		pointer-events: none;
 		opacity: 0;
+		z-index: -1;
 	}
 
 	&.small {
@@ -156,15 +157,6 @@
 					color: @moon-input-placeholder-active-color;
 				});
 			}
-		}
-
-		.inputHighlightContainer {
-			position: absolute;
-			height: 100%;
-			width: 100%;
-			left: 0;
-			box-sizing: border-box;
-			z-index: -1;
 		}
 
 		&.invalid input {

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -72,8 +72,7 @@
 
 	.inputHighlight {
 		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
+		top: 0;
 		height: @moon-input-highlight-height;
 		max-width: @moon-input-highlight-max-width;
 		overflow: hidden;

--- a/packages/moonstone/Input/Input.module.less
+++ b/packages/moonstone/Input/Input.module.less
@@ -72,15 +72,14 @@
 
 	.inputHighlight {
 		position: absolute;
-		top: 6px;
+		top: 50%;
+		transform: translateY(-50%);
 		height: @moon-input-highlight-height;
 		max-width: @moon-input-highlight-max-width;
 		overflow: hidden;
-		text-indent: @moon-input-text-indent;
 		letter-spacing: 0.1px;
 		pointer-events: none;
 		opacity: 0;
-		z-index: -1;
 	}
 
 	&.small {
@@ -157,6 +156,15 @@
 					color: @moon-input-placeholder-active-color;
 				});
 			}
+		}
+
+		.inputHighlightContainer {
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			left: 0;
+			box-sizing: border-box;
+			z-index: -1;
 		}
 
 		&.invalid input {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -263,11 +263,11 @@
 @moon-input-border-outline-width: @moon-input-border-width;
 @moon-input-tooltip-offset: @moon-input-border-width;
 @moon-input-icon-spacing: 15px;
-@moon-input-height: 100%;
+@moon-input-height: @moon-button-height;
 @moon-input-small-height: @moon-button-small-height;
 @moon-input-decorator-small-height: @moon-input-small-height;
 @moon-expandableinput-input-margin: 6px @moon-spotlight-outset;
-@moon-input-highlight-height: (@moon-input-height - 3px);
+@moon-input-highlight-height: 100%;
 @moon-input-highlight-max-width: 378px;
 @moon-input-highlight-small-max-width: 357px;
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -263,7 +263,7 @@
 @moon-input-border-outline-width: @moon-input-border-width;
 @moon-input-tooltip-offset: @moon-input-border-width;
 @moon-input-icon-spacing: 15px;
-@moon-input-height: @moon-button-height;
+@moon-input-height: 100%;
 @moon-input-small-height: @moon-button-small-height;
 @moon-input-decorator-small-height: @moon-input-small-height;
 @moon-expandableinput-input-margin: 6px @moon-spotlight-outset;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Vertically center the highlight node so it'll always align with input text no matter the`InputDecorator` height.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Flexbox centering is not working for TV for some reason so used translate to vertically center.
Some caveats are: the highlight won't align if `<input>` height is changed above 100%.


### Comments
ENYO-6154