### PR TITLE
ENYO-6195: Fix typescript generation for some HoCs

### DIFF
--- a/packages/moonstone/DayPicker/DayPicker.js
+++ b/packages/moonstone/DayPicker/DayPicker.js
@@ -162,6 +162,9 @@ const DayPickerDecorator = compose(
  * @extends moonstone/DayPicker.DayPickerBase
  * @mixes moonstone/ExpandableItem.Expandable
  * @mixes ui/Changeable.Changeable
+ * @omit onChange
+ * @omit value
+ * @omit defaultValue
  * @ui
  * @public
  */

--- a/packages/moonstone/DaySelector/DaySelectorDecorator.js
+++ b/packages/moonstone/DaySelector/DaySelectorDecorator.js
@@ -77,6 +77,9 @@ function getLocaleState (dayNameLength, locale) {
  * @memberof moonstone/DaySelector
  * @mixes ui/Changeable.Changeable
  * @mixes moonstone/Skinnable.Skinnable
+ * @omit onChange
+ * @omit value
+ * @omit defaultValue
  * @public
  */
 const DaySelectorDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -454,7 +454,7 @@ const DropdownDecorator = compose(
  * @public
  */
 
- /**
+/**
  * Index of the selected item.
  *
  * @name selected
@@ -463,7 +463,7 @@ const DropdownDecorator = compose(
  * @public
  */
 
- /**
+/**
  * The initial selected index when `selected` is not defined.
  *
  * @name defaultSelected

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -92,6 +92,13 @@ const DropdownListBase = Skinnable(
 			]),
 
 			/*
+			 * The initial selected index when `selected` is not defined.
+			 *
+			 * @type {Number}
+			 */
+			defaultSelected: PropTypes.number,
+
+			/*
 			 * Called when an item is selected.
 			 *
 			 * @type {Function}
@@ -211,6 +218,7 @@ class DropdownList extends React.Component {
  * @memberof moonstone/Dropdown
  * @extends moonstone/Button.Button
  * @extends moonstone/ContextualPopupDecorator.ContextualPopupDecorator
+ * @omit popupComponent
  * @ui
  * @public
  */
@@ -410,6 +418,11 @@ const DropdownBase = kind({
  * @memberof moonstone/Dropdown
  * @mixes ui/Changeable.Changeable
  * @mixes ui/Toggleable.Toggleable
+ * @omit selected
+ * @omit defaultSelected
+ * @omit value
+ * @omit defaultValue
+ * @omit onChange
  * @public
  */
 const DropdownDecorator = compose(
@@ -430,6 +443,34 @@ const DropdownDecorator = compose(
 		toggle: null
 	})
 );
+
+/**
+ * Displays the items.
+ *
+ * @name open
+ * @memberof moonstone/Dropdown.DropdownDecorator.prototype
+ * @type {Boolean}
+ * @default false
+ * @public
+ */
+
+ /**
+ * Index of the selected item.
+ *
+ * @name selected
+ * @memberof moonstone/Dropdown.DropdownDecorator.prototype
+ * @type {Number}
+ * @public
+ */
+
+ /**
+ * The initial selected index when `selected` is not defined.
+ *
+ * @name defaultSelected
+ * @memberof moonstone/Dropdown.DropdownDecorator.prototype
+ * @type {Number}
+ * @public
+ */
 
 /**
  * A Moonstone Dropdown component.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to retain the proper scroll position when updating the `itemSize` or `spacing` props
+- `ui/Toggleable` TypeScript definitions
 
 ## [3.0.0-rc.2] - 2019-08-08
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -134,6 +134,8 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			 * Default toggled state applied at construction when the toggled prop is `undefined` or
 			 * `null`.
 			 *
+			 * @name defaultSelected
+			 * @memberof ui/Toggleable.Toggleable.prototype
 			 * @type {Boolean}
 			 * @default false
 			 * @public
@@ -156,6 +158,8 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			 * is 'uncontrolled' and `Toggleable` will manage the toggled state using callbacks
 			 * defined by its configuration.
 			 *
+			 * @name selected
+			 * @memberof ui/Toggleable.Toggleable.prototype
 			 * @type {Boolean}
 			 * @public
 			 */
@@ -164,6 +168,8 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Event callback to notify that state should be toggled.
 			 *
+			 * @name onToggle
+			 * @memberof ui/Toggleable.Toggleable.prototype
 			 * @type {Function}
 			 * @public
 			 */


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Toggleable` hoc was not generating `onToggle` type info

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added default value and overrode the settings in places where the default is not used.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When we apply `@omit` to decorators it seems it is not applying.
I did not look at all HOCs exhaustively.  There are certainly some others.  I did touch up `Changeable` at the same time.

### Links
[//]: # (Related issues, references)
Fixes #2510 

### Comments
