### PR TITLE
PLAT-85321: Add EventCacheable to cache event

### DIFF
--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -170,7 +170,7 @@ class VirtualListWithCBScrollTo extends React.Component {
 	}
 }
 
-const VirtualListWithCachedScrollStopParam = EventCacheable({type: 'onScrollStop'}, VirtualList);
+const VirtualListWithCachedScrollStopEvent = EventCacheable({type: 'onScrollStop'}, VirtualList);
 
 class VirtualListLoggingScrollInformation extends React.Component {
 	constructor (props) {
@@ -191,9 +191,9 @@ class VirtualListLoggingScrollInformation extends React.Component {
 		clearInterval(this.intervalID);
 	}
 
-	scrollTo = null
-	intervalID = null
 	handler = action('setInterval');
+	intervalID = null
+	scrollTo = null
 
 	getScrollTo = (scrollTo) => {
 		this.scrollTo = scrollTo;
@@ -201,10 +201,10 @@ class VirtualListLoggingScrollInformation extends React.Component {
 
 	render () {
 		return (
-			<VirtualListWithCachedScrollStopParam
+			<VirtualListWithCachedScrollStopEvent
 				{...this.props}
-				ref={this.listRef}
 				cbScrollTo={this.getScrollTo}
+				ref={this.listRef}
 			/>
 		);
 	}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -179,7 +179,7 @@ class VirtualListLogginScrollInformation extends React.Component {
 		this.listRef = React.createRef();
 	}
 
-	componentDidMount (prevProps) {
+	componentDidMount () {
 		this.scrollTo({animate: false, focus: false, index: 10});
 
 		this.intervalID = setInterval(() => {

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -172,7 +172,7 @@ class VirtualListWithCBScrollTo extends React.Component {
 
 const VirtualListWithCachedScrollStopParam = EventCacheable({type: 'onScrollStop'}, VirtualList);
 
-class VirtualListLogginScrollInformation extends React.Component {
+class VirtualListLoggingScrollInformation extends React.Component {
 	constructor (props) {
 		super(props);
 
@@ -305,7 +305,7 @@ storiesOf('VirtualList', module)
 		'logging scroll information every 5 seconds',
 		() => {
 			return (
-				<VirtualListLogginScrollInformation
+				<VirtualListLoggingScrollInformation
 					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
 					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
 					itemSize={ri.scale(number('itemSize', Config, 72))}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/EventCacheable` to cache the event as a parameter of a configured event prop
+
 ## [3.0.0] - 2019-09-03
 
 ### Fixed

--- a/packages/ui/EventCacheable/EventCacheable.js
+++ b/packages/ui/EventCacheable/EventCacheable.js
@@ -2,7 +2,7 @@ import React from 'react';
 import hoc from '@enact/core/hoc';
 
 const EventCacheable = hoc((config = {defaultEvent: null, type: null}, Wrapped) => {
-    const {defaultEvent, type} = config;
+	const {defaultEvent, type} = config;
 
 	return class EventParamCacheableBase extends React.Component {
 		cachedEvent = defaultEvent || null

--- a/packages/ui/EventCacheable/EventCacheable.js
+++ b/packages/ui/EventCacheable/EventCacheable.js
@@ -1,13 +1,71 @@
+/**
+ * A higher-order component to cache an event.
+ *
+ * @module ui/EventCacheable
+ * @exports EventCacheable
+ */
+
 import {forward, handle, call} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import PropTypes from 'prop-types';
 import React from 'react';
 
-const defaultConfig = {defaultEvent: null, type: null};
+/**
+ * Default config for {@link ui/EventCacheable.EventCacheable}.
+ *
+ * @memberof ui/EventCacheable.EventCacheable
+ * @hocconfig
+ */
+const defaultConfig = {
+	/**
+	 * The default event before caching an event.
+	 *
+	 * @type {*}
+	 * @default null
+	 * @memberof ui/EventCacheable.EventCacheable.defaultConfig
+	 */
+	defaultEvent: null,
 
+	/**
+	 * Configures the event name that cache the event in it.
+	 *
+	 * @type {String}
+	 * @default ''
+	 * @memberof ui/EventCacheable.EventCacheable.defaultConfig
+	 */
+	type: ''
+};
+
+/**
+ * A higher-order component to cache the event as a parameter of a configured event prop.
+ *
+ * Its default event and event prop name can be configured when applied to a component.
+ *
+ * Example:
+ * ```
+ * const VirtualListWithCachedScrollStopEvent = EventCacheable({type: 'onScrollStop'}, VirtualList);
+ * ```
+ *
+ * @class EventCacheable
+ * @memberof ui/EventCacheable
+ * @hoc
+ * @public
+ */
 const EventCacheable = hoc(defaultConfig, (config, Wrapped) => {
 	const {defaultEvent, type} = config;
 
 	return class EventCacheableBase extends React.Component {
+		static propTypes = /** @lends ui/EventCacheable.EventCacheable.prototype */ {
+			/**
+			 * Event callback to cache the event in it.
+			 *
+			 * @memberof ui/EventCacheable.EventCacheable.prototype
+			 * @type {Function}
+			 * @public
+			 */
+			[type]: PropTypes.func
+		}
+
 		cachedEvent = defaultEvent || null
 
 		getEvent = () => (this.cachedEvent)

--- a/packages/ui/EventCacheable/EventCacheable.js
+++ b/packages/ui/EventCacheable/EventCacheable.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import hoc from '@enact/core/hoc';
+
+const EventCacheable = hoc((config = {defaultEvent: null, type: null}, Wrapped) => {
+    const {defaultEvent, type} = config;
+
+	return class EventParamCacheableBase extends React.Component {
+		cachedEvent = defaultEvent || null
+
+		getEvent = () => (this.cachedEvent)
+
+		setEvent = (event) => {
+			this.cachedEvent = event;
+		}
+
+		eventHandler = (ev) => {
+			this.cachedEvent = ev;
+		}
+
+		render () {
+			const eventHandler = type ? {[type]: this.eventHandler} : null;
+
+			return (
+				<Wrapped
+					{...this.props}
+					{...eventHandler}
+				/>
+			);
+		}
+	};
+});
+
+export default EventCacheable;

--- a/packages/ui/EventCacheable/EventCacheable.js
+++ b/packages/ui/EventCacheable/EventCacheable.js
@@ -1,30 +1,35 @@
-import React from 'react';
+import {forward, handle, call} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import React from 'react';
 
-const EventCacheable = hoc((config = {defaultEvent: null, type: null}, Wrapped) => {
+const defaultConfig = {defaultEvent: null, type: null};
+
+const EventCacheable = hoc(defaultConfig, (config, Wrapped) => {
 	const {defaultEvent, type} = config;
 
-	return class EventParamCacheableBase extends React.Component {
+	return class EventCacheableBase extends React.Component {
 		cachedEvent = defaultEvent || null
 
 		getEvent = () => (this.cachedEvent)
 
-		setEvent = (event) => {
-			this.cachedEvent = event;
-		}
-
-		eventHandler = (ev) => {
+		setEvent = (ev) => {
 			this.cachedEvent = ev;
 		}
 
+		eventHandler = handle(
+			forward(type),
+			call('setEvent'),
+		).bindAs(this, 'eventHandler')
+
 		render () {
-			const eventHandler = type ? {[type]: this.eventHandler} : null;
+			const props = {...this.props};
+
+			if (type) {
+				props[type] = this.eventHandler;
+			}
 
 			return (
-				<Wrapped
-					{...this.props}
-					{...eventHandler}
-				/>
+				<Wrapped {...props} />
 			);
 		}
 	};

--- a/packages/ui/EventCacheable/package.json
+++ b/packages/ui/EventCacheable/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "EventCacheable.js"
+}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Needed to cache the event when `onScrollStop` event is bubbled.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

 I added `EventCacheable` component and the sample using it in VirtualList for `onScrollStop`.

### Links
[//]: # (Related issues, references)

PLAT-85321

### Comments

~I'll update CHANGELOG.md and JSDocs after 1st reivew.~