### PR TITLE
ENYO-6227: FormCheckboxItem: there's no opacity when disabled and focused

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
-## unreleased
+## [unreleased]
 
 ### Fixed
-- `moonstone/FormCheckboxItem` to apply `opacity` to `itemicon` when disabled and focused
+
+- `moonstone/FormCheckboxItem` icon opacity when disabled and focused
 
 ## [3.0.0] - 2019-09-03
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## unreleased
+
+### Fixed
+- `moonstone/FormCheckboxItem` to apply `opacity` to `itemicon` when disabled and focused
+
 ## [3.0.0] - 2019-09-03
 
 ### Fixed
@@ -11,7 +16,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/ProgressBar` fill color when `highlighted` is set
 - `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 - `moonstone/Skinnable` TypeScript signature
-- `moonstone/FormCheckboxItem` to apply `opacity` when disabled and focused
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to render the first item properly when the `dataSize` prop is updated and the function as a parameter of the `cbScrollTo` prop is called
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
 - `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 - `moonstone/Skinnable` TypeScript signature
+- `moonstone/FormCheckboxItem` to apply `opacity` when disabled and focused
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -31,11 +31,7 @@
 			background-color: @moon-formcheckboxitem-focus-bg-color;
 
 			.disabled({
-				opacity: 1;
-
-				.content {
-					opacity: @moon-disabled-opacity;
-				}
+				opacity: @moon-disabled-opacity;
 			});
 		});
 	});

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -31,7 +31,8 @@
 			background-color: @moon-formcheckboxitem-focus-bg-color;
 
 			.disabled({
-				opacity: @moon-disabled-opacity;
+				color: @moon-formcheckboxitem-disabled-focus-color;
+				opacity: 1;
 			});
 		});
 	});

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -109,6 +109,7 @@
 
 // FormCheckboxItem
 // ---------------------------------------
+@moon-formcheckboxitem-disabled-focus-color: fade(@moon-black, 40%);
 @moon-formcheckboxitem-focus-text-color: @moon-black;
 @moon-formcheckboxitem-focus-bg-color: transparent;
 

--- a/packages/moonstone/styles/colors.less
+++ b/packages/moonstone/styles/colors.less
@@ -116,6 +116,7 @@
 
 // FormCheckboxItem
 // ---------------------------------------
+@moon-formcheckboxitem-disabled-focus-color: fade(@moon-white, 40%);
 @moon-formcheckboxitem-focus-text-color: @moon-spotlight-text-color;
 @moon-formcheckboxitem-focus-bg-color: transparent;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Itemicon` is displayed with white color when it's disabled and focused.
Because there's no opacity when disabled and focused

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
fixed FormChckboxItem to apply opacity when disabled and focused

### Links
[//]: # (Related issues, references)
ENYO-6227
