### PR TITLE
ENYO-6292: Moonstone Input missing inline doc for `inputHighlight` css prop

### DIFF
--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -51,6 +51,7 @@ const InputBase = kind({
 		 *
 		 * * `decorator` - The root class name
 		 * * `input` - The <input> class name
+		 *  * `inputHighlight` - The class used to make input text appear highlighted when `.decorator` has focus, but not `.input`
 		 *
 		 * @type {Object}
 		 * @private

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -51,7 +51,7 @@ const InputBase = kind({
 		 *
 		 * * `decorator` - The root class name
 		 * * `input` - The <input> class name
-		 *  * `inputHighlight` - The class used to make input text appear highlighted when `.decorator` has focus, but not `.input`
+		 * * `inputHighlight` - The class used to make input text appear highlighted when `.decorator` has focus, but not `.input`
 		 *
 		 * @type {Object}
 		 * @private


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`moonstone/Input` is missing a description for the `inputHighlight` class that can be overridden via the `css` prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added inline doc for `inputHighlight` class to let developers know of its existence.  This should be zero-impact :D

### Links
[//]: # (Related issues, references)
ENYO-6292
