### PR TITLE
ENYO-6143: Show overscroll effect properly via page up and down keys on paging controls

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -192,6 +192,14 @@ class ScrollButtons extends Component {
 		return current === this.prevButtonRef.current || current === this.nextButtonRef.current;
 	}
 
+	checkAndApplyOverscrollEffect = (keyCode, checkAndApplyOverscrollEffect) => {
+		if (isPageUp(keyCode) && this.state.prevButtonDisabled) {
+			checkAndApplyOverscrollEffect('vertical', 'before');
+		} else if (isPageDown(keyCode) && this.state.nextButtonDisabled) {
+			checkAndApplyOverscrollEffect('vertical', 'after');
+		}
+	}
+
 	onDownPrev = () => {
 		if (this.announceRef.current.announce) {
 			const {rtl, vertical} = this.props;

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -192,11 +192,11 @@ class ScrollButtons extends Component {
 		return current === this.prevButtonRef.current || current === this.nextButtonRef.current;
 	}
 
-	checkAndApplyOverscrollEffect = (keyCode, checkAndApplyOverscrollEffect) => {
+	checkAndApplyOverscrollEffect = (keyCode, checkAndApplyOverscrollEffect, type) => {
 		if (isPageUp(keyCode) && this.state.prevButtonDisabled) {
-			checkAndApplyOverscrollEffect('vertical', 'before');
+			checkAndApplyOverscrollEffect('vertical', 'before', type);
 		} else if (isPageDown(keyCode) && this.state.nextButtonDisabled) {
-			checkAndApplyOverscrollEffect('vertical', 'after');
+			checkAndApplyOverscrollEffect('vertical', 'after', type);
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -595,11 +595,15 @@ class ScrollableBase extends Component {
 			let direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-					direction = isPageUp(keyCode) ? 'up' : 'down';
-					this.scrollByPage(direction);
-					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+					if (this.isContent(target)) {
+						direction = isPageUp(keyCode) ? 'up' : 'down';
+						this.scrollByPage(direction);
+						if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+							this.checkAndApplyOverscrollEffectByDirection(direction);
+						}
+					} else if (this.props.overscrollEffectOn.pageKey) {
+						this.uiRef.current.verticalScrollbarRef.current.checkAndApplyOverscrollEffect(keyCode, this.uiRef.current.checkAndApplyOverscrollEffect);
 					}
 				}
 			} else if (getDirection(keyCode)) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -603,7 +603,7 @@ class ScrollableBase extends Component {
 							this.checkAndApplyOverscrollEffectByDirection(direction);
 						}
 					} else if (this.props.overscrollEffectOn.pageKey) {
-						this.uiRef.current.verticalScrollbarRef.current.checkAndApplyOverscrollEffect(keyCode, this.uiRef.current.checkAndApplyOverscrollEffect);
+						this.uiRef.current.verticalScrollbarRef.current.checkAndApplyOverscrollEffect(keyCode, this.uiRef.current.checkAndApplyOverscrollEffect, overscrollTypeOnce);
 					}
 				}
 			} else if (getDirection(keyCode)) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -660,11 +660,15 @@ class ScrollableBaseNative extends Component {
 			let direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-					direction = isPageUp(keyCode) ? 'up' : 'down';
-					this.scrollByPage(direction);
-					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+					if (this.isContent(target)) {
+						direction = isPageUp(keyCode) ? 'up' : 'down';
+						this.scrollByPage(direction);
+						if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+							this.checkAndApplyOverscrollEffectByDirection(direction);
+						}
+					} else if (this.props.overscrollEffectOn.pageKey) {
+						this.uiRef.current.verticalScrollbarRef.current.checkAndApplyOverscrollEffect(keyCode, this.uiRef.current.checkAndApplyOverscrollEffect, overscrollTypeOnce);
 					}
 				}
 			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
@@ -985,7 +989,6 @@ class ScrollableBaseNative extends Component {
 				clearOverscrollEffect={this.clearOverscrollEffect}
 				handleResizeWindow={this.handleResizeWindow}
 				onFlick={this.onFlick}
-				onKeyDown={this.onKeyDown}
 				onMouseDown={this.onMouseDown}
 				onScroll={this.handleScroll}
 				onWheel={this.onWheel}
@@ -1015,6 +1018,7 @@ class ScrollableBaseNative extends Component {
 						data-spotlight-container={spotlightContainer}
 						data-spotlight-container-disabled={spotlightContainerDisabled}
 						data-spotlight-id={spotlightId}
+						onKeyDown={this.onKeyDown}
 						onTouchStart={this.onTouchStart}
 						ref={uiContainerRef}
 						style={style}

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -104,8 +104,9 @@ class ScrollbarBase extends Component {
 		this.startHidingThumb = startHidingThumb;
 		this.uiUpdate = uiUpdate;
 
-		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = this.scrollButtonsRef.current;
+		const {checkAndApplyOverscrollEffect, isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = this.scrollButtonsRef.current;
 
+		this.checkAndApplyOverscrollEffect = checkAndApplyOverscrollEffect;
 		this.isOneOfScrollButtonsFocused = isOneOfScrollButtonsFocused;
 		this.update = (bounds) => {
 			updateButtons(bounds);
@@ -156,6 +157,7 @@ const Scrollbar = ApiDecorator(
 	{api: [
 		'focusOnButton',
 		'getContainerRef',
+		'checkAndApplyOverscrollEffect',
 		'isOneOfScrollButtonsFocused',
 		'showThumb',
 		'startHidingThumb',

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -2,6 +2,7 @@ import Item from '@enact/moonstone/Item';
 import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
 import Scroller from '@enact/moonstone/Scroller';
 import SwitchItem from '@enact/moonstone/SwitchItem';
+import {ScrollableBase} from '@enact/moonstone/Scrollable';
 import VirtualList, {VirtualListBase} from '@enact/moonstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
@@ -14,7 +15,7 @@ import {action} from '@storybook/addon-actions';
 import {boolean, number, select} from '../../src/enact-knobs';
 import {mergeComponentMetadata} from '../../src/utils/propTables';
 
-const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase, ScrollableBase);
 
 const
 	itemStyle = {
@@ -187,6 +188,36 @@ storiesOf('VirtualList', module)
 					onKeyDown={action('onKeyDown')}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}
+					spacing={ri.scale(number('spacing', Config))}
+					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+				/>
+			);
+		},
+		{propTables: [Config]}
+	)
+	.add(
+		'with Overscroll Effect',
+		() => {
+			return (
+				<VirtualList
+					dataSize={updateDataSize(number('dataSize', Config, 10))}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
+					itemSize={ri.scale(number('itemSize', Config, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', Config)}
+					onKeyDown={action('onKeyDown')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					overscrollEffectOn={{
+						arrowKey: boolean('overscrollEffectOn arrowKey', Config, false),
+						drag: boolean('overscrollEffectOn drag', Config),
+						pageKey: boolean('overscrollEffectOn pageKey', Config),
+						scrollbarButton: boolean('overscrollEffectOn scrollbarButton', Config),
+						wheel: boolean('overscrollEffectOn wheel', Config, true)
+					}}
 					spacing={ri.scale(number('spacing', Config))}
 					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
 					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -780,7 +780,7 @@ class ScrollableBase extends Component {
 		this.setOverscrollStatus(orientation, edge, type === overscrollTypeOnce ? overscrollTypeDone : type, ratio);
 	}
 
-	checkAndApplyOverscrollEffect = (orientation, edge, type, ratio = 1) => {
+	checkAndApplyOverscrollEffect = (orientation, edge, type = overscrollTypeOnce, ratio = 1) => {
 		const
 			isVertical = (orientation === 'vertical'),
 			curPos = isVertical ? this.scrollTop : this.scrollLeft,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -780,7 +780,7 @@ class ScrollableBase extends Component {
 		this.setOverscrollStatus(orientation, edge, type === overscrollTypeOnce ? overscrollTypeDone : type, ratio);
 	}
 
-	checkAndApplyOverscrollEffect = (orientation, edge, type = overscrollTypeOnce, ratio = 1) => {
+	checkAndApplyOverscrollEffect = (orientation, edge, type, ratio = 1) => {
 		const
 			isVertical = (orientation === 'vertical'),
 			curPos = isVertical ? this.scrollTop : this.scrollLeft,


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

After passing `overscrollEffectOn` prop with {`pageKey`: true} in it to `VirtualList`, Overscroll Effect did not show properly via page up and down keys on paging controls.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`Scrollable` did not handle this case before. So I fixed this case via page up and down keys on paging controls

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- I added `with Overscroll Effect` sample in qa-sampler to adjuest `overscrollEffectOn` prop.
- `onKeyDown` was not called via page up and down on paging controls because the event handler was hooked in not ScrollableBase but VirtualListBase. So I fixed it.

### Links
[//]: # (Related issues, references)

ENYO-6143