### PR TITLE
ENYO-6200: Req: ProgressBar: add prop to fix direction of ProgressTooltip

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/ProgressBar` prop `noTooltipFlip`
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 ### Fixed

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -59,7 +59,7 @@ const ProgressBarBase = kind({
 		highlighted: PropTypes.bool,
 
 		/**
-		 * Disables tooltip reversal if proportion is greater than 0.5.
+		 * Disables horizontal tooltip reversal if proportion is greater than 0.5.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -59,6 +59,15 @@ const ProgressBarBase = kind({
 		highlighted: PropTypes.bool,
 
 		/**
+		 * Disables tooltip reversal if proportion is greater than 0.5.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		noTooltipFlip: PropTypes.bool,
+
+		/**
 		 * Sets the orientation of the slider.
 		 *
 		 * * Values: `'horizontal'`, `'vertical'`
@@ -119,6 +128,7 @@ const ProgressBarBase = kind({
 	},
 
 	defaultProps: {
+		noTooltipFlip: false,
 		orientation: 'horizontal',
 		progress: 0
 	},
@@ -133,7 +143,7 @@ const ProgressBarBase = kind({
 		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
 	},
 
-	render: ({css, orientation, progress, tooltip, ...rest}) => {
+	render: ({css, noTooltipFlip, orientation, progress, tooltip, ...rest}) => {
 		delete rest.tooltip;
 		delete rest.highlighted;
 
@@ -146,6 +156,7 @@ const ProgressBarBase = kind({
 			>
 				<ComponentOverride
 					component={tooltip}
+					noTooltipFlip={noTooltipFlip}
 					orientation={orientation}
 					percent
 					proportion={progress}

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -45,6 +45,15 @@ const ProgressBarTooltipBase = kind({
 
 	propTypes: /** @lends moonstone/ProgressBar.ProgressBarTooltip.prototype */{
 		/**
+		 * Disables tooltip reversal if proportion is greater than 0.5.
+		 *
+		 * @type {Boolean}
+		 * @default true
+		 * @public
+		 */
+		noTooltipFlip: PropTypes.bool,
+
+		/**
 		 * Sets the orientation of the tooltip based on the orientation of the bar.
 		 *
 		 * 'vertical' sends the tooltip to one of the sides, 'horizontal'  positions it above the bar.
@@ -113,6 +122,7 @@ const ProgressBarTooltipBase = kind({
 	},
 
 	defaultProps: {
+		noTooltipFlip: false,
 		orientation: 'horizontal',
 		percent: false,
 		proportion: 0,
@@ -135,21 +145,21 @@ const ProgressBarTooltipBase = kind({
 
 			return children;
 		},
-		className: ({orientation, proportion, side, styler}) => {
+		className: ({orientation, proportion, side, noTooltipFlip, styler}) => {
 			side = getSide(orientation, side);
 
 			return styler.append(
 				orientation,
 				{
-					afterMidpoint: proportion > 0.5,
+					afterMidpoint: !noTooltipFlip && proportion > 0.5,
 					ignoreLocale: side === 'left' || side === 'right'
 				},
 				(side === 'before' || side === 'left') ? 'before' : 'after'
 			);
 		},
-		arrowAnchor: ({proportion, orientation}) => {
+		arrowAnchor: ({proportion, orientation, noTooltipFlip}) => {
 			if (orientation === 'vertical') return 'middle';
-			return proportion > 0.5 ? 'left' : 'right';
+			return !noTooltipFlip && proportion > 0.5 ? 'left' : 'right';
 		},
 		direction: ({orientation, rtl, side}) => {
 			side = getSide(orientation, side);
@@ -180,6 +190,7 @@ const ProgressBarTooltipBase = kind({
 	render: ({children, visible, ...rest}) => {
 		if (!visible) return null;
 
+		delete rest.noTooltipFlip;
 		delete rest.orientation;
 		delete rest.percent;
 		delete rest.proportion;

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -45,7 +45,7 @@ const ProgressBarTooltipBase = kind({
 
 	propTypes: /** @lends moonstone/ProgressBar.ProgressBarTooltip.prototype */{
 		/**
-		 * Disables tooltip reversal if proportion is greater than 0.5.
+		 * Disables horizontal tooltip reversal if proportion is greater than 0.5.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -48,7 +48,7 @@ const ProgressBarTooltipBase = kind({
 		 * Disables tooltip reversal if proportion is greater than 0.5.
 		 *
 		 * @type {Boolean}
-		 * @default true
+		 * @default false
 		 * @public
 		 */
 		noTooltipFlip: PropTypes.bool,

--- a/packages/sampler/stories/default/ProgressBar.js
+++ b/packages/sampler/stories/default/ProgressBar.js
@@ -17,12 +17,14 @@ storiesOf('Moonstone', module)
 		() => {
 			const side = select('side', ['after', 'before', 'left', 'right'], ProgressBarTooltipConfig, 'before');
 			const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
+			const noTooltipFlip = boolean('noTooltipFlip', ProgressBarTooltipConfig);
 
 			return (
 				<ProgressBar
 					backgroundProgress={number('backgroundProgress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
 					disabled={boolean('disabled', ProgressBarConfig)}
 					highlighted={boolean('highlighted', ProgressBarConfig)}
+					noTooltipFlip={boolean('noTooltipFlip', ProgressBarConfig)}
 					orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig, 'horizontal')}
 					progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
 					side={select('side', ['after', 'before', 'left', 'right'], ProgressBarConfig, 'before')}
@@ -30,6 +32,7 @@ storiesOf('Moonstone', module)
 					{tooltip ? (
 						<ProgressBarTooltip
 							side={side}
+							noTooltipFlip={noTooltipFlip}
 						/>
 					) : null}
 				</ProgressBar>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
That requirement is adding prop to fix direction of ProgressToolip when propertion is greater than 0.5.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a new prop `noTooltipFlip`. (The prop name can be changed after review.)

### Links
[//]: # (Related issues, references)
ENYO-6200
