### PR TITLE
PLAT-87182: Update Enact to use updated ResBundle basepath format

### DIFF
--- a/docs/migration/enact/migrating-to-enact-3.md
+++ b/docs/migration/enact/migrating-to-enact-3.md
@@ -21,13 +21,13 @@ Apps that use `@enact/i18n` must install `ilib` as a dependency.  This includes 
 
 #### Example
 ```bash
-npm install ilib@^14.2.0 --save
+npm install ilib@^14.4.0 --save
 ```
 webOS TV developers can optionally use an alias for `ilib` that will provide the webOS-specific locale data for local development.  It is not required as the webOS build tools will automatically provide the correct locale data at build time.  Alias support is in `npm` version `6.9.0` or greater.
 
 #### Example
 ```bash
-npm install ilib@ilib-webos-tv@^14.2.0-webostv.1 --save
+npm install ilib@ilib-webos-tv@^14.4.0-webostv.1 --save
 ```
 
 Import references using `@enact/i18n/ilib` must be updated to use `ilib`.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ilib` peer dependency to `^14.4.0 || ^14.4.0-webostv1` baseline to target support for caching improvements.
+
 ## [3.1.3] - 2019-10-09
 
 No significant changes.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -49,9 +49,9 @@
     "xhr": "^2.4.1"
   },
   "peerDependencies": {
-    "ilib": "^14.2.0 || ^14.2.0-webostv1"
+    "ilib": "^14.4.0 || ^14.4.0-webostv1"
   },
   "devDependencies": {
-    "ilib": "^14.2.0"
+    "ilib": "^14.4.0"
   }
 }

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -108,10 +108,12 @@ EnyoLoader.prototype._pathjoin = function (_root, subpath) {
  *
  * @returns {Promise}
  */
-EnyoLoader.prototype._loadFilesAsync = function (path, params, cache) {
+EnyoLoader.prototype._loadFilesAsync = function (path, params, cache, rootPath) {
 	let _root = iLibResources;
-	if (params && typeof params.root !== 'undefined') {
-		_root = params.root;
+	if (typeof rootPath !== 'undefined') {
+		_root = rootPath;
+	} else if (params && typeof params.root !== 'undefined') {
+		_root = params.root; // Deprecated; to be removed in future
 	}
 	let cacheItem = cache.data.shift(),
 		url;
@@ -191,8 +193,13 @@ EnyoLoader.prototype._validateCache = function () {
 	this._cacheValidated = true;
 };
 
-EnyoLoader.prototype.loadFiles = function (paths, sync, params, callback) {
-	let _root = (params && typeof params.root !== 'undefined') ? params.root : iLibResources;
+EnyoLoader.prototype.loadFiles = function (paths, sync, params, callback, rootPath) {
+	let _root = iLibResources;
+	if (typeof rootPath !== 'undefined') {
+		_root = rootPath;
+	} else if (params && typeof params.root !== 'undefined') {
+		_root = params.root; // Deprecated; to be removed in future
+	}
 	let cache = {data: this._loadFilesCache(_root, paths)};
 	if (sync) {
 		let ret = [];

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `ilib` peer dependency to `^14.4.0 || ^14.4.0-webostv1` baseline to target support for caching improvements.
+
 ### Fixed
 
 - `moonstone/Icon` icon sizes

--- a/packages/moonstone/internal/$L/$L.js
+++ b/packages/moonstone/internal/$L/$L.js
@@ -32,8 +32,10 @@ function createResBundle (options) {
 	if (typeof ILIB_MOONSTONE_PATH !== 'undefined') {
 		opts = {
 			loadParams: {
+				// Deprecated; to be removed in future
 				root: ILIB_MOONSTONE_PATH
 			},
+			basePath: ILIB_MOONSTONE_PATH
 			...options
 		};
 	}

--- a/packages/moonstone/internal/$L/$L.js
+++ b/packages/moonstone/internal/$L/$L.js
@@ -35,7 +35,7 @@ function createResBundle (options) {
 				// Deprecated; to be removed in future
 				root: ILIB_MOONSTONE_PATH
 			},
-			basePath: ILIB_MOONSTONE_PATH
+			basePath: ILIB_MOONSTONE_PATH,
 			...options
 		};
 	}

--- a/packages/moonstone/package.json
+++ b/packages/moonstone/package.json
@@ -42,9 +42,9 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "ilib": "^14.2.0 || ^14.2.0-webostv1"
+    "ilib": "^14.4.0 || ^14.4.0-webostv1"
   },
   "devDependencies": {
-    "ilib": "^14.2.0"
+    "ilib": "^14.4.0"
   }
 }

--- a/packages/sampler/CHANGELOG.md
+++ b/packages/sampler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact Sampler, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ilib` dependency to `^14.4.0` baseline to target support for caching improvements.
+
 ## [3.1.3] - 2019-10-09
 
 No significant changes.

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -24,7 +24,7 @@
     "@enact/ui": "^3.1.3",
     "@enact/webos": "^3.1.3",
     "classnames": "^2.2.6",
-    "ilib": "^14.2.0",
+    "ilib": "^14.4.0",
     "query-string": "^6.7.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* iLib 14.4.0 introduces new handling to ResBundle pathing in its cache. Specifically, added support for `basePath` ResBundle parameter as well as passing a root path argument in the Loader functions.

### Resolution
* Adds support for new iLib format, while still providing backward support for older copies of iLib temporarily.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>