### PR TITLE
PLAT-86565: Hide Storybook Notification with non-root URLs

### DIFF
--- a/packages/sampler/src/manager-styles.js
+++ b/packages/sampler/src/manager-styles.js
@@ -18,7 +18,7 @@ const styles = `
 		display: none;
 	}
 
-	a[href='/?path=/settings/about'] {
+	a[href$='/?path=/settings/about'] {
         display: none;
     }
 `;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* The current Storybook update notification hide fix only appears to work on base-level hosting, like `npm run serve`, however we often host on subdirectories which factor into the CSS selector.

### Resolution
* Adjust the fix to support public path prefixes by changing CSS selector from `href=` to `href$=`

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>