### PR TITLE
Scrollable - adjust next focus position after paging

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -550,7 +550,7 @@ class ScrollableBase extends Component {
 						yAdjust = isUp ? 1 : -1,
 						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
 						y = bounds.maxTop <= scrollTop + pageDistance || 0 >= scrollTop + pageDistance ?
-							contentRect[direction === 'up' ? 'top' : 'bottom'] + yAdjust :
+							contentRect[isUp ? 'top' : 'bottom'] + yAdjust :
 							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -546,9 +546,11 @@ class ScrollableBase extends Component {
 					const
 						contentRect = contentNode.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
+						isUp = direction === 'up',
+						yAdjust = isUp ? 1 : -1,
 						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
 						y = bounds.maxTop <= scrollTop + pageDistance || 0 >= scrollTop + pageDistance ?
-							contentRect[direction === 'up' ? 'top' : 'bottom'] :
+							contentRect[direction === 'up' ? 'top' : 'bottom'] + yAdjust :
 							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -610,9 +610,11 @@ class ScrollableBaseNative extends Component {
 				if (contentNode.contains(focusedItem)) {
 					const
 						clientRect = focusedItem.getBoundingClientRect(),
+						isUp = direction === 'up',
+						yAdjust = isUp ? 1 : -1,
 						x = (clientRect.right + clientRect.left) / 2,
 						y = bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance ?
-							contentNode.getBoundingClientRect()[direction === 'up' ? 'top' : 'bottom'] :
+							contentNode.getBoundingClientRect()[isUp ? 'top' : 'bottom'] + yAdjust :
 							(clientRect.bottom + clientRect.top) / 2;
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Adjusting the next point to focus by 1 px, keeping focus *inside* the `Scroller` bounds after paging.

