### PR TITLE
ENYO-6252: Add support for focusing nodes with Spotlight.focus() 

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Added
 
-- `spotlight` support for passing a spottable node or a container node to `Spotlight.focus()`
+- `spotlight` support for passing a spottable node or a container node or selector to `Spotlight.focus()`
 
 ## [3.0.1] - 2019-09-09
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `spotlight` support for passing a spottable node or a container node to `Spotlight.focus()`
+
 ## [3.0.1] - 2019-09-09
 
 No significant changes.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -1100,6 +1100,7 @@ export {
 	configureDefaults,
 	configureContainer,
 	getContainerFocusTarget,
+	getContainerId,
 	getContainerPreviousTarget,
 	getDefaultContainer,
 	getLastContainer,

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -717,8 +717,9 @@ const Spotlight = (function () {
 		 * If Spotlight is in pointer mode, focus is not changed but `elem` will be set as the last
 		 * focused element of its spotlight containers.
 		 *
-		 * @param {String|Object|Node|undefined} elem Component ID, container ID, element selector,
-		 *  or spottable node. If not supplied, the default container will be focused.
+		 * @param {String|Node|undefined} elem The spotlight ID or selector for either a spottable
+		 *  component or a spootliht container, or spottable node. If not supplied, the default
+		 *  container will be focused.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -33,6 +33,7 @@ import {
 	configureDefaults,
 	getAllContainerIds,
 	getContainerConfig,
+	getContainerId,
 	getContainerLastFocusedElement,
 	getContainerNode,
 	getContainersForNode,
@@ -716,8 +717,8 @@ const Spotlight = (function () {
 		 * If Spotlight is in pointer mode, focus is not changed but `elem` will be set as the last
 		 * focused element of its spotlight containers.
 		 *
-		 * @param {String|Object|undefined} elem Component ID, container, ID or element selector.
-		 *	If not supplied, the default container will be focused.
+		 * @param {String|Object|Node|undefined} elem Component ID, container ID, element selector,
+		 *  or spottable node. If not supplied, the default container will be focused.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */
@@ -737,6 +738,8 @@ const Spotlight = (function () {
 				} else {
 					target = getTargetBySelector(elem);
 				}
+			} else if (isContainer(elem)) {
+				target = getTargetByContainer(getContainerId(elem));
 			}
 
 			const nextContainerIds = getContainersForNode(target);

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -717,8 +717,8 @@ const Spotlight = (function () {
 		 * If Spotlight is in pointer mode, focus is not changed but `elem` will be set as the last
 		 * focused element of its spotlight containers.
 		 *
-		 * @param {String|Node|undefined} elem The spotlight ID or selector for either a spottable
-		 *  component or a spootliht container, or spottable node. If not supplied, the default
+		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
+		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -5,6 +5,7 @@ import {
 	getAllContainerIds,
 	getContainerConfig,
 	getContainerFocusTarget,
+	getContainerId,
 	getContainerNode,
 	getContainerPreviousTarget,
 	getContainersForNode,
@@ -82,6 +83,11 @@ function getTargetBySelector (selector) {
 
 	const next = parseSelector(selector)[0];
 	if (next) {
+
+		if (isContainer(next)) {
+			return getTargetByContainer(getContainerId(next));
+		}
+
 		const nextContainerIds = getContainersForNode(next);
 		if (isNavigable(next, last(nextContainerIds), true)) {
 			return next;

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -1,0 +1,143 @@
+import {
+	configureContainer,
+	configureDefaults,
+	containerAttribute,
+	getSpottableDescendants,
+	removeAllContainers,
+	rootContainerId,
+	setLastContainer
+} from '../container';
+import Spotlight from '../spotlight';
+
+import {
+	container,
+	join,
+	node,
+	someSpottables,
+	spottable,
+	testScenario
+} from './utils';
+
+const nonSpottable = () => node({className: 'other'});
+
+const scenarios = {
+	complexTree: join(
+		spottable({'data-spotlight-id': 's1'}),
+		spottable(nonSpottable()),
+		container({[containerAttribute]: 'first-container', children: join(
+			someSpottables(2),
+			container({[containerAttribute]: 'second-container', children: join(
+				spottable({id: 'secondContainerFirstSpottable'}),
+				someSpottables(2),
+				container({
+					[containerAttribute]: 'third-container',
+					'data-spotlight-container-disabled': true,
+					children: join(
+						someSpottables(4),
+						node({id: 'child-of-third'})
+					)
+				})
+			)})
+		)})
+	)
+};
+
+const setupContainers = () => {
+	Spotlight.setPointerMode(false);
+	configureDefaults({
+		selector: '.spottable'
+	});
+	configureContainer(rootContainerId);
+	setLastContainer(rootContainerId);
+};
+
+const teardownContainers = () => {
+	// clean up any containers we create for safe tests
+	removeAllContainers();
+};
+
+const mockFocus = (n) => {
+	const fn = jest.fn().mockImplementation(() => true);
+	Object.defineProperty(n, 'focus', {
+		get: () => fn
+	});
+
+	return fn;
+};
+
+describe('Spotlight', () => {
+	describe('#focus', () => {
+		beforeEach(setupContainers);
+		afterEach(teardownContainers);
+
+		test('should focus spottable by id', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				const fn = mockFocus(root.querySelector('[data-spotlight-id="s1"]'));
+				Spotlight.focus('s1');
+
+				expect(fn).toBeCalled();
+			}
+		));
+
+		test('should focus container by id', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				configureContainer('first-container');
+
+				const fn = mockFocus(root.querySelector('[data-spotlight-id="first-container"] > .spottable'));
+				Spotlight.focus('first-container');
+
+				expect(fn).toBeCalled();
+			}
+		));
+
+		test('should focus spottable by node', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				const n = root.querySelector('[data-spotlight-id="s1"]');
+				const fn = mockFocus(n);
+				Spotlight.focus(n);
+
+				expect(fn).toBeCalled();
+			}
+		));
+
+		test('should focus container by node', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				configureContainer('first-container');
+
+				const n = root.querySelector('[data-spotlight-id="first-container"]')
+				const fn = mockFocus(n.querySelector('.spottable'));
+				Spotlight.focus(n);
+
+				expect(fn).toBeCalled();
+			}
+		));
+
+		test('should focus spottable by selector', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				const n = root.querySelector('[data-spotlight-id="s1"]');
+				const fn = mockFocus(n);
+				Spotlight.focus('[data-spotlight-id="s1"]');
+
+				expect(fn).toBeCalled();
+			}
+		));
+
+		test('should focus container by node', testScenario(
+			scenarios.complexTree,
+			(root) => {
+				configureContainer('first-container');
+
+				const n = root.querySelector('[data-spotlight-id="first-container"]')
+				const fn = mockFocus(n.querySelector('.spottable'));
+				Spotlight.focus('[data-spotlight-id="first-container"]');
+
+				expect(fn).toBeCalled();
+			}
+		));
+	});
+});

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -2,7 +2,6 @@ import {
 	configureContainer,
 	configureDefaults,
 	containerAttribute,
-	getSpottableDescendants,
 	removeAllContainers,
 	rootContainerId,
 	setLastContainer
@@ -108,7 +107,7 @@ describe('Spotlight', () => {
 			(root) => {
 				configureContainer('first-container');
 
-				const n = root.querySelector('[data-spotlight-id="first-container"]')
+				const n = root.querySelector('[data-spotlight-id="first-container"]');
 				const fn = mockFocus(n.querySelector('.spottable'));
 				Spotlight.focus(n);
 
@@ -132,7 +131,7 @@ describe('Spotlight', () => {
 			(root) => {
 				configureContainer('first-container');
 
-				const n = root.querySelector('[data-spotlight-id="first-container"]')
+				const n = root.querySelector('[data-spotlight-id="first-container"]');
 				const fn = mockFocus(n.querySelector('.spottable'));
 				Spotlight.focus('[data-spotlight-id="first-container"]');
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
While used internally, the API for `Spotlight.focus()` did not officially support passing nodes (either spottables or containers).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Officially adding support and extending the existing logic to handle container nodes correctly.
