### PR TITLE
Simplified CSS, rearranged classes, dropped css custom properties

### DIFF
--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -1,28 +1,6 @@
 // Marquee.module.less
 //
 
-/*
-    &.fade {
-        // fade left side only
-        -webkit-mask-box-image: linear-gradient(to right, transparent, black 48px, black calc(100% - 48px), transparent);
-        transition: -webkit-mask-box-image-outset 0.5s ease;
-        -webkit-mask-box-image-outset: 0 48px 0 96px;
-        -webkit-mask-box-image-width: 0 48px 0 48px;
-
-        &.rtl {
-            // fade right side only
-            -webkit-mask-box-image-outset: 0 96px 0 48px;
-        }
-
-        // using willAnimate allows the fade to remain during the reset pause since the GPU layer isn't
-        // removed until marquee is cancelled
-        &.willAnimate {
-            // fade both sides
-            -webkit-mask-box-image-outset: 0 48px 0 48px;
-        }
-	}
-*/
-
 .marquee {
 	// NOTE: Keeping this around for now to validate if we want to use box layout instead of white-space
 	// This obscure set of code implements single-line ellipsis-clipped text that doesn't interfere with layout.
@@ -31,43 +9,30 @@
 	// display: -webkit-box;
 	// -webkit-box-orient: block-axis;
 	// -webkit-line-clamp: 1;
-
-	--ui-marquee-padding: 0;
-	--ui-marquee-fade-size: 48px;
+	@ui-marquee-fade-width: 48px;
 
 	width: auto;
 	white-space: pre !important;
 	overflow: hidden;
 	text-align: left;
 
-	// "Fade" style but the fade class hasn't been applied yet because measurement hasn't occurred.
-	&.clip {
-		-webkit-mask-box-image: linear-gradient(
-			to right,
-			transparent,
-			black var(--ui-marquee-fade-size),
-			black calc(100% - var(--ui-marquee-fade-size)),
-			transparent
-		);	
-		-webkit-mask-box-image-outset: 0 calc(2 * var(--ui-marquee-fade-size)) 0 calc(2 * var(--ui-marquee-fade-size));
-		-webkit-mask-box-image-width: 0 var(--ui-marquee-fade-size) 0 var(--ui-marquee-fade-size);
-	}
-
 	&.fade {
-		// fade left side only		
-        -webkit-mask-box-image-outset: 0 var(--ui-marquee-fade-size) 0 calc(2 * var(--ui-marquee-fade-size));
-        transition: -webkit-mask-box-image-outset 0.5s ease;
+		// fade left side only
+		-webkit-mask-box-image: linear-gradient(to right, transparent, black @ui-marquee-fade-width, black calc(100% - @ui-marquee-fade-width), transparent);
+	    transition: -webkit-mask-box-image-outset 250ms ease;
+	    -webkit-mask-box-image-outset: 0 @ui-marquee-fade-width 0 (@ui-marquee-fade-width * 2);
+		-webkit-mask-box-image-width: 0 @ui-marquee-fade-width 0 @ui-marquee-fade-width;
 
 		&.rtl {
 			// fade right side only
-			-webkit-mask-box-image-outset: 0 calc(2 * var(--ui-marquee-fade-size)) 0 var(--ui-marquee-fade-size);
+			-webkit-mask-box-image-outset: 0 (@ui-marquee-fade-width * 2) 0 @ui-marquee-fade-width;
 		}
 
 		// using willAnimate allows the fade to remain during the reset pause since the GPU layer isn't
 		// removed until marquee is cancelled
-		&.willAnimate {
+		&.animate {
 			// fade both sides
-			-webkit-mask-box-image-outset: 0 var(--ui-marquee-fade-size) 0 var(--ui-marquee-fade-size);
+			-webkit-mask-box-image-outset: 0 @ui-marquee-fade-width 0 @ui-marquee-fade-width;
 		}
 	}
 
@@ -83,18 +48,18 @@
 		transition-timing-function: linear;
 		position: relative;
 
-		&.willAnimate {
-			will-change: left, right;
-		}
-
-		&.animate {
-			overflow: visible;
-		}
-
 		.padding {
 			display: inline-block;
 			width: calc(1px * var(--ui-marquee-padding, 0));
 		}
+	}
+
+	&.willAnimate .text {
+		will-change: left, right;
+	}
+
+	&.animate .text {
+		overflow: visible;
 	}
 
 	:global(.enact-locale-right-to-left) & {

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -9,7 +9,10 @@
 	// display: -webkit-box;
 	// -webkit-box-orient: block-axis;
 	// -webkit-line-clamp: 1;
-	@ui-marquee-fade-width: 48px;
+
+
+	// DEV NOTE: The following should move into the styles/ directory when this is ready for review/integration
+	@ui-marquee-fade-width: 48px;  // Width of the fade gradient
 
 	width: auto;
 	white-space: pre !important;

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -170,14 +170,10 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
-		className: ({distance, overflow, rtl, willAnimate, styler}) => styler.append(overflow, {
+		className: ({animating, distance, overflow, rtl, willAnimate, styler}) => styler.append({
+			animate: animating,
 			fade: shouldFade(distance, overflow),
 			rtl,
-			willAnimate
-		}),
-		clientClassName: ({animating, willAnimate, styler}) => styler.join({
-			animate: animating,
-			text: true,
 			willAnimate
 		}),
 		clientStyle: ({alignment, animating, distance, overflow, padding, rtl, speed}) => {
@@ -208,7 +204,7 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, duplicate, onMarqueeComplete, ...rest}) => {
+	render: ({children, clientRef, clientStyle, duplicate, onMarqueeComplete, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
@@ -222,7 +218,7 @@ const MarqueeBase = kind({
 		return (
 			<div {...rest}>
 				<div
-					className={clientClassName}
+					className={css.text}
 					ref={clientRef}
 					style={clientStyle}
 					onTransitionEnd={onMarqueeComplete}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -318,7 +318,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			marqueeOn: 'focus',
 			marqueeOnRenderDelay: 1000,
 			marqueeOverflow: 'fade',
-			marqueePadding: '50%',
+			marqueePadding: 48,
 			marqueeResetDelay: 1000,
 			marqueeSpeed: 60
 		}


### PR DESCRIPTION
### Recomendation for Styling

This change relocates the masking code into simple CSS and LESS variables (easier for a theme/skin to set) and repositions the "state" classes to be on the root element, which provides the same targetability of selectors, improves customization and overridability, and makes it possible to have the root element and other nodes be able to respond to said state changes.

### Note

This does change where classes are being applied which could break previously customized Marquees, but the impact and prevalence of this is unknown at this time and requires **A)** further research or **B)** new alternate root-level class names, and we'll just keep the existing ones on the child node.