### PR TITLE
Adjust VirtualList keydown event consumption when leaving via ScrollB…

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -320,12 +320,19 @@ class ScrollButtons extends Component {
 					// If it is vertical `Scrollable`, move focus to the left for ltr or to the right for rtl
 					// If is is horizontal `Scrollable`, move focus to the up
 					directionToContent = !vertical && 'up' || rtl && 'right' || 'left',
+					isLeavingDown = vertical && isNextButton && isDown,
+					isLeavingUp = vertical && isPrevButton && isUp,
+					isLeavingLeft = !vertical && isPrevButton && isLeftMovement,
+					isLeavingRight = !vertical && isNextButton && isRightMovement,
 					isDirectionToLeave =
-						vertical && (isRightMovement || isPrevButton && isUp || isNextButton && isDown) ||
-						!vertical && (isDown || isPrevButton && isLeftMovement || isNextButton && isRightMovement);
+						(vertical && isRightMovement || isLeavingUp || isLeavingDown) ||
+						(!vertical && isDown || isLeavingLeft || isLeavingRight);
 
 				if (isDirectionToLeave) {
 					if (!focusableScrollButtons && !getTargetByDirectionFromElement(direction, ev.target)) {
+						if (preventBubbling && isLeavingDown || isLeavingUp || isLeavingLeft || isLeavingRight) {
+							consumeEvent(ev);
+						}
 						// move focus into contents and allow bubbling
 						Spotlight.move(directionToContent);
 					}


### PR DESCRIPTION
…utton

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Re-adding the `keydown` consumption - which was being done previously - only I'm adding a guard for when to consume it. Without it, the original issue in the ticket can be reproduced when using a `VirtualList`. Pressing 5way down on a vertical list's "down" scroll button could result in the item outside the viewport becoming focused.