### PR TITLE
ENYO-6283: Dropdown: calls onOpen handler twice

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone` internationalization resource loading
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` scrolling when an item which will be in viewport gets focus
 - `moonstone/VirtualList.VirtualList` to scroll properly when an item gets focus in VirtualList with different item size
+- `moonstone/Dropdown` to call `onOpen` handler once
 
 ## [3.1.0] - 2019-09-16
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,11 +6,11 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Input` text color
 - `moonstone` internationalization resource loading
+- `moonstone/Dropdown` to only call `onOpen` when closed
+- `moonstone/Input` text color
 - `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` scrolling when an item which will be in viewport gets focus
 - `moonstone/VirtualList.VirtualList` to scroll properly when an item gets focus in VirtualList with different item size
-- `moonstone/Dropdown` to call `onOpen` handler once
 
 ## [3.1.0] - 2019-09-16
 

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -16,7 +16,7 @@
  * @exports DropdownBaseDecorator
  */
 
-import {handle, forKey, forward} from '@enact/core/handle';
+import {handle, forKey, forward, forProp} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
@@ -197,6 +197,9 @@ const DropdownBase = kind({
 		onSelect: handle(
 			forward('onSelect'),
 			forward('onClose')
+		),
+		handleOpen: handle(
+			forProp('open', false), forward('onOpen')
 		)
 	},
 
@@ -247,13 +250,14 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({children, disabled, onKeyDown, onOpen, onSelect, open, selected, width, title, ...rest}) => {
+	render: ({children, disabled, handleOpen, onKeyDown, onSelect, open, selected, width, title, ...rest}) => {
 		const popupProps = {children, onKeyDown, onSelect, selected, width, role: ''};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
 		// prevent Dropdown to open if there are no children.
 		const hasChildren = children.length > 0;
 		const openDropdown = hasChildren && !disabled && open;
+		delete rest.onOpen;
 		delete rest.width;
 
 		return (
@@ -263,7 +267,7 @@ const DropdownBase = kind({
 				icon={openDropdown ? 'arrowlargeup' : 'arrowlargedown'}
 				popupProps={popupProps}
 				popupComponent={DropdownList}
-				onClick={onOpen}
+				onClick={handleOpen}
 				open={openDropdown}
 			>
 				{title}

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -198,8 +198,10 @@ const DropdownBase = kind({
 			forward('onSelect'),
 			forward('onClose')
 		),
-		handleOpen: handle(
-			forProp('open', false), forward('onOpen')
+		onOpen: handle(
+			forward('onClick'),
+			forProp('open', false),
+			forward('onOpen')
 		)
 	},
 
@@ -250,7 +252,7 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({children, disabled, handleOpen, onKeyDown, onSelect, open, selected, width, title, ...rest}) => {
+	render: ({children, disabled, onKeyDown, onOpen, onSelect, open, selected, width, title, ...rest}) => {
 		const popupProps = {children, onKeyDown, onSelect, selected, width, role: ''};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
@@ -267,7 +269,7 @@ const DropdownBase = kind({
 				icon={openDropdown ? 'arrowlargeup' : 'arrowlargedown'}
 				popupProps={popupProps}
 				popupComponent={DropdownList}
-				onClick={handleOpen}
+				onClick={onOpen}
 				open={openDropdown}
 			>
 				{title}

--- a/packages/moonstone/Dropdown/Dropdown.js
+++ b/packages/moonstone/Dropdown/Dropdown.js
@@ -259,7 +259,7 @@ const DropdownBase = kind({
 		// prevent Dropdown to open if there are no children.
 		const hasChildren = children.length > 0;
 		const openDropdown = hasChildren && !disabled && open;
-		delete rest.onOpen;
+
 		delete rest.width;
 
 		return (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Opening a `dropdownList` by clicking a button with `cursor` always invokes the 'onOpen' handler twice. This is because whenever we click on the `ContextualButton` of the `Dropdown`, it calls the 'onOpen' handler directly through the `onClick` event handler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added `handleOpen` handler in the `Dorpdown`. Once `click` event occurs, it forwards `onOpen` handler when current prop `open` is `false` only.

### Links
[//]: # (Related issues, references)
ENYO-6283
