### PR TITLE
ENYO-6230: Render the first item properly when `dataSize` prop is updated and the function as a parameter of the `cbScrollTo` prop in VirtualList is called

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
 - `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 - `moonstone/Skinnable` TypeScript signature
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to render the first item properly when the function as a parameter of the `cbScrollTo` prop in them is called
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to render the first item properly when the `dataSize` prop is updated and the function as a parameter of the `cbScrollTo` prop is called
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` progress bar fill color when focused with `noFill` set
 - `moonstone/Scroller` to correctly handle horizontally scrolling focused elements into view when using a `direction` value of `'both'`
 - `moonstone/Skinnable` TypeScript signature
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to render the first item properly when the function as a parameter of the `cbScrollTo` prop in them is called
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -142,6 +142,34 @@ const InPanels = ({className, title, ...rest}) => {
 	);
 };
 
+// eslint-disable-next-line enact/prop-types
+class VirtualListWithCBScrollTo extends React.Component {
+	static propTypes = {
+		dataSize: PropTypes.number
+	}
+
+	componentDidUpdate (prevProps) {
+		if (this.props.dataSize !== prevProps.dataSize) {
+			this.scrollTo({animate: false, focus: false, index: 0});
+		}
+	}
+
+	scrollTo = null
+
+	getScrollTo = (scrollTo) => {
+		this.scrollTo = scrollTo;
+	}
+
+	render () {
+		return (
+			<VirtualList
+				{...this.props}
+				cbScrollTo={this.getScrollTo}
+			/>
+		);
+	}
+}
+
 storiesOf('VirtualList', module)
 	.add(
 		'horizontal scroll in Scroller',
@@ -219,4 +247,27 @@ storiesOf('VirtualList', module)
 				/>
 			);
 		}
+	)
+	.add(
+		'call cbScrollTo() when dataSize changes',
+		() => {
+			return (
+				<VirtualListWithCBScrollTo
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
+					itemSize={ri.scale(number('itemSize', Config, 72))}
+					noScrollByWheel={boolean('noScrollByWheel', Config)}
+					onKeyDown={action('onKeyDown')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					spacing={ri.scale(number('spacing', Config))}
+					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
+					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+				/>
+			);
+		},
+		{propTables: [Config]}
 	);

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -249,23 +249,13 @@ storiesOf('VirtualList', module)
 		}
 	)
 	.add(
-		'call cbScrollTo() when dataSize changes',
+		'scrolling to 0 whenever dataSize changes',
 		() => {
 			return (
 				<VirtualListWithCBScrollTo
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
-					focusableScrollbar={boolean('focusableScrollbar', Config)}
-					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}
-					noScrollByWheel={boolean('noScrollByWheel', Config)}
-					onKeyDown={action('onKeyDown')}
-					onScrollStart={action('onScrollStart')}
-					onScrollStop={action('onScrollStop')}
-					spacing={ri.scale(number('spacing', Config))}
-					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
-					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
-					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
 		},

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -816,9 +816,7 @@ const VirtualListBaseFactory = (type) => {
 			this.scrollPosition = pos;
 			this.updateMoreInfo(dataSize, pos);
 
-			if (firstIndex !== newFirstIndex) {
-				this.setState({firstIndex: newFirstIndex});
-			}
+			this.setState({firstIndex: newFirstIndex});
 		}
 
 		// For individually sized item


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When changing the `dataSize` prop in `VirtualList` or `VirtualGridList`, the first visible item in it is not rendered properly if the function as a parameter of the `cbScrollTo` prop in it is called in `componentDidUpdate` of an app.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When changing the `dataSize` prop in `VirtualList` or `VirtualGridList`, the list updates the information about which item would be rendered at first.
When calling the function as a parameter of the `cbScrollTo`, the list updates the scroll position, but does not update the information about which item would be rendered at first because of the following condition.
```
if (firstIndex !== newFirstIndex) {
   ...
}
```
We added the condition before because of preventing unnecessary rendering with a same state in React 15 by calling `setState`. But we don't need the condition anymore in React 16 because the list does not render again if using the same state. In addition, we don't have to use the condition because `setState` works async and the list could use the previous state. So it's the best to remove the condition.

### Links
[//]: # (Related issues, references)

ENYO-6230

### Comments

I created this PR to `release/3.0.0` branch because I hope this PR would be merged ASAP.