### PR TITLE
ENYO-6296: Fix Slider to display tooltip when disabled

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
+- `moonstone/Slider` to show `tooltip` when disabled
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -51,7 +51,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static propTypes = {
 			'aria-valuetext': PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-			disabled: PropTypes.bool,
 			max: PropTypes.number,
 			min: PropTypes.number,
 			orientation: PropTypes.string,

--- a/packages/moonstone/Slider/SliderBehaviorDecorator.js
+++ b/packages/moonstone/Slider/SliderBehaviorDecorator.js
@@ -151,10 +151,8 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleFocus (ev) {
-			if (!this.props.disabled) {
-				forward('onFocus', ev, this.props);
-				this.setState({focused: true});
-			}
+			forward('onFocus', ev, this.props);
+			this.setState({focused: true});
 		}
 
 		handleSpotlightEvents (ev) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There's no tooltip when changed disabled state.
So, if Slider retains spotlight while changing value and disabled state, tooltip doesn't show even if value is changed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Currently, `SliderBehaviorDecorator` doesn't change focus state if that's disabled.
I removed condition that checking disabled state to show tooltip when disabled.
Because I thought users may want to know value via tooltip once they focus on knob when Slider is disabled.

### Links
[//]: # (Related issues, references)
ENYO-6296