### PR TITLE
ENYO-6216: Fix Slider noFill style when focused

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/ContextualPopupDecorator` layout in large text mode in RTL locales
+- `moonstone/Slider` progress bar fill color when focused with `noFill` set
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/Slider/Slider.module.less
+++ b/packages/moonstone/Slider/Slider.module.less
@@ -216,6 +216,7 @@
 			}
 
 			.spottable({
+				&,
 				&.active,
 				&.pressed {
 					.fill {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Slider` and `IncrementSlider` fill color is incorrect when `noFill` is set and focused due to insufficient specificity of the subsequent CSS rules.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a ruleset for noFill + spottable which matches the specificity (5) of the focus rules earlier in the stylesheet.
