### PR TITLE
PLAT-85115: LS2Request should handle omitting luna:// prefix

### DIFF
--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact webos module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `webos/LS2Request` to automatically prefix `luna://` service protocol when absent.
+
 ## [3.0.0-rc.4] - 2019-08-22
 
 No significant changes.

--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -12,9 +12,8 @@ import {Job} from '@enact/core/util';
 const refs = {};
 
 const adjustPath = (path) => {
-	if (path.slice(-1) !== '/') {
-		path += '/';
-	}
+	if (!/^(luna|palm):\/\//.test(path)) path = 'luna://' + path;
+	if (path.slice(-1) !== '/') path += '/';
 	return path;
 };
 
@@ -52,7 +51,7 @@ export default class LS2Request {
 	 * @method
 	 * @memberof webos/LS2Request.LS2Request.prototype
 	 * @param {Object} options Options for the LS2 Request call
-	 * @param {String} options.service The name of the LS2 service.  Do not include 'luna://'.
+	 * @param {String} options.service The name of the LS2 service.
 	 * @param {String} options.method The name of the method.
 	 * @param {Object} options.parameters Any parameters required by the service method.
 	 * @param {Function} options.onSuccess The success handler for the request.


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Previously the Enact tutorial indicated `luna://` protocol was required in the `LS2Request` service property, however inline documents said it wasn't. Realistically, `LS2Request should be able to easily prefix as needed.

### Resolution
* Auto-prefixes the service path with `luna://` if it (or the old `palm://` are omitted.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>