### PR TITLE
ENYO-6338: Change default value of marqueeOn for Header

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `moonstone/Panels.Header` prop `marqueeOn` default value to `'render'` to improve usability on systems without a pointer
+
 ## [3.2.2] - 2019-10-24
 
 ### Fixed

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -179,7 +179,7 @@ const HeaderBase = kind({
 
 	defaultProps: {
 		fullBleed: false,
-		marqueeOn: 'hover',
+		marqueeOn: 'render',
 		// titleAbove: '00',
 		type: 'standard'
 	},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Hyeok Jo <hyeok.jo@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For models without the Magic Motion remote control, there is no way to start marquee animation if marqueeOn is 'hover'

I contacted the app developers and found that the hover is not required.
So the app developers need to change the 'hover' to 'render'.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I think it's also a way to change default value in the framework so that all apps are applied in batches.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6338

### Comments
