### PR TITLE
ENYO-6314: Fix feedback icon to change to same font size

### DIFF
--- a/packages/moonstone/VideoPlayer/Feedback.module.less
+++ b/packages/moonstone/VideoPlayer/Feedback.module.less
@@ -28,10 +28,6 @@
 		line-height: inherit;
 		vertical-align: bottom;
 
-		&.shrink {
-			font-size: @moon-video-feedback-icon-shrunken-size;
-		}
-
 		.applySkins({
 			color: inherit;
 		});

--- a/packages/moonstone/VideoPlayer/FeedbackIcon.js
+++ b/packages/moonstone/VideoPlayer/FeedbackIcon.js
@@ -39,10 +39,7 @@ const FeedbackIconBase = kind({
 	},
 
 	computed: {
-		children: ({children}) => children && iconMap[children] && iconMap[children].icon,
-		className: ({children, styler}) => styler.append({
-			shrink: children === 'play' || children === 'pause'
-		})
+		children: ({children}) => children && iconMap[children] && iconMap[children].icon
 	},
 
 	render: ({children, ...rest}) => {

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -522,3 +522,9 @@
 // Generic
 // ---------------------------------------
 @moon-translate-center: translate3d(-50%, -50%, 0);
+
+// Deprecated - Will be removed in 4.0
+// ---------------------------------------
+
+// No longer shrinking these with updated moonstone font
+@moon-video-feedback-icon-shrunken-size:           2em; // For play and pause icons, the em value is smaller since these glyphs are larger scale than the others.

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -493,8 +493,7 @@
 @moon-video-slider-tooltip-thumbnail-border-width: 3px;
 @moon-video-slider-tooltip-thumbnail-border-radius: @moon-contextual-popup-border-radius;
 @moon-video-feedback-icon-width:                   0.5em; // The width of the icon is half of its own font size
-@moon-video-feedback-icon-font-size:               3em; // For most icons; The icon size is 3 times the nearby text font size, so the icon is big enough to visually match
-@moon-video-feedback-icon-shrunken-size:           2em; // For play and pause icons, the em value is smaller since these glyphs are larger scale than the others.
+@moon-video-feedback-icon-font-size:               2em;
 @moon-video-feedback-mini-font-family:             @moon-alt-font-family;
 @moon-video-feedback-mini-font-weight:             bold;
 @moon-video-feedback-mini-font-style:              normal;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Before moonstone.ttf is changed recently, 
font size of PLAY, PAUSE dingbat was larger than the others.
After moonstone.ttf is changed, All fonts have been changed to the same size.
Therefore, font-size needs to be adjusted.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As a result of asking GUI member's review, I received  result that 2em is appropriate.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
[ENYO-6314]

### Comments
