### PR TITLE
PLAT-85398: Fix Dropdown option read out behavior

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Header` to fix font size of `titleBelow` and `subTitleBelow`
 - `moonstone/Dropdown` to apply `tiny` width
 - `moonstone/Dropdown` to include selected `data` in the `onSelect` handler
+- `moonstone/Dropdown` accessibility read out behavior of options
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` spotlight behavior to focus the last item when reaching the bounds after scroll by page up or down
 - `moonstone/VirtualList.VirtualList` dynamically extended item scrolling into view properly
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -212,7 +212,9 @@ const DropdownBase = kind({
 			return children.map((child, i) => {
 				const aria = {
 					role: 'checkbox',
-					'aria-checked': selected === i
+					'aria-checked': selected === i,
+					'aria-posinset': i + 1,
+					'aria-setsize': children.length
 				};
 
 				warning(

--- a/packages/moonstone/Dropdown/DropdownList.js
+++ b/packages/moonstone/Dropdown/DropdownList.js
@@ -117,6 +117,7 @@ const DropdownListBase = kind({
 		return (
 			<VirtualList
 				{...rest}
+				role="group"
 				cbScrollTo={scrollTo}
 				dataSize={dataSize}
 				itemSize={itemSize}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -153,6 +153,15 @@ const VirtualListBaseFactory = (type) => {
 			 */
 			pageScroll: PropTypes.bool,
 
+			/*
+			 * The ARIA role for the list
+			 *
+			 * @type {String}
+			 * @default 'list'
+			 * @private
+			 */
+			role: PropTypes.string,
+
 			/**
 			 * `true` if rtl, `false` if ltr.
 			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
@@ -200,6 +209,7 @@ const VirtualListBaseFactory = (type) => {
 			dataSize: 0,
 			focusableScrollbar: false,
 			pageScroll: false,
+			role: 'list',
 			spacing: 0,
 			wrap: false
 		}
@@ -796,7 +806,7 @@ const VirtualListBaseFactory = (type) => {
 
 		render () {
 			const
-				{itemRenderer, itemsRenderer, ...rest} = this.props,
+				{itemRenderer, itemsRenderer, role, ...rest} = this.props,
 				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
 
 			delete rest.initUiChildRef;
@@ -824,7 +834,8 @@ const VirtualListBaseFactory = (type) => {
 						return itemsRenderer({
 							...props,
 							handlePlaceholderFocus: this.handlePlaceholderFocus,
-							needsScrollingPlaceholder
+							needsScrollingPlaceholder,
+							role
 						});
 					}}
 				/>
@@ -930,13 +941,14 @@ const listItemsRenderer = (props) => {
 		handlePlaceholderFocus,
 		itemContainerRef: initUiItemContainerRef,
 		needsScrollingPlaceholder,
-		primary
+		primary,
+		role
 	} = props;
 
 	return (
 		<React.Fragment>
 			{cc.length ? (
-				<div ref={initUiItemContainerRef} role="list">{cc}</div>
+				<div ref={initUiItemContainerRef} role={role}>{cc}</div>
 			) : null}
 			{primary ? null : (
 				<SpotlightPlaceholder


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Dropdown did not include the index and set size ("1 of 3") in its read out. This is a regression from #2516 which replaced `Group` (which included this support) with `VirtualList` (which doesn't).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add `aria-posinset` and `aria-setsize` to items
* Add support for overriding `role` of VirtualList