### PR TITLE
ENYO-6189: Add Dropdown size value x-large

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/Dropdown` to add new size `x-large`
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 ### Fixed

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -122,9 +122,9 @@ const DropdownListBase = Skinnable(
 			/*
 			 * The width of DropdownList.
 			 *
-			 * @type {('huge'|'large'|'medium'|'small'|'tiny')}
+			 * @type {('huge'|'x-large'|'large'|'medium'|'small'|'tiny')}
 			 */
-			width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+			width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'x-large', 'huge'])
 		},
 
 		styles: {
@@ -307,11 +307,11 @@ const DropdownBase = kind({
 		/**
 		 * The width of Dropdown.
 		 *
-		 * @type {('huge'|'large'|'medium'|'small'|'tiny')}
+		 * @type {('huge'|'large'|'x-large'|'medium'|'small'|'tiny')}
 		 * @default 'medium'
 		 * @public
 		 */
-		width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+		width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'x-large', 'huge'])
 	},
 
 	defaultProps: {

--- a/packages/moonstone/Dropdown/Dropdown.module.less
+++ b/packages/moonstone/Dropdown/Dropdown.module.less
@@ -22,6 +22,11 @@
 		width: @moon-dropdown-large-width;
 	}
 
+	&.x-large {
+		max-width: @moon-dropdown-x-large-width;
+		width: @moon-dropdown-x-large-width;
+	}
+
 	&.huge {
 		max-width: @moon-dropdown-huge-width;
 		width: @moon-dropdown-huge-width;
@@ -57,6 +62,10 @@
 
 	&.large {
 		width: @moon-dropdown-list-large-width;
+	}
+
+	&.x-large {
+		width: @moon-dropdown-list-x-large-width
 	}
 
 	&.huge {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -208,11 +208,13 @@
 @moon-dropdown-small-width: @moon-button-min-width;
 @moon-dropdown-medium-width: 345px;
 @moon-dropdown-large-width: 390px;
+@moon-dropdown-x-large-width: 525px;
 @moon-dropdown-huge-width: 690px;
 @moon-dropdown-list-tiny-width: (@moon-dropdown-tiny-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-small-width: (@moon-dropdown-small-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-medium-width: (@moon-dropdown-medium-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-large-width: (@moon-dropdown-large-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
+@moon-dropdown-list-x-large-width: (@moon-dropdown-x-large-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-huge-width: (@moon-dropdown-huge-width - (@moon-contextual-popup-padding * 2) - @moon-button-border-width);
 @moon-dropdown-list-max-height: (5 * @moon-item-height);
 @moon-dropdown-list-max-height-large: (5 * @moon-item-height-large);

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -26,7 +26,7 @@ storiesOf('Moonstone', module)
 					onSelect={action('onSelect')}
 					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
-					width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+					width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 				>
 					{items}
 				</Dropdown>

--- a/packages/sampler/stories/qa/Dropdown.js
+++ b/packages/sampler/stories/qa/Dropdown.js
@@ -31,7 +31,7 @@ storiesOf('Dropdown', module)
 				size={select('size', ['small', 'large'], Config)}
 				title={text('title', Config, 'Dropdown')}
 				style={{position: 'absolute', top: 'calc(50% - 4rem)'}}
-				width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+				width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 			>
 				{['Option 1', 'Option 2']}
 			</Dropdown>
@@ -48,7 +48,7 @@ storiesOf('Dropdown', module)
 				onSelect={action('onSelect')}
 				size={select('size', ['small', 'large'], Config)}
 				title={text('title', Config, 'Dropdown')}
-				width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+				width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 			>
 				{items(30)}
 			</Dropdown>
@@ -64,7 +64,7 @@ storiesOf('Dropdown', module)
 				onSelect={action('onSelect')}
 				size={select('size', ['small', 'large'], Config)}
 				title={text('title', Config, 'Dropdown')}
-				width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+				width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 			>
 				{items(10, 'Looooooooooooooooooooooong')}
 			</Dropdown>
@@ -82,7 +82,7 @@ storiesOf('Dropdown', module)
 					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
 					style={{position: 'absolute', top: 'calc(50% - 4rem)'}}
-					width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+					width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 				>
 					{items(5)}
 				</Dropdown>
@@ -94,7 +94,7 @@ storiesOf('Dropdown', module)
 					onSelect={action('onSelect')}
 					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
-					width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+					width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 				>
 					{items(5)}
 				</Dropdown>
@@ -113,7 +113,7 @@ storiesOf('Dropdown', module)
 					size={select('size', ['small', 'large'], Config)}
 					title={text('title', Config, 'Dropdown')}
 					style={{position: 'absolute', top: 'calc(50% - 4rem)'}}
-					width={select('width', ['tiny', 'small', 'medium', 'large', 'huge'], Config)}
+					width={select('width', ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
 				>
 					{list}
 				</Dropdown>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Channel Edit requested proper size for using `Dropdown` component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It support additional x-large size in a short term.
In the feature, it can support customized size with pixel value.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
