### PR TITLE
ENYO-6124: Update FormCheckbox and RadioItem high contrast colors

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 - `moonstone/Slider` to show `tooltip` when disabled
 - `moonstone/TooltipDecorator` to keep showing when changing from pointer mode to 5-way mode
 - `moonstone/Scroller`, `moonstone/VirtualList.VirtualGridList`, and `moonstone/VirtualList.VirtualList` not to stop scrolling when clicking on paging controls
+- `moonstone/FormCheckbox` and `moonstone/RadioItem` high contrast colors
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/moonstone/styles/colors-highcontrast.less
+++ b/packages/moonstone/styles/colors-highcontrast.less
@@ -57,12 +57,12 @@
 // ---------------------------------------
 @moon-radio-item-indicator-color: @high-contrast-white;
 @moon-radio-item-indicator-bg-color: #4d4d4d;
-@moon-radio-item-focus-indicator-color: @moon-radio-item-indicator-color;
-@moon-radio-item-focus-indicator-bg-color: @moon-radio-item-indicator-bg-color;
+@moon-radio-item-focus-indicator-color: @high-contrast-black;
+@moon-radio-item-focus-indicator-bg-color: fade(#a6a6a6, 80%);
 @moon-radio-item-selected-indicator-color: @moon-radio-item-indicator-color;
-@moon-radio-item-selected-indicator-bg-color: @high-contrast-light-gray;
-@moon-radio-item-selected-focus-indicator-color: @moon-radio-item-selected-indicator-color;
-@moon-radio-item-selected-focus-indicator-bg-color: @moon-radio-item-selected-indicator-bg-color;
+@moon-radio-item-selected-indicator-bg-color: @moon-radio-item-indicator-bg-color;
+@moon-radio-item-selected-focus-indicator-color: @moon-radio-item-focus-indicator-color;
+@moon-radio-item-selected-focus-indicator-bg-color: @moon-radio-item-focus-indicator-bg-color;
 
 // Scroller
 // ---------------------------------------

--- a/packages/moonstone/styles/colors-light-highcontrast.less
+++ b/packages/moonstone/styles/colors-light-highcontrast.less
@@ -36,8 +36,7 @@
 
 // FormCheckbox
 // ---------------------------------------
-@moon-formcheckbox-text-color: @high-contrast-black;
-@moon-formcheckbox-border-color: @moon-formcheckbox-text-color;
+@moon-formcheckbox-text-color: @high-contrast-text-color;
 
 // Header
 // ---------------------------------------

--- a/packages/moonstone/styles/colors-light.less
+++ b/packages/moonstone/styles/colors-light.less
@@ -101,9 +101,9 @@
 
 // FormCheckbox
 // ---------------------------------------
-@moon-formcheckbox-bg-color: #686868;
+@moon-formcheckbox-bg-color: #a2a2a2;
 @moon-formcheckbox-text-color: @moon-white;
-@moon-formcheckbox-border-color: @moon-dark-gray;
+@moon-formcheckbox-border-color: #888888;
 @moon-formcheckbox-focus-bg-color: @moon-spotlight-color;
 @moon-formcheckbox-focus-text-color: @moon-spotlight-text-color;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update `FormCheckbox` and `RadioItem` high contrast colors.
Tested on TV with light and dark skins high contrast along with `ProgressBar`, which seems to match the specs as-is.
