### PR TITLE
ENYO-6295: Hide the Tooltip over an Icon Button when moving a Panel

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
-- `moonstone/TooltipDecorator` to hide a tooltip when leaving via clicking and pressing a key
+- `moonstone/TooltipDecorator` and `moonstone/Panels` to hide a tooltip moving a panel
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
-- `moonstone/TooltipDecorator` and `moonstone/Panels` to hide a tooltip moving a panel
+- `moonstone/TooltipDecorator` and `moonstone/Panels` to hide a tooltip when moving a panel
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
+- `moonstone/TooltipDecorator` to show a tooltip when hovering and to hide a tooltip when leaving and pressing a key
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
-- `moonstone/TooltipDecorator` to show a tooltip when hovering and to hide a tooltip when leaving and pressing a key
+- `moonstone/TooltipDecorator` to hide a tooltip when leaving via clicking and pressing a key
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -1,4 +1,6 @@
 import kind from '@enact/core/kind';
+import {forward, handle, returnsTrue} from '@enact/core/handle';
+import Spotlight from '@enact/spotlight';
 import Measurable from '@enact/ui/Measurable';
 import Slottable from '@enact/ui/Slottable';
 import IdProvider from '@enact/ui/internal/IdProvider';
@@ -203,6 +205,19 @@ const PanelsBase = kind({
 		className: 'panels enact-fit'
 	},
 
+	handlers: {
+		onWillTransition: handle(
+			returnsTrue(() => {
+				const node = Spotlight.getCurrent();
+
+				if (node) {
+					node.dispatchEvent(new Event('willtransition'))
+				}
+			}),
+			forward('onWillTransition')
+		)
+	},
+
 	computed: {
 		className: ({controls, noCloseButton, styler}) => styler.append({
 			'moon-panels-hasControls': (!noCloseButton || !!controls) // If there is a close button or controls were specified
@@ -231,7 +246,7 @@ const PanelsBase = kind({
 		viewportId: ({id}) => id && `${id}-viewport`
 	},
 
-	render: ({arranger, childProps, children, closeButtonAriaLabel, closeButtonBackgroundOpacity, controls, controlsRef, generateId, id, index, noAnimation, noCloseButton, noSharedState, onApplicationClose, viewportId, ...rest}) => {
+	render: ({arranger, childProps, children, closeButtonAriaLabel, closeButtonBackgroundOpacity, controls, controlsRef, generateId, id, index, noAnimation, noCloseButton, noSharedState, onApplicationClose, onWillTransition, viewportId, ...rest}) => {
 		delete rest.controlsMeasurements;
 		delete rest.onBack;
 
@@ -258,6 +273,7 @@ const PanelsBase = kind({
 					index={index}
 					noAnimation={noAnimation}
 					noSharedState={noSharedState}
+					onWillTransition={onWillTransition}
 				>
 					{children}
 				</Viewport>

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -211,7 +211,7 @@ const PanelsBase = kind({
 				const node = Spotlight.getCurrent();
 
 				if (node) {
-					node.dispatchEvent(new Event('willtransition'))
+					node.dispatchEvent(new CustomEvent('willtransition'));
 				}
 			}),
 			forward('onWillTransition')

--- a/packages/moonstone/Panels/Panels.js
+++ b/packages/moonstone/Panels/Panels.js
@@ -211,7 +211,7 @@ const PanelsBase = kind({
 				const node = Spotlight.getCurrent();
 
 				if (node) {
-					node.dispatchEvent(new CustomEvent('willtransition'));
+					node.dispatchEvent(new CustomEvent('willtransition')); // eslint-disable-line no-undef
 				}
 			}),
 			forward('onWillTransition')

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -16,6 +16,7 @@ import {forward, handle, forProp} from '@enact/core/handle';
 import {Job} from '@enact/core/util';
 import {on, off} from '@enact/core/dispatcher';
 import React from 'react';
+import {findDOMNode} from 'react-dom';
 import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
 
@@ -233,6 +234,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (window.ResizeObserver) {
 				this.resizeObserver = new ResizeObserver(this.startTooltipLayoutJob);
 			}
+
+			findDOMNode(this).addEventListener('willtransition', this.handleWilltransition);
 		}
 
 		componentDidUpdate (prevProps, prevState) {
@@ -264,6 +267,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.props.disabled) {
 				off('keydown', this.handleKeyDown);
 			}
+
+			findDOMNode(this).removeEventListener('willtransition', this.handleWilltransition);
 		}
 
 		setTooltipLayout () {
@@ -380,6 +385,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		// Global keydown handler to hide the tooltip for when the pointer is hovering over disabled wrapped component (showing the tooltip), and then the pointer times out and switches to 5-way, which will trigger this keydown handler, and spotting another component.
 		handleGlobalKeyDown = this.handle(
+			forProp('disabled', true),
 			() => {
 				this.hideTooltip();
 				off('keydown', this.handleGlobalKeyDown);
@@ -401,6 +407,10 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				off('keydown', this.handleGlobalKeyDown);
 			}
 		)
+
+		handleWilltransition = this.handle(
+			this.hideTooltip
+		).bindAs(this, 'handleWilltransition')
 
 		handleFocus = this.handle(
 			forward('onFocus'),

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -235,7 +235,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.resizeObserver = new ResizeObserver(this.startTooltipLayoutJob);
 			}
 
-			findDOMNode(this).addEventListener('willtransition', this.handleWilltransition);
+			findDOMNode(this).addEventListener('willtransition', this.handleWilltransition); // eslint-disable-line react/no-find-dom-node
 		}
 
 		componentDidUpdate (prevProps, prevState) {
@@ -268,7 +268,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				off('keydown', this.handleKeyDown);
 			}
 
-			findDOMNode(this).removeEventListener('willtransition', this.handleWilltransition);
+			findDOMNode(this).removeEventListener('willtransition', this.handleWilltransition); // eslint-disable-line react/no-find-dom-node
 		}
 
 		setTooltipLayout () {
@@ -350,7 +350,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		hideTooltip = () => {
+		hideTooltip = (ev) => {
 			if (this.props.tooltipText) {
 				if (this.mutationObserver) {
 					this.mutationObserver.disconnect();
@@ -394,6 +394,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleMouseOver = this.handle(
 			forward('onMouseOver'),
+			forProp('disabled', true),
 			(ev) => {
 				this.showTooltip(ev.target);
 				on('keydown', this.handleGlobalKeyDown);
@@ -402,6 +403,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleMouseOut = this.handle(
 			forward('onMouseOut'),
+			forProp('disabled', true),
 			() => {
 				this.hideTooltip();
 				off('keydown', this.handleGlobalKeyDown);

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -380,7 +380,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		// Global keydown handler to hide the tooltip for when the pointer is hovering over disabled wrapped component (showing the tooltip), and then the pointer times out and switches to 5-way, which will trigger this keydown handler, and spotting another component.
 		handleGlobalKeyDown = this.handle(
-			forProp('disabled', true),
 			() => {
 				this.hideTooltip();
 				off('keydown', this.handleGlobalKeyDown);
@@ -389,7 +388,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleMouseOver = this.handle(
 			forward('onMouseOver'),
-			forProp('disabled', true),
 			(ev) => {
 				this.showTooltip(ev.target);
 				on('keydown', this.handleGlobalKeyDown);
@@ -398,7 +396,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleMouseOut = this.handle(
 			forward('onMouseOut'),
-			forProp('disabled', true),
 			() => {
 				this.hideTooltip();
 				off('keydown', this.handleGlobalKeyDown);

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -350,7 +350,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		hideTooltip = (ev) => {
+		hideTooltip = () => {
 			if (this.props.tooltipText) {
 				if (this.mutationObserver) {
 					this.mutationObserver.disconnect();

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -374,7 +374,11 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forward('onKeyDown'),
 			forProp('disabled', false),
 			() => {
-				this.startTooltipLayoutJob();
+				if (this.state.showing) {
+					this.hideTooltip();
+				} else {
+					this.startTooltipLayoutJob();
+				}
 			}
 		);
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -374,11 +374,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forward('onKeyDown'),
 			forProp('disabled', false),
 			() => {
-				if (this.state.showing) {
-					this.hideTooltip();
-				} else {
-					this.startTooltipLayoutJob();
-				}
+				this.startTooltipLayoutJob();
 			}
 		);
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If clicking or pressing an icon button after showing the tooltip on the icon button by hovering the icon button, the tooltip was not hidden until the icon button was removed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

No proper event was passed to the Tooltip. So I defined `willtransition` event and passed it to the Tooltip when a panel including the Tooltip moves.

### Links
[//]: # (Related issues, references)

ENYO-6295