### PR TITLE
ENYO-6248: Fix VirtualList with different item sizes to scroll properly

### DIFF
--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -456,8 +456,16 @@ const VirtualListBaseFactory = (type) => {
 					{dimensionToExtent, primary, secondary, itemPositions} = this,
 					extent = Math.floor(index / dimensionToExtent),
 					firstIndexInExtent = extent * dimensionToExtent,
-					primaryPosition = itemPositions[firstIndexInExtent] ? itemPositions[firstIndexInExtent].position : extent * primary.gridSize,
 					secondaryPosition = (index % dimensionToExtent) * secondary.gridSize;
+				let primaryPosition = extent * primary.gridSize;
+
+				if (!itemPositions[firstIndexInExtent]) {
+					// Cache individually sized item positions
+					for (let i = itemPositions.length; i <= index; i++) {
+						this.calculateAndCacheItemPosition(i);
+					}
+				}
+				primaryPosition = itemPositions[firstIndexInExtent].position;
 
 				return {primaryPosition, secondaryPosition};
 			} else {
@@ -908,13 +916,12 @@ const VirtualListBaseFactory = (type) => {
 		updateThresholdWithItemPosition () {
 			const
 				{overhang} = this.props,
-				{firstIndex, numOfItems} = this.state,
+				{firstIndex} = this.state,
 				{maxFirstIndex} = this,
-				lastIndex = firstIndex + numOfItems - 1,
 				numOfUpperLine = Math.floor(overhang / 2);
 
 			this.threshold.min = firstIndex === 0 ? -Infinity : this.getItemBottomPosition(firstIndex + numOfUpperLine);
-			this.threshold.max = lastIndex === maxFirstIndex ? Infinity : this.getItemBottomPosition(firstIndex + (numOfUpperLine + 1));
+			this.threshold.max = firstIndex === maxFirstIndex ? Infinity : this.getItemBottomPosition(firstIndex + (numOfUpperLine + 1));
 		}
 
 		// For individually sized item

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -451,13 +451,13 @@ const VirtualListBaseFactory = (type) => {
 		getMoreInfo = () => this.moreInfo
 
 		getGridPosition (index) {
+			const {dimensionToExtent, itemPositions, primary, secondary} = this;
+			const secondaryPosition = (index % dimensionToExtent) * secondary.gridSize;
+			const extent = Math.floor(index / dimensionToExtent);
+			let primaryPosition;
+
 			if (this.props.itemSizes) {
-				const
-					{dimensionToExtent, primary, secondary, itemPositions} = this,
-					extent = Math.floor(index / dimensionToExtent),
-					firstIndexInExtent = extent * dimensionToExtent,
-					secondaryPosition = (index % dimensionToExtent) * secondary.gridSize;
-				let primaryPosition = extent * primary.gridSize;
+				const firstIndexInExtent = extent * dimensionToExtent;
 
 				if (!itemPositions[firstIndexInExtent]) {
 					// Cache individually sized item positions
@@ -465,17 +465,13 @@ const VirtualListBaseFactory = (type) => {
 						this.calculateAndCacheItemPosition(i);
 					}
 				}
+
 				primaryPosition = itemPositions[firstIndexInExtent].position;
-
-				return {primaryPosition, secondaryPosition};
 			} else {
-				const
-					{dimensionToExtent, primary, secondary} = this,
-					primaryPosition = Math.floor(index / dimensionToExtent) * primary.gridSize,
-					secondaryPosition = (index % dimensionToExtent) * secondary.gridSize;
-
-				return {primaryPosition, secondaryPosition};
+				primaryPosition = extent * primary.gridSize;
 			}
+
+			return {primaryPosition, secondaryPosition};
 		}
 
 		// For individually sized item


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualList with Different item Size could not reach the end via 5-way key or fast wheeling.
- Sometimes, a list was scrolled _backward_ during scroll down via 5-way key
- (Found after fixing the issue above) Sometimes, items at the end of a list did not display via fast wheeling

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The first issue (backward scrolling) occurs due to not-yet-calculated position info of item to be rendered. A list already has all item sizes (from apps) but it doesn't calculate all item positions at the beginning to spread out computation cost at mounting. So, in some cases, position info could be not calculated yet. This is fixed by adding calculation logic for the case.

The second issue occurs due to a simple bug on updating threshold.max value which is used to reuse virtualized slots.


### Links
[//]: # (Related issues, references)
ENYO-6248

