### PR TITLE
Hide tooltip when transiting panels

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
+- `moonstone/Tooltip` to hide when transitioning panels
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -405,6 +405,13 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		)
 
+		handleMouseLeave = this.handle(
+			forward('onMouseLeave'),
+			() => {
+				this.hideTooltip();
+			}
+		)
+
 		handleFocus = this.handle(
 			forward('onFocus'),
 			({target}) => this.showTooltip(target)
@@ -485,6 +492,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onBlur: this.handleBlur,
 					onFocus: this.handleFocus,
 					onMouseOut: this.handleMouseOut,
+					onMouseLeave: this.handleMouseLeave,
 					onMouseOver: this.handleMouseOver,
 					onKeyDown: this.handleKeyDown
 				}


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Tooltip is still remain on the screen during panel transition.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Hide tooltip when cursor leave target by panel transition. (handleMouseOut is used, but it will works when disabled status is true)

### Links
[//]: # (Related issues, references)
ENYO-6295

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee <changgi.lee@lge.com>