### PR TITLE
ENYO-6334: Fix to round spacing downward to its nearest integer

### DIFF
--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -550,14 +550,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (typeof marqueeSpacing === 'string') {
 				if (/^\d+(\.\d+)?%$/.test(marqueeSpacing)) {
-					return width * Number.parseFloat(marqueeSpacing) / 100;
+					return Math.floor(width * Number.parseFloat(marqueeSpacing) / 100);
 				}
 
 				// warning for invalid string value;
 				return 0;
 			}
 
-			return scale(marqueeSpacing);
+			return Math.floor(scale(marqueeSpacing));
 		}
 
 		/*


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Text shakes before the restart animation with odd `width`
`spacing` can be calculated with a decimal point.
This causes `transition` using the decimal point value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix to round `spacing` downward to its nearest integer using `Math.floor`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6334

### Comments
