### PR TITLE
Add focus restoring for container in voice control

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Scroller` to restore focus properly when newly target is container in voice control
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` to restore focus properly when newly target is container in voice control
 - `moonstone/Button` text alignment when `color` is set
 - `moonstone/FormCheckboxItem` opacity of `itemIcon` value when focused and disabled
 - `moonstone/Notification` to shrink to fit small content

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Scroller` to restore focus properly when newly target is container in voice control
 - `moonstone/Button` text alignment when `color` is set
 - `moonstone/FormCheckboxItem` opacity of `itemIcon` value when focused and disabled
 - `moonstone/Notification` to shrink to fit small content

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -853,7 +853,12 @@ class ScrollableBase extends Component {
 				for (let i = 0; i < nodes.length; i++) {
 					const nodeBounds = nodes[i].getBoundingClientRect();
 					if (nodeBounds[first] > viewportBounds[first] && nodeBounds[last] < viewportBounds[last]) {
-						Spotlight.focus(nodes[i]);
+						const node = nodes[i];
+						if (node && node.dataset && 'spotlightContainer' in node.dataset) {
+							Spotlight.focus(`@${node.dataset.spotlightId}`);
+						} else {
+							Spotlight.focus(node);
+						}
 						break;
 					}
 				}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -914,7 +914,12 @@ class ScrollableBaseNative extends Component {
 				for (let i = 0; i < nodes.length; i++) {
 					const nodeBounds = nodes[i].getBoundingClientRect();
 					if (nodeBounds[first] > viewportBounds[first] && nodeBounds[last] < viewportBounds[last]) {
-						Spotlight.focus(nodes[i]);
+						const node = nodes[i];
+						if (node && node.dataset && 'spotlightContainer' in node.dataset) {
+							Spotlight.focus(`@${node.dataset.spotlightId}`);
+						} else {
+							Spotlight.focus(node);
+						}
 						break;
 					}
 				}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When scroll position is changed with voice control, focus has to restored.
But in case of newly target is container, focus is not restored.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add focus restoring logic in case of container

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/ENYO-6252

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>