### PR TITLE
ENYO-6322: Fixed a list to render different sized items properly in RTL locales

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualList` to render different sized items properly in RTL locales
+
 ## [3.2.0] - 2019-10-18
 
 ### Added

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -919,10 +919,11 @@ const VirtualListBaseFactory = (type) => {
 				childNode = this.itemContainerRef.current.children[index % numOfItems];
 
 			if (childNode && itemPositions[index]) {
+				const position = itemPositions[index].position;
 				if (direction === 'vertical') {
-					childNode.style.transform = `translate3d(0, ${itemPositions[index].position}px, 0)`;
+					childNode.style.transform = `translate3d(0, ${position}px, 0)`;
 				} else {
-					childNode.style.transform = `translate3d(${itemPositions[index].position}px, 0, 0)`;
+					childNode.style.transform = `translate3d(${position * (this.props.rtl ? -1 : 1)}px, 0, 0)`;
 				}
 			}
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In RTL locales, different sized items are not displayed on the screen.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Missing logic to position items in RTL locales is added.

### Links
[//]: # (Related issues, references)
ENYO-6322
