### PR TITLE
ENYO-6285: VirtualList scrolls speedfully when wheeling

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to scroll speedfully when wheeling
+
 ## [3.1.1] - 2019-09-23
 
 ### Fixed

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -319,8 +319,9 @@ const VirtualListBaseFactory = (type) => {
 
 		componentDidUpdate (prevProps, prevState) {
 			let deferScrollTo = false;
-
 			const {firstIndex, numOfItems} = this.state;
+
+			this.isNeededToUpdateBounds = false;
 
 			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
 			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
@@ -1179,8 +1180,6 @@ const VirtualListBaseFactory = (type) => {
 			if (primary) {
 				this.positionItems();
 			}
-
-			this.isNeededToUpdateBounds = false;
 
 			return (
 				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} ref={this.containerRef} style={style}>

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -321,7 +321,7 @@ const VirtualListBaseFactory = (type) => {
 			let deferScrollTo = false;
 			const {firstIndex, numOfItems} = this.state;
 
-			this.isNeededToUpdateBounds = false;
+			this.shouldUpdateBounds = false;
 
 			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
 			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
@@ -434,7 +434,7 @@ const VirtualListBaseFactory = (type) => {
 		isPrimaryDirectionVertical = true
 		isItemSized = false
 
-		isNeededToUpdateBounds = false
+		shouldUpdateBounds = false
 
 		dimensionToExtent = 0
 		threshold = 0
@@ -619,11 +619,11 @@ const VirtualListBaseFactory = (type) => {
 				dataSizeDiff = dataSize - this.curDataSize;
 			let newFirstIndex = firstIndex;
 
-			// When calling setState() except in didScroll(), `isNeededToUpdateBounds` should be `true`
+			// When calling setState() except in didScroll(), `shouldUpdateBounds` should be `true`
 			// so that setState() in didScroll() could be called to override state.
 			// Before calling setState() except in didScroll(), getStatesAndUpdateBounds() is always called.
-			// So `isNeededToUpdateBounds` is true here.
-			this.isNeededToUpdateBounds = true;
+			// So `shouldUpdateBounds` is true here.
+			this.shouldUpdateBounds = true;
 
 			this.maxFirstIndex = Math.ceil((dataSize - numOfItems) / dimensionToExtent) * dimensionToExtent;
 			this.curDataSize = dataSize;
@@ -892,7 +892,7 @@ const VirtualListBaseFactory = (type) => {
 			this.scrollPosition = pos;
 			this.updateMoreInfo(dataSize, pos);
 
-			if (this.isNeededToUpdateBounds || firstIndex !== newFirstIndex) {
+			if (this.shouldUpdateBounds || firstIndex !== newFirstIndex) {
 				this.setState({firstIndex: newFirstIndex});
 			}
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When wheeling over a VirtualList, the VirtualList scrolls smoothly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Due to the patch for ENYO-6230, VirtualList rendered again whenever the list scroll position updated. So I reverted the patch and create a new patch for ENYO-6230.

If firstIndex state is not updated, setState() in didScroll() is usually not called as before except the case when setState() is called in other functions so that the state could be always overriden when an app wants to scroll.

### Links
[//]: # (Related issues, references)

ENYO-6285