### PR TITLE
ENYO-6343: add a sample to qa-sampler to test allipsis in marquee when content changes 

### DIFF
--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -107,7 +107,6 @@ class MarqueeWithShortContent extends React.Component {
 	}
 }
 
-
 class MarqueeWithContentChanged extends React.Component {
 	constructor (props) {
 		super(props);

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -129,9 +129,9 @@ class MarqueeWithContentChanged extends React.Component {
 		return (
 			<div>
 				<ol>
-					<li>Click once to disable the marquee.</li>
-					<li>Click a second time to show the ellipsis just before the text marquees the first time.</li>
-					<li>Click a third time to show the ellipsis just before the text marquees the first time</li>
+					<li>Click once to show the ellipsis just before the text marquees the first time.</li>
+					<li>Click a second time to show the ellipsis just before the text marquees the first time</li>
+					<li>Click again to return to a short string without marquee.</li>
 				</ol>
 				<Button onClick={this.handleClick}>
 					{'Click Me'}

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -291,8 +291,6 @@ storiesOf('Marquee', module)
 	.add(
 		'with Content Changed',
 		() => (
-			<div>
-				<MarqueeWithContentChanged />
-			</div>
+			<MarqueeWithContentChanged />
 		)
 	);

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -32,6 +32,12 @@ const RTL = [
 	'فوری بھوری لومڑی سست کتے پر چھلانگ لگا. بین پرندوں سوریاست میں پرواز.'
 ];
 
+const texts = [
+	'No marquee no marquee',
+	'Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.',
+	'Second test to show that the Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.'
+];
+
 const disabledDisclaimer = (disabled) => (disabled ? <p style={{fontSize: '70%', fontStyle: 'italic'}}><sup>*</sup>Marquee does not visually respond to <code>disabled</code> state.</p> : <p />);
 
 const MarqueeI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale'}, kind({
@@ -110,46 +116,31 @@ class MarqueeWithShortContent extends React.Component {
 class MarqueeWithContentChanged extends React.Component {
 	constructor (props) {
 		super(props);
-		this.cnt = 0;
 		this.state = {
-			text: 'Ellipsis show. Wait for marquee to start.'
+			count: 0
 		};
 	}
 
-handleClick	= () => {
-	if (this.cnt === 0) {
-		this.setState({
-			text: 'No marquee no marquee'
-		});
-	} else if (this.cnt === 1) {
-		this.setState({
-			text: 'Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.'
-		});
-	} else if (this.cnt === 2) {
-		this.setState({
-			text: 'Second test to show that the Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.'
-		});
+	handleClick	= () => {
+		this.setState(({count}) => ({count: ++count % 3}));
 	}
-	this.cnt++;
-}
 
-render = () => {
-	return (
-		<div>
-			<ol>
-				<li>Click once to disable the marquee.</li>
-				<li>Click a second time to show the ellipsis just before the text marquees the first time.</li>
-				<li>Click a third time to show the ellipsis just before the text marquees the first time</li>
-			</ol>
-			<Button onClick={this.handleClick}>
-				{'Click Me'}
-			</Button>
-			<Marquee style={{width: '400px'}} marqueeOn={'render'} >{this.state.text}</Marquee>
-		</div>
-	);
+	render = () => {
+		return (
+			<div>
+				<ol>
+					<li>Click once to disable the marquee.</li>
+					<li>Click a second time to show the ellipsis just before the text marquees the first time.</li>
+					<li>Click a third time to show the ellipsis just before the text marquees the first time</li>
+				</ol>
+				<Button onClick={this.handleClick}>
+					{'Click Me'}
+				</Button>
+				<Marquee style={{width: '400px'}} marqueeOn={'render'} >{texts[this.state.count]}</Marquee>
+			</div>
+		);
+	}
 }
-}
-
 
 storiesOf('Marquee', module)
 	.add(

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -121,11 +121,11 @@ class MarqueeWithContentChanged extends React.Component {
 		};
 	}
 
-	handleClick	= () => {
+	handleClick = () => {
 		this.setState(({count}) => ({count: ++count % 3}));
 	}
 
-	render = () => {
+	render () {
 		return (
 			<div>
 				<ol>

--- a/packages/sampler/stories/qa/Marquee.js
+++ b/packages/sampler/stories/qa/Marquee.js
@@ -107,6 +107,51 @@ class MarqueeWithShortContent extends React.Component {
 	}
 }
 
+
+class MarqueeWithContentChanged extends React.Component {
+	constructor (props) {
+		super(props);
+		this.cnt = 0;
+		this.state = {
+			text: 'Ellipsis show. Wait for marquee to start.'
+		};
+	}
+
+handleClick	= () => {
+	if (this.cnt === 0) {
+		this.setState({
+			text: 'No marquee no marquee'
+		});
+	} else if (this.cnt === 1) {
+		this.setState({
+			text: 'Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.'
+		});
+	} else if (this.cnt === 2) {
+		this.setState({
+			text: 'Second test to show that the Ellipsis show before the initial start of the marquee. Ellipsis will not show on the subsequent starts.'
+		});
+	}
+	this.cnt++;
+}
+
+render = () => {
+	return (
+		<div>
+			<ol>
+				<li>Click once to disable the marquee.</li>
+				<li>Click a second time to show the ellipsis just before the text marquees the first time.</li>
+				<li>Click a third time to show the ellipsis just before the text marquees the first time</li>
+			</ol>
+			<Button onClick={this.handleClick}>
+				{'Click Me'}
+			</Button>
+			<Marquee style={{width: '400px'}} marqueeOn={'render'} >{this.state.text}</Marquee>
+		</div>
+	);
+}
+}
+
+
 storiesOf('Marquee', module)
 	.add(
 		'LTR',
@@ -249,6 +294,15 @@ storiesOf('Marquee', module)
 		() => (
 			<div>
 				<MarqueeWithShortContent />
+			</div>
+		)
+	)
+
+	.add(
+		'with Content Changed',
+		() => (
+			<div>
+				<MarqueeWithContentChanged />
 			</div>
 		)
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
