### PR TITLE
ENYO-6200: Add position prop to ProgressBarTooltip

### DIFF
--- a/packages/core/internal/prop-types/prop-types.js
+++ b/packages/core/internal/prop-types/prop-types.js
@@ -49,10 +49,20 @@ const componentOverride = PropTypes.oneOfType([
 	component
 ]);
 
+/*
+ * Wrap a prop type validator with a deprecation warning when the prop has a non-null value
+ *
+ * @param {Function} base Prop type validator
+ * @param {Object} config deprecatioon configuration
+ */
 const deprecated = (base, config) => {
+	// Wrap in a no-op so deprecate only warns once
 	const warn = deprecate(() => true, config);
 	return (props, key, ...rest) => {
+		// Warn on a non-null value for the prop
 		if (props[key] != null) warn();
+
+		// Pass on to the prop type validator
 		return base(props, key, ...rest);
 	};
 };

--- a/packages/core/internal/prop-types/prop-types.js
+++ b/packages/core/internal/prop-types/prop-types.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 
 import {isRenderable} from '../../util';
 
+import deprecate from '../deprecate';
+
 const isRequired = (fn) => {
 	fn.isRequired = function (props, key, componentName, location, propFullName, ...rest) {
 		const propValue = props[key];
@@ -47,9 +49,18 @@ const componentOverride = PropTypes.oneOfType([
 	component
 ]);
 
+const deprecated = (base, config) => {
+	const warn = deprecate(() => true, config);
+	return (props, key, ...rest) => {
+		if (props[key] != null) warn();
+		return base(props, key, ...rest);
+	};
+};
+
 const EnactPropTypes = {
 	component,
 	componentOverride,
+	deprecated,
 	renderable,
 	renderableOverride
 };

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,9 +4,14 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Deprecated
+
+- `moonstone/ProgressBar.ProgressBarTooltip` and `moonstone/Slider.SliderTooltip` prop `side`, will be replaced by `position` in 4.0.0
+
 ### Added
 
 - `moonstone/Dropdown` to add new size `x-large`
+- `moonstone/ProgressBar.ProgressBarTooltip` and `moonstone/Slider.SliderTooltip` prop `position`, replacing `side`
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` prop `role` to set its ARIA `role`
 
 ### Fixed

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -13,6 +13,7 @@ import Tooltip from '../TooltipDecorator/Tooltip';
 import css from './ProgressBarTooltip.module.less';
 
 // prop-type validator that warns on invalid orientation + position
+/* istanbul ignore next */
 const validatePosition = (base) => (props, key, componentName, location, propFullName, ...rest) => {
 	const {position} = props;
 	let result = base(props, key, componentName, location, propFullName, ...rest);
@@ -263,12 +264,12 @@ const ProgressBarTooltipBase = kind({
 			return styler.append(
 				orientation,
 				{
-					above: v === 'above',
-					below: v === 'below',
-					before: h === 'before',
-					after: h === 'after',
-					left: h === 'left' || (h === 'auto' && proportion <= 0.5),
-					right: h === 'right' || (h === 'auto' && proportion > 0.5)
+					above: (v === 'above'),
+					below: (v === 'below'),
+					before: (h === 'before'),
+					after: (h === 'after'),
+					left: (h === 'left' || (h === 'auto' && proportion <= 0.5)),
+					right: (h === 'right' || (h === 'auto' && proportion > 0.5))
 				}
 			);
 		},

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -86,7 +86,7 @@ const getSide = (orientation, side, position) => {
 
 		if (orientation === 'horizontal') {
 			// Testing for 'after' so if side === left or right, we default to "above"
-			return [side === 'after' ? 'below' : 'above', 'auto'];
+			return ['auto', side === 'after' ? 'below' : 'above'];
 		}
 
 		return [side, 'auto'];

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -11,6 +11,7 @@ import Tooltip from '../TooltipDecorator/Tooltip';
 
 import css from './ProgressBarTooltip.module.less';
 
+// prop-type validator that warns on invalid orientation + position
 const validatePosition = (base) => (props, key, componentName, location, propFullName, ...rest) => {
 	const {position} = props;
 	let result = base(props, key, componentName, location, propFullName, ...rest);
@@ -38,6 +39,7 @@ const memoizedPercentFormatter = memoize((/* locale */) => new NumFmt({
 
 const getDefaultPosition = (orientation) => orientation === 'horizontal' ? 'above' : 'before';
 
+// Returns an array of keywords with horizontal first and vetical second
 const getSide = (orientation, side, position) => {
 	warning(
 		!side,

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -66,6 +66,49 @@ const ProgressBarTooltipBase = kind({
 		percent: PropTypes.bool,
 
 		/**
+		 * Position of the tooltip with respect to the wrapped component.
+		 *
+		 * | *Value* | *Tooltip Direction* |
+		 * |---|---|
+		 * | `'above'` | Above component, flowing to the right |
+		 * | `'above center'` | Above component, centered |
+		 * | `'above left'` | Above component, flowing to the left |
+		 * | `'above right'` | Above component, flowing to the right |
+		 * | `'below'` | Below component, flowing to the right |
+		 * | `'below center'` | Below component, centered |
+		 * | `'below left'` | Below component, flowing to the left |
+		 * | `'below right'` | Below component, flowing to the right |
+		 * | `'left bottom'` | Left of the component, contents at the bottom |
+		 * | `'left middle'` | Left of the component, contents middle aligned |
+		 * | `'left top'` | Left of the component, contents at the top |
+		 * | `'right bottom'` | Right of the component, contents at the bottom |
+		 * | `'right middle'` | Right of the component, contents middle aligned |
+		 * | `'right top'` | Right of the component, contents at the top |
+		 *
+		 * `TooltipDectorator` attempts to choose the best direction to meet layout and language
+		 * requirements. Left and right directions will reverse for RTL languages. Additionally,
+		 * the tooltip will reverse direction if it will prevent overflowing off the viewport
+		 *
+		 * @type {('above'|'above center'|'above left'|'above right'|'below'|
+		 *  'below center'|'below left'|'below right'|'left bottom'|'left middle'|'left top'|
+		 * 	'right bottom'|'right middle'|'right top')}
+		 * @default 'above'
+		 * @public
+		 */
+		position: PropTypes.oneOf([
+			'above' /* default center */
+			'above before', /* above and left in LTR, above and right in RTL */
+			'above left', /* above and left */
+			'above center', /* above and center */
+			'above right' /* above and right */
+			'above after' /* above and right in LTR, above and left in RTL */
+			'before'
+			'above', 'above center', 'above left', 'above right',
+			'below', 'below center', 'below left', 'below right',
+			'left bottom', 'left middle', 'left top',
+			'right bottom', 'right middle', 'right top']),
+
+		/**
 		 * The proportion of the filled part of the bar.
 		 *
 		 * * Should be a number between 0 and 1.

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -96,27 +96,29 @@ const ProgressBarTooltipBase = kind({
 		percent: PropTypes.bool,
 
 		/**
-		 * Position of the tooltip with respect to the wrapped component.
+		 * Position of the tooltip with respect to the progress bar.
+		 *
+		 * * For `orientation="horizontal"` progress bars, the default value is `'above'`.
+		 * * For `orientation="vertical"` progress bars, the default value is `'above'`.
 		 *
 		 * | *Value* | *Tooltip Direction* |
 		 * |---|---|
-		 * | `'above'` | Above component, flowing to the right |
-		 * | `'above center'` | Above component, centered |
+		 * | `'above'` | Above component, flowing to the nearest end |
 		 * | `'above left'` | Above component, flowing to the left |
+		 * | `'above before'` | Above component, flowing to the start of text |
 		 * | `'above right'` | Above component, flowing to the right |
-		 * | `'below'` | Below component, flowing to the right |
-		 * | `'below center'` | Below component, centered |
+		 * | `'above after'` | Above component, flowing to the end of text |=
+		 * | `'below'` | Below component, flowing to the nearest end |
 		 * | `'below left'` | Below component, flowing to the left |
+		 * | `'below before'` | Below component, flowing to the start of text |
 		 * | `'below right'` | Below component, flowing to the right |
-		 * | `'left bottom'` | Left of the component, contents at the bottom |
-		 * | `'left middle'` | Left of the component, contents middle aligned |
-		 * | `'left top'` | Left of the component, contents at the top |
-		 * | `'right bottom'` | Right of the component, contents at the bottom |
-		 * | `'right middle'` | Right of the component, contents middle aligned |
-		 * | `'right top'` | Right of the component, contents at the top |
+		 * | `'below after'` | Below component, flowing to the end of text |
+		 * | `'left'` | Left of the component, contents middle aligned |
+		 * | `'before'` | Start of text side of the component, contents middle aligned |
+		 * | `'right'` | right of the component, contents middle aligned |
+		 * | `'after'` | End of text side of the component, contents middle aligned |
 		 *
-		 * @type {...}
-		 * @default 'above'
+		 * @type {('above'|'above before'|'above left'|'above after'|'above right'|'below'|'below left'|'below before'|'below right'|'below after'|'left'|'before'|'right'|'after')}
 		 * @public
 		 */
 		position: PropTypes.oneOf([
@@ -126,16 +128,16 @@ const ProgressBarTooltipBase = kind({
 			'above after', /* above and right */
 			'above right', /* above and right */
 
-			'before', /* left and middle in LTR, right and middle in RTL */
-			'left', /* left and middle */
-			'right', /* right and middle in LTR, left and middle in RTL */
-			'after', /* right and middle in LTR, left and middle in RTL */
-
 			'below', /* below and auto flipping */
 			'below left', /* below and left */
 			'below before', /* below and left */
 			'below right', /* below and right */
-			'below after' /* below and right */
+			'below after', /* below and right */
+
+			'left', /* left and middle */
+			'before', /* left and middle in LTR, right and middle in RTL */
+			'right', /* right and middle in LTR, left and middle in RTL */
+			'after' /* right and middle in LTR, left and middle in RTL */
 		]),
 
 		/**
@@ -170,7 +172,7 @@ const ProgressBarTooltipBase = kind({
 		 * * `'right'` renders to the right of a `vertical` ProgressBar/Slider regardless of locale
 		 *
 		 * @type {String}
-		 * @default 'before'
+		 * @deprecated Deprecated since 3.1 until 4.0 in favor of `position`
 		 * @public
 		 */
 		side: PropTypes.oneOf(['after', 'before', 'left', 'right']),

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -1,3 +1,4 @@
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
 import {memoize} from '@enact/core/util';
 import ilib from '@enact/i18n';
@@ -41,11 +42,6 @@ const getDefaultPosition = (orientation) => orientation === 'horizontal' ? 'abov
 
 // Returns an array of keywords with horizontal first and vetical second
 const getSide = (orientation, side, position) => {
-	warning(
-		!side,
-		'side is deprecated'
-	);
-
 	if (position || !side) {
 		position = position || getDefaultPosition(orientation);
 
@@ -219,7 +215,15 @@ const ProgressBarTooltipBase = kind({
 		 * @deprecated Deprecated since 3.1 until 4.0 in favor of `position`
 		 * @public
 		 */
-		side: PropTypes.oneOf(['after', 'before', 'left', 'right']),
+		side: EnactPropTypes.deprecated(
+			PropTypes.oneOf(['after', 'before', 'left', 'right']),
+			{
+				name: 'side',
+				since: '3.1.0',
+				until: '4.0.0',
+				replacedBy: 'position'
+			}
+		),
 
 		/**
 		 * Visibility of the tooltip

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -101,6 +101,8 @@ const ProgressBarTooltipBase = kind({
 		 * * For `orientation="horizontal"` progress bars, the default value is `'above'`.
 		 * * For `orientation="vertical"` progress bars, the default value is `'above'`.
 		 *
+		 * Valid values when `orientation="horizontal"`
+		 *
 		 * | *Value* | *Tooltip Direction* |
 		 * |---|---|
 		 * | `'above'` | Above component, flowing to the nearest end |
@@ -113,6 +115,11 @@ const ProgressBarTooltipBase = kind({
 		 * | `'below before'` | Below component, flowing to the start of text |
 		 * | `'below right'` | Below component, flowing to the right |
 		 * | `'below after'` | Below component, flowing to the end of text |
+		 *
+		 * Valid values when `orientation="vertical"`
+		 *
+		 * | *Value* | *Tooltip Direction* |
+		 * |---|---|
 		 * | `'left'` | Left of the component, contents middle aligned |
 		 * | `'before'` | Start of text side of the component, contents middle aligned |
 		 * | `'right'` | right of the component, contents middle aligned |
@@ -122,22 +129,23 @@ const ProgressBarTooltipBase = kind({
 		 * @public
 		 */
 		position: PropTypes.oneOf([
-			'above', /* above and auto flipping */
-			'above before', /* above and left */
-			'above left', /* above and left */
-			'above after', /* above and right */
-			'above right', /* above and right */
+			// horizontal
+			'above',
+			'above before',
+			'above left',
+			'above after',
+			'above right',
+			'below',
+			'below left',
+			'below before',
+			'below right',
+			'below after',
 
-			'below', /* below and auto flipping */
-			'below left', /* below and left */
-			'below before', /* below and left */
-			'below right', /* below and right */
-			'below after', /* below and right */
-
-			'left', /* left and middle */
-			'before', /* left and middle in LTR, right and middle in RTL */
-			'right', /* right and middle in LTR, left and middle in RTL */
-			'after' /* right and middle in LTR, left and middle in RTL */
+			// vertical
+			'left',
+			'before',
+			'right',
+			'after'
 		]),
 
 		/**

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -11,6 +11,26 @@ import Tooltip from '../TooltipDecorator/Tooltip';
 
 import css from './ProgressBarTooltip.module.less';
 
+const validatePosition = (base) => (props, key, componentName, location, propFullName, ...rest) => {
+	const {position} = props;
+	let result = base(props, key, componentName, location, propFullName, ...rest);
+
+	if (!result && position) {
+		const orientation = props.orientation || 'horizontal';
+		const hasVerticalValue = ['before', 'after', 'left', 'right'].includes(position);
+		if (
+			(orientation === 'vertical' && !hasVerticalValue) ||
+			(orientation === 'horizontal' && hasVerticalValue)
+		) {
+			result = new Error(
+				`'${key}' value '${position}' is not a valid value for the orientation '${orientation}'`
+			);
+		}
+	}
+
+	return result;
+};
+
 const memoizedPercentFormatter = memoize((/* locale */) => new NumFmt({
 	type: 'percentage',
 	useNative: false
@@ -128,7 +148,7 @@ const ProgressBarTooltipBase = kind({
 		 * @type {('above'|'above before'|'above left'|'above after'|'above right'|'below'|'below left'|'below before'|'below right'|'below after'|'left'|'before'|'right'|'after')}
 		 * @public
 		 */
-		position: PropTypes.oneOf([
+		position: validatePosition(PropTypes.oneOf([
 			// horizontal
 			'above',
 			'above before',
@@ -146,7 +166,7 @@ const ProgressBarTooltipBase = kind({
 			'before',
 			'right',
 			'after'
-		]),
+		])),
 
 		/**
 		 * The proportion of the filled part of the bar.

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -51,8 +51,12 @@ const getSide = (orientation, side, position) => {
 				case 'above':
 				case 'below':
 					return ['auto', position];
+				case 'above after':
+				case 'above before':
 				case 'above left':
 				case 'above right':
+				case 'below after':
+				case 'below before':
 				case 'below left':
 				case 'below right':
 					return position.split(' ').reverse();

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -44,21 +44,35 @@ const getSide = (orientation, side, position) => {
 		'side is deprecated'
 	);
 
-	if (!side) {
+	if (position || !side) {
 		position = position || getDefaultPosition(orientation);
 
-		switch (position) {
-			case 'above':
-			case 'below':
-				return ['auto', position];
-			case 'after':
-			case 'before':
-			case 'left':
-			case 'right':
-				return [position, 'auto'];
-			default:
-				// "(above|below) (left|right)"
-				return position.split(' ').reverse();
+		if (orientation === 'horizontal') {
+			switch (position) {
+				case 'above':
+				case 'below':
+					return ['auto', position];
+				case 'after':
+				case 'before':
+				case 'left':
+				case 'right':
+					// invalid values for horizontal so use defaults
+					return ['auto', 'above'];
+				default:
+					// "(above|below) (left|right)"
+					return position.split(' ').reverse();
+			}
+		} else {
+			switch (position) {
+				case 'after':
+				case 'before':
+				case 'left':
+				case 'right':
+					return [position, 'above'];
+				default:
+					// invalid values for horizontal so use defaults
+					return ['before', 'auto'];
+			}
 		}
 	} else {
 		const valid = orientation === 'vertical' || (

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.js
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.js
@@ -51,15 +51,14 @@ const getSide = (orientation, side, position) => {
 				case 'above':
 				case 'below':
 					return ['auto', position];
-				case 'after':
-				case 'before':
-				case 'left':
-				case 'right':
+				case 'above left':
+				case 'above right':
+				case 'below left':
+				case 'below right':
+					return position.split(' ').reverse();
+				default:
 					// invalid values for horizontal so use defaults
 					return ['auto', 'above'];
-				default:
-					// "(above|below) (left|right)"
-					return position.split(' ').reverse();
 			}
 		} else {
 			switch (position) {
@@ -132,7 +131,13 @@ const ProgressBarTooltipBase = kind({
 		 * Position of the tooltip with respect to the progress bar.
 		 *
 		 * * For `orientation="horizontal"` progress bars, the default value is `'above'`.
-		 * * For `orientation="vertical"` progress bars, the default value is `'above'`.
+		 * * For `orientation="vertical"` progress bars, the default value is `'before'`.
+		 *
+		 * When using `'before'` or `'after'` alone or in any of the below combinations, `'before'`
+		 * will position the tooltip on the side of the current locale's text directionality. In LTR
+		 * locales, it will be on the left; in RTL locales, it will be on the right. Similarly,
+		 * `'after'` will position the tooltip on the oppoosite side: the right side for LTR and
+		 * left for RTL.
 		 *
 		 * Valid values when `orientation="horizontal"`
 		 *
@@ -142,7 +147,7 @@ const ProgressBarTooltipBase = kind({
 		 * | `'above left'` | Above component, flowing to the left |
 		 * | `'above before'` | Above component, flowing to the start of text |
 		 * | `'above right'` | Above component, flowing to the right |
-		 * | `'above after'` | Above component, flowing to the end of text |=
+		 * | `'above after'` | Above component, flowing to the end of text |
 		 * | `'below'` | Below component, flowing to the nearest end |
 		 * | `'below left'` | Below component, flowing to the left |
 		 * | `'below before'` | Below component, flowing to the start of text |

--- a/packages/moonstone/ProgressBar/ProgressBarTooltip.module.less
+++ b/packages/moonstone/ProgressBar/ProgressBarTooltip.module.less
@@ -10,34 +10,55 @@
 
 	@offset-large: 0;
 
+	.before (@ruleset) {
+		&.left,
+		&.before,
+		:global(.enact-locale-right-to-left) &.after {
+			@ruleset();
+		}
+	}
+
+	.after (@ruleset) {
+		&.right,
+		&.after,
+		:global(.enact-locale-right-to-left) &.before {
+			@ruleset();
+		}
+	}
+
 	&.horizontal {
 		left: var(--tooltip-progress-percent);
 
-		&.before {
+		&.above {
 			top: 0;
-			transform: translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
+
+			.before({
+				transform: translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
+			});
+
+			.after({
+				transform: translateX(-100%) translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
+			});
 
 			.moon-custom-text({
 				bottom: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
 			});
 		}
-		&.after {
+
+		&.below {
 			bottom: 0;
-			transform: translateY(~"calc(100% + var(--tooltip-calculated-offset))");
+
+			.before({
+				transform: translateY(~"calc(100% + var(--tooltip-calculated-offset))");
+			});
+
+			.after({
+				transform: translateX(-100%) translateY(~"calc(100% + var(--tooltip-calculated-offset))");
+			});
 
 			.moon-custom-text({
 				top: ~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")";
 			});
-		}
-
-		&.afterMidpoint {
-			&.before {
-				transform: translateX(-100%) translateY(~"calc(-100% - var(--tooltip-calculated-offset))");
-			}
-
-			&.after {
-				transform: translateX(-100%) translateY(~"calc(100% + var(--tooltip-calculated-offset))");
-			}
 		}
 	}
 
@@ -45,27 +66,23 @@
 		bottom: var(--tooltip-progress-percent);
 
 		// Left side
-		&.before,
-		:global(.enact-locale-right-to-left) &.before.ignoreLocale,
-		:global(.enact-locale-right-to-left) &.after {
+		.before({
 			right: 0;
 			transform: translate(~"calc(var(--tooltip-calculated-offset) * -1)", 50%);
 
 			.moon-custom-text({
 				transform: translate(~"calc(var(--tooltip-calculated-offset) * -1 - " @offset-large ~")", 50%);
 			});
-		}
+		});
 
 		// Right side
-		&.after,
-		:global(.enact-locale-right-to-left) &.after.ignoreLocale,
-		:global(.enact-locale-right-to-left) &.before {
+		.after({
 			right: auto;
 			transform: translate(var(--tooltip-calculated-offset), 50%);
 
 			.moon-custom-text({
 				transform: translate(~"calc(var(--tooltip-calculated-offset) + " @offset-large ~")", 50%);
 			});
-		}
+		});
 	}
 }

--- a/packages/sampler/stories/default/ProgressBar.js
+++ b/packages/sampler/stories/default/ProgressBar.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {mergeComponentMetadata} from '../../src/utils';
+import {mergeComponentMetadata, nullify} from '../../src/utils';
 
 const ProgressBarConfig = mergeComponentMetadata('ProgressBar', ProgressBar);
 const ProgressBarTooltipConfig = mergeComponentMetadata('ProgressBarTooltip', ProgressBarTooltip);
@@ -21,7 +21,7 @@ storiesOf('Moonstone', module)
 			// tooltip is first so it appears at the top of the tab. the rest are alphabetical
 			const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
 			const position = select('position', ['', 'above', 'above left', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below right', 'below before', 'below after'], ProgressBarTooltipConfig, '');
-			const side = select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], ProgressBarTooltipConfig, '');
+			const side = nullify(select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], ProgressBarTooltipConfig, ''));
 
 			return (
 				<ProgressBar

--- a/packages/sampler/stories/default/ProgressBar.js
+++ b/packages/sampler/stories/default/ProgressBar.js
@@ -15,8 +15,9 @@ storiesOf('Moonstone', module)
 	.add(
 		'ProgressBar',
 		() => {
-			const side = select('side', ['after', 'before', 'left', 'right'], ProgressBarTooltipConfig, 'before');
 			const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
+			const position = select('position', ['', 'above', 'above left', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below right', 'below before', 'below after'], ProgressBarTooltipConfig, '');
+			const side = select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], ProgressBarTooltipConfig, '');
 
 			return (
 				<ProgressBar
@@ -25,10 +26,10 @@ storiesOf('Moonstone', module)
 					highlighted={boolean('highlighted', ProgressBarConfig)}
 					orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig, 'horizontal')}
 					progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
-					side={select('side', ['after', 'before', 'left', 'right'], ProgressBarConfig, 'before')}
 				>
 					{tooltip ? (
 						<ProgressBarTooltip
+							position={position}
 							side={side}
 						/>
 					) : null}

--- a/packages/sampler/stories/default/ProgressBar.js
+++ b/packages/sampler/stories/default/ProgressBar.js
@@ -15,6 +15,10 @@ storiesOf('Moonstone', module)
 	.add(
 		'ProgressBar',
 		() => {
+			// added here to force Storybook to put the ProgressBar tab first
+			const disabled = boolean('disabled', ProgressBarConfig);
+
+			// tooltip is first so it appears at the top of the tab. the rest are alphabetical
 			const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
 			const position = select('position', ['', 'above', 'above left', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below right', 'below before', 'below after'], ProgressBarTooltipConfig, '');
 			const side = select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], ProgressBarTooltipConfig, '');
@@ -22,7 +26,7 @@ storiesOf('Moonstone', module)
 			return (
 				<ProgressBar
 					backgroundProgress={number('backgroundProgress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
-					disabled={boolean('disabled', ProgressBarConfig)}
+					disabled={disabled}
 					highlighted={boolean('highlighted', ProgressBarConfig)}
 					orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig, 'horizontal')}
 					progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}

--- a/packages/sampler/stories/default/Slider.js
+++ b/packages/sampler/stories/default/Slider.js
@@ -15,15 +15,20 @@ storiesOf('Moonstone', module)
 	.add(
 		'Slider',
 		() => {
-			const side = select('side', ['after', 'before', 'left', 'right'], SliderTooltipConfig, 'before');
+			// added here to force Storybook to put the Slider tab first
+			const disabled = boolean('disabled', SliderConfig);
+
+			// tooltip is first so it appears at the top of the tab. the rest are alphabetical
 			const tooltip = boolean('tooltip', SliderTooltipConfig);
 			const percent = boolean('percent', SliderTooltipConfig);
+			const position = select('position', ['', 'above', 'above left', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below right', 'below before', 'below after'], SliderTooltipConfig, '');
+			const side = select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], SliderTooltipConfig, '');
 
 			return (
 				<Slider
 					activateOnFocus={boolean('activateOnFocus', SliderConfig)}
 					backgroundProgress={number('backgroundProgress', SliderConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
-					disabled={boolean('disabled', SliderConfig)}
+					disabled={disabled}
 					knobStep={number('knobStep', SliderConfig)}
 					max={number('max', SliderConfig, 10)}
 					min={number('min', SliderConfig, 0)}
@@ -36,6 +41,7 @@ storiesOf('Moonstone', module)
 					{tooltip ? (
 						<SliderTooltip
 							percent={percent}
+							position={position}
 							side={side}
 						/>
 					) : null}

--- a/packages/sampler/stories/default/Slider.js
+++ b/packages/sampler/stories/default/Slider.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {boolean, number, select} from '../../src/enact-knobs';
-import {action, mergeComponentMetadata} from '../../src/utils';
+import {action, mergeComponentMetadata, nullify} from '../../src/utils';
 
 const SliderConfig = mergeComponentMetadata('Slider', Slider);
 const SliderTooltipConfig = mergeComponentMetadata('SliderTooltip', SliderTooltip);
@@ -22,7 +22,7 @@ storiesOf('Moonstone', module)
 			const tooltip = boolean('tooltip', SliderTooltipConfig);
 			const percent = boolean('percent', SliderTooltipConfig);
 			const position = select('position', ['', 'above', 'above left', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below right', 'below before', 'below after'], SliderTooltipConfig, '');
-			const side = select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], SliderTooltipConfig, '');
+			const side = nullify(select('side (Deprecated)', ['', 'after', 'before', 'left', 'right'], SliderTooltipConfig, ''));
 
 			return (
 				<Slider


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Authors are unable to control the position of `ProgressBarTooltip` and `SliderTooltip` effectively with the current API. For example, it is not possible to force the tooltip to always display to one side.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add `position` prop with broader set of values to replace `side`
* Deprecate `side`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* Reordered knobs in `ProgressBar` and `Slider` stories to force the component tab to appear before the tooltip tab
* Added an internal `deprecated` prop type to simplify deprecating props
* Added a custom prop type validate for `position` to warn when using invalid values with `orientation`