### PR TITLE
ENYO-6125: ui/Button to not require `children`

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -11,7 +11,6 @@ import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
-import warning from 'warning';
 
 import Touchable from '../Touchable';
 
@@ -181,8 +180,6 @@ const ButtonBase = kind({
 		delete rest.pressed;
 		delete rest.selected;
 		delete rest.size;
-
-		warning(icon || children, 'Button requires that either the "icon" or "children" props be specified.');
 
 		return (
 			<div role="button" {...rest} aria-disabled={disabled} disabled={disabled}>

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -11,6 +11,7 @@ import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
+import warning from 'warning';
 
 import Touchable from '../Touchable';
 
@@ -28,8 +29,6 @@ const ButtonBase = kind({
 	name: 'ui:Button',
 
 	propTypes: /** @lends ui/Button.ButtonBase.prototype */ {
-		children: PropTypes.node.isRequired,
-
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
 		 * corresponding internal Elements and states of this component.
@@ -182,6 +181,8 @@ const ButtonBase = kind({
 		delete rest.pressed;
 		delete rest.selected;
 		delete rest.size;
+
+		warning(icon || children, 'Button requires that either the "icon" or "children" props be specified.');
 
 		return (
 			<div role="button" {...rest} aria-disabled={disabled} disabled={disabled}>

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Added
+
+- `ui/Button` to warn if `icon` and `children` props aren't passed
+
 ## [3.1.1] - 2019-09-23
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,9 +4,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
-### Added
+### Fixed
 
-- `ui/Button` to warn if `icon` and `children` props aren't passed
+- `ui/Button` to not require `children`
 
 ## [3.1.1] - 2019-09-23
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is the following warning when using ui/Button with not `children` but `icon` prop.
```
Warning: Failed prop type: The prop `children` is marked as required in `ui:Button`, but its value is `undefined`.
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

ui/Button could conceivably be used with `children` or `icon` with the right CSS, so, we'll just make it all optional.

### Links
[//]: # (Related issues, references)

ENYO-6125