### PR TITLE
ENYO-6347: Sinhala text overlaps in Notification popup

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Notification` CSS `line-height` for non-latin locales
+
 ## [3.2.3] - 2019-11-01
 
 ### Changed

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Notification` CSS `line-height` for non-latin locales
+- `moonstone/Notification` line height for non-latin locales
 
 ## [3.2.3] - 2019-11-01
 

--- a/packages/moonstone/styles/mixins.less
+++ b/packages/moonstone/styles/mixins.less
@@ -304,7 +304,9 @@
 }
 
 .moon-notification-content() {
-	.moon-font(@moon-notification-font-family, @moon-non-latin-font-family-light);
+	.moon-font(@moon-notification-font-family, @moon-non-latin-font-family-light, {
+		line-height: @moon-non-latin-body-line-height;
+	});
 	font-weight: @moon-notification-font-weight;
 	font-style: @moon-notification-font-style;
 	font-size: @moon-notification-font-size;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I found this problem while testing translated text.
Notification popup use line-height of BodyText, not Popup's.
Thus, the line-height is calculated as `px` (rem). I think it should be changed in 'em' units.
When I changed the locale to a non-Latin language, the line-height did not change in 'em' units.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I fixed CSS `line-height` to use `em` unit for non-Latin locales.

### Links
[//]: # (Related issues, references)
ENYO-6347
