### PR TITLE
ENYO-6299: Call stop() when clicking not on but out of paging controls

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Button` `color` bar height
+- `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to stop scrolling when clicking on paging controls
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -406,8 +406,8 @@ class ScrollableBase extends Component {
 	}
 
 	onMouseDown = (ev) => {
-		if (!this.isScrollButtonFocused()) {
-			this.uiRef.current.stop();
+		if (this.isScrollButtonFocused()) {
+			ev.preventDefault();
 		}
 
 		if (this.props['data-spotlight-container-disabled']) {

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -406,6 +406,10 @@ class ScrollableBase extends Component {
 	}
 
 	onMouseDown = (ev) => {
+		if (!this.isScrollButtonFocused()) {
+			this.uiRef.current.stop();
+		}
+
 		if (this.props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
 		}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -389,8 +389,8 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onMouseDown = (ev) => {
-		if (!this.isScrollButtonFocused()) {
-			this.uiRef.current.stop();
+		if (this.isScrollButtonFocused()) {
+			ev.preventDefault();
 		}
 
 		if (this.props['data-spotlight-container-disabled']) {

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -389,6 +389,10 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onMouseDown = (ev) => {
+		if (!this.isScrollButtonFocused()) {
+			this.uiRef.current.stop();
+		}
+
 		if (this.props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
 		} else {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -604,8 +604,11 @@ class ScrollableBase extends Component {
 	getRtlX = (x) => (this.props.rtl ? -x : x)
 
 	onMouseDown = (ev) => {
-		this.stop();
-		forward('onMouseDown', ev, this.props);
+		if (this.props.onMouseDown) {
+			forward('onMouseDown', ev, this.props);
+		} else {
+			this.stop();
+		}
 	}
 
 	onDragStart = (ev) => {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -9,7 +9,7 @@
  */
 
 import classNames from 'classnames';
-import {forward} from '@enact/core/handle';
+import handle, {forward, forwardWithPrevent} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
@@ -603,13 +603,10 @@ class ScrollableBase extends Component {
 
 	getRtlX = (x) => (this.props.rtl ? -x : x)
 
-	onMouseDown = (ev) => {
-		if (this.props.onMouseDown) {
-			forward('onMouseDown', ev, this.props);
-		} else {
-			this.stop();
-		}
-	}
+	onMouseDown = handle(
+		forwardWithPrevent('onMouseDown'),
+		this.stop
+	).bindAs(this, 'onMouseDown')
 
 	onDragStart = (ev) => {
 		if (ev.type === 'dragstart') return;

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -559,9 +559,11 @@ class ScrollableBaseNative extends Component {
 	getRtlX = (x) => (this.props.rtl ? -x : x)
 
 	onMouseDown = (ev) => {
-		this.isScrollAnimationTargetAccumulated = false;
-		this.stop();
-		forward('onMouseDown', ev, this.props);
+		if (this.props.onMouseDown) {
+			forward('onMouseDown', ev, this.props);
+		} else {
+			this.stop();
+		}
 	}
 
 	onTouchStart = () => {

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {forward} from '@enact/core/handle';
+import handle, {forward, forwardWithPrevent} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import {platform} from '@enact/core/platform';
 import Registry from '@enact/core/internal/Registry';
@@ -558,13 +558,10 @@ class ScrollableBaseNative extends Component {
 
 	getRtlX = (x) => (this.props.rtl ? -x : x)
 
-	onMouseDown = (ev) => {
-		if (this.props.onMouseDown) {
-			forward('onMouseDown', ev, this.props);
-		} else {
-			this.stop();
-		}
-	}
+	onMouseDown = handle(
+		forwardWithPrevent('onMouseDown'),
+		this.stop
+	).bindAs(this, 'onMouseDown')
 
 	onTouchStart = () => {
 		this.isTouching = true;


### PR DESCRIPTION
### Checklist
* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If clicking on a paging control several times, the Scroller including the paging control did not scroll smoothly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Historically to stop scrolling when pressing a mouse down on items while flicking, stop() in Scrollable was called in https://github.com/enactjs/enact/pull/1502.
But the DOM element having that mouse down event handler was changed from the container having items to the container having not only items but also paging controls in https://github.com/enactjs/enact/pull/2468.
Then whenever clicking on the paging controls, the stop() was called and the Scroller did not scroll smoothly.

So if clicking on paging controls, the stop() is now not called.

### Links
[//]: # (Related issues, references)

ENYO-6299

### Comments

I tried to make any unit test for this issue and spent several time. But it failed. I hope that we could use TC instead of unit test case for this issue.