### PR TITLE
ENYO-6298: Fix TooltipDecorator to retain visibility when to 5-way mode

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
-- `moonstone/TooltipDecorator` to keep showing it when changing from pointer mode to 5-way key mode
+- `moonstone/TooltipDecorator` to keep showing when changing from pointer mode to 5-way mode
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
+- `moonstone/TooltipDecorator` to keep showing it when changing from pointer mode to 5-way key mode
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -14,7 +14,6 @@ import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {FloatingLayerBase} from '@enact/ui/FloatingLayer';
 import {forward, handle, forProp} from '@enact/core/handle';
 import {Job} from '@enact/core/util';
-import {on, off} from '@enact/core/dispatcher';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ri from '@enact/ui/resolution';
@@ -259,10 +258,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				this.showTooltipJob.stop();
 				this.setTooltipLayoutJob.stop();
-			}
-
-			if (this.props.disabled) {
-				off('keydown', this.handleKeyDown);
 			}
 		}
 

--- a/packages/moonstone/TooltipDecorator/TooltipDecorator.js
+++ b/packages/moonstone/TooltipDecorator/TooltipDecorator.js
@@ -378,21 +378,11 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		);
 
-		// Global keydown handler to hide the tooltip for when the pointer is hovering over disabled wrapped component (showing the tooltip), and then the pointer times out and switches to 5-way, which will trigger this keydown handler, and spotting another component.
-		handleGlobalKeyDown = this.handle(
-			forProp('disabled', true),
-			() => {
-				this.hideTooltip();
-				off('keydown', this.handleGlobalKeyDown);
-			}
-		);
-
 		handleMouseOver = this.handle(
 			forward('onMouseOver'),
 			forProp('disabled', true),
 			(ev) => {
 				this.showTooltip(ev.target);
-				on('keydown', this.handleGlobalKeyDown);
 			}
 		)
 
@@ -401,7 +391,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forProp('disabled', true),
 			() => {
 				this.hideTooltip();
-				off('keydown', this.handleGlobalKeyDown);
 			}
 		)
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Tooltip over a disabled component was hidden when changing from pointer mode to 5-way key mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Tooltip should be hidden before because a disabled component could not get focus and Spotlight would be on another component when changing to 5-way key mode. But now, the disabled component could get focus. So I removed the logic to hide the tooltip.

### Links
[//]: # (Related issues, references)

ENYO-6298