### PR TITLE
PLAT-88301: Fix scrolling by 5-way key of horizontal lists in RTL locales

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` not to scroll to horizontally wrong position via 5-way navigation in RTL languages
+- `moonstone/VirtualList` horizontal scrolling in RTL locales
 
 ## [3.2.0] - 2019-10-18
 

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/VirtualList.VirtualGridList` and `moonstone/VirtualList.VirtualList` not to scroll to horizontally wrong position via 5-way navigation in RTL languages
+
 ## [3.2.0] - 2019-10-18
 
 ### Added

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -777,14 +777,14 @@ const VirtualListBaseFactory = (type) => {
 		// Native only
 		scrollToPosition (x, y, rtl = this.props.rtl) {
 			if (this.containerRef.current) {
-				if (rtl) {
-					x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
-				}
-
 				if (this.isPrimaryDirectionVertical) {
 					this.scrollPositionTarget = y;
 				} else {
 					this.scrollPositionTarget = x;
+				}
+
+				if (rtl) {
+					x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
 				}
 
 				this.containerRef.current.scrollTo(x, y);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When 5-way key input invokes scrolling by crossing the edge of horizontal lists, a list scrolls too far so the focused item is located on the other edge.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed lists to cache a right value for the scroll position in RTL cases.

### Links
[//]: # (Related issues, references)
PLAT-88301
