### PR TITLE
ENYO-6316: Fix Marquee to start on focus when disabled

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to start on focus when disabled
+
 ## [3.1.3] - 2019-10-09
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -178,18 +178,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			children: PropTypes.node,
 
 			/**
-			 * Passed through to the wrapped component.
-			 *
-			 * Does not affect Marquee behavior except that components that are `marqueeOn="focus"`
-			 * will be treated as if they were `marqueeOn="hover"`, to allow disabled (and thus,
-			 * unfocusable) components to marquee.
-			 *
-			 * @type {Boolean}
-			 * @public
-			 */
-			disabled: PropTypes.bool,
-
-			/**
 			 * Forces the `direction` of the marquee.
 			 *
 			 * Valid values are `'rtl'` and `'ltr'`. This includes non-text elements as well.
@@ -787,7 +775,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {
 				alignment,
 				children,
-				disabled,
 				marqueeOn,
 				marqueeSpeed,
 				...rest
@@ -824,7 +811,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			delete rest.rtl;
 
 			return (
-				<Wrapped {...rest} onBlur={this.handleBlur} disabled={disabled}>
+				<Wrapped {...rest} onBlur={this.handleBlur}>
 					<MarqueeComponent
 						alignment={alignment}
 						animating={this.state.animating}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -730,8 +730,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forwardBlur(ev, this.props);
 			if (this.isFocused) {
 				this.isFocused = false;
-				if (!this.sync &&
-						!(this.isHovered && (this.props.disabled || this.props.marqueeOn === 'hover'))) {
+				if (!this.sync && !(this.isHovered && this.props.marqueeOn === 'hover')) {
 					this.cancelAnimation();
 				}
 			}
@@ -739,7 +738,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleEnter = (ev) => {
 			this.isHovered = true;
-			if (this.props.disabled || this.props.marqueeOn === 'hover') {
+			if (this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.enter(this);
 				} else if (!this.state.animating) {
@@ -763,7 +762,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleUnhover () {
 			this.isHovered = false;
-			if (this.props.disabled || this.props.marqueeOn === 'hover') {
+			if (this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.leave(this);
 				} else {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -340,7 +340,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			const {children, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
+			const {children, disabled, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
 
 			let forceRestartMarquee = false;
 
@@ -365,7 +365,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				prevProps.forceDirection !== forceDirection
 			) {
 				this.cancelAnimation();
-			} else if (this.isHovered && marqueeOn === 'focus' && this.sync) {
+			} else if (disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
 			}
 
@@ -448,12 +448,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {Boolean} - `true` if a possible marquee condition exists
 		 */
 		shouldStartMarquee () {
-			const {marqueeDisabled, marqueeOn} = this.props;
+			const {disabled, marqueeDisabled, marqueeOn} = this.props;
 			return !marqueeDisabled && (
 				marqueeOn === 'render' ||
 				!this.sync && (
-					(this.isFocused && marqueeOn === 'focus') ||
-					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus'))
+					(this.isFocused && marqueeOn === 'focus' && !disabled) ||
+					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus' && disabled))
 				)
 			);
 		}
@@ -719,7 +719,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.isFocused) {
 				this.isFocused = false;
 				if (!this.sync &&
-						!(this.isHovered && (this.props.marqueeOn === 'hover'))) {
+						!(this.isHovered && (this.props.disabled || this.props.marqueeOn === 'hover'))) {
 					this.cancelAnimation();
 				}
 			}
@@ -727,7 +727,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleEnter = (ev) => {
 			this.isHovered = true;
-			if (this.props.marqueeOn === 'hover') {
+			if (this.props.disabled || this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.enter(this);
 				} else if (!this.state.animating) {
@@ -751,7 +751,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleUnhover () {
 			this.isHovered = false;
-			if (this.props.marqueeOn === 'hover') {
+			if (this.props.disabled || this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.leave(this);
 				} else {

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -178,6 +178,18 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			children: PropTypes.node,
 
 			/**
+			 * Passed through to the wrapped component.
+			 *
+			 * Does not affect Marquee behavior except that components that are `marqueeOn="focus"`
+			 * will be treated as if they were `marqueeOn="hover"`, to allow disabled (and thus,
+			 * unfocusable) components to marquee.
+			 *
+			 * @type {Boolean}
+			 * @public
+			 */
+			disabled: PropTypes.bool,
+
+			/**
 			 * Forces the `direction` of the marquee.
 			 *
 			 * Valid values are `'rtl'` and `'ltr'`. This includes non-text elements as well.
@@ -775,6 +787,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {
 				alignment,
 				children,
+				disabled,
 				marqueeOn,
 				marqueeSpeed,
 				...rest
@@ -811,7 +824,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			delete rest.rtl;
 
 			return (
-				<Wrapped {...rest} onBlur={this.handleBlur}>
+				<Wrapped {...rest} onBlur={this.handleBlur} disabled={disabled}>
 					<MarqueeComponent
 						alignment={alignment}
 						animating={this.state.animating}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -753,7 +753,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const marqueeOnHover = marqueeOn === 'hover';
 			const marqueeOnRender = marqueeOn === 'render';
 
-			if (marqueeOnFocus && !disabled) {
+			if (marqueeOnFocus) {
 				rest[focus] = this.handleFocus;
 			}
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -352,7 +352,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			const {children, disabled, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
+			const {children, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
 
 			let forceRestartMarquee = false;
 
@@ -377,7 +377,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				prevProps.forceDirection !== forceDirection
 			) {
 				this.cancelAnimation();
-			} else if (disabled && this.isHovered && marqueeOn === 'focus' && this.sync) {
+			} else if (this.isHovered && marqueeOn === 'focus' && this.sync) {
 				this.context.enter(this);
 			}
 
@@ -460,12 +460,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {Boolean} - `true` if a possible marquee condition exists
 		 */
 		shouldStartMarquee () {
-			const {disabled, marqueeDisabled, marqueeOn} = this.props;
+			const {marqueeDisabled, marqueeOn} = this.props;
 			return !marqueeDisabled && (
 				marqueeOn === 'render' ||
 				!this.sync && (
-					(this.isFocused && marqueeOn === 'focus' && !disabled) ||
-					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus' && disabled))
+					(this.isFocused && marqueeOn === 'focus') ||
+					(this.isHovered && (marqueeOn === 'hover' || marqueeOn === 'focus'))
 				)
 			);
 		}
@@ -731,7 +731,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.isFocused) {
 				this.isFocused = false;
 				if (!this.sync &&
-						!(this.isHovered && (this.props.disabled || this.props.marqueeOn === 'hover'))) {
+						!(this.isHovered && (this.props.marqueeOn === 'hover'))) {
 					this.cancelAnimation();
 				}
 			}
@@ -739,7 +739,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleEnter = (ev) => {
 			this.isHovered = true;
-			if (this.props.disabled || this.props.marqueeOn === 'hover') {
+			if (this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.enter(this);
 				} else if (!this.state.animating) {
@@ -763,7 +763,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleUnhover () {
 			this.isHovered = false;
-			if (this.props.disabled || this.props.marqueeOn === 'hover') {
+			if (this.props.marqueeOn === 'hover') {
 				if (this.sync) {
 					this.context.leave(this);
 				} else {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focusing a disabled marquee element does not start marquee

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the `!disabled` check in `MarqueeDecorator`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This matches `MarqueeController` which already allowed marqueeing when it was disabled. This regression is a hold over from the change to allow focusing disabled elements.
