### PR TITLE
ENYO-6173: Fix Notification to shrink to fit its content

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Notification` so it shrinks to fit small content
 - `moonstone/Scroller` to restore focus properly when pressing page up after holding 5-way down
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to properly navigate from paging controls to items by 5-way key when `focusableScrollbar` is false
 

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -153,7 +153,7 @@ const NotificationBase = kind({
 
 	render: ({buttons, children, css, ...rest}) => {
 		return (
-			<Popup noAnimation {...rest} css={css}>
+			<Popup noAnimation {...rest} css={css} shrinkBody>
 				<div className={css.notificationBody} ref={fixTransform}>
 					{children}
 				</div>

--- a/packages/moonstone/Notification/Notification.module.less
+++ b/packages/moonstone/Notification/Notification.module.less
@@ -9,6 +9,7 @@
 	left: 50%;
 	min-width: @moon-notification-min-width;
 	max-width: @moon-notification-max-width;
+	width: fit-content;  // Notification should shrink to the size of the content
 	text-align: center;
 	border-radius: @moon-notification-border-radius;
 	border-style: solid;

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -141,6 +141,20 @@ const PopupBase = kind({
 		showCloseButton: PropTypes.bool,
 
 		/**
+		 * Tells the body element to shrink to the size of the content.
+		 *
+		 * Popup is composed of a [Layout]{@link ui/Layout.Layout} and [Cells]{@link ui/Layout.Cell}.
+		 * This informs the body cell to use the [shrink]{@link ui/Layout.Cell#shrink} property so
+		 * it will match the dimensions of its contents rather than expand to the width of the
+		 * Popup's assigned dimensions.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		shrinkBody: PropTypes.bool,
+
+		/**
 		 * The container id for {@link spotlight/Spotlight}.
 		 *
 		 * @type {String}
@@ -168,6 +182,7 @@ const PopupBase = kind({
 		noAnimation: false,
 		open: false,
 		showCloseButton: false,
+		shrinkBody: false,
 		spotlightRestrict: 'self-only'
 	},
 
@@ -200,7 +215,7 @@ const PopupBase = kind({
 		}
 	},
 
-	render: ({children, closeButton, css, noAnimation, onHide, onShow, open, spotlightId, spotlightRestrict, ...rest}) => {
+	render: ({children, closeButton, css, noAnimation, onHide, onShow, open, shrinkBody, spotlightId, spotlightRestrict, ...rest}) => {
 		delete rest.closeButtonAriaLabel;
 		delete rest.onCloseButtonClick;
 		delete rest.showCloseButton;
@@ -224,7 +239,7 @@ const PopupBase = kind({
 					role="alert"
 					{...rest}
 				>
-					<Cell className={css.body}>
+					<Cell className={css.body} shrink={shrinkBody}>
 						{children}
 					</Cell>
 					{closeButton}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The design of Notification sets the size to be too wide when there is small content and it looks awkward.


### Resolution
Added a new private prop to `Popup` to set the body cell to shrink, which allows the `width: fit-content` code in `Notification` to work as expected. By default, Cells try to fill their maximum space, so this was taking precedence over and child rules and preferences.