### PR TITLE
PLAT-84674: Fix Dropdown performance with long lists

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Dropdown` performance when using many options
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 ### Fixed

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import Spotlight from '@enact/spotlight';
@@ -23,10 +24,10 @@ const DropdownListBase = kind({
 
 	propTypes: {
 		/*
-		* The selections for Dropdown
-		*
-		* @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
-		*/
+		 * The selections for Dropdown
+		 *
+		 * @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
+		 */
 		children: PropTypes.oneOfType([
 			PropTypes.arrayOf(PropTypes.string),
 			PropTypes.arrayOf(PropTypes.shape({
@@ -36,24 +37,24 @@ const DropdownListBase = kind({
 		]),
 
 		/*
-		* Called when an item is selected.
-		*
-		* @type {Function}
-		*/
+		 * Called when an item is selected.
+		 *
+		 * @type {Function}
+		 */
 		onSelect: PropTypes.func,
 
 		/*
-		* Callback function that will receive the scroller's scrollTo() method
-		*
-		* @type {Function}
-		*/
+		 * Callback function that will receive the scroller's scrollTo() method
+		 *
+		 * @type {Function}
+		 */
 		scrollTo: PropTypes.func,
 
 		/*
-		* Index of the selected item.
-		*
-		* @type {Number}
-		*/
+		 * Index of the selected item.
+		 *
+		 * @type {Number}
+		 */
 		selected: PropTypes.number,
 
 		/*
@@ -66,10 +67,10 @@ const DropdownListBase = kind({
 		skinVariants: PropTypes.object,
 
 		/*
-		* The width of DropdownList.
-		*
-		* @type {('huge'|'large'|'medium'|'small'|'tiny')}
-		*/
+		 * The width of DropdownList.
+		 *
+		 * @type {('huge'|'large'|'medium'|'small'|'tiny')}
+		 */
 		width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
 	},
 
@@ -79,7 +80,9 @@ const DropdownListBase = kind({
 	},
 
 	handlers: {
-		itemRenderer: ({index, ...rest}, {children, onSelect}) => {
+		itemRenderer: ({index, ...rest}, props) => {
+			const {children, selected} = props;
+
 			let child = children[index];
 			if (typeof child === 'string') {
 				child = {children: child};
@@ -89,8 +92,9 @@ const DropdownListBase = kind({
 				<Item
 					{...rest}
 					{...child}
+					data-selected={index === selected}
 					// eslint-disable-next-line react/jsx-no-bind
-					onClick={() => onSelect({selected: index})}
+					onClick={() => forward('onSelect', {selected: index}, props)}
 				/>
 			);
 		}
@@ -127,10 +131,10 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 
 		static propTypes = {
 			/*
-			* Index of the selected item.
-			*
-			* @type {Number}
-			*/
+			 * Index of the selected item.
+			 *
+			 * @type {Number}
+			 */
 			selected: PropTypes.number
 		}
 
@@ -145,26 +149,20 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 			this.scrollIntoView();
 		}
 
-		getNodeToFocus = (selected) => {
-			const scrollIndex = selected > scrollOffset ? selected - scrollOffset : 0;
-
-			return {
-				nodeToFocus: this.node.querySelector(`[data-index='${selected}']`),
-				nodeToScroll: this.node.querySelector(`[data-index='${scrollIndex}']`)
-			};
-		}
-
 		getScrollTo = (scrollTo) => {
 			this.scrollTo = scrollTo;
 		}
 
 		scrollIntoView = () => {
+			const {selected} = this.props;
+
 			if (!this.isScrolledIntoView) {
 				if (isSelectedValid(this.props)) {
-					const {nodeToFocus, nodeToScroll} = this.getNodeToFocus(this.props.selected);
+					const scrollIndex = selected > scrollOffset ? selected - scrollOffset : 0;
+					const selectedNode = this.node.querySelector(`[data-index='${selected}']`);
 
-					this.scrollTo({animate: false, node: nodeToScroll});
-					Spotlight.focus(nodeToFocus);
+					this.scrollTo({animate: false, index: scrollIndex});
+					Spotlight.focus(selectedNode);
 				}
 				this.isScrolledIntoView = true;
 			}

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -2,6 +2,7 @@ import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import Spotlight from '@enact/spotlight';
+import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import React from 'react';
@@ -98,7 +99,7 @@ const DropdownListBase = kind({
 	computed: {
 		className: ({width, styler}) => styler.append(width),
 		dataSize: ({children}) => children ? children.length : 0,
-		itemSize: ({skinVariants}) => skinVariants && skinVariants.largeText ? 72 : 60
+		itemSize: ({skinVariants}) => ri.scale(skinVariants && skinVariants.largeText ? 72 : 60)
 	},
 
 	render: ({dataSize, itemSize, scrollTo, ...rest}) => {

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -1,0 +1,192 @@
+import kind from '@enact/core/kind';
+import hoc from '@enact/core/hoc';
+import EnactPropTypes from '@enact/core/internal/prop-types';
+import Spotlight from '@enact/spotlight';
+import PropTypes from 'prop-types';
+import compose from 'ramda/src/compose';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Item from '../Item';
+import Skinnable from '../Skinnable';
+import VirtualList from '../VirtualList';
+
+import css from './Dropdown.module.less';
+
+const scrollOffset = 2;
+
+const isSelectedValid = ({children, selected}) => Array.isArray(children) && children[selected] != null;
+
+const DropdownListBase = kind({
+	name: 'DropdownListBase',
+
+	propTypes: {
+		/*
+		* The selections for Dropdown
+		*
+		* @type {String[]|Array.<{key: (Number|String), children: (String|Component)}>}
+		*/
+		children: PropTypes.oneOfType([
+			PropTypes.arrayOf(PropTypes.string),
+			PropTypes.arrayOf(PropTypes.shape({
+				children: EnactPropTypes.renderable.isRequired,
+				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+			}))
+		]),
+
+		/*
+		* Called when an item is selected.
+		*
+		* @type {Function}
+		*/
+		onSelect: PropTypes.func,
+
+		/*
+		* Callback function that will receive the scroller's scrollTo() method
+		*
+		* @type {Function}
+		*/
+		scrollTo: PropTypes.func,
+
+		/*
+		* Index of the selected item.
+		*
+		* @type {Number}
+		*/
+		selected: PropTypes.number,
+
+		/*
+		 * State of possible skin variants.
+		 *
+		 * Used to scale the `itemSize` of the `VirtualList` based on large-text mode
+		 *
+		 * @type {Object}
+		 */
+		skinVariants: PropTypes.object,
+
+		/*
+		* The width of DropdownList.
+		*
+		* @type {('huge'|'large'|'medium'|'small'|'tiny')}
+		*/
+		width: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge'])
+	},
+
+	styles: {
+		css,
+		className: 'dropDownList'
+	},
+
+	handlers: {
+		itemRenderer: ({index, ...rest}, {children, onSelect}) => {
+			let child = children[index];
+			if (typeof child === 'string') {
+				child = {children: child};
+			}
+
+			return (
+				<Item
+					{...rest}
+					{...child}
+					// eslint-disable-next-line react/jsx-no-bind
+					onClick={() => onSelect({selected: index})}
+				/>
+			);
+		}
+	},
+
+	computed: {
+		className: ({width, styler}) => styler.append(width),
+		dataSize: ({children}) => children ? children.length : 0,
+		itemSize: ({skinVariants}) => skinVariants && skinVariants.largeText ? 72 : 60
+	},
+
+	render: ({dataSize, itemSize, scrollTo, ...rest}) => {
+		delete rest.children;
+		delete rest.onSelect;
+		delete rest.selected;
+		delete rest.skinVariants;
+		delete rest.width;
+
+		return (
+			<VirtualList
+				{...rest}
+				cbScrollTo={scrollTo}
+				dataSize={dataSize}
+				itemSize={itemSize}
+				style={{height: itemSize * dataSize}}
+			/>
+		);
+	}
+});
+
+const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
+	return class extends React.Component {
+		static displayName = 'DropdownListSpotlightDecorator'
+
+		static propTypes = {
+			/*
+			* Index of the selected item.
+			*
+			* @type {Number}
+			*/
+			selected: PropTypes.number
+		}
+
+		componentDidMount () {
+			// eslint-disable-next-line react/no-find-dom-node
+			this.node = ReactDOM.findDOMNode(this);
+			Spotlight.set(this.node.dataset.spotlightId, {leaveFor: {up: '', down: ''}});
+			this.isScrolledIntoView = false;
+		}
+
+		componentDidUpdate () {
+			this.scrollIntoView();
+		}
+
+		getNodeToFocus = (selected) => {
+			const scrollIndex = selected > scrollOffset ? selected - scrollOffset : 0;
+
+			return {
+				nodeToFocus: this.node.querySelector(`[data-index='${selected}']`),
+				nodeToScroll: this.node.querySelector(`[data-index='${scrollIndex}']`)
+			};
+		}
+
+		getScrollTo = (scrollTo) => {
+			this.scrollTo = scrollTo;
+		}
+
+		scrollIntoView = () => {
+			if (!this.isScrolledIntoView) {
+				if (isSelectedValid(this.props)) {
+					const {nodeToFocus, nodeToScroll} = this.getNodeToFocus(this.props.selected);
+
+					this.scrollTo({animate: false, node: nodeToScroll});
+					Spotlight.focus(nodeToFocus);
+				}
+				this.isScrolledIntoView = true;
+			}
+		}
+
+		render () {
+			return (
+				<Wrapped {...this.props} scrollTo={this.getScrollTo} />
+			);
+		}
+	};
+});
+
+const DropdownListDecorator = compose(
+	DropdownListSpotlightDecorator,
+	Skinnable({variantsProp: 'skinVariants'})
+);
+
+const DropdownList = DropdownListDecorator(DropdownListBase);
+
+export default DropdownList;
+export {
+	DropdownList,
+	DropdownListBase,
+	isSelectedValid
+};

--- a/packages/sampler/stories/default/Dropdown.js
+++ b/packages/sampler/stories/default/Dropdown.js
@@ -14,7 +14,7 @@ storiesOf('Moonstone', module)
 	.add(
 		'Dropdown',
 		() => {
-			const itemCount = number('items', Config, {range: true, min: 0, max: 8}, 5);
+			const itemCount = number('items', Config, {range: true, min: 0, max: 50}, 5);
 			const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);
 
 			return (


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Render performance of `Dropdown` is poor when using many options.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adopt `VirtualList` within `Dropdown` instead of `Group` + `Scroller` to reduce the render load.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* Because `VirtualList` requires `itemSize` to lay out the list, I had to hard code the height of `Item` and include `skinVariants` from `Skinnable` to scale for large text mode.
* Dropdown.js was getting long so I refactored the list component into a new file and converted the previous list component into a HOC so `Skinnable` could be moved to the decorator for consistency with other framework components.
