### PR TITLE
ENYO-6308: Prevent Input focus when Spotlight is paused

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/Icon` icon sizes
+- `moonstone/InputSpotlightDecorator` to not focus when Spotlight is paused
 
 ## [3.1.3] - 2019-10-09
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -143,9 +143,11 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 
 		updateFocus = (prevState) => {
 			// focus node if `InputSpotlightDecorator` is pausing Spotlight or if Spotlight is paused
-			if (this.state.node &&
-			Spotlight.getCurrent() !== this.state.node &&
-			(this.paused.isPaused() || !Spotlight.isPaused())) {
+			if (
+				this.state.node &&
+				Spotlight.getCurrent() !== this.state.node &&
+				(this.paused.isPaused() || !Spotlight.isPaused())
+			) {
 				this.state.node.focus();
 			}
 

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -142,10 +142,11 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 		}
 
 		updateFocus = (prevState) => {
-			if (this.state.node) {
-				if (Spotlight.getCurrent() !== this.state.node) {
-					this.state.node.focus();
-				}
+			// focus node if `InputSpotlightDecorator` is pausing Spotlight or if Spotlight is paused
+			if (this.state.node &&
+			Spotlight.getCurrent() !== this.state.node &&
+			(this.paused.isPaused() || !Spotlight.isPaused())) {
+				this.state.node.focus();
 			}
 
 			const focusChanged = this.state.focused !== prevState.focused;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Guard focus against paused Spotlight outside of `InputSpotlightDecorator`.

### Links
[//]: # (Related issues, references)
ENYO-6308
