### PR TITLE
PLAT-86868: Fixed Routable.Linkable to properly support event forwarding

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee` to display an ellipsis when its content changes and overflows its bounds
-- `ui/Routable.Linkable` to properly support event forwarding
 
 ## [3.2.2] - 2019-10-24
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee` to display an ellipsis when its content changes and overflows its bounds
+- `ui/Routable.Linkable` to properly support event forwarding
 
 ## [3.2.2] - 2019-10-24
 

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -46,9 +46,12 @@ const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
 		},
 
 		handlers: {
-			[navigate]: (ev, {path}, {navigate: nav}) => {
-				if (nav) nav({path});
-			}
+			[navigate]: handle(
+				forward(navigate),
+				(ev, {path}, {navigate: nav}) => {
+					if (nav) nav({path});
+				}
+			)
 		},
 
 		render: (props) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Linkable` doesn't support adding your own event handler, as it's clobbered by Linkable's own event handler.


### Resolution
Consumer-provided events are now _also_ fired, as expected, like in the rest of the framework.