### PR TITLE
PLAT-85170: Apply `will-change` CSS property to the proper node in lists

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to apply `will-change` CSS property to the proper node
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 ### Fixed

--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -3,7 +3,6 @@
 	position: relative;
 	width: 100%;
 	height: 100%;
-	will-change: transform;
 }
 
 .scrollable {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -195,7 +195,7 @@ class ScrollerBase extends Component {
 		return (
 			<div
 				{...rest}
-				className={classNames(className, css.willChange, css.hideNativeScrollbar)}
+				className={classNames(className, css.scroller)}
 				ref={this.containerRef}
 				style={mergedStyle}
 			/>

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -195,7 +195,7 @@ class ScrollerBase extends Component {
 		return (
 			<div
 				{...rest}
-				className={classNames(className, css.hideNativeScrollbar)}
+				className={classNames(className, css.willChange, css.hideNativeScrollbar)}
 				ref={this.containerRef}
 				style={mergedStyle}
 			/>

--- a/packages/ui/Scroller/Scroller.module.less
+++ b/packages/ui/Scroller/Scroller.module.less
@@ -1,3 +1,7 @@
+.willChange {
+	will-change: transform;
+}
+
 .hideNativeScrollbar {
 	&::-webkit-scrollbar {
 		display: none;

--- a/packages/ui/Scroller/Scroller.module.less
+++ b/packages/ui/Scroller/Scroller.module.less
@@ -1,8 +1,7 @@
-.willChange {
+.scroller {
 	will-change: transform;
-}
 
-.hideNativeScrollbar {
+	/* hide native scrollbar */
 	&::-webkit-scrollbar {
 		display: none;
 	}

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -18,7 +18,8 @@
 
 		will-change: transform;
 	}
-	& > .willChange {
+	
+	.content {
 		will-change: transform;
 	}
 }

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -18,6 +18,9 @@
 
 		will-change: transform;
 	}
+	& > .willChange {
+		will-change: transform;
+	}
 }
 
 .virtualList::-webkit-scrollbar {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1058,7 +1058,7 @@ const VirtualListBaseFactory = (type) => {
 
 		// render
 
-		mergeClasses = (className) => {
+		makeContainerClasses = (className) => {
 			let containerClass = null;
 
 			if (type === Native) {
@@ -1068,11 +1068,14 @@ const VirtualListBaseFactory = (type) => {
 			return classNames(css.virtualList, containerClass, className);
 		}
 
+		makeContentClasses = () => (type === Native ? null : css.willChange)
+
 		render () {
 			const
 				{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, itemsRenderer, style, ...rest} = this.props,
 				{cc, itemContainerRef, primary} = this,
-				containerClasses = this.mergeClasses(className);
+				containerClasses = this.makeContainerClasses(className),
+				contentClasses = this.makeContentClasses();
 
 			delete rest.cbScrollTo;
 			delete rest.childProps;
@@ -1099,7 +1102,7 @@ const VirtualListBaseFactory = (type) => {
 
 			return (
 				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} ref={this.containerRef} style={style}>
-					<div {...rest} ref={this.contentRef}>
+					<div {...rest} className={contentClasses} ref={this.contentRef}>
 						{itemsRenderer({cc, itemContainerRef, primary})}
 					</div>
 				</div>

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1058,7 +1058,7 @@ const VirtualListBaseFactory = (type) => {
 
 		// render
 
-		makeContainerClasses (className) {
+		getContainerClasses (className) {
 			let containerClass = null;
 
 			if (type === Native) {
@@ -1068,7 +1068,7 @@ const VirtualListBaseFactory = (type) => {
 			return classNames(css.virtualList, containerClass, className);
 		}
 
-		makeContentClasses () {
+		getContentClasses () {
 			return type === Native ? null : css.content;
 		}
 
@@ -1076,8 +1076,8 @@ const VirtualListBaseFactory = (type) => {
 			const
 				{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, itemsRenderer, style, ...rest} = this.props,
 				{cc, itemContainerRef, primary} = this,
-				containerClasses = this.makeContainerClasses(className),
-				contentClasses = this.makeContentClasses();
+				containerClasses = this.getContainerClasses(className),
+				contentClasses = this.getContentClasses();
 
 			delete rest.cbScrollTo;
 			delete rest.childProps;

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1058,17 +1058,19 @@ const VirtualListBaseFactory = (type) => {
 
 		// render
 
-		makeContainerClasses = (className) => {
+		makeContainerClasses (className) {
 			let containerClass = null;
 
 			if (type === Native) {
-				containerClass = (this.isPrimaryDirectionVertical) ? css.vertical : css.horizontal;
+				containerClass = this.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
 			}
 
 			return classNames(css.virtualList, containerClass, className);
 		}
 
-		makeContentClasses = () => (type === Native ? null : css.willChange)
+		makeContentClasses () {
+			return type === Native ? null : css.content;
+		}
 
 		render () {
 			const


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`ui/VirtualList` and `ui/VirtualGridList` have `will-change: transform` CSS property which is added mainly for scroller in #1857, and the CSS property was applied to an unintended node in lists due to the difference of node structure between lists and scrollers.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This PR moves `will-change` CSS property to the proper node in `ui/VirtualList` and `ui/VirtualGridList`.

### Links
[//]: # (Related issues, references)
PLAT-85170

### Comments
