### PR TITLE
ENYO-6165: Fix horizontal scroll behavior in Scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,8 +7,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` layout in large text mode in RTL locales
-- `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
+- `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` layout in large text mode in RTL locales
+- `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -439,8 +439,7 @@ class ScrollableBase extends Component {
 		const
 			spotItem = Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
-			{containerRef} = this.uiRef.current.childRefCurrent,
-			containerNode = containerRef.current;
+			containerNode = this.uiRef.current.childRefCurrent.containerRef.current;
 
 		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
 			const lastPos = this.lastScrollPositionOnFocus;

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -439,16 +439,27 @@ class ScrollableBase extends Component {
 		const
 			spotItem = Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
-			{containerRef} = this.uiRef.current.childRefCurrent;
+			{containerRef} = this.uiRef.current.childRefCurrent,
+			containerNode = containerRef.current;
 
-		if (spotItem && positionFn && containerRef.current && containerRef.current.contains(spotItem)) {
+		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
 			const lastPos = this.lastScrollPositionOnFocus;
 			let pos;
 
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
 			if (this.uiRef.current.animator.isAnimating() && lastPos) {
-				pos = positionFn({item: spotItem, scrollPosition: (this.props.direction !== 'horizontal') ? lastPos.top : lastPos.left});
+				const containerRect = getRect(containerNode);
+				const itemRect = getRect(spotItem);
+				let scrollPosition;
+
+				if (this.props.direction === 'horizontal' || this.props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
+					scrollPosition = lastPos.left;
+				} else if (this.props.direction === 'vertical' || this.props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
+					scrollPosition = lastPos.top;
+				}
+
+				pos = positionFn({item: spotItem, scrollPosition});
 			} else {
 				// scrollInfo passes in current `scrollHeight` and `scrollTop` before calculations
 				const

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -509,7 +509,8 @@ class ScrollableBaseNative extends Component {
 		const
 			spotItem = Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
-			{containerRef} = this.uiRef.current.childRefCurrent;
+			{containerRef} = this.uiRef.current.childRefCurrent,
+			containerNode = containerRef.current;
 
 		if (spotItem && positionFn && containerRef.current && containerRef.current.contains(spotItem)) {
 			const lastPos = this.lastScrollPositionOnFocus;
@@ -518,7 +519,17 @@ class ScrollableBaseNative extends Component {
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
 			if (this.uiRef.current.scrolling && lastPos) {
-				pos = positionFn({item: spotItem, scrollPosition: (this.props.direction !== 'horizontal') ? lastPos.top : lastPos.left});
+				const containerRect = getRect(containerNode);
+				const itemRect = getRect(spotItem);
+				let scrollPosition;
+
+				if (this.props.direction === 'horizontal' || this.props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
+					scrollPosition = lastPos.left;
+				} else if (this.props.direction === 'vertical' || this.props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
+					scrollPosition = lastPos.top;
+				}
+
+				pos = positionFn({item: spotItem, scrollPosition});
 			} else {
 				// scrollInfo passes in current `scrollHeight` and `scrollTop` before calculations
 				const

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -509,10 +509,9 @@ class ScrollableBaseNative extends Component {
 		const
 			spotItem = Spotlight.getCurrent(),
 			positionFn = this.childRef.current.calculatePositionOnFocus,
-			{containerRef} = this.uiRef.current.childRefCurrent,
-			containerNode = containerRef.current;
+			containerNode = this.uiRef.current.childRefCurrent.containerRef.current;
 
-		if (spotItem && positionFn && containerRef.current && containerRef.current.contains(spotItem)) {
+		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
 			const lastPos = this.lastScrollPositionOnFocus;
 			let pos;
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -291,14 +291,12 @@ class ScrollerBase extends Component {
 		const containerRect = getRect(containerNode);
 		const itemRect = getRect(item);
 
-		if (!contains(containerRect, itemRect)) {
-			if (horizontal && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
-				this.uiRefCurrent.scrollPos.left = this.calculateScrollLeft(item, scrollPosition);
-			}
+		if (horizontal && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
+			this.uiRefCurrent.scrollPos.left = this.calculateScrollLeft(item, scrollPosition);
+		}
 
-			if (vertical && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
-				this.uiRefCurrent.scrollPos.top = this.calculateScrollTop(item);
-			}
+		if (vertical && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
+			this.uiRefCurrent.scrollPos.top = this.calculateScrollTop(item);
 		}
 
 		return this.uiRefCurrent.scrollPos;

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -17,7 +17,7 @@
  */
 
 import {Spotlight} from '@enact/spotlight';
-import {contains, getRect} from '@enact/spotlight/src/utils';
+import {getRect} from '@enact/spotlight/src/utils';
 import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When using a `Scroller` that is expected to be scrolled vertically and horizontally - using `direction="both"`, the `Scroller` cannot scroll horizontally when navigating contents via 5way left/right.

The issue stems from how `Scroller` is checking its `direction` prop and calculating the next scroll position because of it. It's only accounting for the values of `'vertical'` and/or `'horizontal'`. If `'both'` is used instead, it defaults to the behavior of `'vertical'`.


### Resolution
Check for all valid values of `direction` and calculate the next scroll position accordingly.

