### PR TITLE
PLAT-85707: Forward drag events from Scrollable

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -676,7 +676,7 @@ class ScrollableBase extends Component {
 		);
 
 		if (this.props.onFlick) {
-			forward('onFlick', ev, this.props);
+			forward('onFlick', {...ev, flickTarget: this.flickTarget}, this.props);
 		}
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -676,7 +676,7 @@ class ScrollableBase extends Component {
 		);
 
 		if (this.props.onFlick) {
-			forward('onFlick', {...ev, flickTarget: this.flickTarget}, this.props);
+			forward('onFlick', ev, this.props);
 		}
 	}
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -609,14 +609,11 @@ class ScrollableBase extends Component {
 	onDragStart = (ev) => {
 		if (ev.type === 'dragstart') return;
 
+		forward('onDragStart', ev, this.props);
 		this.stop();
 		this.isDragging = true;
 		this.dragStartX = this.scrollLeft + this.getRtlX(ev.x);
 		this.dragStartY = this.scrollTop + ev.y;
-
-		if (this.props.onDragStart) {
-			forward('onDragStart', ev, this.props);
-		}
 	}
 
 	onDrag = (ev) => {
@@ -626,16 +623,13 @@ class ScrollableBase extends Component {
 
 		this.lastInputType = 'drag';
 
+		forward('onDrag', ev, this.props);
 		this.start({
 			targetX: (direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
 			targetY: (direction === 'horizontal') ? 0 : this.dragStartY - ev.y, // 'vertical' or 'both'
 			animate: false,
 			overscrollEffect: this.props.overscrollEffectOn.drag
 		});
-
-		if (this.props.onDrag) {
-			forward('onDrag', ev, this.props);
-		}
 	}
 
 	onDragEnd = (ev) => {
@@ -643,6 +637,7 @@ class ScrollableBase extends Component {
 
 		this.isDragging = false;
 
+		forward('onDragEnd', ev, this.props);
 		if (this.flickTarget) {
 			const {targetX, targetY, duration} = this.flickTarget;
 
@@ -659,10 +654,6 @@ class ScrollableBase extends Component {
 		}
 
 		this.flickTarget = null;
-
-		if (this.props.onDragEnd) {
-			forward('onDragEnd', ev, this.props);
-		}
 	}
 
 	onFlick = (ev) => {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -205,6 +205,30 @@ class ScrollableBase extends Component {
 		noScrollByWheel: PropTypes.bool,
 
 		/**
+		 * Called when trigerring a drag event.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onDrag: PropTypes.func,
+
+		/**
+		 * Called when trigerring a dragend event.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onDragEnd: PropTypes.func,
+
+		/**
+		 * Called when trigerring a dragstart event.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onDragStart: PropTypes.func,
+
+		/**
 		 * Called when flicking with a mouse or a touch screen.
 		 *
 		 * @type {Function}
@@ -589,6 +613,10 @@ class ScrollableBase extends Component {
 		this.isDragging = true;
 		this.dragStartX = this.scrollLeft + this.getRtlX(ev.x);
 		this.dragStartY = this.scrollTop + ev.y;
+
+		if (this.props.onDragStart) {
+			forward('onDragStart', ev, this.props);
+		}
 	}
 
 	onDrag = (ev) => {
@@ -604,6 +632,10 @@ class ScrollableBase extends Component {
 			animate: false,
 			overscrollEffect: this.props.overscrollEffectOn.drag
 		});
+
+		if (this.props.onDrag) {
+			forward('onDrag', ev, this.props);
+		}
 	}
 
 	onDragEnd = (ev) => {
@@ -627,6 +659,10 @@ class ScrollableBase extends Component {
 		}
 
 		this.flickTarget = null;
+
+		if (this.props.onDragEnd) {
+			forward('onDragEnd', ev, this.props);
+		}
 	}
 
 	onFlick = (ev) => {
@@ -1304,8 +1340,7 @@ class ScrollableBase extends Component {
 					onDrag: this.onDrag,
 					onDragEnd: this.onDragEnd,
 					onDragStart: this.onDragStart,
-					onFlick: this.onFlick,
-					onTouchStart: this.onTouchStart
+					onFlick: this.onFlick
 				})
 			};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`ui/Scrollable` did not forward drag events.

### Resolution
If the appropriate drag events are present (`onDrag`, `onDragStart`, `onDragEnd`), we will forward them.


### Additional Considerations
- These event props are private, so I did not include a changelog. I also removed a reference to a non-existent `this.onTouchStart` class method.

