### PR TITLE
PLAT-84350: Fix EditableIntegerPicker to include the `unit` in the ARIA read out

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Icon` icon sizes
 - `moonstone/InputSpotlightDecorator` to not focus when Spotlight is paused
+- `moonstone/EditableIntegerPicker` prop `unit` to set the aria-valuetext after value
 
 ## [3.1.3] - 2019-10-09
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/EditableIntegerPicker` prop `unit` to set the aria-valuetext after value
+- `moonstone/EditableIntegerPicker` to include the `unit` in the ARIA read out
 
 ## [3.2.0] - 2019-10-18
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/EditableIntegerPicker` prop `unit` to set the aria-valuetext after value
+
 ## [3.2.0] - 2019-10-18
 
 ### Added
@@ -16,7 +22,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 - `moonstone/Icon` icon sizes
 - `moonstone/InputSpotlightDecorator` to not focus when Spotlight is paused
-- `moonstone/EditableIntegerPicker` prop `unit` to set the aria-valuetext after value
 
 ## [3.1.3] - 2019-10-09
 

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -301,12 +301,12 @@ const EditableIntegerPickerBase = kind({
 				</PickerItem>
 			);
 		},
-		ariaLabel: ({unit, value}) => unit ? `${value} ${unit}` : null,
+		ariaValueText: ({unit, value}) => unit ? `${value} ${unit}` : null,
 		className: ({className, editMode, styler}) => editMode ? styler.append({editMode}) : className,
 		disabled: ({disabled, max, min}) => min >= max ? true : disabled
 	},
 
-	render: ({ariaLabel, pickerRef, ...rest}) => {
+	render: ({ariaValueText, pickerRef, ...rest}) => {
 		delete rest.editMode;
 		delete rest.inputRef;
 		delete rest.onInputBlur;
@@ -315,7 +315,7 @@ const EditableIntegerPickerBase = kind({
 		delete rest.unit;
 
 		return (
-			<Picker aria-valuetext={ariaLabel} {...rest} index={0} ref={pickerRef} />
+			<Picker aria-valuetext={ariaValueText} {...rest} index={0} ref={pickerRef} />
 		);
 	}
 });

--- a/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
+++ b/packages/moonstone/EditableIntegerPicker/EditableIntegerPicker.js
@@ -301,11 +301,12 @@ const EditableIntegerPickerBase = kind({
 				</PickerItem>
 			);
 		},
+		ariaLabel: ({unit, value}) => unit ? `${value} ${unit}` : null,
 		className: ({className, editMode, styler}) => editMode ? styler.append({editMode}) : className,
 		disabled: ({disabled, max, min}) => min >= max ? true : disabled
 	},
 
-	render: ({pickerRef, ...rest}) => {
+	render: ({ariaLabel, pickerRef, ...rest}) => {
 		delete rest.editMode;
 		delete rest.inputRef;
 		delete rest.onInputBlur;
@@ -314,7 +315,7 @@ const EditableIntegerPickerBase = kind({
 		delete rest.unit;
 
 		return (
-			<Picker {...rest} index={0} ref={pickerRef} />
+			<Picker aria-valuetext={ariaLabel} {...rest} index={0} ref={pickerRef} />
 		);
 	}
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
TV does not read out strings of `unit` prop after `value` string


### Resolution
Set the string of `unit` prop to aria-valuetext of EditableIntegerPicker


### Additional Considerations

### Links
PLAT-84350

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)