### PR TITLE
PLAT-90767: The POC to resize the VirtualList depending on the scroll position

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -46,15 +46,6 @@ class ScrollButtons extends Component {
 
 	static propTypes = /** @lends moonstone/Scrollable.ScrollButtons.prototype */ {
 		/**
-		 * The render function for thumb.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		thumbRenderer: PropTypes.func.isRequired,
-
-		/**
 		 * Called to alert the user for accessibility notifications.
 		 *
 		 * @type {Function}
@@ -141,6 +132,15 @@ class ScrollButtons extends Component {
 		 * @private
 		 */
 		rtl: PropTypes.bool,
+
+		/**
+		 * The render function for thumb.
+		 *
+		 * @type {Function}
+		 * @required
+		 * @private
+		 */
+		thumbRenderer: PropTypes.func,
 
 		/**
 		 * The scrollbar will be oriented vertically.
@@ -355,7 +355,7 @@ class ScrollButtons extends Component {
 
 	render () {
 		const
-			{disabled, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
+			{disabled, nextButtonAriaLabel, overSize, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
 			prevIcon = preparePrevButton(vertical),
 			nextIcon = prepareNextButton(vertical);
@@ -373,7 +373,7 @@ class ScrollButtons extends Component {
 			>
 				{prevIcon}
 			</ScrollButton>,
-			thumbRenderer(),
+			thumbRenderer ? thumbRenderer() : null,
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -519,7 +519,9 @@ class ScrollableBase extends Component {
 			this.alertThumb();
 		}
 
-		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || isDragging)) {
+		// Temporary fix to allow to scroll by focus in PC.
+		// This fix should be removed when adapting the POC to `develop` branch.
+		if (!(/*shouldPreventScrollByFocus ||*/ Spotlight.getPointerMode() || isDragging)) {
 			const
 				item = ev.target,
 				spotItem = Spotlight.getCurrent();
@@ -995,14 +997,7 @@ class ScrollableBase extends Component {
 					scrollTo,
 					style,
 					verticalScrollbarProps
-				}) => {
-				const
-					{direction} = this.props,
-					containerStyle = overSize && (direction == 'vertical' || direction === 'both') ?
-						{height: 'calc(100% + ' + overSize + 'px)'} :
-						null;
-
-				return (
+				}) => (
 					<div
 						className={classNames(className, overscrollCss.scrollable)}
 						data-spotlight-container={spotlightContainer}
@@ -1027,8 +1022,7 @@ class ScrollableBase extends Component {
 									ref: this.childRef,
 									rtl,
 									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
-									spotlightId,
-									style: containerStyle
+									spotlightId
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?
@@ -1039,6 +1033,7 @@ class ScrollableBase extends Component {
 									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
+									overSize={overSize}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}
@@ -1062,8 +1057,7 @@ class ScrollableBase extends Component {
 							null
 						}
 					</div>
-				);
-				}}
+				)}
 			/>
 		);
 	}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -990,11 +990,19 @@ class ScrollableBase extends Component {
 					initChildRef: initUiChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
+					overSize,
 					rtl,
 					scrollTo,
 					style,
 					verticalScrollbarProps
-				}) => (
+				}) => {
+				const
+					{direction} = this.props,
+					containerStyle = overSize && (direction == 'vertical' || direction === 'both') ?
+						{height: 'calc(100% + ' + overSize + 'px)'} :
+						null;
+
+				return (
 					<div
 						className={classNames(className, overscrollCss.scrollable)}
 						data-spotlight-container={spotlightContainer}
@@ -1015,10 +1023,12 @@ class ScrollableBase extends Component {
 									isVerticalScrollbarVisible,
 									onScroll: handleScroll,
 									onUpdate: this.handleScrollerUpdate,
+									overSize,
 									ref: this.childRef,
 									rtl,
 									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
-									spotlightId
+									spotlightId,
+									style: containerStyle
 								})}
 							</ChildWrapper>
 							{isVerticalScrollbarVisible ?
@@ -1052,7 +1062,8 @@ class ScrollableBase extends Component {
 							null
 						}
 					</div>
-				)}
+				);
+				}}
 			/>
 		);
 	}

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -112,6 +112,10 @@ class ScrollbarBase extends Component {
 			this.uiUpdate(bounds);
 		};
 		this.focusOnButton = focusOnButton;
+
+		this.syncHeight = (overSize, scrollPosition) => {
+			this.getContainerRef().current.style.height = 'calc(100% - ' + overSize + 'px + ' + scrollPosition + 'px)';
+		}
 	}
 
 	render () {
@@ -159,6 +163,7 @@ const Scrollbar = ApiDecorator(
 		'isOneOfScrollButtonsFocused',
 		'showThumb',
 		'startHidingThumb',
+		'syncHeight',
 		'update'
 	]}, Skinnable(ScrollbarBase)
 );

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -1,5 +1,6 @@
 import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
@@ -94,6 +95,7 @@ class ScrollbarBase extends Component {
 
 		this.scrollbarRef = React.createRef();
 		this.scrollButtonsRef = React.createRef();
+		this.overSizeRef = React.createRef();
 	}
 
 	componentDidMount () {
@@ -114,12 +116,48 @@ class ScrollbarBase extends Component {
 		this.focusOnButton = focusOnButton;
 
 		this.syncHeight = (overSize, scrollPosition) => {
-			this.getContainerRef().current.style.height = 'calc(100% - ' + overSize + 'px + ' + scrollPosition + 'px)';
+			const
+				height = parseInt(window.getComputedStyle(this.overSizeRef.current).getPropertyValue('height')),
+				thumbRef = this.getContainerRef(),
+				nextButtonRef = this.scrollButtonsRef.current.nextButtonRef;
+
+			thumbRef.current.style.transform =
+				'scale3d(1, ' + (height - overSize + scrollPosition - 120) / (height - overSize - 120) + ', 1)';
+			nextButtonRef.current.style.transform =
+				'translate3d(0, ' + (scrollPosition - overSize) + 'px, 0)';
 		}
 	}
 
 	render () {
-		const {cbAlertThumb, clientSize, corner, vertical, ...rest} = this.props;
+		const {cbAlertThumb, clientSize, corner, overSize, vertical, ...rest} = this.props;
+
+		if (overSize) {
+			return (
+				<div className={componentCss.overSize} ref={this.overSizeRef}>
+					<ScrollButtons
+						{...rest}
+						ref={this.scrollButtonsRef}
+						vertical={vertical}
+					/>
+					<UiScrollbarBase
+					corner={corner}
+					clientSize={clientSize}
+					css={componentCss}
+					ref={this.scrollbarRef}
+					style={{height: 'calc(100% - ' + (overSize + 120) + 'px)'}}
+					vertical={vertical}
+					childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
+						<ScrollThumb
+							cbAlertThumb={cbAlertThumb}
+							key="thumb"
+							ref={thumbRef}
+							vertical={vertical}
+						/>
+					)}
+				/>
+				</div>
+			);
+		}
 
 		return (
 			<UiScrollbarBase

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -121,8 +121,11 @@ class ScrollbarBase extends Component {
 				thumbRef = this.getContainerRef(),
 				nextButtonRef = this.scrollButtonsRef.current.nextButtonRef;
 
+			// To scale the thumb height depending on the VirtualList position
 			thumbRef.current.style.transform =
 				'scale3d(1, ' + (height - overSize + scrollPosition - 120) / (height - overSize - 120) + ', 1)';
+
+			// To move the next scroll bar button depending on the VirtualList position
 			nextButtonRef.current.style.transform =
 				'translate3d(0, ' + (scrollPosition - overSize) + 'px, 0)';
 		}

--- a/packages/moonstone/Scrollable/Scrollbar.module.less
+++ b/packages/moonstone/Scrollable/Scrollbar.module.less
@@ -83,10 +83,13 @@
 	width: 60px;
 	height: 100%;
 
+	// previous scroll bar button
 	& > div:first-child {
 		position: relative;
 		margin: 0;
 	}
+
+	// next scroll bar button
 	& > div:nth-child(2) {
 		position: absolute;
 		left: 0;
@@ -94,6 +97,7 @@
 		bottom: 0;
 	}
 
+	// thumb
 	& > div:nth-child(4) {
 		position: relative;
 		will-change: transform;

--- a/packages/moonstone/Scrollable/Scrollbar.module.less
+++ b/packages/moonstone/Scrollable/Scrollbar.module.less
@@ -77,3 +77,26 @@
 		}
 	}
 });
+
+.overSize {
+	position: relative;
+	width: 60px;
+	height: 100%;
+
+	& > div:first-child {
+		position: relative;
+		margin: 0;
+	}
+	& > div:nth-child(2) {
+		position: absolute;
+		left: 0;
+		margin: 0;
+		bottom: 0;
+	}
+
+	& > div:nth-child(4) {
+		position: relative;
+		will-change: transform;
+		transform-origin: top
+	}
+}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -718,6 +718,7 @@ const VirtualListBaseFactory = (type) => {
 				{numOfItems} = this.uiRefCurrent.state,
 				{primary} = this.uiRefCurrent,
 				overSizeOffset = overSize - Math.min(overSize, scrollPosition),
+				// The offset varies depending on the VirtualList position.
 				offsetToClientEnd = primary.clientSize - primary.itemSize - overSizeOffset,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -714,10 +714,11 @@ const VirtualListBaseFactory = (type) => {
 
 		calculatePositionOnFocus = ({item, scrollPosition = this.uiRefCurrent.scrollPosition}) => {
 			const
-				{pageScroll} = this.props,
+				{overSize, pageScroll} = this.props,
 				{numOfItems} = this.uiRefCurrent.state,
 				{primary} = this.uiRefCurrent,
-				offsetToClientEnd = primary.clientSize - primary.itemSize,
+				overSizeOffset = overSize - Math.min(overSize, scrollPosition),
+				offsetToClientEnd = primary.clientSize - primary.itemSize - overSizeOffset,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
 			if (!isNaN(focusedIndex)) {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1051,6 +1051,9 @@ class ScrollableBase extends Component {
 		}
 
 		this.childRefCurrent.setScrollPosition(this.scrollLeft, this.scrollTop, this.props.rtl, ...rest);
+		if (this.scrollTop < this.props.overSize) {
+			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop)
+		}
 		this.forwardScrollEvent('onScroll');
 	}
 
@@ -1323,7 +1326,7 @@ class ScrollableBase extends Component {
 
 	render () {
 		const
-			{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = this.props,
+			{className, containerRenderer, noScrollByDrag, overSize, rtl, style, ...rest} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			scrollableClasses = classNames(css.scrollable, className),
 			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
@@ -1374,6 +1377,7 @@ class ScrollableBase extends Component {
 					initChildRef: this.initChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
+					overSize,
 					rtl,
 					scrollTo: this.scrollTo,
 					style,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1053,6 +1053,8 @@ class ScrollableBase extends Component {
 		this.childRefCurrent.setScrollPosition(this.scrollLeft, this.scrollTop, this.props.rtl, ...rest);
 		if (this.scrollTop < this.props.overSize) {
 			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop)
+		} else {
+			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.props.overSize)
 		}
 		this.forwardScrollEvent('onScroll');
 	}

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -443,6 +443,7 @@ const VirtualListBaseFactory = (type) => {
 		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
+		containerScrollPosition = 0
 		scrollPositionTarget = 0
 
 		// For individually sized item
@@ -793,6 +794,23 @@ const VirtualListBaseFactory = (type) => {
 
 		// JS only
 		setScrollPosition (x, y, rtl = this.props.rtl, targetX = 0, targetY = 0) {
+			if (this.props.overSize && this.isPrimaryDirectionVertical && this.containerRef.current) {
+				if (y < this.props.overSize) {
+					this.containerScrollPosition = y;
+					this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, 0, 0)`;
+
+					return;
+				} else {
+					if (y > this.props.overSize && this.containerScrollPosition < this.props.overSize) {
+						this.containerScrollPosition = this.isPrimaryDirectionVertical ? this.props.overSize : x;
+					}
+
+					if (this.containerScrollPosition > this.props.overSize) {
+						this.containerScrollPosition = this.props.overSize;
+					}
+				}
+			}
+
 			if (this.contentRef.current) {
 				this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -797,6 +797,7 @@ const VirtualListBaseFactory = (type) => {
 			if (this.props.overSize && this.isPrimaryDirectionVertical && this.containerRef.current) {
 				if (y < this.props.overSize) {
 					this.containerScrollPosition = y;
+
 					this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, 0, 0)`;
 
 					return;
@@ -1190,6 +1191,7 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.onUpdate;
 			delete rest.onUpdateItems;
 			delete rest.overhang;
+			delete rest.overSize;
 			delete rest.pageScroll;
 			delete rest.rtl;
 			delete rest.spacing;

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -794,6 +794,8 @@ const VirtualListBaseFactory = (type) => {
 
 		// JS only
 		setScrollPosition (x, y, rtl = this.props.rtl, targetX = 0, targetY = 0) {
+			// if the scrollPosition is less than overSize, then the VirtualList does not scroll.
+			// But the list generates `onScroll` event so that the list could move upper by an App.
 			if (this.props.overSize && this.isPrimaryDirectionVertical && this.containerRef.current) {
 				if (y < this.props.overSize) {
 					this.containerScrollPosition = y;
@@ -908,7 +910,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			this.syncThreshold(maxPos);
-			this.scrollPosition = pos;
+			this.scrollPosition = this.props.overSize ? pos - this.props.overSize : pos;
 			this.updateMoreInfo(dataSize, pos);
 
 			if (this.shouldUpdateBounds || firstIndex !== newFirstIndex) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

TBD
: The POC to resize the VirtualList depending on the scroll position

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

TBD

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When starting scrolling the VirtualList, the list moves upper. I expect that behavior would be implemented by a panel or a the POC controller.  To verify this PC, I implemented that behavior app side. Please use the app described in the JIRA to verify this PR.

### Links
[//]: # (Related issues, references)

PLAT-90767

### Comments
