### PR TITLE
ENYO-6224: Fix docs to improve generate TypeScript definitions

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ContextualPopupDecorator` layout in large text mode in RTL locales
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
 - `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
+- `moonstone/Skinnable` TypeScript signature
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/Skinnable/Skinnable.js
+++ b/packages/moonstone/Skinnable/Skinnable.js
@@ -2,6 +2,7 @@
  * Exports the {@link moonstone/Skinnable.Skinnable} higher-order component (HOC).
  *
  * @module moonstone/Skinnable
+ * @exports Skinnable
  * @public
  */
 

--- a/packages/spotlight/Accelerator/Accelerator.js
+++ b/packages/spotlight/Accelerator/Accelerator.js
@@ -2,6 +2,7 @@
  * Provides the {@link spotlight/Accelerator.Accelerator} class.
  *
  * @module spotlight/Accelerator
+ * @exports Accelerator
  */
 
 /**

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` TypeScript signatures
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 No significant changes.

--- a/packages/spotlight/Pause/Pause.js
+++ b/packages/spotlight/Pause/Pause.js
@@ -37,6 +37,10 @@
  * ```
  *
  * @module spotlight/Pause
+ * @exports Pause
+ * @exports isPaused
+ * @exports pause
+ * @exports resume
  */
 
 let paused = false;

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -1,10 +1,8 @@
 /**
- * Exports the {@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator}
- * higher-order component and {@link spotlight/SpotlightContainerDecorator.spotlightDefaultClass}
- * `className`. The default export is
- * {@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator}.
+ * A component for managing groups of spottable components.
  *
  * @module spotlight/SpotlightContainerDecorator
+ * @exports SpotlightContainerDecorator
  */
 
 import {call, forProp, forward, handle, oneOf, returnsTrue, stop} from '@enact/core/handle';

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -41,11 +41,12 @@ const defaultConfig = {
  * ```
  *	const App = SpotlightRootDecorator(ApplicationView);
  * ```
- * @param  {Object} defaultConfig Set of default configuration parameters
- * @param  {Function} higher-order component
  *
- * @returns {Function} SpotlightRootDecorator
+ * @class SpotlightRootDecorator
  * @memberof spotlight/SpotlightRootDecorator
+ * @param  {Object} defaultConfig Set of default configuration parameters
+ * @param  {Function} Wrapped higher-order component
+ * @returns {Function} SpotlightRootDecorator
  * @hoc
  */
 const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -3,6 +3,7 @@
  * higher-order component.
  *
  * @module spotlight/SpotlightRootDecorator
+ * @exports SpotlightRootDecorator
  */
 
 import hoc from '@enact/core/hoc';

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -1,9 +1,9 @@
 /**
- * Exports the {@link spotlight/Spottable.Spottable} higher-order component and
- * the {@link spotlight/Spottable.spottableClass} `className`. The default export is
- * {@link spotlight/Spottable.Spottable}.
+ * Adds spottability to components.
  *
  * @module spotlight/Spottable
+ * @exports Spottable
+ * @exports spottableClass
  */
 
 import {forward, forwardWithPrevent, handle, preventDefault, stop} from '@enact/core/handle';

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -14,6 +14,8 @@
  * The default export is {@link spotlight.Spotlight}.
  *
  * @module spotlight
+ * @exports default Spotlight
+ * @exports getDirection
  */
 
 import {is} from '@enact/core/keymap';

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` TypeScript signatures
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 ### Fixed

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -361,7 +361,7 @@ class ScrollerBase extends Component {
  *
  * @class Scroller
  * @memberof ui/Scroller
- * @extends ui/Scrollable.ScrollerBase
+ * @extends ui/Scroller.ScrollerBase
  * @ui
  * @public
  */
@@ -395,8 +395,7 @@ Scroller.defaultProps = {
  *
  * @class ScrollerNative
  * @memberof ui/Scroller
- * @extends ui/Scrollable.ScrollableNative
- * @extends ui/Scrollable.ScrollerBase
+ * @extends ui/Scroller.ScrollerBase
  * @ui
  * @private
  */


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Many typescript signatures were incomplete

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated jsdoc comments to properly generate the TS signatures

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Requires updated jsdoc-to-ts to properly generate `spotlight` (the root) default export.

### Links
[//]: # (Related issues, references)
ENYO-6224
ENYO-6225

### Comments
