### PR TITLE
PLAT-86483: Fix Button color bar height

### DIFF
--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -82,9 +82,9 @@ const ButtonBase = kind({
 		 * @type {Object}
 		 * @public
 		 */
-		// `transparent` was intentionally excluded from the adove documented exported classes as it
-		// does not appear to provide value to the end-developer, but is needed by IconButton
-		// internally for its design guidelines, which differ from Button regarding `transparent`.
+		// `transparent` and  `client` were intentionally excluded from the adove documented
+		// exported classes as it does not appear to provide value to the end-developer, but is
+		// needed by IconButton internally for its design guidelines.
 		// Same for `pressed` which is used by Dropdown to nullify the key-press activate animation.
 		css: PropTypes.object,
 
@@ -114,7 +114,7 @@ const ButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['button', 'bg', 'large', 'pressed', 'selected', 'small', 'transparent']
+		publicClassNames: ['button', 'bg', 'client', 'large', 'pressed', 'selected', 'small', 'transparent']
 	},
 
 	computed: {

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Button` `color` bar height
+
 ## [3.1.2] - 2019-09-30
 
 ### Fixed

--- a/packages/moonstone/IconButton/IconButton.module.less
+++ b/packages/moonstone/IconButton/IconButton.module.less
@@ -46,8 +46,17 @@
 	&.blue {
 		line-height: 42px;
 
+		.client::before {
+			height: @moon-icon-button-colordot-height;
+		}
+
 		&.small {
 			line-height: 30px;
+
+
+			.client::before {
+				height: @moon-icon-button-small-colordot-height;
+			}
 		}
 	}
 

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -183,7 +183,7 @@
 @moon-button-max-width: 450px;
 @moon-button-min-width: 300px;
 @moon-button-pressed-scale: 0.05;
-@moon-button-small-colordot-height: 6px;
+@moon-button-small-colordot-height: 9px;
 @moon-button-small-colordot-width: 21px;
 @moon-button-small-font-family: @moon-button-font-family;
 @moon-button-small-font-style: @moon-button-font-style;
@@ -231,8 +231,10 @@
 
 // Icon Button
 // ---------------------------------------
+@moon-icon-button-colordot-height: 9px;
 @moon-icon-button-size: @moon-button-height;
 @moon-icon-button-size-large: @moon-button-height-large;
+@moon-icon-button-small-colordot-height: 6px;
 @moon-icon-button-small-size: @moon-button-small-height;
 @moon-icon-button-small-size-large: @moon-button-small-height-large;
 // @moon-icon-button-border-radius: 6px;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Height of the color bar should be 9px for both small and large buttons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Added `client` class to `publicClassNames` in order to override it in `IconButton` which has different requirements for the size of the color bar.
* Added/updated LESS variables for the sizes

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I included `client` in our "not for public consumption" note since we've avoided exposing it in the past. I feel like we've expanded the list enough that we're nearing the point where exposing everything might be useful since the component is reused so broadly. Alternatively, we might make an `internal/Button` that is more open and inline it in `moonstone/Button` with a more limited API.

### Links
[//]: # (Related issues, references)


### Comments
