### PR TITLE
ENYO-6176: Implement a more complete font definition system

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` arrow rendering issue in Chromium
+- Language-specific fonts so they always use the correct typeface for their locale
 
 ## [3.0.0-rc.3] - 2019-08-15
 

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -46,7 +46,7 @@
 	pa: local("LG Smart UI Gurmukhi");
 	ta: local("LG Smart UI Tamil");
 	te: local("LG Smart UI Telugu");
-	ur: local("LG Smart UI_Urdu") normal 300 600 700;
+	ur: local("LG Smart UI Urdu") normal 300 600 700;
 	zh-HK: local("LG Smart UI TC") normal 300 600 700;
 	zh-TW: local("LG Smart UI TC") normal 300 600 700; // same as `zh-HK`
 

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -46,30 +46,30 @@
 	pa: local("LG Smart UI Gurmukhi");
 	ta: local("LG Smart UI Tamil");
 	te: local("LG Smart UI Telugu");
-	ur: local("LG Smart UI Urdu");
-	zh-HK: local("LG Smart UI TC"), local("LG Smart UI TC") 300, local("LG Smart UI TC") 600, local("LG Smart UI TC") 700;
-	zh-TW: local("LG Smart UI TC"), local("LG Smart UI TC") 300, local("LG Smart UI TC") 600, local("LG Smart UI TC") 700; // same as `zh-HK`
+	ur: local("LG Smart UI_Urdu") normal 300 600 700;
+	zh-HK: local("LG Smart UI TC") normal 300 600 700;
+	zh-TW: local("LG Smart UI TC") normal 300 600 700; // same as `zh-HK`
 
 	// DEV NOTE: This is the closest proximity to a collection of unit tests that we have to test this system.
-	// name:						local("name");
-	// nameWeight:					local("name") 100;
-	// nameWeightRange:			local("name") 100 900;
-	// nameWeightStyle:			local("name") 100 italic;
-	// nameWeightRangeStyle:		local("name") 100 900 italic;
-	// nameRepeat:					local("name"), local("name2");
-	// nameWeightRepeat:			local("name") 100, local("name2") 200;
-	// nameWeightRepeat2ndWeight:	local("name"), local("name2") 200;
-	// nameWeightRangeRepeat:		local("name") 100 900, local("name2") 200 800;
-	// nameWeightStyleRepeat:		local("name") 100 italic, local("name2") 200 normal;
-	// nameWeightRangeStyleRepeat:	local("name") 100 900 italic, local("name2") 200 800 normal;
+	// name:							local("name");
+	// nameRepeat:						local("name"), local("name2");
+	// nameWeight:						local("name") 100;
+	// nameMultipleWeight:				local("name") 100 900;
+	// nameWeightStyle:				local("name") 100 italic;
+	// nameMultipleWeightStyle:		local("name") 100 900 italic;
+	// nameWeightRepeat:				local("name") 100, local("name2") 200;
+	// nameWeightRepeat2ndWeight:		local("name"), local("name2") 200;
+	// nameMultipleWeightRepeat:		local("name") 100 900, local("name2") 200 800;
+	// nameWeightStyleRepeat:			local("name") 100 italic, local("name2") 200 normal;
+	// nameMultipleWeightStyleRepeat:	local("name") 100 900 italic, local("name2") 200 800 normal;
 };
 
 
 // Deprecated Mixin. Retained for legacy references.
 // Generate a pair of rules in the correct order for the fallback glyphs and the preferred glyphs
-.buildFontFamily(@name; @latin; @fallback; @weight: normal; @style: ""; @stretch: "") {
-	.buildFontFace(@name; @fallback; @weight; @style; @stretch);
-	.buildFontFace(@name; @latin; @weight; @style; @stretch);
+.buildFontFamily(@name; @latin; @fallback; @weight: normal; @style: "") {
+	.buildFontFace(@name; @fallback; @weight; @style);
+	.buildFontFace(@name; @latin; @weight; @style);
 }
 
 // Deprecated "Miso" font family names. Retained for legacy references.
@@ -94,10 +94,10 @@
 
 /* ----- Moonstone Condensed ------ */
 // This collection of fonts is now accessible via the standard CSS rule – `font-stretch: condensed;`
-.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-400; ""; ""; condensed);
-.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-300; 300; ""; condensed);
-.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-600; 600; ""; condensed);
-.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-700; 700; ""; condensed);
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-400; { font-stretch: condensed; });
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-300; { font-stretch: condensed; font-weight: 300; });
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-600; { font-stretch: condensed; font-weight: 600; });
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-700; { font-stretch: condensed; font-weight: 700; });
 
 
 /* ----- Manual Moonstone Locale Fonts (Stacking onto "Moonstone") ------ */

--- a/packages/moonstone/styles/internal/fonts.less
+++ b/packages/moonstone/styles/internal/fonts.less
@@ -5,15 +5,15 @@
 @font-family-base-name: "Moonstone";
 
 // ----- SYSTEM FONT NAMES ------
-@font-system-src-moonstone-condensed-300:  local("LG Smart UI Cond Light"), local("LGSmartUICond-Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
-@font-system-src-moonstone-condensed-400:  local("LG Smart UI Cond"), local("LGSmartUICond-Regular"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
-@font-system-src-moonstone-condensed-600:  local("LG Smart UI Cond SemiBold"), local("LGSmartUICond-SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
-@font-system-src-moonstone-condensed-700:  local("LG Smart UI Cond Bold"), local("LGSmartUICond-Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-300:  local("LG Smart UI Condensed Light"), local("LGSmartUICondensed-Light"), local("Miso"), url("../../fonts/Miso/Miso-Light.ttf") format("truetype");
+@font-system-src-moonstone-condensed-400:  local("LG Smart UI Condensed Regular"), local("LGSmartUICondensed-Regular"), local("Miso"), url("../../fonts/Miso/Miso-Regular.ttf") format("truetype");
+@font-system-src-moonstone-condensed-600:  local("LG Smart UI Condensed SemiBold"), local("LGSmartUICondensed-SemiBold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
+@font-system-src-moonstone-condensed-700:  local("LG Smart UI Condensed Bold"), local("LGSmartUICondensed-Bold"), local("Miso"), url("../../fonts/Miso/Miso-Bold.ttf") format("truetype");
 
 @font-system-src-moonstone-100:    local("LG Smart UI Light"), local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Thin.ttf") format("truetype");
 @font-system-src-moonstone-300:    local("LG Smart UI Light"), local("LGSmartUI-Light"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
-@font-system-src-moonstone-400:    local("LG Smart UI"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
-@font-system-src-moonstone-400-i:  local("LG Smart UI"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
+@font-system-src-moonstone-400:    local("LG Smart UI Regular"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Medium.ttf") format("truetype");
+@font-system-src-moonstone-400-i:  local("LG Smart UI Regular"), local("LGSmartUI-Regular"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-MediumItalic.ttf") format("truetype");
 @font-system-src-moonstone-600:    local("LG Smart UI SemiBold"), local("LGSmartUI-SemiBold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
 @font-system-src-moonstone-700:    local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
 @font-system-src-moonstone-700-i:  local("LG Smart UI Bold"), local("LGSmartUI-Bold"), local("Museo Sans"), url("../../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
@@ -47,16 +47,29 @@
 	ta: local("LG Smart UI Tamil");
 	te: local("LG Smart UI Telugu");
 	ur: local("LG Smart UI Urdu");
-	zh-HK: local("LG Smart UI TC");
-	zh-TW: local("LG Smart UI TC"); // same as `zh-HK`
+	zh-HK: local("LG Smart UI TC"), local("LG Smart UI TC") 300, local("LG Smart UI TC") 600, local("LG Smart UI TC") 700;
+	zh-TW: local("LG Smart UI TC"), local("LG Smart UI TC") 300, local("LG Smart UI TC") 600, local("LG Smart UI TC") 700; // same as `zh-HK`
+
+	// DEV NOTE: This is the closest proximity to a collection of unit tests that we have to test this system.
+	// name:						local("name");
+	// nameWeight:					local("name") 100;
+	// nameWeightRange:			local("name") 100 900;
+	// nameWeightStyle:			local("name") 100 italic;
+	// nameWeightRangeStyle:		local("name") 100 900 italic;
+	// nameRepeat:					local("name"), local("name2");
+	// nameWeightRepeat:			local("name") 100, local("name2") 200;
+	// nameWeightRepeat2ndWeight:	local("name"), local("name2") 200;
+	// nameWeightRangeRepeat:		local("name") 100 900, local("name2") 200 800;
+	// nameWeightStyleRepeat:		local("name") 100 italic, local("name2") 200 normal;
+	// nameWeightRangeStyleRepeat:	local("name") 100 900 italic, local("name2") 200 800 normal;
 };
 
 
 // Deprecated Mixin. Retained for legacy references.
 // Generate a pair of rules in the correct order for the fallback glyphs and the preferred glyphs
-.buildFontFamily(@name; @latin; @fallback; @weight: ""; @style: "") {
-	.buildFontFace(@name; @fallback; @weight; @style);
-	.buildFontFace(@name; @latin; @weight; @style);
+.buildFontFamily(@name; @latin; @fallback; @weight: normal; @style: ""; @stretch: "") {
+	.buildFontFace(@name; @fallback; @weight; @style; @stretch);
+	.buildFontFace(@name; @latin; @weight; @style; @stretch);
 }
 
 // Deprecated "Miso" font family names. Retained for legacy references.
@@ -80,10 +93,11 @@
 
 
 /* ----- Moonstone Condensed ------ */
-.buildFontFace("@{font-family-base-name} Condensed"; @font-system-src-moonstone-condensed-400);
-.buildFontFace("@{font-family-base-name} Condensed"; @font-system-src-moonstone-condensed-300; 300);
-.buildFontFace("@{font-family-base-name} Condensed"; @font-system-src-moonstone-condensed-600; 600);
-.buildFontFace("@{font-family-base-name} Condensed"; @font-system-src-moonstone-condensed-700; 700);
+// This collection of fonts is now accessible via the standard CSS rule – `font-stretch: condensed;`
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-400; ""; ""; condensed);
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-300; 300; ""; condensed);
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-600; 600; ""; condensed);
+.buildFontFace(@font-family-base-name; @font-system-src-moonstone-condensed-700; 700; ""; condensed);
 
 
 /* ----- Manual Moonstone Locale Fonts (Stacking onto "Moonstone") ------ */
@@ -93,7 +107,7 @@
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-700; 700);
 
 /* ----- Generated Moonstone Locale Fonts (Stacking onto "Moonstone") ------ */
-.buildLocaleFonts(@font-family-base-name, @fonts);
+.buildLocaleFonts(@font-family-base-name; @fonts);
 
 /* ----- Moonstone ------ */
 // Unused (parked) rules are commented out.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/styles/mixins.less` mixins: `.buildLocaleFont`, `.buildLocaleFonts`, `.buildFontFace` to properly support font-weight ranges, font-weight default values, and font-stretch values
+
 ## [3.0.0-rc.3] - 2019-08-15
 
 ### Fixed

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -177,6 +177,22 @@
 	-moz-box-sizing: border-box;
 }
 
+// Helpful debugging way to understand how LESS variables are being interpreted
+.debugLessTypes(@value) {
+	:global(.debugLessTypes) {
+		value: @value;
+		isnumber: isnumber(@value);
+		isstring: isstring(@value);
+		iscolor: iscolor(@value);
+		iskeyword: iskeyword(@value);
+		isurl: isurl(@value);
+		ispixel: ispixel(@value);
+		isem: isem(@value);
+		ispercentage: ispercentage(@value);
+		isruleset: isruleset(@value);
+	}
+}
+
 //
 // Mixin classes supporting advanced text
 //
@@ -200,23 +216,75 @@
 //  * List of supported "options" per locale key, in the following order:
 //  * * single font source - Typically a reference to a local() font or a url() font.
 //  * * font-weight - Optional, Numbers (100, 500, 700, etc) and keywords (normal, bold, etc) are supported.
-//  * 	Empty-string represents "null" or default. This excludes the weight rule from the generated code.
+//  * 	Empty-string represents "null". This excludes the font-weight rule from the generated code.
 //  * * font-style - Optional, Keywords (normal, italic, etc) are supported.
+//  * * font-stretch - Optional, Keywords (ultra-condensed, extra-condensed, condensed, semi-condensed, normal, semi-expanded, expanded, extra-expanded, ultra-expanded, initial, inherit) are supported.
 //  *
 //  * OPTIONALLY: repeat the options above after a comma (,) for multiple weights/styles/options based on the same name.
 //  *
 //  * @param  {String} @baseName The name used as the basis for the generated font-family.
 //  * @param  {Object} @f        Object of keys with values detailing the font variants and options.
 //  */
-.buildLocaleFonts(@fontName, @f) {
-	each(@f, .(@specs, @locale) {
-		each(@specs, {
-			@f-weight: if((length(@value) >= 2), extract(@value, 2));
-			@f-style: if((length(@value) >= 3), extract(@value, 3));
 
-			.buildFontFace("@{fontName} @{locale}"; extract(@value, 1); @f-weight; @f-style);
-			.buildFontFace(@fontName;               extract(@value, 1); @f-weight; @f-style);
-		});
+.buildLocaleFont(@fontName; @locale; @args) {
+	@f-src: extract(@args, 1);
+	@arg2:  if((length(@args) >= 2), extract(@args, 2), normal);  // weight – keyword "normal" added as a fallback here to support args that only include a src (and no weight assignment)
+	@arg3:  if((length(@args) >= 3), extract(@args, 3));          // weightRangeEnd (optional) OR style
+	@arg4:  if((length(@args) >= 4), extract(@args, 4));          // style OR stretch
+	@arg5:  if((length(@args) >= 5), extract(@args, 5));          // stretch
+
+	// Reinterpret the 3rd argument if it's a number, assume it's a range of weights, and update f-style and @f-stretch if a weight range was used.
+	// A seemingly simpler `when` block cannot be used here since the scope from inside a `when` doesn't override an outer scope, so nothing you do in one will update the values outside it.
+	@f-weight:  if((length(@args) >= 3) and (isnumber(@arg3)), @arg2 @arg3, @arg2);
+	@f-style:   if((length(@args) >= 3) and (isnumber(@arg3)), @arg4, @arg3);
+	@f-stretch: if((length(@args) >= 3) and (isnumber(@arg3)), @arg5, @arg4);
+
+	// Please retain the following comment for future debugging purposes. This gives insight into how the definition values are being interpreted.
+	// :global(.debug-buildLocaleFont@{fontName}-@{locale}) {
+	// 	fontName: @fontName;
+	// 	locale: @locale;
+	// 	args: @args;
+	// 	args-count: length(@args);
+	// 	arg3-is-number: isnumber(@arg3);
+	// 	f-src: @f-src;
+	// 	f-weight: @f-weight;
+	// 	f-style: @f-style;
+	// }
+
+	.buildFontFace("@{fontName} @{locale}"; @f-src; @f-weight; @f-style; @f-stretch);
+	.buildFontFace(@fontName;               @f-src; @f-weight; @f-style; @f-stretch);
+};
+
+.buildLocaleFonts(@fontName; @f) {
+	each(@f, .(@specs, @locale) {
+		// Determine if we're working with a collection of font definitions or an individual definition
+		@isCollection: if(((length(@specs) > 1) and (length(extract(@specs, 1)) > 1) or (length(extract(@specs, 2)) > 1)), true, false);
+
+		// :global(.debug-buildLocaleFonts-@{locale}) {
+		// 	is-collection: @isCollection;
+		// }
+
+		// Interpret collections of font definitions: [(set1) (set2) (set3)]
+		& when (@isCollection) {
+			each(@specs, {
+				.buildLocaleFont(@fontName; @locale; @value);
+			});
+		}
+		// Interpret individual font defiintions: (set1)
+		& when (not(@isCollection)) {
+			.buildLocaleFont(@fontName; @locale; @specs);
+		}
+		// .debugLessTypes(@specs);
+
+		// Note: The above `when` code will ignore defiintions like the following, because the way
+		// LESS works, it can't (at this time) differentiate between a space separated list and a
+		// comma separated list, making it impossible to differentiate a single set of font rules
+		// with multiple values vs multiple sets with a single value in each.
+		//   {
+		//     nameRepeat: local("name"), local("name2");
+		//   }
+		//   Ex: `local("name") 400` vs `local("name"), local("name2")`
+		// In this case, only the first value will be used, second, ignored.
 	});
 };
 
@@ -231,8 +299,9 @@
 //  *                                     (normal, bold, etc) are supported. Empty-string represents
 //  *                                     "null" or default. This excludes the weight rule from the generated code.
 //  * @param  {Keyword} font-style        Optional, Keywords (normal, italic, etc) are supported.
+//  * @param  {Keyword} font-stretch      Optional, Keywords (ultra-condensed, extra-condensed, condensed, semi-condensed, normal, semi-expanded, expanded, extra-expanded, ultra-expanded, initial, inherit) are supported.
 //  */
-.buildFontFace(@name; @src; @weight: ""; @style: "") {
+.buildFontFace(@name; @src; @weight: normal; @style: ""; @stretch: "") {
 	@font-face {
 		font-family: @name;
 		src: @src;
@@ -244,6 +313,9 @@
 		}
 		& when (iskeyword(@style)) {
 			font-style: @style;
+		}
+		& when (iskeyword(@stretch)) {
+			font-stretch: @stretch;
 		}
 	}
 }

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -208,8 +208,9 @@
 //  * @fonts: {
 //  * 	as: local("LG Smart UI Bengali"); // same as `bn`
 //  * 	bn: local("LG Smart UI Bengali");
-//  * 	en-JP: local("LG Smart UI JP") "", local("LG Display_JP_Bold") 700; // same as `ja`
-//  * 	ja: local("LG Smart UI JP") "", local("LG Display_JP_Bold") 700;
+//  * 	en-JP: local("LG Smart UI JP"), local("LG Display_JP_Bold") 700; // same as `ja`
+//  * 	ja: local("LG Smart UI JP"), local("LG Display_JP_Bold") 700; // Generates 2 entries, one for JP set to "normal" (default) weight and another for JP_Bold set to 700 weight
+//  * 	ur: local("LG Smart UI_Urdu") normal 300 600 700; // Generates 4 entries, one for each weight
 //  * };
 //  * ```
 //  *
@@ -217,8 +218,8 @@
 //  * * single font source - Typically a reference to a local() font or a url() font.
 //  * * font-weight - Optional, Numbers (100, 500, 700, etc) and keywords (normal, bold, etc) are supported.
 //  * 	Empty-string represents "null". This excludes the font-weight rule from the generated code.
+//  * 	Multiple weights can be supplied to generate multiple sets of face rules for a single source file
 //  * * font-style - Optional, Keywords (normal, italic, etc) are supported.
-//  * * font-stretch - Optional, Keywords (ultra-condensed, extra-condensed, condensed, semi-condensed, normal, semi-expanded, expanded, extra-expanded, ultra-expanded, initial, inherit) are supported.
 //  *
 //  * OPTIONALLY: repeat the options above after a comma (,) for multiple weights/styles/options based on the same name.
 //  *
@@ -226,18 +227,17 @@
 //  * @param  {Object} @f        Object of keys with values detailing the font variants and options.
 //  */
 
-.buildLocaleFont(@fontName; @locale; @args) {
-	@f-src: extract(@args, 1);
-	@arg2:  if((length(@args) >= 2), extract(@args, 2), normal);  // weight – keyword "normal" added as a fallback here to support args that only include a src (and no weight assignment)
-	@arg3:  if((length(@args) >= 3), extract(@args, 3));          // weightRangeEnd (optional) OR style
-	@arg4:  if((length(@args) >= 4), extract(@args, 4));          // style OR stretch
-	@arg5:  if((length(@args) >= 5), extract(@args, 5));          // stretch
+.buildLocaleFont(@fontName; @locale; @src; @rules) when (isruleset(@rules)) {
+	.buildFontFace("@{fontName} @{locale}"; @src; @rules);
+	.buildFontFace(@fontName;               @src; @rules);
+}
+.buildLocaleFont(@fontName; @locale; @args) when (default()) {
+	@src: extract(@args, 1);
+	@argLast: extract(@args, length(@args));  // optional style value
 
-	// Reinterpret the 3rd argument if it's a number, assume it's a range of weights, and update f-style and @f-stretch if a weight range was used.
-	// A seemingly simpler `when` block cannot be used here since the scope from inside a `when` doesn't override an outer scope, so nothing you do in one will update the values outside it.
-	@f-weight:  if((length(@args) >= 3) and (isnumber(@arg3)), @arg2 @arg3, @arg2);
-	@f-style:   if((length(@args) >= 3) and (isnumber(@arg3)), @arg4, @arg3);
-	@f-stretch: if((length(@args) >= 3) and (isnumber(@arg3)), @arg5, @arg4);
+	@styleExists: boolean((@argLast = italic) or (@argLast = oblique));  // List all valid font-style values here (except for "normal" since that is a shared keyword with font-weight)
+	@style: if(@styleExists, @argLast);
+	@lastWeightArgIndex: if(@styleExists, length(@args) - 1, length(@args));  // It's possible this could get confused if "normal" or "bold" is used as the last weight. Please use a number as the last weight.
 
 	// Please retain the following comment for future debugging purposes. This gives insight into how the definition values are being interpreted.
 	// :global(.debug-buildLocaleFont@{fontName}-@{locale}) {
@@ -245,20 +245,31 @@
 	// 	locale: @locale;
 	// 	args: @args;
 	// 	args-count: length(@args);
-	// 	arg3-is-number: isnumber(@arg3);
-	// 	f-src: @f-src;
-	// 	f-weight: @f-weight;
-	// 	f-style: @f-style;
+	// 	last-weight-arg-index: @lastWeightArgIndex;
+	// 	src: @src;
+	// 	styleExists: @styleExists;
+	// 	style: @style;
 	// }
 
-	.buildFontFace("@{fontName} @{locale}"; @f-src; @f-weight; @f-style; @f-stretch);
-	.buildFontFace(@fontName;               @f-src; @f-weight; @f-style; @f-stretch);
+	// Run when there are 2 or more arguments
+	each(range(2, @lastWeightArgIndex), .(@argIndex) {
+		@weight: extract(@args, @argIndex);
+		.buildFontFace("@{fontName} @{locale}"; @src; @weight; @style);
+		.buildFontFace(@fontName;               @src; @weight; @style);
+	});
+
+	// Run when there are 1 or fewer arguments
+	& when (length(@args) <= 1) {
+		// There aren't any additional arguments, so weight and style can be safely omitted from the following calls
+		.buildFontFace("@{fontName} @{locale}"; @src);
+		.buildFontFace(@fontName;               @src);
+	}
 };
 
 .buildLocaleFonts(@fontName; @f) {
 	each(@f, .(@specs, @locale) {
 		// Determine if we're working with a collection of font definitions or an individual definition
-		@isCollection: if(((length(@specs) > 1) and (length(extract(@specs, 1)) > 1) or (length(extract(@specs, 2)) > 1)), true, false);
+		@isCollection: if(((length(@specs) > 1) and ((length(extract(@specs, 1)) > 1) or (length(extract(@specs, 2)) > 1))), true, false);
 
 		// :global(.debug-buildLocaleFonts-@{locale}) {
 		// 	is-collection: @isCollection;
@@ -299,13 +310,18 @@
 //  *                                     (normal, bold, etc) are supported. Empty-string represents
 //  *                                     "null" or default. This excludes the weight rule from the generated code.
 //  * @param  {Keyword} font-style        Optional, Keywords (normal, italic, etc) are supported.
-//  * @param  {Keyword} font-stretch      Optional, Keywords (ultra-condensed, extra-condensed, condensed, semi-condensed, normal, semi-expanded, expanded, extra-expanded, ultra-expanded, initial, inherit) are supported.
 //  */
-.buildFontFace(@name; @src; @weight: normal; @style: ""; @stretch: "") {
+
+.buildFontFace(@name; @src; @rules) when (isruleset(@rules)) {
 	@font-face {
 		font-family: @name;
 		src: @src;
-
+		@rules();
+	}
+}
+// The default version of this mixin (below) is the shorthand version, which rearranges its arguments into the format the above mixin expects.
+.buildFontFace(@name; @src; @weight: normal; @style: "") when (default()) {
+	.buildFontFace(@name; @src; {
 		// Conditionally add the following
 		// `length()` below refers to specifying font-weight ranges: `600 900`.
 		& when ((iskeyword(@weight)) or (isnumber(@weight)) or (length(@weight) > 1)) {
@@ -314,10 +330,7 @@
 		& when (iskeyword(@style)) {
 			font-style: @style;
 		}
-		& when (iskeyword(@stretch)) {
-			font-stretch: @stretch;
-		}
-	}
+	});
 }
 
 .locale-japanese-line-break() {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Chinese fonts don't apply consistently.


### Resolution
The font generation mixins now, by default, assign the `font-weight: normal` rule, which motivates the browser to choose the correct font at the correct time. For Chinese specifically, each of the target weights had to be specified due to that font also including Latin characters, instead of just Chinese characters, like the other fonts. The primary mixins for generating rules are now significantly more robust, with advanced argument handling, in a hopefully easy to understand and read way. Font weight ranges and font stretching is now supported by the mixins which were added to support this change as well as LESS debugging tools which are intentionally included but comment out since they aren't necessary for code to function, but will be valuable next time we need to look into any font matter.

Chinese glyphs rendered in the "Moonstone" font will likely only apply the locale font in normal, 300, 600, and 700 font weights, with others relying on the system to supply the fallback. This is OK, however, due to the Moonstone design not leveraging those font weights.