### PR TITLE
ENYO-6311: Fix moonstone/Input to remove correct event handler

### DIFF
--- a/packages/moonstone/Input/pointer.js
+++ b/packages/moonstone/Input/pointer.js
@@ -56,7 +56,7 @@ const releasePointer = (target) => {
 		active = null;
 		document.removeEventListener('mousedown', handlePointerDown, {capture: true});
 		document.removeEventListener('mouseup', handlePointerUp, {capture: true});
-		document.removeEventListener('touchstart', handlePointerDown, {capture: true});
+		document.removeEventListener('touchstart', handleTouchStart, {capture: true});
 		document.removeEventListener('touchend', handleTap, {capture: true});
 		document.removeEventListener('click', handleTap, {capture: true});
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The pointer handling for `moonstone/Input` removes the wrong handler function when releasing the pointer.  This could be a potential cause of memory leaks.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This patch makes sure the correct handlers are removed when the pointer is released.

### Links
[//]: # (Related issues, references)
ENYO-6311
