### PR TITLE
ENYO-6181: LabeledItem and ExpandableInput QA Samples have "Pure" knob

### DIFF
--- a/packages/sampler/stories/qa/ExpandableInput.js
+++ b/packages/sampler/stories/qa/ExpandableInput.js
@@ -6,6 +6,8 @@ import {storiesOf} from '@storybook/react';
 import {boolean, select, text} from '../../src/enact-knobs';
 import {action} from '../../src/utils';
 
+ExpandableInput.displayName = 'ExpandableInput';
+
 const iconNames = ['', ...Object.keys(icons)];
 
 storiesOf('ExpandableInput', module)

--- a/packages/sampler/stories/qa/LabeledItem.js
+++ b/packages/sampler/stories/qa/LabeledItem.js
@@ -6,6 +6,8 @@ import {storiesOf} from '@storybook/react';
 
 import {boolean, select, text} from '../../src/enact-knobs';
 
+LabeledItem.displayName = 'LabeledItem';
+
 const inputData = {
 	longLabel : 'label starts - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac tellus in velit ornare commodo. Nam dignissim fringilla nulla, sit amet hendrerit sapien laoreet quis. Praesent quis tellus non diam viverra feugiat. In quis mattis purus, quis tristique mi. Mauris vitae tellus tempus, convallis ligula id, laoreet eros. Nullam eu tempus odio, non mollis tellus. Phasellus vitae iaculis nisl. = label ends',
 	longChildren : 'children starts - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac tellus in velit ornare commodo. Nam dignissim fringilla nulla, sit amet hendrerit sapien laoreet quis. Praesent quis tellus non diam viverra feugiat. In quis mattis purus, quis tristique mi. Mauris vitae tellus tempus, convallis ligula id, laoreet eros. Nullam eu tempus odio, non mollis tellus. Phasellus vitae iaculis nisl. - children ends',


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* LabeledItem and ExpandableInput QA samples have no displayName explicitly set and have "Pure" as its knob name.

### Resolution
* Adds explicit displayName like other samples

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>