### PR TITLE
ENYO-6123: Correctly scroll to spotted VirtualList control when focus…

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to correctly scroll to a selected component when focused via 5way
+
 ## [3.0.0-rc.2] - 2019-08-08
 
 ### Added

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -437,11 +437,12 @@ const VirtualListBaseFactory = (type) => {
 				const nextRow = (nextIndex - nextColumn) % dataSize / dimensionToExtent;
 				const numOfItemsInPage = Math.floor((clientSize + spacing) / gridSize) * dimensionToExtent;
 				const firstFullyVisibleIndex = Math.ceil(scrollPosition / gridSize) * dimensionToExtent;
+				const isCurrentItemInView = index >= firstFullyVisibleIndex && index < firstFullyVisibleIndex + numOfItemsInPage;
 				const isNextItemInView = nextIndex >= firstFullyVisibleIndex && nextIndex < firstFullyVisibleIndex + numOfItemsInPage;
 
 				this.lastFocusedIndex = nextIndex;
 
-				if (isNextItemInView || row === nextRow) {
+				if (isNextItemInView && (isCurrentItemInView || numOfItemsInPage !== dimensionToExtent) || row === nextRow) {
 					this.focusByIndex(nextIndex);
 				} else {
 					this.isScrolledBy5way = true;


### PR DESCRIPTION
…ed via 5way

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There are scenarios where you can use 5way to set focus to an "out-of-view" component within a `VirtualList` and the list will not scroll the focused control into view.


### Resolution
When quickly tapping 5way to change focus in a `VirtualList`, the successive taps can occur before the list is updated, thus you are not provided updated information about the list's potential scroll position (where the list would be when the momentum of the previously-initiated scroll - caused by a previous keydown - finishes).

When performing the steps outlined in the JIRA, the "next" target would be considered "in view" and the currently-focused item "not in view". We can update the guard used in deciding whether we simply set focus or scroll to the next item.
