### PR TITLE
ENYO-6260: Fix Dropdown to include `data` prop in `onSelect` handler

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Header` to fix font size of `titleBelow` and `subTitleBelow`
 - `moonstone/Dropdown` to apply `tiny` width
+- `moonstone/Dropdown` to forward selected `data` through the `onSelect` handler
 
 ## [3.0.1] - 2019-09-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Header` to fix font size of `titleBelow` and `subTitleBelow`
 - `moonstone/Dropdown` to apply `tiny` width
-- `moonstone/Dropdown` to forward selected `data` through the `onSelect` handler
+- `moonstone/Dropdown` to include selected `data` in the `onSelect` handler
 - `moonstone/VirtualList.VirtualList` dynamically extended item scrolling into view properly
 
 ## [3.0.1] - 2019-09-09

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -128,6 +128,10 @@ const DropdownBase = kind({
 		/**
 		 * Called when an item is selected.
 		 *
+		 * The event payload will be an object with the following members:
+		 * * `data` - The value for the option as received in the `children` prop
+		 * * `selected` - Number representing the selected option, 0 indexed
+		 *
 		 * @type {Function}
 		 * @public
 		 */

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -84,10 +84,10 @@ const DropdownListBase = kind({
 			const {children, selected} = props;
 
 			let child = children[index];
-			const data = child;
 			if (typeof child === 'string') {
 				child = {children: child};
 			}
+			const data = child.children;
 
 			return (
 				<Item

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -87,7 +87,7 @@ const DropdownListBase = kind({
 			if (typeof child === 'string') {
 				child = {children: child};
 			}
-			const data = child[children];
+			const data = child.children;
 
 			return (
 				<Item

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -84,10 +84,10 @@ const DropdownListBase = kind({
 			const {children, selected} = props;
 
 			let child = children[index];
+			const data = child;
 			if (typeof child === 'string') {
 				child = {children: child};
 			}
-			const data = child.children;
 
 			return (
 				<Item

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -87,6 +87,7 @@ const DropdownListBase = kind({
 			if (typeof child === 'string') {
 				child = {children: child};
 			}
+			const data = child[children];
 
 			return (
 				<Item
@@ -94,7 +95,7 @@ const DropdownListBase = kind({
 					{...child}
 					data-selected={index === selected}
 					// eslint-disable-next-line react/jsx-no-bind
-					onClick={() => forward('onSelect', {selected: index}, props)}
+					onClick={() => forward('onSelect', {data, selected: index}, props)}
 				/>
 			);
 		}

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -182,5 +182,41 @@ describe('Dropdown', () => {
 
 			expect(actual).toEqual(expected);
 		});
+
+		test('should pass string as `data` in `onSelect` callback when `children` is a string', () => {
+			const handler = jest.fn();
+			const dropDown = mount(
+				<DropdownList onSelect={handler}>
+					{children}
+				</DropdownList>
+			);
+
+			dropDown.find('Item').at(0).simulate('click');
+
+			const expected = 'option1'
+			const actual = handler.mock.calls[0][0].data;
+
+			expect(actual).toBe(expected);
+		});
+
+		test('should pass object as `data` in `onSelect` callback when `children` is a object', () => {
+			const handler = jest.fn();
+			const dropDown = mount(
+				<DropdownList onSelect={handler}>
+					{[
+						{key: 'o1', children: 'option 1'},
+						{key: 'o2', children: 'option 2'},
+						{key: 'o3', children: 'option 3'}
+					]}
+				</DropdownList>
+			);
+
+			dropDown.find('Item').at(0).simulate('click');
+
+			const expected = {key: 'o1', children: 'option 1'};
+			const actual = handler.mock.calls[0][0].data;
+
+			expect(actual).toEqual(expected);
+		});
 	});
 });

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -182,41 +182,5 @@ describe('Dropdown', () => {
 
 			expect(actual).toEqual(expected);
 		});
-
-		test('should pass string as `data` in `onSelect` callback when `children` is a string', () => {
-			const handler = jest.fn();
-			const dropDown = mount(
-				<DropdownList onSelect={handler}>
-					{children}
-				</DropdownList>
-			);
-
-			dropDown.find('Item').at(0).simulate('click');
-
-			const expected = 'option1'
-			const actual = handler.mock.calls[0][0].data;
-
-			expect(actual).toBe(expected);
-		});
-
-		test('should pass object as `data` in `onSelect` callback when `children` is a object', () => {
-			const handler = jest.fn();
-			const dropDown = mount(
-				<DropdownList onSelect={handler}>
-					{[
-						{key: 'o1', children: 'option 1'},
-						{key: 'o2', children: 'option 2'},
-						{key: 'o3', children: 'option 3'}
-					]}
-				</DropdownList>
-			);
-
-			dropDown.find('Item').at(0).simulate('click');
-
-			const expected = {key: 'o1', children: 'option 1'};
-			const actual = handler.mock.calls[0][0].data;
-
-			expect(actual).toEqual(expected);
-		});
 	});
 });

--- a/packages/moonstone/Dropdown/tests/Dropdown-specs.js
+++ b/packages/moonstone/Dropdown/tests/Dropdown-specs.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 import {Dropdown, DropdownBase} from '../Dropdown';
+import DropdownList from '../DropdownList';
 
 const title = 'Dropdown select';
 const children = ['option1', 'option2', 'option3'];
@@ -163,5 +164,23 @@ describe('Dropdown', () => {
 		const actual = dropDown.prop('popupProps').children[0];
 
 		expect(actual).toMatchObject(expected);
+	});
+
+	describe('DropdownList', () => {
+		test('should include `data` and `selected` in `onSelect` callback', () => {
+			const handler = jest.fn();
+			const dropDown = mount(
+				<DropdownList onSelect={handler}>
+					{children}
+				</DropdownList>
+			);
+
+			dropDown.find('Item').at(0).simulate('click');
+
+			const expected = {data: 'option1', selected: 0};
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expected);
+		});
 	});
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's no `data` prop in `onSelect` handler of `Dropdown` component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `data` into the `onSelect` handler.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
