### PR TITLE
ENYO-6173: Notification: The width is larger than the previous version

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Notification` to fit the width of popup
+
 ## [3.0.0] - 2019-09-03
 
 ### Fixed

--- a/packages/moonstone/Notification/Notification.module.less
+++ b/packages/moonstone/Notification/Notification.module.less
@@ -7,6 +7,7 @@
 .notification {
 	position: relative;
 	left: 50%;
+	width: fit-content;
 	min-width: @moon-notification-min-width;
 	max-width: @moon-notification-max-width;
 	text-align: center;
@@ -22,7 +23,7 @@
 	}
 
 	.body {
-		width: fit-content;
+		display: table;
 		margin: 0;
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The width of `Notification` doesn't fit when inner text is very short.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
fixed size problem of Notification


### Links
[//]: # (Related issues, references)
ENYO-6240

