### PR TITLE
ENYO-6152: Fix IncrementSlider qa sample

### DIFF
--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -3,6 +3,7 @@ import ContextualPopupDecorator from '@enact/moonstone/ContextualPopupDecorator'
 import IconButton from '@enact/moonstone/IconButton';
 import IncrementSlider, {IncrementSliderBase} from '@enact/moonstone/IncrementSlider';
 import ri from '@enact/ui/resolution';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
@@ -88,11 +89,25 @@ class IncrementSliderWithContextualPopup extends React.Component {
 }
 
 class IncrementSliderWithMinValue extends React.Component {
+	static propTypes = {
+		value: PropTypes.number
+	}
+
 	constructor (props) {
 		super(props);
 		this.state = {
+			propValue: props.value,
 			value: 0
 		};
+	}
+
+	static getDerivedStateFromProps (props, state) {
+		if (props.value !== state.propValue) {
+			return {
+				propValue: props.value,
+				value: props.value
+			};
+		}
 	}
 
 	handleChange = ({value}) => this.setState({value})
@@ -104,7 +119,7 @@ class IncrementSliderWithMinValue extends React.Component {
 					max={number('max', IncrementSliderConfig)}
 					min={number('min', IncrementSliderConfig)}
 					onChange={this.handleChange}
-					value={number('value', IncrementSliderConfig, this.state.value)}
+					value={this.state.value}
 				/>
 			</div>
 		);
@@ -144,7 +159,7 @@ storiesOf('IncrementSlider', module)
 		() => (
 			<div>
 				Test the IncrementSlider by changing the values of max, min, and value knobs.
-				<IncrementSliderWithMinValue />
+				<IncrementSliderWithMinValue value={number('value', IncrementSliderConfig, 0)} />
 			</div>
 		)
 	);

--- a/packages/sampler/stories/qa/IncrementSlider.js
+++ b/packages/sampler/stories/qa/IncrementSlider.js
@@ -108,6 +108,7 @@ class IncrementSliderWithMinValue extends React.Component {
 				value: props.value
 			};
 		}
+		return null;
 	}
 
 	handleChange = ({value}) => this.setState({value})


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Using a knob to set the value makes the `IncrementSlider` "controlled" and therefore unresponsive to internal state management.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add some additional prop tracking to allow setting from both the knob and via interaction

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The knob doesn't refresh with the value change which is a bit weird but probably okay for the purposes of the QA sample. If someone disagrees, we can discuss more.