### PR TITLE
ENYO-6186: Fix Text to determine when translations are available when async

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/Text` to generate a proper TypeScript definition and to properly detect if translations were available when async
+
 ## [3.0.0-rc.3] - 2019-08-15
 
 No significant changes.

--- a/packages/i18n/Text/Text.js
+++ b/packages/i18n/Text/Text.js
@@ -164,9 +164,7 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				if (!resBundle) return;
 
 				const translated = props.reduce((obj, prop) => {
-					const text = obj[prop].text || obj[prop];
-					obj[prop].translated = String(getIStringFromBundle(text, resBundle));
-
+					obj[prop].translated = String(getIStringFromBundle(obj[prop].text, resBundle));
 					return obj;
 				}, {...map});
 

--- a/packages/i18n/Text/Text.js
+++ b/packages/i18n/Text/Text.js
@@ -256,7 +256,6 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
  *
  * @class Text
  * @memberof i18n/Text
- * @extends React.ComponentType
  * @mixes i18n/Text.TextDecorator
  * @ui
  * @public

--- a/packages/i18n/Text/Text.js
+++ b/packages/i18n/Text/Text.js
@@ -164,7 +164,8 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				if (!resBundle) return;
 
 				const translated = props.reduce((obj, prop) => {
-					obj[prop].translated = String(getIStringFromBundle(obj[prop].text, resBundle));
+					const text = obj[prop].text || obj[prop];
+					obj[prop].translated = String(getIStringFromBundle(text, resBundle));
 
 					return obj;
 				}, {...map});
@@ -177,7 +178,7 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		canRender () {
 			const entries = Object.values(this.state.map);
-			for (const entry in entries) {
+			for (const entry of entries) {
 				if (entry.translated === false && entry.defaultText === false) {
 					return false;
 				}

--- a/packages/i18n/Text/Text.js
+++ b/packages/i18n/Text/Text.js
@@ -113,8 +113,23 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const Decorator = class extends React.Component {
 		static displayName = 'TextDecorator'
 
-		static propTypes = {
+		static propTypes = /** @lends i18n/Text.TextDecorator.prototype */ {
+			/**
+			 * The string to be translated.
+			 *
+			 * @type {String}
+			 * @public
+			 */
 			children: PropTypes.string,
+
+			/**
+			 * The locale for translation.
+			 *
+			 * If not supplied, the current locale is used.
+			 *
+			 * @type {String}
+			 * @public
+			 */
 			locale: PropTypes.string
 		}
 
@@ -241,6 +256,9 @@ const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
  *
  * @class Text
  * @memberof i18n/Text
+ * @extends React.ComponentType
+ * @mixes i18n/Text.TextDecorator
+ * @ui
  * @public
  */
 const Text = TextDecorator(STRING_ONLY);

--- a/packages/i18n/docs/index.md
+++ b/packages/i18n/docs/index.md
@@ -10,11 +10,13 @@ This guide details how to use some of i18n library's features. For an overview o
 
 `I18nDecorator` is a higher-order component (HOC) that provides easy access to locale information. Applications wishing to receive locale information can wrap the root component with the HOC. It is not necessary to use `I18nDecorator` directly for applications using `MoonstoneDecorator`.
 
-The HOC works by passing locale information to the app through [context](https://reactjs.org/docs/context.html) and CSS classes. It contains three properties via context:
+The HOC works by passing locale information to the app through [context](https://reactjs.org/docs/context.html) and CSS classes. It passes three properties via context:
 
 * `locale` - a string representing the current locale
-* `rtl` - if `true` then the locale is a right-to-left language.
-* `updateLocale` - a function to update the locale of the app.
+* `rtl` - if `true` then the locale is a right-to-left language
+* `updateLocale` - a function to update the locale of the app
+
+When not using `MoosntoneDecorator`, be sure to apply the classes passed from `I18nDecorator` to the root component.
 
 ### Accessing I18nDecorator context properties
 
@@ -116,6 +118,13 @@ Many localization companies are able to provide translations in this format.
 The string returned from a call to `$L()` will be the translated string for the
 current UI locale. If a different locale or a bundle with a different name is
 needed, use `ResBundle` directly instead of `$L()`.
+
+Translation files should be placed into locale specific directories and added to the `resources/ilibmanifest.json` file:
+
+```javascript
+{
+	"files": ["en/US/strings.json", "ja/JP/strings.json", ...]
+}
 
 ## Updating Locale
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some uses of `Text`/`TextDecorator` were causing errors

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Corrected some parts of `TextDecorator` to work correctly with bare strings and to correctly recognize when a translation is not yet available.  Also, updated the documentation to better describe how to add `strings.json` since I could not find a reference on the ilib docs for this.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6182

### Comments
