### PR TITLE
ENYO-6186: Fix EditableIntegerPicker to display value after editing

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` arrow rendering issue in Chromium
+- `moonstone/EditableIntegerPicker` to properly rerender when the edited value is invalid
 
 ## [3.0.0-rc.3] - 2019-08-15
 

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -280,7 +280,7 @@ const EditableIntegerPickerBase = kind({
 				return (
 					<input
 						className={css.input}
-						key={value}
+						key="edit"
 						onBlur={onInputBlur}
 						ref={inputRef}
 					/>

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPickerDecorator.js
@@ -62,6 +62,14 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 			disabled: PropTypes.bool,
 
 			/**
+			 * Disables transition animation.
+			 *
+			 * @type {Boolean}
+			 * @public
+			 */
+			noAnimation: PropTypes.bool,
+
+			/**
 			 * The value displayed in the picker.
 			 *
 			 * @type {Number}
@@ -80,14 +88,18 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 			this.paused = new Pause('EditableIntegerPickerDecorator');
 			this.state = {
 				isActive: false,
-				value: props.value
+				value: props.value,
+				// Animation is disabled on the picker when activating edit mode and enabled on the
+				// next onChange event. The `noAnimation` prop takes precedence over this.
+				noAnimation: false
 			};
 		}
 
 		handleChange = (ev) => {
 			if (!this.state.isActive) {
 				this.setState({
-					value: this.validateValue(parseInt(ev.value))
+					value: this.validateValue(parseInt(ev.value)),
+					noAnimation: false
 				});
 			}
 			forwardChange(ev, this.props);
@@ -95,7 +107,8 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 
 		prepareInput = () => {
 			this.setState({
-				isActive: true
+				isActive: true,
+				noAnimation: true
 			});
 			this.freezeSpotlight(true);
 		}
@@ -159,6 +172,7 @@ const EditableIntegerPickerDecorator = hoc((config, Wrapped) => {	// eslint-disa
 					editMode={this.state.isActive}
 					inputRef={this.getInputNode}
 					joined
+					noAnimation={this.props.noAnimation || this.state.noAnimation}
 					onChange={this.handleChange}
 					onPickerItemClick={this.handleClick}
 					onInputBlur={this.handleBlur}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When editing `EditableIntegerPicker` an invalid value would cause the value in the picker to disappear

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Regression from #2475 .  The input was reusing the `key` of the current value, so restoring the current value would not cause the old value to animate back in.  Solution: Use a different key for the edit mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
ENYO-6186

### Comments
