### PR TITLE
ENYO-6334: Fix Marquee text alignment on restart

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Marquee` text alignment when restarting
 - `ui/Marquee` to display an ellipsis when its content changes and overflows its bounds
 
 ## [3.2.2] - 2019-10-24

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -11,6 +11,7 @@
 	// -webkit-line-clamp: 1;
 
 	--ui-marquee-spacing: 0;
+	--ui-marquee-offset: 0;
 
 	width: auto;
 	white-space: pre !important;
@@ -38,7 +39,7 @@
 
 		.spacing {
 			display: inline-block;
-			width: calc(1px * var(--ui-marquee-spacing, 0));
+			width: calc(1px * (var(--ui-marquee-spacing, 0) + var(--ui-marquee-offset, 0)));
 		}
 	}
 

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -7,6 +7,19 @@ import componentCss from './Marquee.module.less';
 
 const isEventSource = (ev) => ev.target === ev.currentTarget;
 
+const applyOffset = (node) => {
+	if (!node || !global.IntersectionObserver) return;
+
+	const root = node.parentNode;
+	new global.IntersectionObserver(function (entries, observer) {
+		const {left} = entries[0].boundingClientRect;
+		const offset = Math.round(left) - left;
+		node.style.setProperty('--ui-marquee-offset', offset);
+
+		observer.disconnect();
+	}, {root}).observe(node);
+};
+
 /**
  * Marquees the children of the component.
  *
@@ -171,7 +184,7 @@ const MarqueeBase = kind({
 			text: true,
 			willAnimate
 		}),
-		clientStyle: ({alignment, animating, distance, overflow, spacing, rtl, speed}) => {
+		clientStyle: ({alignment, animating, distance, overflow, rtl, spacing, speed}) => {
 			// If the components content directionality doesn't match the context, we need to set it
 			// inline
 			const direction = rtl ? 'rtl' : 'ltr';
@@ -205,8 +218,8 @@ const MarqueeBase = kind({
 		delete rest.distance;
 		delete rest.onMarqueeComplete;
 		delete rest.overflow;
-		delete rest.spacing;
 		delete rest.rtl;
+		delete rest.spacing;
 		delete rest.speed;
 		delete rest.willAnimate;
 
@@ -221,7 +234,7 @@ const MarqueeBase = kind({
 					{children}
 					{duplicate ? (
 						<React.Fragment>
-							<div className={css.spacing} />
+							<div className={css.spacing} ref={applyOffset} />
 							{children}
 						</React.Fragment>
 					) : null}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -555,14 +555,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (typeof marqueeSpacing === 'string') {
 				if (/^\d+(\.\d+)?%$/.test(marqueeSpacing)) {
-					return Math.floor(width * Number.parseFloat(marqueeSpacing) / 100);
+					return width * Number.parseFloat(marqueeSpacing) / 100;
 				}
 
 				// warning for invalid string value;
 				return 0;
 			}
 
-			return Math.floor(scale(marqueeSpacing));
+			return scale(marqueeSpacing);
 		}
 
 		/*
@@ -666,7 +666,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 *
 		 * @returns {undefined}
 		 */
-		restartAnimation = () => {
+		restartAnimation = (delay) => {
 			this.setState({
 				animating: false
 			});
@@ -674,7 +674,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.sync) {
 				this.context.complete(this);
 			} else if (!this.state.animating) {
-				this.startAnimation();
+				this.startAnimation(delay);
 			}
 		}
 
@@ -684,11 +684,21 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		resetAnimation = () => {
-			const marqueeResetDelay = Math.max(40, this.props.marqueeResetDelay);
+			const delay = Math.max(40, this.props.marqueeResetDelay + this.props.marqueeDelay);
 			// If we're already timing a start action, don't reset.  Start actions will clear us if
 			// sync.
 			if (this.timerState === TimerState.CLEAR) {
-				this.setTimeout(this.restartAnimation, marqueeResetDelay, TimerState.RESET_PENDING);
+				// If invoked immediately, the setState call in restartAnimation is batched and will
+				// break any non-marquee-on-render instances because the subsequent startAnimation
+				// isn't invoked. By setting a brief timeout, we decouple from the `onTransitionEnd`
+				// event and setState is synchronous allowing the startAnimation to be called
+				// immediately.
+				//
+				// This would be better moved into componentDidUpdate with more expansive state
+				// values to indicate we need to reset an animation vs starting fresh.
+				this.setTimeout(() => {
+					this.restartAnimation(delay);
+				}, 0, TimerState.RESET_PENDING);
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If the length of the content of marquee is a sub-pixel value, the duplicate content doesn't line up correctly when the animation completes causing the text to "jump" when the animation restarts.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add an `IntersectionObserver` to calculate the difference and adjust the spacer to account for it
* Change the reset behavior to immediately re-render the original text to further mask any offsets in text alignment.