### PR TITLE
ENYO-6309: Properly attach click handler to FloatingLayer

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/FloatingLayer` to properly respond to click events if set to open when mounted
+- `ui/FloatingLayer` to be dismissable when `open` on mount
 
 ## [3.1.2] - 2019-09-30
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/FloatingLayer` to properly respond to click events if set to open when mounted
+
 ## [3.1.2] - 2019-09-30
 
 ### Fixed

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -133,6 +133,10 @@ class FloatingLayerBase extends React.Component {
 		if (this.context && typeof this.context === 'function') {
 			this.controller = this.context(this.handleNotify.bind(this));
 		}
+
+		if (this.props.scrimType === 'none' && this.props.open) {
+			on('click', this.handleClick);
+		}
 	}
 
 	componentDidUpdate (prevProps, prevState) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`ui/FloatingLayer` does not attach a click handler when it is mounted while opened. This results in not being able to dismiss the component via clicks.


### Resolution
Attach the click handler during `componentDidMount` when appropriate.
