### PR TITLE
ENYO-6334: Fix marquee text alignment on restart

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` text alignment when restarting
+
 ## [3.2.2] - 2019-10-24
 
 No significant changes.

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -11,6 +11,7 @@
 	// -webkit-line-clamp: 1;
 
 	--ui-marquee-spacing: 0;
+	--ui-marquee-offset: 0;
 
 	width: auto;
 	white-space: pre !important;
@@ -38,7 +39,7 @@
 
 		.spacing {
 			display: inline-block;
-			width: calc(1px * var(--ui-marquee-spacing, 0));
+			width: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 		}
 	}
 

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -38,6 +38,7 @@
 		}
 
 		.spacing {
+			display: inline;
 			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 
 			&.rtl {

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -38,7 +38,7 @@
 		}
 
 		.spacing {
-			display: inline-block;
+			display: inline;
 			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 
 			&.rtl {

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -38,6 +38,9 @@
 		}
 
 		.spacing {
+			// inline-block would be better here because it behaves better with punctuation in RTL
+			// locales. However, some versions of chromium (~v72) do not handle `inline-block`
+			// children within `white-space: pre` containers correctly so `inline` is required atm.
 			display: inline;
 			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -14,7 +14,7 @@
 	--ui-marquee-offset: 0;
 
 	width: auto;
-	white-space: pre !important;
+	white-space: nowrap !important;
 	overflow: hidden;
 	text-align: left;
 
@@ -23,7 +23,7 @@
 		text-overflow: ellipsis;
 		overflow: hidden;
 		width: 100%;
-		white-space: pre !important;
+		white-space: nowrap !important;
 		transition-property: left, right;
 		transition-timing-function: linear;
 		position: relative;
@@ -37,17 +37,13 @@
 			/* Public Class Name */
 		}
 
-		.spacing {
-			// inline-block would be better here because it behaves better with punctuation in RTL
-			// locales. However, some versions of chromium (~v72) do not handle `inline-block`
-			// children within `white-space: pre` containers correctly so `inline` is required atm.
-			display: inline;
-			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
+		> * {
+			white-space: pre !important;
+			display: inline-block;
+		}
 
-			&.rtl {
-				padding-left: 0;
-				padding-right: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
-			}
+		.spacing {
+			text-indent: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 		}
 	}
 

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -38,7 +38,6 @@
 		}
 
 		.spacing {
-			display: inline;
 			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 
 			&.rtl {

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -39,7 +39,12 @@
 
 		.spacing {
 			display: inline-block;
-			width: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
+			padding-left: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
+
+			&.rtl {
+				padding-left: 0;
+				padding-right: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
+			}
 		}
 	}
 

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -3,17 +3,24 @@ import {forProp, forward, handle, stop} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Pure from '../internal/Pure';
-
 import componentCss from './Marquee.module.less';
 
 const isEventSource = (ev) => ev.target === ev.currentTarget;
 
-const SpacingBase = kind({
+const Spacing = kind({
 	name: 'Spacing',
 
+	propTypes: {
+		rtl: PropTypes.bool
+	},
+
+	styles: {
+		className: 'spacing',
+		css: componentCss
+	},
+
 	handlers: {
-		ref: (node, props) => {
+		ref: (node) => {
 			if (!node) return;
 
 			const root = node.parentNode;
@@ -27,14 +34,18 @@ const SpacingBase = kind({
 		}
 	},
 
+	computed: {
+		className: ({rtl, styler}) => styler.append({rtl})
+	},
+
 	render: (props) => {
+		delete props.rtl;
+
 		return (
-			<div {...props} />
+			<span {...props} />
 		);
 	}
 });
-
-const Spacing = Pure(SpacingBase);
 
 /**
  * Marquees the children of the component.
@@ -228,14 +239,13 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, ...rest}) => {
+	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, rtl, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
 		delete rest.onMarqueeComplete;
 		delete rest.overflow;
 		delete rest.spacing;
-		delete rest.rtl;
 		delete rest.speed;
 		delete rest.willAnimate;
 
@@ -249,10 +259,9 @@ const MarqueeBase = kind({
 				>
 					{children}
 					{duplicate ? (
-						<React.Fragment>
-							<Spacing className={css.spacing} />
+						<Spacing rtl={rtl}>
 							{children}
-						</React.Fragment>
+						</Spacing>
 					) : null}
 				</div>
 			</div>

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -211,7 +211,7 @@ const MarqueeBase = kind({
 			text: true,
 			willAnimate
 		}),
-		clientStyle: ({alignment, animating, distance, overflow, spacing, rtl, speed}) => {
+		clientStyle: ({alignment, animating, distance, overflow, rtl, spacing, speed}) => {
 			// If the components content directionality doesn't match the context, we need to set it
 			// inline
 			const direction = rtl ? 'rtl' : 'ltr';

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -7,45 +7,18 @@ import componentCss from './Marquee.module.less';
 
 const isEventSource = (ev) => ev.target === ev.currentTarget;
 
-const Spacing = kind({
-	name: 'Spacing',
+const applyOffset = (node) => {
+	if (!node || !global.IntersectionObserver) return;
 
-	propTypes: {
-		rtl: PropTypes.bool
-	},
+	const root = node.parentNode;
+	new global.IntersectionObserver(function (entries, observer) {
+		const {left} = entries[0].boundingClientRect;
+		const offset = Math.round(left) - left;
+		node.style.setProperty('--ui-marquee-offset', offset);
 
-	styles: {
-		className: 'spacing',
-		css: componentCss
-	},
-
-	handlers: {
-		ref: (node) => {
-			if (!node || !global.IntersectionObserver) return;
-
-			const root = node.parentNode;
-			new global.IntersectionObserver(function (entries, observer) {
-				const {left} = entries[0].boundingClientRect;
-				const offset = Math.round(left) - left;
-				node.style.setProperty('--ui-marquee-offset', offset);
-
-				observer.disconnect();
-			}, {root}).observe(node);
-		}
-	},
-
-	computed: {
-		className: ({rtl, styler}) => styler.append({rtl})
-	},
-
-	render: (props) => {
-		delete props.rtl;
-
-		return (
-			<span {...props} />
-		);
-	}
-});
+		observer.disconnect();
+	}, {root}).observe(node);
+};
 
 /**
  * Marquees the children of the component.
@@ -239,12 +212,13 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, duplicate, onMarqueeComplete, rtl, ...rest}) => {
+	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
 		delete rest.onMarqueeComplete;
 		delete rest.overflow;
+		delete rest.rtl;
 		delete rest.spacing;
 		delete rest.speed;
 		delete rest.willAnimate;
@@ -257,11 +231,11 @@ const MarqueeBase = kind({
 					style={clientStyle}
 					onTransitionEnd={onMarqueeComplete}
 				>
-					{children}
+					<span>{children}</span>
 					{duplicate ? (
-						<Spacing rtl={rtl}>
+						<span className={css.spacing} ref={applyOffset}>
 							{children}
-						</Spacing>
+						</span>
 					) : null}
 				</div>
 			</div>

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -3,9 +3,38 @@ import {forProp, forward, handle, stop} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Pure from '../internal/Pure';
+
 import componentCss from './Marquee.module.less';
 
 const isEventSource = (ev) => ev.target === ev.currentTarget;
+
+const SpacingBase = kind({
+	name: 'Spacing',
+
+	handlers: {
+		ref: (node, props) => {
+			if (!node) return;
+
+			const root = node.parentNode;
+			new IntersectionObserver(function (entries, observer) {
+				const {left} = entries[0].boundingClientRect;
+				const offset = Math.round(left) - left;
+				node.style.setProperty('--ui-marquee-offset', offset);
+
+				observer.disconnect();
+			}, {root}).observe(node);
+		}
+	},
+
+	render: (props) => {
+		return (
+			<div {...props} />
+		);
+	}
+});
+
+const Spacing = Pure(SpacingBase);
 
 /**
  * Marquees the children of the component.
@@ -179,6 +208,7 @@ const MarqueeBase = kind({
 			const style = {
 				'--ui-marquee-spacing': spacing,
 				direction,
+				[sideProperty]: 0,
 				textAlign: alignment,
 				textOverflow: overflow
 			};
@@ -188,8 +218,6 @@ const MarqueeBase = kind({
 
 				style[sideProperty] = `${distance}px`;
 				style.transitionDuration = `${duration}s`;
-			} else {
-				style[sideProperty] = 0;
 			}
 
 			return style;
@@ -199,7 +227,7 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, ...rest}) => {
+	render: ({children, clientClassName, clientRef, clientStyle, css, io, duplicate, onMarqueeComplete, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
@@ -218,13 +246,13 @@ const MarqueeBase = kind({
 					style={clientStyle}
 					onTransitionEnd={onMarqueeComplete}
 				>
-					{children}
 					{duplicate ? (
 						<React.Fragment>
-							<div className={css.spacing} />
 							{children}
+							<Spacing className={css.spacing} />
 						</React.Fragment>
 					) : null}
+					{children}
 				</div>
 			</div>
 		);

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -21,10 +21,10 @@ const Spacing = kind({
 
 	handlers: {
 		ref: (node) => {
-			if (!node) return;
+			if (!node || !global.IntersectionObserver) return;
 
 			const root = node.parentNode;
-			new IntersectionObserver(function (entries, observer) {
+			new global.IntersectionObserver(function (entries, observer) {
 				const {left} = entries[0].boundingClientRect;
 				const offset = Math.round(left) - left;
 				node.style.setProperty('--ui-marquee-offset', offset);

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -239,7 +239,7 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, rtl, ...rest}) => {
+	render: ({children, clientClassName, clientRef, clientStyle, duplicate, onMarqueeComplete, rtl, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -208,7 +208,6 @@ const MarqueeBase = kind({
 			const style = {
 				'--ui-marquee-spacing': spacing,
 				direction,
-				[sideProperty]: 0,
 				textAlign: alignment,
 				textOverflow: overflow
 			};
@@ -218,6 +217,8 @@ const MarqueeBase = kind({
 
 				style[sideProperty] = `${distance}px`;
 				style.transitionDuration = `${duration}s`;
+			} else {
+				style[sideProperty] = 0;
 			}
 
 			return style;
@@ -227,7 +228,7 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({children, clientClassName, clientRef, clientStyle, css, io, duplicate, onMarqueeComplete, ...rest}) => {
+	render: ({children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
@@ -246,13 +247,13 @@ const MarqueeBase = kind({
 					style={clientStyle}
 					onTransitionEnd={onMarqueeComplete}
 				>
+					{children}
 					{duplicate ? (
 						<React.Fragment>
-							{children}
 							<Spacing className={css.spacing} />
+							{children}
 						</React.Fragment>
 					) : null}
-					{children}
 				</div>
 			</div>
 		);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -683,6 +683,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// If we're already timing a start action, don't reset.  Start actions will clear us if
 			// sync.
 			if (this.timerState === TimerState.CLEAR) {
+				// If invoked immediately, the setState call in restartAnimation is batched and will
+				// break any non-marquee-on-render instances because the subsequent startAnimation
+				// isn't invoked. By setting a brief timeout, we decouple from the `onTransitionEnd`
+				// event and setState is synchronous allowing the startAnimation to be called
+				// immediately.
+				//
+				// This would be better moved into componentDidUpdate with more expansive state
+				// values to indicate we need to reset an animation vs starting fresh.
 				this.setTimeout(() => {
 					this.restartAnimation(delay);
 				}, 0, TimerState.RESET_PENDING);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -550,14 +550,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (typeof marqueeSpacing === 'string') {
 				if (/^\d+(\.\d+)?%$/.test(marqueeSpacing)) {
-					return Math.floor(width * Number.parseFloat(marqueeSpacing) / 100);
+					return width * Number.parseFloat(marqueeSpacing) / 100;
 				}
 
 				// warning for invalid string value;
 				return 0;
 			}
 
-			return Math.floor(scale(marqueeSpacing));
+			return scale(marqueeSpacing);
 		}
 
 		/*

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -661,7 +661,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 *
 		 * @returns {undefined}
 		 */
-		restartAnimation = () => {
+		restartAnimation = (delay) => {
 			this.setState({
 				animating: false
 			});
@@ -669,7 +669,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.sync) {
 				this.context.complete(this);
 			} else if (!this.state.animating) {
-				this.startAnimation();
+				this.startAnimation(delay);
 			}
 		}
 
@@ -679,11 +679,13 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		resetAnimation = () => {
-			const marqueeResetDelay = Math.max(40, this.props.marqueeResetDelay);
+			const delay = Math.max(40, this.props.marqueeResetDelay + this.props.marqueeDelay);
 			// If we're already timing a start action, don't reset.  Start actions will clear us if
 			// sync.
 			if (this.timerState === TimerState.CLEAR) {
-				this.setTimeout(this.restartAnimation, marqueeResetDelay, TimerState.RESET_PENDING);
+				this.setTimeout(() => {
+					this.restartAnimation(delay);
+				}, 0, TimerState.RESET_PENDING);
 			}
 		}
 

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -287,7 +287,7 @@ describe('MarqueeBase', () => {
 	});
 
 	test('should duplicate from content when promoted and a non-zero distance', () => {
-		const subject = mount(
+		const subject = shallow(
 			<MarqueeBase willAnimate distance={100}>
 				Text
 			</MarqueeBase>
@@ -298,7 +298,7 @@ describe('MarqueeBase', () => {
 	});
 
 	test('should not duplicate from content when promoted and a zero distance', () => {
-		const subject = mount(
+		const subject = shallow(
 			<MarqueeBase willAnimate distance={0}>
 				Text
 			</MarqueeBase>

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -287,7 +287,7 @@ describe('MarqueeBase', () => {
 	});
 
 	test('should duplicate from content when promoted and a non-zero distance', () => {
-		const subject = shallow(
+		const subject = mount(
 			<MarqueeBase willAnimate distance={100}>
 				Text
 			</MarqueeBase>
@@ -298,7 +298,7 @@ describe('MarqueeBase', () => {
 	});
 
 	test('should not duplicate from content when promoted and a zero distance', () => {
-		const subject = shallow(
+		const subject = mount(
 			<MarqueeBase willAnimate distance={0}>
 				Text
 			</MarqueeBase>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Uses IntersectionObserver on the spacer to calculate the subpixel offset missed by `scrollWidth` and adjust the width by that amount.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
