### PR TITLE
PLAT-85398: Fix accessibility read out of the Dropdown components.

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Dropdown` to add new size `x-large`
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` ability to change of the role
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` prop `role` to set its ARIA `role`
 
 ### Fixed
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,12 +7,14 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Added
 
 - `moonstone/Dropdown` to add new size `x-large`
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` ability to change of the role
 
 ### Fixed
 
 - `moonstone/Header` to fix font size of `titleBelow` and `subTitleBelow`
 - `moonstone/Dropdown` to apply `tiny` width
 - `moonstone/VirtualList.VirtualList` dynamically extended item scrolling into view properly
+- `moonstone/Dropdown` accessibility read out when an item is focused
 
 ## [3.0.1] - 2019-09-09
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -208,7 +208,9 @@ const DropdownBase = kind({
 			return children.map((child, i) => {
 				const aria = {
 					role: 'checkbox',
-					'aria-checked': selected === i
+					'aria-checked': selected === i,
+					'aria-posinset': i + 1,
+					'aria-setsize': children.length
 				};
 
 				warning(

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -81,9 +81,7 @@ const DropdownListBase = kind({
 
 	handlers: {
 		itemRenderer: ({index, ...rest}, props) => {
-			const
-				{children, selected} = props,
-				posinset = index + 1;
+			const {children, selected} = props;
 
 			let child = children[index];
 			if (typeof child === 'string') {
@@ -94,8 +92,6 @@ const DropdownListBase = kind({
 				<Item
 					{...rest}
 					{...child}
-					aria-posinset={posinset}
-					aria-setsize={children.length}
 					data-selected={index === selected}
 					// eslint-disable-next-line react/jsx-no-bind
 					onClick={() => forward('onSelect', {selected: index}, props)}

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -81,7 +81,9 @@ const DropdownListBase = kind({
 
 	handlers: {
 		itemRenderer: ({index, ...rest}, props) => {
-			const {children, selected} = props;
+			const
+				{children, selected} = props,
+				posinset = index + 1;
 
 			let child = children[index];
 			if (typeof child === 'string') {
@@ -92,6 +94,8 @@ const DropdownListBase = kind({
 				<Item
 					{...rest}
 					{...child}
+					aria-posinset={posinset}
+					aria-setsize={children.length}
 					data-selected={index === selected}
 					// eslint-disable-next-line react/jsx-no-bind
 					onClick={() => forward('onSelect', {selected: index}, props)}
@@ -119,6 +123,7 @@ const DropdownListBase = kind({
 				cbScrollTo={scrollTo}
 				dataSize={dataSize}
 				itemSize={itemSize}
+				role="group"
 				style={{height: itemSize * dataSize}}
 			/>
 		);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -155,7 +155,6 @@ const VirtualListBaseFactory = (type) => {
 
 			/**
 			 * The role for the list.
-			 * If unset, it defaults to the `list` of `role`
 			 *
 			 * @type {String}
 			 * @default 'list'

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -154,7 +154,7 @@ const VirtualListBaseFactory = (type) => {
 			pageScroll: PropTypes.bool,
 
 			/**
-			 * The role for the list.
+			 * The ARIA role for the list.
 			 *
 			 * @type {String}
 			 * @default 'list'

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -154,6 +154,16 @@ const VirtualListBaseFactory = (type) => {
 			pageScroll: PropTypes.bool,
 
 			/**
+			 * The role for the list.
+			 * If unset, it defaults to the `list` of `role`
+			 *
+			 * @type {String}
+			 * @default 'list'
+			 * @publie
+			 */
+			role: PropTypes.string,
+
+			/**
 			 * `true` if rtl, `false` if ltr.
 			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
 			 *
@@ -796,7 +806,7 @@ const VirtualListBaseFactory = (type) => {
 
 		render () {
 			const
-				{itemRenderer, itemsRenderer, ...rest} = this.props,
+				{itemRenderer, itemsRenderer, role, ...rest} = this.props,
 				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
 
 			delete rest.initUiChildRef;
@@ -812,7 +822,7 @@ const VirtualListBaseFactory = (type) => {
 					getComponentProps={this.getComponentProps}
 					itemRenderer={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
 						itemRenderer({
-							... itemRest,
+							...itemRest,
 							[dataIndexAttribute]: index,
 							index
 						})
@@ -824,7 +834,8 @@ const VirtualListBaseFactory = (type) => {
 						return itemsRenderer({
 							...props,
 							handlePlaceholderFocus: this.handlePlaceholderFocus,
-							needsScrollingPlaceholder
+							needsScrollingPlaceholder,
+							role
 						});
 					}}
 				/>
@@ -930,13 +941,14 @@ const listItemsRenderer = (props) => {
 		handlePlaceholderFocus,
 		itemContainerRef: initUiItemContainerRef,
 		needsScrollingPlaceholder,
-		primary
+		primary,
+		role
 	} = props;
 
 	return (
 		<React.Fragment>
 			{cc.length ? (
-				<div ref={initUiItemContainerRef} role="list">{cc}</div>
+				<div ref={initUiItemContainerRef} role={role}>{cc}</div>
 			) : null}
 			{primary ? null : (
 				<SpotlightPlaceholder
@@ -956,22 +968,21 @@ const listItemsRenderer = (props) => {
 };
 /* eslint-enable enact/prop-types */
 
-const ScrollableVirtualList = (props) => { // eslint-disable-line react/jsx-no-bind
-	const {focusableScrollbar} = props;
-
+const ScrollableVirtualList = ({role, ...rest}) => { // eslint-disable-line react/jsx-no-bind
 	warning(
-		!props.itemSizes || !props.cbScrollTo,
+		!rest.itemSizes || !rest.cbScrollTo,
 		'VirtualList with `minSize` in `itemSize` prop does not support `cbScrollTo` prop'
 	);
 
 	return (
 		<Scrollable
-			{...props}
+			{...rest}
 			childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
 				<VirtualListBase
 					{...childProps}
-					focusableScrollbar={focusableScrollbar}
+					focusableScrollbar={rest.focusableScrollbar}
 					itemsRenderer={listItemsRenderer}
+					role={role}
 				/>
 			)}
 		/>
@@ -983,31 +994,32 @@ ScrollableVirtualList.propTypes = /** @lends moonstone/VirtualList.VirtualListBa
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 	focusableScrollbar: PropTypes.bool,
 	itemSizes: PropTypes.array,
-	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic'])
+	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
+	role: PropTypes.string
 };
 
 ScrollableVirtualList.defaultProps = {
 	direction: 'vertical',
 	focusableScrollbar: false,
-	preventBubblingOnKeyDown: 'programmatic'
+	preventBubblingOnKeyDown: 'programmatic',
+	role: 'list'
 };
 
-const ScrollableVirtualListNative = (props) => {
-	const {focusableScrollbar} = props;
-
+const ScrollableVirtualListNative = ({role, ...rest}) => {
 	warning(
-		!props.itemSizes || !props.cbScrollTo,
+		!rest.itemSizes || !rest.cbScrollTo,
 		'VirtualList with `minSize` in `itemSize` prop does not support `cbScrollTo` prop'
 	);
 
 	return (
 		<ScrollableNative
-			{...props}
+			{...rest}
 			childRenderer={(childProps) => ( // eslint-disable-line react/jsx-no-bind
 				<VirtualListBaseNative
 					{...childProps}
-					focusableScrollbar={focusableScrollbar}
+					focusableScrollbar={rest.focusableScrollbar}
 					itemsRenderer={listItemsRenderer}
+					role={role}
 				/>
 			)}
 		/>
@@ -1019,13 +1031,15 @@ ScrollableVirtualListNative.propTypes = /** @lends moonstone/VirtualList.Virtual
 	direction: PropTypes.oneOf(['horizontal', 'vertical']),
 	focusableScrollbar: PropTypes.bool,
 	itemSizes: PropTypes.array,
-	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic'])
+	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
+	role: PropTypes.string
 };
 
 ScrollableVirtualListNative.defaultProps = {
 	direction: 'vertical',
 	focusableScrollbar: false,
-	preventBubblingOnKeyDown: 'programmatic'
+	preventBubblingOnKeyDown: 'programmatic',
+	role: 'list'
 };
 
 export default VirtualListBase;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -144,7 +144,7 @@ const VirtualListBaseFactory = (type) => {
 			 */
 			itemSizes: PropTypes.array,
 
-			/*
+			/**
 			 * It scrolls by page when `true`, by item when `false`.
 			 *
 			 * @type {Boolean}
@@ -159,7 +159,7 @@ const VirtualListBaseFactory = (type) => {
 			 *
 			 * @type {String}
 			 * @default 'list'
-			 * @publie
+			 * @public
 			 */
 			role: PropTypes.string,
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` prop `role` to set its ARIA `role`
+
 ## [3.0.1] - 2019-09-09
 
 No significant changes.
@@ -12,7 +18,6 @@ No significant changes.
 
 - `ui/Scroller` TypeScript signatures
 - `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to apply `will-change` CSS property to the proper node
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` ability to change of the role
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ No significant changes.
 
 - `ui/Scroller` TypeScript signatures
 - `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to apply `will-change` CSS property to the proper node
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` ability to change of the role
 
 ## [3.0.0-rc.4] - 2019-08-22
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1326,14 +1326,14 @@ VirtualListBaseNative.displayName = 'ui:VirtualListBaseNative';
  * @public
  */
 
-const ScrollableVirtualList = (props) => (
+const ScrollableVirtualList = ({role, ...rest}) => (
 	<Scrollable
-		{...props}
-		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
+		{...rest}
+		childRenderer={({initChildRef, ...childRest}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBase
-				{...rest}
+				{...childRest}
 				itemsRenderer={({cc, itemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={itemContainerRef} role="list">{cc}</div> : null
+					cc.length ? <div ref={itemContainerRef} role={role}>{cc}</div> : null
 				)}
 				ref={initChildRef}
 			/>
@@ -1342,21 +1342,23 @@ const ScrollableVirtualList = (props) => (
 );
 
 ScrollableVirtualList.propTypes = {
-	direction: PropTypes.oneOf(['horizontal', 'vertical'])
+	direction: PropTypes.oneOf(['horizontal', 'vertical']),
+	role: PropTypes.string
 };
 
 ScrollableVirtualList.defaultProps = {
-	direction: 'vertical'
+	direction: 'vertical',
+	role: 'list'
 };
 
-const ScrollableVirtualListNative = (props) => (
+const ScrollableVirtualListNative = ({role, ...rest}) => (
 	<ScrollableNative
-		{...props}
-		childRenderer={({initChildRef, ...rest}) => ( // eslint-disable-line react/jsx-no-bind
+		{...rest}
+		childRenderer={({initChildRef, ...childRest}) => ( // eslint-disable-line react/jsx-no-bind
 			<VirtualListBaseNative
-				{...rest}
+				{...childRest}
 				itemsRenderer={({cc, itemContainerRef}) => ( // eslint-disable-line react/jsx-no-bind
-					cc.length ? <div ref={itemContainerRef} role="list">{cc}</div> : null
+					cc.length ? <div ref={itemContainerRef} role={role}>{cc}</div> : null
 				)}
 				ref={initChildRef}
 			/>
@@ -1365,11 +1367,13 @@ const ScrollableVirtualListNative = (props) => (
 );
 
 ScrollableVirtualListNative.propTypes = /** @lends ui/VirtualList.VirtualListBaseNative.prototype */ {
-	direction: PropTypes.oneOf(['horizontal', 'vertical'])
+	direction: PropTypes.oneOf(['horizontal', 'vertical']),
+	role: PropTypes.string
 };
 
 ScrollableVirtualListNative.defaultProps = {
-	direction: 'vertical'
+	direction: 'vertical',
+	role: 'list'
 };
 
 export default VirtualListBase;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved
The TV should read "X of Y" when focusing on items in Dropdown component.
Expected > "Option 1 + Checked + X of Y"
Actual > "Option 1 + Checked"

### Resolution
- To propagate `aria-posinset` and `aria-setsize` to the Item component to include the X of Y information of the item.
- For the expected behavior above, the `role` of VirtualList must be `group`, not `list`. So I modified the `role` prop given by the Dropdown component to apply to the VirtualList.


### Links
PLAT-85398