### PR TITLE
ENYO-6249: Fix to show items properly when reducing data size

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to show items properly when reducing data size
+
 ## [3.0.1] - 2019-09-09
 
 No significant changes.

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -393,8 +393,13 @@ const VirtualListBaseFactory = (type) => {
 				});
 			} else if (this.hasDataSizeChanged) {
 				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
-				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(newState);
+				// We need to call `setState` asynchronously.
+				// If not, the `firstIndex` in the state will be overridden
+				// by calling `scrollTo` in `ui/Scrollable` and updating the `firstIndex` again.
+				setTimeout(() => {
+					// eslint-disable-next-line react/no-did-update-set-state
+					this.setState(newState);
+				});
 				this.setContainerSize();
 			} else if (prevProps.rtl !== this.props.rtl) {
 				this.updateScrollPosition(this.getXY(this.scrollPosition, 0));


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When reducing `dataSize` prop in `VirtualList, some items do not show properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If the `dataSize` prop is reduced and the scroll position is needed to be updated together, the first index of the item is calculated incorrectly because the first index is updated when the `dataSize` prop is updated and the first index is updated again when scrolling and items are needed to swap.

So the first calculation for the first index was deferred by calling `setTimeout`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

My solution is calling `setState` asynchronously with `setTimeout`. VirtuaList lifecycle is very complex now. So currently, I could not find any other way to remove the `setTimeout`.

1) Updating the `firstIndex` by scrolling was deferred in the commit - https://github.com/enactjs/enact/commit/9eeeed8194f909bd1b1958703179ef9680e0e155#diff-cd0137f683e41402c5d8c0e084142452R1316. If the commit is reverted, then there is no problem.

2) If https://github.com/enactjs/enact/pull/2529 is reverted, then there is also no problem.

So those two patches generate this issue. But currently I also could not find any other patches for those issues.

### Links
[//]: # (Related issues, references)

ENYO-6249