### PR TITLE
PLAT-86339: Fix docs for core/handle.oneOf

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/handle` documentation for even better Typescript output
+
 ## [3.1.1] - 2019-09-23
 
 ### Fixed

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -111,15 +111,6 @@ import {is} from '../keymap';
  * @returns {any}
  */
 
-/**
- * An entry for {@link core/handle.oneOf}.
- *
- * If the return of the first handler is truthy, the second handler is executed
- *
- * @typedef {[HandlerFunction, HandlerFunction]} OneOfEntry
- * @memberof core/handle
- */
-
 // Accepts an array of handlers, sanitizes them, and returns a handler function
 // compose(allPass, map(makeSafeHandler));
 const makeHandler = (handlers) => {
@@ -258,10 +249,10 @@ const handle = function (...handlers) {
  * ```
  *
  * @method   oneOf
- * @param    {...OneOfEntry}  handlers List of conditions and handlers to process the event
+ * @param    {...[HandlerFunction, HandlerFunction]}  handlers List of conditions and handlers to process the event
  *
  * @returns  {HandlerFunction} A function that accepts an event which is dispatched to each of the
- *                          conditions and, if it passes, onto the provided handler.
+ *                             conditions and, if it passes, onto the provided handler.
  * @memberof core/handle
  * @public
  */

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -83,12 +83,16 @@ import curry from 'ramda/src/curry';
 import {is} from '../keymap';
 
 /**
+ * The signature for event handlers
+ *
  * @callback EventHandler
  * @memberof core/handle
  * @param {any} event
  */
 
 /**
+ * The signature for event handling functions supported by `handle` and related functions
+ *
  * @callback HandlerFunction
  * @memberof core/handle
  * @param {any} event
@@ -97,6 +101,8 @@ import {is} from '../keymap';
  */
 
 /**
+ * The signature for {@link core/handle.adaptEvent} parameter `adapter`
+ *
  * @callback EventAdapter
  * @memberof core/handle
  * @param {any} event
@@ -105,6 +111,14 @@ import {is} from '../keymap';
  * @returns {any}
  */
 
+/**
+ * An entry for {@link core/handle.oneOf}.
+ *
+ * If the return of the first handler is truthy, the second handler is executed
+ *
+ * @typedef {[HandlerFunction, HandlerFunction]} OneOfEntry
+ * @memberof core/handle
+ */
 
 // Accepts an array of handlers, sanitizes them, and returns a handler function
 // compose(allPass, map(makeSafeHandler));
@@ -244,7 +258,7 @@ const handle = function (...handlers) {
  * ```
  *
  * @method   oneOf
- * @param    {...Function[]}  handlers List of conditions and handlers to process the event
+ * @param    {...OneOfEntry}  handlers List of conditions and handlers to process the event
  *
  * @returns  {HandlerFunction} A function that accepts an event which is dispatched to each of the
  *                          conditions and, if it passes, onto the provided handler.


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The `oneOf` method did not have typing information for the handlers record type.
See sample in attached Jira or use the sample in the docs for `oneOf`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a new typedef for the `oneOf` function's parameters.
Also, added documentation for the various typedefs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Needs updated jsdoc to typescript PR (in same ticket) and enactjs/docs#124 for best results

### Links
[//]: # (Related issues, references)
PLAT-86339

### Comments
