### PR TITLE
ENYO-6187: Remove remaining small prop references

### DIFF
--- a/packages/sampler/stories/default/CheckboxItem.js
+++ b/packages/sampler/stories/default/CheckboxItem.js
@@ -20,7 +20,7 @@ storiesOf('Moonstone', module)
 		() => {
 			const iconPosition = select('iconPosition', ['before', 'after'], Config);
 			const icon = select('itemIcon', ['', ...listIcons], Config);
-			const itemIcon = nullify(icon ? <Icon small>{icon}</Icon> : null);
+			const itemIcon = nullify(icon ? <Icon>{icon}</Icon> : null);
 			const itemIconPosition = select('itemIconPosition', [null, 'before', 'beforeChildren', 'afterChildren', 'after'], Config);
 			return (
 				<CheckboxItem

--- a/packages/sampler/stories/default/FormCheckboxItem.js
+++ b/packages/sampler/stories/default/FormCheckboxItem.js
@@ -19,7 +19,7 @@ storiesOf('Moonstone', module)
 		() => {
 			const iconPosition = select('iconPosition', ['before', 'after'], Config);
 			const icon = select('itemIcon', ['', ...listIcons], Config);
-			const itemIcon = nullify(icon ? <Icon small>{icon}</Icon> : null);
+			const itemIcon = nullify(icon ? <Icon>{icon}</Icon> : null);
 			const itemIconPosition = select('itemIconPosition', [null, 'before', 'beforeChildren', 'afterChildren', 'after'], Config);
 			return (
 				<FormCheckboxItem

--- a/packages/sampler/stories/default/Layout.js
+++ b/packages/sampler/stories/default/Layout.js
@@ -20,10 +20,10 @@ storiesOf('UI', module)
 					orientation={select('orientation', ['horizontal', 'vertical'], Layout, 'horizontal')}
 				>
 					<Cell size={number('cell size', Cell, {range: true, min: 0, max: 300, step: 5}, 100) + 'px'} shrink>
-						<Button small>First</Button>
+						<Button>First</Button>
 					</Cell>
 					<Cell shrink={boolean('shrinkable cell', Cell)}>
-						<Button small>Second</Button>
+						<Button>Second</Button>
 					</Cell>
 					<Cell>
 						<Item>An auto-sizing Item that has a marquee so it will always show the full text string even if it&apos;s too long to fit</Item>

--- a/packages/sampler/stories/default/RadioItem.js
+++ b/packages/sampler/stories/default/RadioItem.js
@@ -19,7 +19,7 @@ storiesOf('Moonstone', module)
 		() => {
 			const iconPosition = select('iconPosition', ['before', 'after'], Config);
 			const icon = select('itemIcon', ['', ...listIcons], Config);
-			const itemIcon = nullify(icon ? <Icon small>{icon}</Icon> : null);
+			const itemIcon = nullify(icon ? <Icon>{icon}</Icon> : null);
 			const itemIconPosition = select('itemIconPosition', [null, 'before', 'beforeChildren', 'afterChildren', 'after'], Config);
 			return (
 				<RadioItem

--- a/packages/sampler/stories/default/SelectableItem.js
+++ b/packages/sampler/stories/default/SelectableItem.js
@@ -19,7 +19,7 @@ storiesOf('Moonstone', module)
 		() => {
 			const iconPosition = select('iconPosition', ['before', 'after'], Config);
 			const icon = select('itemIcon', ['', ...listIcons], Config);
-			const itemIcon = nullify(icon ? <Icon small>{icon}</Icon> : null);
+			const itemIcon = nullify(icon ? <Icon>{icon}</Icon> : null);
 			const itemIconPosition = select('itemIconPosition', [null, 'before', 'beforeChildren', 'afterChildren', 'after'], Config);
 			return (
 				<SelectableItem

--- a/packages/sampler/stories/default/SwitchItem.js
+++ b/packages/sampler/stories/default/SwitchItem.js
@@ -18,7 +18,7 @@ storiesOf('Moonstone', module)
 		'SwitchItem',
 		() => {
 			const icon = select('itemIcon', ['', ...listIcons], Config);
-			const itemIcon = nullify(icon ? <Icon small>{icon}</Icon> : null);
+			const itemIcon = nullify(icon ? <Icon>{icon}</Icon> : null);
 			const itemIconPosition = select('itemIconPosition', ['', 'before', 'beforeChildren', 'afterChildren', 'after'], Config);
 			return (
 				<SwitchItem


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Console error from passing removed `small` prop

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `small` prop (replaced by `size="small", but `"small"` is the default now).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6187

### Comments
