### PR TITLE
ENYO-6318: Fix mediaTitle to adjust horizontal alignment

### DIFF
--- a/packages/moonstone/VideoPlayer/VideoPlayer.module.less
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.module.less
@@ -104,8 +104,9 @@
 						}
 
 						.moon-locale-non-latin({
-							bottom: 5px;
-							line-height: @moon-non-latin-header-line-height;
+							// The font-size .times is the same as .title in non-latin locales so no
+							// vertical adjustment is required to align their baselines
+							bottom: 0px;
 						});
 					}
 

--- a/packages/moonstone/VideoPlayer/VideoPlayer.module.less
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.module.less
@@ -103,7 +103,10 @@
 							transform: translateY(~"calc(var(--infoComponentsOffset) * -1)") translateZ(0);
 						}
 
-						.moon-locale-non-latin({line-height: @moon-non-latin-header-line-height;});
+						.moon-locale-non-latin({
+							bottom: 5px;
+							line-height: @moon-non-latin-header-line-height;
+						});
 					}
 
 					// Badges and title components


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is horizontal alignment issue between title and playing time.
The title has `bottom: -5px`.
I think that It is intended to be horizontally aligned with the baseline of the font.
But there is a problem in non latin languages.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
title has bottom: 5px in non latin languages

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
[ENYO-6318]

### Comments
