### PR TITLE
ENYO-6227: Fix FormCheckboxItem itemIcon opacity

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/FormCheckboxItem` opacity of `itemIcon` value when focused and disabled
 - `moonstone/Scroller` to restore focus properly when pressing page up after holding 5-way down
 
 ## [3.0.0] - 2019-09-03

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
@@ -52,6 +52,14 @@ const FormCheckboxItemBase = kind({
 		publicClassNames: ['formCheckboxItem']
 	},
 
+	computed: {
+		itemIcon: ({css, itemIcon}) => {
+			return itemIcon ? (
+				<span className={css.itemIcon}>{itemIcon}</span>
+			) : null;
+		}
+	},
+
 	render: ({children, css, ...props}) => (
 		<ToggleItemBase
 			data-webos-voice-intent="SelectCheckItem"

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -33,7 +33,8 @@
 			.disabled({
 				opacity: 1;
 
-				.content {
+				.content,
+				.itemIcon {
 					opacity: @moon-disabled-opacity;
 				}
 			});


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using `itemIcon` with `FormCheckboxItem`, the contents would remain full opacity when focused and disabled.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Wrap `itemIcon` with an extra node to manage its opacity in this case.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It's possible to try to append the class to the node via `React.cloneElement` but it requires dipping into the Element struct (which should be black box) and doesn't guarantee the desired behavior since the `className` prop could be ignored by whatever component was passed.

This approach seemed safest and while the extra node is not ideal, its use is minimized to just `FormCheckbox` which has unique focus and disabled requirements to the other `ToggleItems`.
