### PR TITLE
ENYO-6250: Fix samples in READMEs

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -13,20 +13,23 @@ import {I18nContextDecorator, I18nDecorator} from '@enact/i18n/I18nDecorator';
 import React from 'react';
 
 const MyComponent = I18nContextDecorator(
-    {rtlProp: 'rtl'},
-    (props) => (
-        <div>{props.rtl ? 'right to left' : 'left to right'}</div>
-    )
+	{rtlProp: 'rtl'},
+	(props) => (
+		<div>{props.rtl ? 'right to left' : 'left to right'}</div>
+	)
 );
 
 const MyApp = () => (
-    <div>
-        <MyComponent />
-    </div>
+	<div>
+		<MyComponent />
+	</div>
 );
 
 const MyI18nApp = I18nDecorator(MyApp);
+
+export default MyI18nApp;
 ```
+**Note**: The `@enact/i18n` module will attempt to determine the locale automatically.  Pass a `locale` prop (`"en-US"` for example) to this component where it is rendered to test.
 
 ## Install
 

--- a/packages/moonstone/README.md
+++ b/packages/moonstone/README.md
@@ -8,12 +8,16 @@
 import kind from '@enact/core/kind';
 import Button from '@enact/moonstone/Button';
 import MoonstoneDecorator from '@enact/moonstone/MoonstoneDecorator';
+import React from 'react';
 
 const MyApp = kind({
-    name: 'MyApp',
-    render: () => (<Button>Hello, Enact!</Button>);
+	name: 'MyApp',
+	render: () => (<Button>Hello, Enact!</Button>)
 });
+
 const MyMoonstoneApp = MoonstoneDecorator(MyApp);
+
+export default MyMoonstoneApp;
 ```
 
 > Note: The moonstone decorator must be applied to the base component. This decorator also applies

--- a/packages/spotlight/README.md
+++ b/packages/spotlight/README.md
@@ -12,15 +12,19 @@ computer-with-mouse.
 
 ```
 import kind from '@enact/core/kind';
-import {SpotlightRootDecorator, Spottable} from '@enact/spotlight';
+import React from 'react';
+import SpotlightRootDecorator from '@enact/spotlight/SpotlightRootDecorator'
+import Spottable from '@enact/spotlight/Spottable'
 
 const MySpottableComponent = Spottable('div');
 
 const MyApp = kind({
-    name: 'MyApp',
-    render: () => (<MySpottableComponent>Hello, Enact!</MySpottableComponent>)
+	name: 'MyApp',
+	render: () => (<MySpottableComponent>Hello, Enact!</MySpottableComponent>)
 });
 const MySpotlightApp = SpotlightRootDecorator(MyApp);
+
+export default MySpotlightApp;
 ```
 
 See the [docs](docs/) for more information.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -6,21 +6,22 @@ This library contains a set of unstyled components as well as a number of Higher
 
 ## Example
 
-One of the components supplied is `Repeater`. A repeater stamps out copies of a provided component:
+One of the components supplied is `Repeater`. A repeater stamps out copies of a component (the `childComponent` prop) using the elements of an array provided as its `children`:
 ```
 import kind from '@enact/core/kind';
+import React from 'react';
 import Repeater from '@enact/ui/Repeater';
 
 const MyApp = kind({
-    name: 'MyApp',
-    render: () => (
-        <Repeater childComponent="div">
-            One
-            Two
-            Three
-        </Repeater>
-    )
+	name: 'MyApp',
+	render: () => (
+		<Repeater childComponent="div">
+			{['One', 'Two', 'Three']}
+		</Repeater>
+	)
 });
+
+export default MyApp;
 ```
 
 See the documentation for each component for more information.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Individual package `README`s for `@enact/i18n`, `@enact/moonstone`, `@enact/spotlight`, and `@enact/ui` had incorrect or incomplete example usages.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This patch updates the example usages with complete and functional code.


### Links
[//]: # (Related issues, references)
ENYO-6250