### PR TITLE
PLAT-83223: An item scrolls into view when the item expands or shrinks dynamically

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` layout in large text mode in RTL locales
+- `moonstone/VirtualList.VirtualList` dynamically extended item scrolling into view properly
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -327,6 +327,9 @@ const VirtualListBaseFactory = (type) => {
 				this.emitUpdateItems();
 			}
 
+			// When an item expands or shrinks,
+			// we need to calculate the item position again and
+			// the item needs to scroll into view if the item does not show fully.
 			if (this.props.itemSizes) {
 				if (this.itemPositions.length > this.props.itemSizes.length) {
 					// The item with `this.props.itemSizes.length` index is not rendered yet.
@@ -337,24 +340,26 @@ const VirtualListBaseFactory = (type) => {
 					this.itemPositions = [...this.itemPositions.slice(0, this.props.itemSizes.length)];
 					this.adjustItemPositionWithItemSize();
 				} else {
-					const indexToScroll = this.indexToScrollIntoView;
+					const {indexToScrollIntoView} = this;
 
 					this.adjustItemPositionWithItemSize();
 
-					if (indexToScroll !== -1) {
+					if (indexToScrollIntoView !== -1) {
+						// Currently we support expandable items in only vertical VirtualList.
+						// So the top and bottom of the boundaries are checked.
 						const
 							scrollBounds = {top: this.scrollPosition, bottom: this.scrollPosition + this.scrollBounds.clientHeight},
-							itemBounds = {top: this.getGridPosition(indexToScroll).primaryPosition, bottom: this.getItemBottomPosition(indexToScroll)};
+							itemBounds = {top: this.getGridPosition(indexToScrollIntoView).primaryPosition, bottom: this.getItemBottomPosition(indexToScrollIntoView)};
 
 						if (itemBounds.top < scrollBounds.top) {
 							this.props.cbScrollTo({
-								index: indexToScroll,
+								index: indexToScrollIntoView,
 								stickTo: 'start',
 								animate: true
 							});
 						} else if (itemBounds.bottom > scrollBounds.bottom) {
 							this.props.cbScrollTo({
-								index: indexToScroll,
+								index: indexToScrollIntoView,
 								stickTo: 'end',
 								animate: true
 							});

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -329,9 +329,40 @@ const VirtualListBaseFactory = (type) => {
 
 			if (this.props.itemSizes) {
 				if (this.itemPositions.length > this.props.itemSizes.length) {
+					// The item with `this.props.itemSizes.length` index is not rendered yet.
+					// So the item could scroll into view after it rendered.
+					// To do it, `this.props.itemSizes.length` value is cached in `this.indexToScrollIntoView`.
+					this.indexToScrollIntoView = this.props.itemSizes.length;
+
 					this.itemPositions = [...this.itemPositions.slice(0, this.props.itemSizes.length)];
+					this.adjustItemPositionWithItemSize();
+				} else {
+					const indexToScroll = this.indexToScrollIntoView;
+
+					this.adjustItemPositionWithItemSize();
+
+					if (indexToScroll !== -1) {
+						const
+							scrollBounds = {top: this.scrollPosition, bottom: this.scrollPosition + this.scrollBounds.clientHeight},
+							itemBounds = {top: this.getGridPosition(indexToScroll).primaryPosition, bottom: this.getItemBottomPosition(indexToScroll)};
+
+						if (itemBounds.top < scrollBounds.top) {
+							this.props.cbScrollTo({
+								index: indexToScroll,
+								stickTo: 'start',
+								animate: true
+							});
+						} else if (itemBounds.bottom > scrollBounds.bottom) {
+							this.props.cbScrollTo({
+								index: indexToScroll,
+								stickTo: 'end',
+								animate: true
+							});
+						}
+					}
+
+					this.indexToScrollIntoView = -1;
 				}
-				this.adjustItemPositionWithItemSize();
 			}
 
 			if (
@@ -395,6 +426,7 @@ const VirtualListBaseFactory = (type) => {
 
 		// For individually sized item
 		itemPositions = []
+		indexToScrollIntoView = -1
 
 		updateScrollPosition = ({x, y}, rtl = this.props.rtl) => {
 			if (type === Native) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When an item in VirtualList with different item size expands or shrinks, the part of item or the item hides.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When changing the item size, the item sticks to the top when being shrunk and sticks to the bottom when being expanded.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

As mentioned in JIRA description, the requirement of the expanded or shrunk item behavior is not defined yet because there is no app using it. So I implemented the behavior reasonably.

### Links
[//]: # (Related issues, references)

PLAT-83223