### PR TITLE
ENYO-6227: Fix FormCheckboxItem styling of `itemIcon`

### DIFF
--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
@@ -52,22 +52,14 @@ const FormCheckboxItemBase = kind({
 		publicClassNames: ['formCheckboxItem']
 	},
 
-	computed: {
-		itemIcon: ({css, itemIcon}) => {
-			return itemIcon ? (
-				<span className={css.itemIcon}>{itemIcon}</span>
-			) : null;
-		}
-	},
-
 	render: ({children, css, ...props}) => (
 		<ToggleItemBase
 			data-webos-voice-intent="SelectCheckItem"
 			{...props}
 			css={css}
-			iconComponent={FormCheckbox}
+			iconComponent={<FormCheckbox className={componentCss.toggleIcon} />}
 		>
-			<span className={componentCss.content}>{children}</span>
+			{children}
 		</ToggleItemBase>
 	)
 });

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -24,6 +24,15 @@
 		overflow: hidden;
 	}
 
+	.itemIcon {
+		display: inline-block;
+
+		* {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
 	// Skin colors
 	.applySkins({
 		.focus({

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.module.less
@@ -24,27 +24,36 @@
 		overflow: hidden;
 	}
 
-	.itemIcon {
-		display: inline-block;
-
-		* {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
-	}
-
 	// Skin colors
 	.applySkins({
+		// The following code targets all elements that don't act as an invisible frame, and sets
+		// them to the disabled opacity. Invisible frames however are set to fully opaque so their
+		// children can be affected. Below toggleIcon is specifically targeted so it remains full
+		// opacity when focused and disabled, overriding these more general rules.
+		.disabled({
+			opacity: 1;
+
+			> * {
+			    opacity: @moon-disabled-opacity;
+			}
+			.slot {
+			    opacity: 1;
+
+				> * {
+				    opacity: @moon-disabled-opacity;
+				}
+			}
+		});
+
 		.focus({
 			color: @moon-formcheckboxitem-focus-text-color;
 			background-color: @moon-formcheckboxitem-focus-bg-color;
 
 			.disabled({
-				opacity: 1;
-
-				.content,
-				.itemIcon {
-					opacity: @moon-disabled-opacity;
+				.slot {
+					.toggleIcon {
+					    opacity: 1;
+					}
 				}
 			});
 		});

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -67,7 +67,7 @@ const SlotItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['slotItem']
+		publicClassNames: ['slotItem', 'slot']
 	},
 
 	render: (props) => {

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -95,11 +95,10 @@ const ToggleItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['toggleItem']
+		publicClassNames: ['toggleItem', 'slot']
 	},
 
 	render: (props) => {
-
 		return (
 			<UiToggleItem
 				role="checkbox"

--- a/packages/moonstone/ToggleItem/ToggleItem.module.less
+++ b/packages/moonstone/ToggleItem/ToggleItem.module.less
@@ -3,4 +3,7 @@
 	.content {
 		flex: 1 1 auto;
 	}
+	.slot {
+		/* Public Class Names */
+	}
 }

--- a/packages/ui/ToggleItem/ToggleItem.module.less
+++ b/packages/ui/ToggleItem/ToggleItem.module.less
@@ -1,3 +1,9 @@
 .toggleItem {
 	/* Placeholder for CSS overrides */
+	.slot,
+	.after,
+	.before,
+	.hidden {
+		/* Public Class Names */
+	}
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Items change size when an icon is added

### Resolution
Remove the margin of child icons which bump the item to be taller than intended.
Also sets the block sizing so the new span element has the correct dimensions.