### PR TITLE
ENYO-6241: Fix Scroller focusing when pressing page up after holding 5-way down in Scroller

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to restore focus properly when pressing page up after holding 5-way down
+- `moonstone/Scroller` to restore focus properly when pressing page up after holding 5-way down
 
 ## [3.0.0] - 2019-09-03
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to restore focus properly when pressing page up after holding 5-way down
+
 ## [3.0.0] - 2019-09-03
 
 ### Fixed

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import handle, {forward} from '@enact/core/handle';
 import platform from '@enact/core/platform';
 import {onWindowReady} from '@enact/core/snapshot';
-import {Job} from '@enact/core/util';
+import {clamp, Job} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {constants, ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import Spotlight, {getDirection} from '@enact/spotlight';
@@ -528,9 +528,10 @@ class ScrollableBase extends Component {
 				// Should do nothing when focusedItem is paging control button of Scrollbar
 				if (childRefCurrent.containerRef.current.contains(focusedItem)) {
 					const
+						contentRect = this.uiRef.current.childRefCurrent.containerRef.current.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
-						x = (clientRect.right + clientRect.left) / 2,
-						y = (clientRect.bottom + clientRect.top) / 2;
+						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
+						y = clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {
@@ -712,13 +713,15 @@ class ScrollableBase extends Component {
 				const position = {x, y};
 				const {current: {containerRef: {current}}} = this.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
-				const target =
-					getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
-					getTargetInViewByDirectionFromPosition(direction, position, current) ||
-					getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
+				if (elemFromPoint) {
+					const target =
+						getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
+						getTargetInViewByDirectionFromPosition(direction, position, current) ||
+						getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
 
-				if (target) {
-					Spotlight.focus(target);
+					if (target) {
+						Spotlight.focus(target);
+					}
 				}
 			}
 			this.pointToFocus = null;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing page up when Spotlight is on the item out of viewport while holding 5-way Down, Spotlight suddenly hides. There is the following error in console.
```
Cannot read property 'closest' of null
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When pressing page up, we cache current position. But in this case, the position is out of viewport in Scroller. When trying to restore focus with the cached position, there is no item at the position and focus could not be restored. So when caching the position, I clamped it with the Scroller viewport area.

### Links
[//]: # (Related issues, references)

ENYO-6241