### PR TITLE
PLAT-85023: Fix Button text alignment when color is set

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -119,6 +119,7 @@ const ButtonBase = kind({
 
 	computed: {
 		className: ({backgroundOpacity, color, iconPosition, styler}) => styler.append(
+			{hasColor: color},
 			backgroundOpacity,
 			color,
 			`icon${cap(iconPosition)}`

--- a/packages/moonstone/Button/Button.module.less
+++ b/packages/moonstone/Button/Button.module.less
@@ -140,7 +140,7 @@
 
 	// Only center the text if there is no icon. Otherwise, the default is to just leave its
 	// alignment alone, since we don't want to try to override marquee's directionality alignment.
-	&:not(.hasIcon) {
+	&:not(.hasIcon):not(.hasColor) {
 		.marquee {
 			text-align: center;
 		}

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Buttoon` text alignment when `color` is set
 - `moonstone/Scroller` to restore focus properly when pressing page up after holding 5-way down
 
 ## [3.0.0] - 2019-09-03


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Button text was centered when `color` was set and should be start aligned.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `.hasColor` class which, along with `.hasIcon`, will suppress text centering

![image](https://user-images.githubusercontent.com/788456/64393665-591e0980-d007-11e9-9f91-52dced18a377.png)
![image](https://user-images.githubusercontent.com/788456/64393670-60451780-d007-11e9-9a83-f9df8c68336b.png)
