### PR TITLE
ENYO-6236: QA Sampler Scroller: ScrollingToBoundaryWithSmallOverflow and…

### DIFF
--- a/packages/sampler/stories/qa/Scroller.js
+++ b/packages/sampler/stories/qa/Scroller.js
@@ -401,7 +401,7 @@ storiesOf('Scroller', module)
 	.add(
 		'Test scrolling to boundary with small overflow',
 		() => {
-			const size = number('Spacer size', Scroller, {max: 300, min: 0, range: true}, 100);
+			const size = number('Spacer size', Config, {max: 300, min: 0, range: true}, 100);
 			return (
 				<Scroller
 					onKeyDown={action('onKeyDown')}
@@ -419,7 +419,7 @@ storiesOf('Scroller', module)
 	.add(
 		'Test scrolling to boundary with long overflow',
 		() => {
-			const size = number('Spacer size', Scroller, {max: 300, min: 0, range: true}, 200);
+			const size = number('Spacer size', Config, {max: 300, min: 0, range: true}, 200);
 			return (
 				<Scroller
 					focusableScrollbar={boolean('focusableScrollbar', Config, true)}


### PR DESCRIPTION
…ScrollingToBoundaryWithLongOverflow samples show 'Other' as a knob

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* 2 QA Scroller samples were using `Scroller` directly for config object. This resulted in some options appearing in an "Other" knob category.

### Resolution
* Use the `Config` object like all the other Scroller samples do. This categories the options back under "Scroller" knob category.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>