### PR TITLE
ENYO-6143: Apply overscroll effect via page keys on VirtualList scrollbar

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -634,22 +634,17 @@ class ScrollableBase extends Component {
 			const {overscrollEffectOn} = this.props;
 			let direction = null;
 
-			if ((isPageUp(keyCode) || isPageDown(keyCode)) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-				const
-					{scrollTop} = this.uiRef.current,
-					{maxTop} = this.uiRef.current.getScrollBounds();
-
-				if (this.isContent(target)) {
-					ev.stopPropagation();
+			if (isPageUp(keyCode) || isPageDown(keyCode)) {
+				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
-					this.scrollByPage(direction);
-					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+
+					if (this.isContent(target)) {
+						ev.stopPropagation();
+						this.scrollByPage(direction);
+					}
+					if (overscrollEffectOn.pageKey) {
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
-				} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
-					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
-				} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
-					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -635,12 +635,22 @@ class ScrollableBase extends Component {
 			let direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-					ev.stopPropagation();
-					direction = isPageUp(keyCode) ? 'up' : 'down';
-					this.scrollByPage(direction);
-					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+				if ((this.props.direction === 'vertical' || this.props.direction === 'both')) {
+					const
+						{scrollTop} = this.uiRef.current,
+						{maxTop} = this.uiRef.current.getScrollBounds();
+
+					if (this.isContent(target)) {
+						ev.stopPropagation();
+						direction = isPageUp(keyCode) ? 'up' : 'down';
+						this.scrollByPage(direction);
+						if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+							this.checkAndApplyOverscrollEffectByDirection(direction);
+						}
+					} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
+						this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
+					} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
+						this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
 					}
 				}
 			} else if (getDirection(keyCode)) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -634,24 +634,22 @@ class ScrollableBase extends Component {
 			const {overscrollEffectOn} = this.props;
 			let direction = null;
 
-			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if ((this.props.direction === 'vertical' || this.props.direction === 'both')) {
-					const
-						{scrollTop} = this.uiRef.current,
-						{maxTop} = this.uiRef.current.getScrollBounds();
+			if ((isPageUp(keyCode) || isPageDown(keyCode)) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
+				const
+					{scrollTop} = this.uiRef.current,
+					{maxTop} = this.uiRef.current.getScrollBounds();
 
-					if (this.isContent(target)) {
-						ev.stopPropagation();
-						direction = isPageUp(keyCode) ? 'up' : 'down';
-						this.scrollByPage(direction);
-						if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-							this.checkAndApplyOverscrollEffectByDirection(direction);
-						}
-					} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
-						this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
-					} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
-						this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
+				if (this.isContent(target)) {
+					ev.stopPropagation();
+					direction = isPageUp(keyCode) ? 'up' : 'down';
+					this.scrollByPage(direction);
+					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
+				} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
+					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
+				} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
+					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -699,22 +699,17 @@ class ScrollableBaseNative extends Component {
 			const {overscrollEffectOn} = this.props;
 			let direction = null;
 
-			if ((isPageUp(keyCode) || isPageDown(keyCode)) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
-				const
-					{scrollTop} = this.uiRef.current,
-					{maxTop} = this.uiRef.current.getScrollBounds();
-
-				if (this.isContent(target)) {
-					ev.stopPropagation();
+			if (isPageUp(keyCode) || isPageDown(keyCode)) {
+				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
-					this.scrollByPage(direction);
-					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+
+					if (this.isContent(target)) {
+						ev.stopPropagation();
+						this.scrollByPage(direction);
+					}
+					if (overscrollEffectOn.pageKey) {
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
-				} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
-					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
-				} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
-					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
 				}
 			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -699,14 +699,22 @@ class ScrollableBaseNative extends Component {
 			const {overscrollEffectOn} = this.props;
 			let direction = null;
 
-			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.isContent(target) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
+			if ((isPageUp(keyCode) || isPageDown(keyCode)) && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
+				const
+					{scrollTop} = this.uiRef.current,
+					{maxTop} = this.uiRef.current.getScrollBounds();
+
+				if (this.isContent(target)) {
 					ev.stopPropagation();
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 					this.scrollByPage(direction);
 					if (overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
 						this.checkAndApplyOverscrollEffectByDirection(direction);
 					}
+				} else if (isPageUp(keyCode) && this.isReachedEdge(scrollTop, 0)) {
+					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'before', overscrollTypeOnce);
+				} else if (isPageDown(keyCode) && this.isReachedEdge(scrollTop, maxTop)) {
+					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', 'after', overscrollTypeOnce);
 				}
 			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -280,9 +280,5 @@ storiesOf('VirtualList', module)
 				/>
 			);
 		},
-		{
-			info: {
-				text: 'Basic usage of VirtualList'
-			}
-		}
+		{propTables: [Config]}
 	);

--- a/packages/sampler/stories/qa/VirtualList.js
+++ b/packages/sampler/stories/qa/VirtualList.js
@@ -260,4 +260,29 @@ storiesOf('VirtualList', module)
 			);
 		},
 		{propTables: [Config]}
+	)
+	.add(
+		'overscrollEffectOn',
+		() => {
+			return (
+				<VirtualList
+					overscrollEffectOn={{
+						arrowKey: false,
+						drag: false,
+						pageKey: true,
+						scrollbarButton: false,
+						wheel: false
+					}}
+					dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+					focusableScrollbar={boolean('focusableScrollbar', Config)}
+					itemRenderer={renderItem(StatefulSwitchItem, ri.scale(number('itemSize', Config, 72)), true)}
+					itemSize={ri.scale(number('itemSize', Config, 72))}
+				/>
+			);
+		},
+		{
+			info: {
+				text: 'Basic usage of VirtualList'
+			}
+		}
 	);

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -777,9 +777,7 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onKeyDown = (ev) => {
-		if (this.props.onKeyDown) {
-			forward('onKeyDown', ev, this.props);
-		}
+		forward('onKeyDown', ev, this.props);
 	}
 
 	scrollToAccumulatedTarget = (delta, vertical, overscrollEffect) => {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -199,6 +199,14 @@ class ScrollableBaseNative extends Component {
 		onFlick: PropTypes.func,
 
 		/**
+		 * Called when pressing a key.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onKeyDown: PropTypes.func,
+
+		/**
 		 * Called when trigerring a mousedown event.
 		 *
 		 * @type {Function}
@@ -768,6 +776,12 @@ class ScrollableBaseNative extends Component {
 		this.scrollStopJob.start();
 	}
 
+	onKeyDown = (ev) => {
+		if (this.props.onKeyDown) {
+			forward('onKeyDown', ev, this.props);
+		}
+	}
+
 	scrollToAccumulatedTarget = (delta, vertical, overscrollEffect) => {
 		if (!this.isScrollAnimationTargetAccumulated) {
 			this.accumulatedTargetX = this.scrollLeft;
@@ -1259,6 +1273,7 @@ class ScrollableBaseNative extends Component {
 
 		if (containerRef.current && containerRef.current.addEventListener) {
 			containerRef.current.addEventListener('wheel', this.onWheel);
+			containerRef.current.addEventListener('keydown', this.onKeyDown);
 			containerRef.current.addEventListener('mousedown', this.onMouseDown);
 		}
 
@@ -1284,6 +1299,7 @@ class ScrollableBaseNative extends Component {
 
 		if (containerRef.current && containerRef.current.removeEventListener) {
 			containerRef.current.removeEventListener('wheel', this.onWheel);
+			containerRef.current.removeEventListener('keydown', this.onKeyDown);
 			containerRef.current.removeEventListener('mousedown', this.onMouseDown);
 		}
 
@@ -1334,6 +1350,7 @@ class ScrollableBaseNative extends Component {
 		delete rest.horizontalScrollbar;
 		delete rest.noScrollByWheel;
 		delete rest.onFlick;
+		delete rest.onKeyDown;
 		delete rest.onMouseDown;
 		delete rest.onScroll;
 		delete rest.onScrollStart;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

After applying `overscrollEffectOn` prop with `{pageKey: true}` property in VirtualList, overscroll effect did not show via page keys on scroll bar.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Scrollable did not cover that edge case. So I moved the following code out of the this.isContent(target) condition.
```
    if (overscrollEffectOn.pageKey) {
        this.checkAndApplyOverscrollEffectByDirection(direction);
    }
```
- In addition, I added VirtualList sampler to verify this issue.
- For `ScrollableNative`, `onKeyDown` should be handled in not `VirtualListBase` but `ui/ScrollableNative` to capture the `onKeyDown` event on scroll bar.
- `overscrollEffectOn` prop is private. So I did not update CHANGELOG.md

### Links
[//]: # (Related issues, references)

ENYO-6143