### PR TITLE
PLAT-85351: Fix lists and scrollers spotlight behavior after page up/down

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
-### Changed
-
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move spotlight to the last item when they reached the top or the bottom after scroll by page
-
 ### Added
 
 - `moonstone/Dropdown` to add new size `x-large`
@@ -16,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Header` to fix font size of `titleBelow` and `subTitleBelow`
 - `moonstone/Dropdown` to apply `tiny` width
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` spotlight behavior to focus the last item when reaching the bounds after scroll by page up or down
 
 ## [3.0.1] - 2019-09-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move spotlight to the last item when unable to scroll by page up/down keys
+
 ### Fixed
 
 - `moonstone/Scroller` to restore focus properly when pressing page up after holding 5-way down

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Changed
 
-- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move spotlight to the last item when unable to scroll by page up/down keys
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` to move spotlight to the last item when they reached the top or the bottom after scroll by page
 
 ### Fixed
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -544,6 +544,28 @@ class ScrollableBase extends Component {
 			}
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
+		} else if (!Spotlight.getPointerMode()) { // no need to focus on pointer mode
+			const
+				contentNode = this.uiRef.current.childRefCurrent.containerRef.current,
+				originNode = focusedItem || contentNode,
+				contentRect = contentNode.getBoundingClientRect(),
+				originRect = originNode.getBoundingClientRect(),
+				x = (originRect.left + originRect.right) / 2,
+				y = direction === 'up' ? contentRect.top : contentRect.bottom,
+				position = {x, y},
+				{current: {containerRef: {current}}} = this.uiRef,
+				target = getTargetInViewByDirectionFromPosition(
+					reverseDirections[direction],
+					position,
+					current
+				);
+
+			if (target) {
+				if (target !== focusedItem) {
+					Spotlight.focus(target);
+				}
+				this.pointToFocus = null;
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -546,9 +546,11 @@ class ScrollableBase extends Component {
 					const
 						contentRect = contentNode.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
+						isUp = direction === 'up',
+						yAdjust = isUp ? 1 : -1,
 						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
 						y = bounds.maxTop <= scrollTop + pageDistance || 0 >= scrollTop + pageDistance ?
-							contentRect[direction === 'up' ? 'top' : 'bottom'] :
+							contentRect[isUp ? 'top' : 'bottom'] + yAdjust :
 							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -525,13 +525,16 @@ class ScrollableBase extends Component {
 
 		if (scrollPossible) {
 			if (focusedItem) {
+				const contentNode = childRefCurrent.containerRef.current;
 				// Should do nothing when focusedItem is paging control button of Scrollbar
-				if (childRefCurrent.containerRef.current.contains(focusedItem)) {
+				if (contentNode.contains(focusedItem)) {
 					const
-						contentRect = this.uiRef.current.childRefCurrent.containerRef.current.getBoundingClientRect(),
+						contentRect = contentNode.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
 						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
-						y = clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
+						y = bounds.maxTop <= scrollTop + pageDistance || 0 >= scrollTop + pageDistance ?
+							contentRect[direction === 'up' ? 'top' : 'bottom'] :
+							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {
@@ -544,28 +547,6 @@ class ScrollableBase extends Component {
 			}
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
-		} else if (!Spotlight.getPointerMode()) { // no need to focus on pointer mode
-			const
-				contentNode = this.uiRef.current.childRefCurrent.containerRef.current,
-				originNode = focusedItem || contentNode,
-				contentRect = contentNode.getBoundingClientRect(),
-				originRect = originNode.getBoundingClientRect(),
-				x = (originRect.left + originRect.right) / 2,
-				y = direction === 'up' ? contentRect.top : contentRect.bottom,
-				position = {x, y},
-				{current: {containerRef: {current}}} = this.uiRef,
-				target = getTargetInViewByDirectionFromPosition(
-					reverseDirections[direction],
-					position,
-					current
-				);
-
-			if (target) {
-				if (target !== focusedItem) {
-					Spotlight.focus(target);
-				}
-				this.pointToFocus = null;
-			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -527,9 +527,10 @@ class ScrollableBase extends Component {
 			{childRefCurrent, scrollTop} = this.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
 			bounds = this.uiRef.current.getScrollBounds(),
-			directionFactor = direction === 'up' ? -1 : 1,
+			isUp = direction === 'up',
+			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier,
-			scrollPossible = scrollTop > 0 && direction === 'up' || bounds.maxTop > scrollTop && direction === 'down';
+			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop > scrollTop;
 
 		this.uiRef.current.lastInputType = 'pageKey';
 
@@ -546,7 +547,6 @@ class ScrollableBase extends Component {
 					const
 						contentRect = contentNode.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
-						isUp = direction === 'up',
 						yAdjust = isUp ? 1 : -1,
 						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
 						y = bounds.maxTop <= scrollTop + pageDistance || 0 >= scrollTop + pageDistance ?

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -608,6 +608,28 @@ class ScrollableBaseNative extends Component {
 			}
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
+		} else if (!Spotlight.getPointerMode()) { // no need to focus on pointer mode
+			const
+				contentNode = this.uiRef.current.childRefCurrent.containerRef.current,
+				originNode = focusedItem || contentNode,
+				contentRect = contentNode.getBoundingClientRect(),
+				originRect = originNode.getBoundingClientRect(),
+				x = (originRect.left + originRect.right) / 2,
+				y = direction === 'up' ? contentRect.top : contentRect.bottom,
+				position = {x, y},
+				{current: {containerRef: {current}}} = this.uiRef,
+				target = getTargetInViewByDirectionFromPosition(
+					reverseDirections[direction],
+					position,
+					current
+				);
+
+			if (target) {
+				if (target !== focusedItem) {
+					Spotlight.focus(target);
+				}
+				this.pointToFocus = null;
+			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -590,13 +590,15 @@ class ScrollableBaseNative extends Component {
 
 		if (scrollPossible) {
 			if (focusedItem) {
+				const contentNode = childRefCurrent.containerRef.current;
 				// Should do nothing when focusedItem is paging control button of Scrollbar
-				if (childRefCurrent.containerRef.current.contains(focusedItem)) {
+				if (contentNode.contains(focusedItem)) {
 					const
 						clientRect = focusedItem.getBoundingClientRect(),
 						x = (clientRect.right + clientRect.left) / 2,
-						y = (clientRect.bottom + clientRect.top) / 2;
-
+						y = bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance ?
+							contentNode.getBoundingClientRect()[direction === 'up' ? 'top' : 'bottom'] :
+							(clientRect.bottom + clientRect.top) / 2;
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {
 						this.childRef.current.setContainerDisabled(true);
@@ -608,28 +610,6 @@ class ScrollableBaseNative extends Component {
 			}
 
 			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
-		} else if (!Spotlight.getPointerMode()) { // no need to focus on pointer mode
-			const
-				contentNode = this.uiRef.current.childRefCurrent.containerRef.current,
-				originNode = focusedItem || contentNode,
-				contentRect = contentNode.getBoundingClientRect(),
-				originRect = originNode.getBoundingClientRect(),
-				x = (originRect.left + originRect.right) / 2,
-				y = direction === 'up' ? contentRect.top : contentRect.bottom,
-				position = {x, y},
-				{current: {containerRef: {current}}} = this.uiRef,
-				target = getTargetInViewByDirectionFromPosition(
-					reverseDirections[direction],
-					position,
-					current
-				);
-
-			if (target) {
-				if (target !== focusedItem) {
-					Spotlight.focus(target);
-				}
-				this.pointToFocus = null;
-			}
 		}
 	}
 

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -592,9 +592,10 @@ class ScrollableBaseNative extends Component {
 			{childRefCurrent, scrollTop} = this.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
 			bounds = this.uiRef.current.getScrollBounds(),
-			directionFactor = direction === 'up' ? -1 : 1,
+			isUp = direction === 'up',
+			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier,
-			scrollPossible = scrollTop > 0 && direction === 'up' || bounds.maxTop - scrollTop > epsilon && direction === 'down';
+			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop - scrollTop > epsilon;
 
 		this.uiRef.current.lastInputType = 'pageKey';
 
@@ -610,7 +611,6 @@ class ScrollableBaseNative extends Component {
 				if (contentNode.contains(focusedItem)) {
 					const
 						clientRect = focusedItem.getBoundingClientRect(),
-						isUp = direction === 'up',
 						yAdjust = isUp ? 1 : -1,
 						x = (clientRect.right + clientRect.left) / 2,
 						y = bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance ?

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -610,9 +610,11 @@ class ScrollableBaseNative extends Component {
 				if (contentNode.contains(focusedItem)) {
 					const
 						clientRect = focusedItem.getBoundingClientRect(),
+						isUp = direction === 'up',
+						yAdjust = isUp ? 1 : -1,
 						x = (clientRect.right + clientRect.left) / 2,
 						y = bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance ?
-							contentNode.getBoundingClientRect()[direction === 'up' ? 'top' : 'bottom'] :
+							contentNode.getBoundingClientRect()[isUp ? 'top' : 'bottom'] + yAdjust :
 							(clientRect.bottom + clientRect.top) / 2;
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have got a new requirement to move spotlight to the last item (especially on the same column for grid lists) when a list or a scroller is expected that no more scroll by page up/down keys is possible on a given direction. This behavior will be helpful to end users to indicate whether further scrolling is possible or not.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added logic to lists and scrollers to move spotlight to the last item on the same column when a list/scroller is about to touch the edge as a result of scroll by page toward a given direction.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This behavior is applied only to 5-way mode. For pointer mode, there is no change.
Since scroll by page works only for vertical scrolling, this behavior is invalid for horizontal scrolling.

### Links
[//]: # (Related issues, references)
PLAT-85351

### Comments
