### PR TITLE
ENYO-6280: Add QA Sampler for VirtualList with with small minSize and large size

### DIFF
--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -236,7 +236,7 @@ storiesOf('VirtualList', module)
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
 					itemRenderer={renderItem(Item, ri.scale(number('size', Config, 200)), false)}
 					itemSize={updateItemSize({
-						minSize: ri.scale(number('minSize', Config, 10)),
+						minSize: ri.scale(number('minSize', Config, 1)),
 						dataSize: number('dataSize', Config, defaultDataSize),
 						size: ri.scale(number('size', Config, 200))
 					})}

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -68,6 +68,8 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
+const updateItemSize = ({minSize, dataSize, size}) => ({minSize, size: new Array(dataSize).fill(size)});
+
 class StatefulSwitchItem extends React.Component {
 	static propTypes = {
 		index: PropTypes.number
@@ -219,6 +221,26 @@ storiesOf('VirtualList', module)
 					spotlightDisabled={boolean('spotlightDisabled', Config, false)}
 					verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+				/>
+			);
+		},
+		{propTables: [Config]}
+	)
+	.add(
+		'with small item min size and large item size',
+		() => {
+			return (
+				<VirtualList
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					direction="horizontal"
+					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+					itemRenderer={renderItem(Item, ri.scale(number('size', Config, 200)), false)}
+					itemSize={updateItemSize({
+						minSize: ri.scale(number('minSize', Config, 10)),
+						dataSize: number('dataSize', Config, defaultDataSize),
+						size: ri.scale(number('size', Config, 200))
+					})}
+					spacing={ri.scale(number('spacing', Config))}
 				/>
 			);
 		},

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -27,6 +27,9 @@ const
 	borderStyle = ri.unit(3, 'rem') + ' solid #202328',
 	items = [],
 	defaultDataSize = 1000,
+	defaultDataSizeForSmallMinLargeSize = 5,
+	defaultItemSize = 500,
+	defaultMinItemSize = 100,
 	prop = {
 		scrollbarOption: ['auto', 'hidden', 'visible']
 	},
@@ -231,14 +234,14 @@ storiesOf('VirtualList', module)
 		() => {
 			return (
 				<VirtualList
-					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSizeForSmallMinLargeSize))}
 					direction="horizontal"
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
-					itemRenderer={renderItem(Item, ri.scale(number('size', Config, 200)), false)}
+					itemRenderer={renderItem(Item, ri.scale(number('size', Config, defaultItemSize)), false)}
 					itemSize={updateItemSize({
-						minSize: ri.scale(number('minSize', Config, 1)),
-						dataSize: number('dataSize', Config, defaultDataSize),
-						size: ri.scale(number('size', Config, 200))
+						minSize: ri.scale(number('minSize', Config, defaultMinItemSize)),
+						dataSize: number('dataSize', Config, defaultDataSizeForSmallMinLargeSize),
+						size: ri.scale(number('size', Config, defaultItemSize))
 					})}
 					spacing={ri.scale(number('spacing', Config))}
 				/>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is no sampler for VirtualList with with small `minSize` and large `size` props.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Created a new QA sampler with minSize of 1 and size of 200 props in VirtualList.

### Links
[//]: # (Related issues, references)

ENYO-6280