### PR TITLE
ENYO-6272: Fix ScrollerNative generating console error when pressing page down after 5-way down several times in ScrollerNative

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -733,7 +733,7 @@ class ScrollableBase extends Component {
 				const position = {x, y};
 				const {current: {containerRef: {current}}} = this.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
-				if (elemFromPoint) {
+				if (elemFromPoint && elemFromPoint.closest) {
 					const target =
 						getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
 						getTargetInViewByDirectionFromPosition(direction, position, current) ||

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -733,15 +733,13 @@ class ScrollableBase extends Component {
 				const position = {x, y};
 				const {current: {containerRef: {current}}} = this.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
-				if (elemFromPoint && elemFromPoint.closest) {
-					const target =
-						getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
-						getTargetInViewByDirectionFromPosition(direction, position, current) ||
-						getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
+				const target =
+					elemFromPoint && elemFromPoint.closest && getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
+					getTargetInViewByDirectionFromPosition(direction, position, current) ||
+					getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
 
-					if (target) {
-						Spotlight.focus(target);
-					}
+				if (target) {
+					Spotlight.focus(target);
 				}
 			}
 			this.pointToFocus = null;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -797,15 +797,13 @@ class ScrollableBaseNative extends Component {
 				const position = {x, y};
 				const {current: {containerRef: {current}}} = this.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
-				if (elemFromPoint && elemFromPoint.closest) {
-					const target =
-						getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
-						getTargetInViewByDirectionFromPosition(direction, position, current) ||
-						getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
+				const target =
+					elemFromPoint && elemFromPoint.closest && getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
+					getTargetInViewByDirectionFromPosition(direction, position, current) ||
+					getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
 
-					if (target) {
-						Spotlight.focus(target);
-					}
+				if (target) {
+					Spotlight.focus(target);
 				}
 			}
 			this.pointToFocus = null;

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import handle, {forward} from '@enact/core/handle';
 import platform from '@enact/core/platform';
 import {onWindowReady} from '@enact/core/snapshot';
-import {Job} from '@enact/core/util';
+import {clamp, Job} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {constants, ScrollableBaseNative as UiScrollableBaseNative} from '@enact/ui/Scrollable/ScrollableNative';
 import Spotlight, {getDirection} from '@enact/spotlight';
@@ -610,12 +610,14 @@ class ScrollableBaseNative extends Component {
 				// Should do nothing when focusedItem is paging control button of Scrollbar
 				if (contentNode.contains(focusedItem)) {
 					const
+						contentRect = contentNode.getBoundingClientRect(),
 						clientRect = focusedItem.getBoundingClientRect(),
 						yAdjust = isUp ? 1 : -1,
-						x = (clientRect.right + clientRect.left) / 2,
+						x = clamp(contentRect.left, contentRect.right, (clientRect.right + clientRect.left) / 2),
 						y = bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance ?
 							contentNode.getBoundingClientRect()[isUp ? 'top' : 'bottom'] + yAdjust :
-							(clientRect.bottom + clientRect.top) / 2;
+							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
+
 					focusedItem.blur();
 					if (!this.props['data-spotlight-container-disabled']) {
 						this.childRef.current.setContainerDisabled(true);
@@ -795,13 +797,15 @@ class ScrollableBaseNative extends Component {
 				const position = {x, y};
 				const {current: {containerRef: {current}}} = this.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
-				const target =
-					getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
-					getTargetInViewByDirectionFromPosition(direction, position, current) ||
-					getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
+				if (elemFromPoint && elemFromPoint.closest) {
+					const target =
+						getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
+						getTargetInViewByDirectionFromPosition(direction, position, current) ||
+						getTargetInViewByDirectionFromPosition(reverseDirections[direction], position, current);
 
-				if (target) {
-					Spotlight.focus(target);
+					if (target) {
+						Spotlight.focus(target);
+					}
 				}
 			}
 			this.pointToFocus = null;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If pressing page down when Spotlight is on the item out of viewport while 5-way Down several times, Spotlight suddenly hides. There is the following error in console.
```
Cannot read property 'closest' of null
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When pressing page down, then Spotlight stored the current focus point, then tried to restore focus from the point. But the point is out of viewport sometimes. So the point is clamped with the viewport.

### Links
[//]: # (Related issues, references)

ENYO-6272

### Comments

This issue should be fixed in https://github.com/enactjs/enact/pull/2532 properly. But I forgot to update ScrollableNative part.