### PR TITLE
PLAT-85817: Remove maxDuration from Scroller flick config

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Button` to not require `children`
 - `ui/VirtualList.VirtualGridList` and `ui/VirtualList.VirtualList` to scroll smoothly when wheeling
+- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` to scroll correctly after performing flick events
 
 ## [3.1.1] - 2019-09-23
 

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -31,6 +31,7 @@ const
 	constants = {
 		animationDuration: 1000,
 		epsilon: 1,
+		flickConfig: {maxDuration: null},
 		isPageDown: is('pageDown'),
 		isPageUp: is('pageUp'),
 		nop: () => {},
@@ -45,6 +46,7 @@ const
 	{
 		animationDuration,
 		epsilon,
+		flickConfig,
 		isPageDown,
 		isPageUp,
 		nop,
@@ -1328,6 +1330,7 @@ class ScrollableBase extends Component {
 			childWrapperProps = {
 				className: css.content,
 				...(!noScrollByDrag && {
+					flickConfig,
 					onDrag: this.onDrag,
 					onDragEnd: this.onDragEnd,
 					onDragStart: this.onDragStart,

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -20,6 +20,7 @@ import css from './Scrollable.module.less';
 const
 	constants = {
 		epsilon: 1,
+		flickConfig: {maxDuration: null},
 		isPageDown: is('pageDown'),
 		isPageUp: is('pageUp'),
 		nop: () => {},
@@ -33,6 +34,7 @@ const
 	},
 	{
 		epsilon,
+		flickConfig,
 		nop,
 		overscrollTypeDone,
 		overscrollTypeHold,
@@ -1318,6 +1320,7 @@ class ScrollableBaseNative extends Component {
 			childWrapperProps = {
 				className: contentClasses,
 				...(!noScrollByDrag && {
+					flickConfig,
 					onDrag: this.onDrag,
 					onDragEnd: this.onDragEnd,
 					onDragStart: this.onDragStart,

--- a/packages/ui/Touchable/Flick.js
+++ b/packages/ui/Touchable/Flick.js
@@ -11,11 +11,13 @@ class Flick {
 		return this.tracking;
 	}
 
-	begin = (config, {onFlick}, coords) => {
-		this.minVelocity = config.minVelocity;
-		this.maxMoves = config.maxMoves;
+	begin = ({maxDuration, maxMoves, minVelocity}, {onFlick}, coords) => {
+		this.minVelocity = minVelocity;
+		this.maxMoves = maxMoves;
 
-		this.cancelJob.startAfter(config.maxDuration);
+		if (maxDuration !== null) {
+			this.cancelJob.startAfter(maxDuration);
+		}
 		this.tracking = !!onFlick;
 		this.moves.length = 0;
 		this.onFlick = onFlick;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`ui/Scroller` does not properly scroll with inertia after flick events are fired.


### Resolution
By default, `Touchable` configures a `maxDuration` time value where after `x` amount of time after a drag has begun, then the drag stops being tracked. At that point, flick events do not provide flick target data. In the case of `Scroller`, this means we're unable to scroll after flick events have occurred when a drag has continued for over `250ms` (the default config value). We need to continually track a drag, so I've configured a `null` value for `Scroller`'s `maxDuration` config and added some validation in `Touchable` to not cancel tracking unless a value is provided.
