### PR TITLE
ENYO-6325: Fix Marquee to show ellipsis when content changes

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee` to display ellipsis when its content changes and overflows its bounds
+- `ui/Marquee` to display an ellipsis when its content changes and overflows its bounds
 
 ## [3.2.2] - 2019-10-24
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to display ellipsis when its content changes and overflows its bounds
+
 ## [3.2.2] - 2019-10-24
 
 No significant changes.

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -483,7 +483,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.contentFits = false;
 
 			this.setState(state => {
-				return state.overflow === 'ellipsis' ? null : {overflow: 'ellipsis'};
+				if (state.overflow === 'ellipsis' && state.promoted === false) return null;
+
+				return {
+					overflow: 'ellipsis',
+					promoted: false
+				};
 			});
 		}
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When changing the content of a Marquee when it had been promoted, the text would not be truncated with an ellipsis.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The logic was close before in that we called `cancelAnimation()` when the content changed which would start the demote job. However, in cases where we immediately restart marquee on update (render, hover when hovered, focus when focused) the demote job is stopped by the promote job so `promoted` was never reset.

The proposed fix resets `promoted` to `false` when invalidating metrics to ensure it's in the correct state. It will then be re-promoted later just before the animation starts as designed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The underlying issue existed before but manifested now due to the change in Marquee to maintain the clipped text when restarting marquee. Previously, the layer would have remained promoted (and therefore add the `willAnimate` class) but the text would still have been truncated with an ellipsis due to the prior CSS.
