### PR TITLE
ENYO-6278: Fix moontone internationalization resource loading

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone` internationalization resource loading
 - `moonstone/VirtualList.VirtualList` to scroll properly when an item gets focus in VirtualList with different item size
 
 ## [3.1.0] - 2019-09-16

--- a/packages/moonstone/internal/$L/$L.js
+++ b/packages/moonstone/internal/$L/$L.js
@@ -2,9 +2,13 @@
 
 import {getIStringFromBundle} from '@enact/i18n/src/resBundle';
 import ResBundle from 'ilib/lib/ResBundle';
+import ilib from 'ilib';
 
 // The ilib.ResBundle for the active locale used by $L
 let resBundle;
+
+// The ilib.data cache object for moonstone ilib usage
+let cache = {};
 
 /**
  * Returns the current ilib.ResBundle
@@ -36,10 +40,15 @@ function createResBundle (options) {
 
 	if (!opts.onLoad) return;
 
+	// Swap out app cache for moonstone's
+	const appCache = ilib.data;
+	ilib.data = cache;
+
 	// eslint-disable-next-line no-new
 	new ResBundle({
 		...opts,
 		onLoad: (bundle) => {
+			ilib.data = appCache;
 			opts.onLoad(bundle || null);
 		}
 	});
@@ -52,6 +61,7 @@ function createResBundle (options) {
 function clearResBundle () {
 	delete ResBundle.strings;
 	delete ResBundle.sysres;
+	cache = {};
 	resBundle = null;
 }
 

--- a/packages/moonstone/internal/$L/$L.js
+++ b/packages/moonstone/internal/$L/$L.js
@@ -42,7 +42,7 @@ function createResBundle (options) {
 
 	// Swap out app cache for moonstone's
 	const appCache = ilib.data;
-	ilib.data = cache;
+	ilib.data = global.moonstoneILibCache || cache;
 
 	// eslint-disable-next-line no-new
 	new ResBundle({


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* When we switch from `@enact/i18n/ilib` v13.2.0 to an external `ilib` v14.2.0 package, it introduced an internal iLib change in how iLib cache ResBundles. It appears that now iLib only allow 1 of each kind of file, and caches it.  So when the app loads the app's `['strings.json', 'en/strings.json', 'en/US/strings.json']` from the app's `./resources` directory, those files/contents are cached to their respective objects on `ilib.data`.
    
    Moonstone (and agate/other themes) have their own embedded localizations. When iLib then attempts to load the ResBundle strings from `./node_modules/@enact/moonstone/resources`, it's seeing the `'*strings.json'` files cached already in `ilib.data` and it uses that (the app's localization data) instead, to avoid what it thinks would be a repetitious XHR. As a result, Moonstone localizations are never correctly applied or even loaded.

### Resolution
* This workaround sets up a local moonstone-contained cache object which it swaps in and out to `ilib.data` to avoid app resource cache interfering with moonstone resource cache.

### Additional Considerations
* Since moonstone's `$L` is guaranteed sync, we don't need to worry about any async issues (cross/parallel requests could cause resource cache to be saved to the wrong object). If/when the moonstone `$L` is updated to support async, an alternate solution may be required.

### Comments
* Additionally, I think it will be worthwhile to get in touch with the iLib folks to see if we can get them to support differing iLib cache objects depending on `loadParams` object.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>