### PR TITLE
ENYO-6348: Fix Notification to show all buttons on one line

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unrelease]
+
+### Fixed
+
+- `moonstone/Notification` to show all buttons in one line
+
 ## [3.2.3] - 2019-11-01
 
 ### Changed

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -135,8 +135,9 @@ const NotificationBase = kind({
 	},
 
 	computed: {
-		className: ({buttons, styler}) =>
-			styler.append({wide: (buttons && buttons.filter(Boolean).length > 2)}),
+		className: ({buttons, styler}) => styler.append({
+			wide: (buttons && React.Children.toArray(buttons).filter(Boolean).length > 2)
+		}),
 		buttons: ({buttons}) => React.Children.map(buttons, (button) => {
 			if (button && button.props && !button.props.small) {
 				return React.cloneElement(button, {size: 'small'});

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -135,13 +135,8 @@ const NotificationBase = kind({
 	},
 
 	computed: {
-		className: ({className, buttons, styler}) => {
-			if (buttons && buttons.length > 2) {
-				return styler.append({wide: true});
-			} else {
-				return className;
-			}
-		},
+		className: ({buttons, styler}) =>
+			styler.append({wide: (buttons && buttons.filter(Boolean).length > 2)}),
 		buttons: ({buttons}) => React.Children.map(buttons, (button) => {
 			if (button && button.props && !button.props.small) {
 				return React.cloneElement(button, {size: 'small'});

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -136,7 +136,7 @@ const NotificationBase = kind({
 
 	computed: {
 		className: ({className, buttons, styler}) => {
-			if (buttons && buttons.length > 3) {
+			if (buttons && buttons.length > 2) {
 				return styler.append({wide: true});
 			} else {
 				return className;

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -470,7 +470,7 @@
 @moon-notification-padding-left-right: 39px;
 @moon-notification-padding-top-bottom: 24px;
 @moon-notification-min-width: 300px;
-@moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-max-width)));  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
+@moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)));  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
 @moon-notification-wide-width: 1287px;
 
 // Tooltip

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -470,7 +470,7 @@
 @moon-notification-padding-left-right: 39px;
 @moon-notification-padding-top-bottom: 24px;
 @moon-notification-min-width: 300px;
-@moon-notification-max-width: 978px;
+@moon-notification-max-width: 1017px;
 @moon-notification-wide-width: 1287px;
 
 // Tooltip

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -470,7 +470,7 @@
 @moon-notification-padding-left-right: 39px;
 @moon-notification-padding-top-bottom: 24px;
 @moon-notification-min-width: 300px;
-@moon-notification-max-width: 1017px;
+@moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-max-width)));  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
 @moon-notification-wide-width: 1287px;
 
 // Tooltip


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If Notification currently has more than three buttons, it adds wide CSS.
But currently it has two long buttons but the buttons overflow.
We need to improve the root cause and consider whether or not to add wide CSS when it has a three buttons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I fixed `max-width` of Notification by `max-width` of Button and changed to add `wide` css if length of the buttons is greater than two.

### Links
[//]: # (Related issues, references)
ENYO-6348
