### PR TITLE
ENYO-6237: Fix Dropdown tiny width

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Dropdown` to apply `tiny` width
+
 ## [3.0.1] - 2019-09-09
 
 ### Fixed

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -230,7 +230,7 @@ const DropdownBase = kind({
 				};
 			});
 		},
-		className: ({width, styler}) => styler.append(width),
+		className: ({width, styler}) => styler.append(`${width}Width`),
 		title: ({children, selected, title}) => {
 			if (isSelectedValid({children, selected})) {
 				const child = children[selected];

--- a/packages/moonstone/Dropdown/Dropdown.module.less
+++ b/packages/moonstone/Dropdown/Dropdown.module.less
@@ -5,24 +5,24 @@
 @import "../styles/skin.less";
 
 .dropdown {
-	&.tiny {
+	&.tinyWidth {
 		min-width: @moon-dropdown-tiny-width;
 		width: @moon-dropdown-tiny-width;
 	}
 
-	&.small {
+	&.smallWidth {
 		width: @moon-dropdown-small-width;
 	}
 
-	&.medium {
+	&.mediumWidth {
 		width: @moon-dropdown-medium-width;
 	}
 
-	&.large {
+	&.largeWidth {
 		width: @moon-dropdown-large-width;
 	}
 
-	&.huge {
+	&.hugeWidth {
 		max-width: @moon-dropdown-huge-width;
 		width: @moon-dropdown-huge-width;
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix conflicting class name in `Dropdown`. `Dropdown`'s `width` prop and `Button`'s `size` prop share the same set of names as values: `['small', 'large']`  that led to unintended css rule override and specificity issues when applying props such as `width="tiny"` and `size="small"`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`Dropdown` has a class name `small` that is meant to only be used by the prop `width`, but it was passed down to `Button`  through `ContextualButton`, so the rule that was meant for `width` was also applied to `Button`'s `size`. Renaming the width classes avoids unintended css overrides.


### Links
[//]: # (Related issues, references)
ENYO-6237

