### PR TITLE
PLAT-90766: Add support for minimized Header

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `moonstone/Panels.Header` prop `minimized`
+
 ## [3.2.3] - 2019-11-01
 
 ### Changed

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {isRtlText} from '@enact/i18n/util';
 import {Layout, Cell} from '@enact/ui/Layout';
 import Slottable from '@enact/ui/Slottable';
+import Transition from '@enact/ui/Transition';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 
 import {MarqueeDecorator, MarqueeBase} from '../Marquee';
@@ -227,7 +228,7 @@ const HeaderBase = kind({
 		}
 	},
 
-	render: ({children, direction, marqueeOn, subTitleBelowComponent, title, titleOrInput, /* titleAbove, */titleBelowComponent, type, ...rest}) => {
+	render: ({children, collapsed, direction, marqueeOn, subTitleBelowComponent, title, titleOrInput, /* titleAbove, */titleBelowComponent, type, ...rest}) => {
 		delete rest.centered;
 		delete rest.fullBleed;
 		delete rest.headerInput;
@@ -238,9 +239,11 @@ const HeaderBase = kind({
 		switch (type) {
 			case 'compact': return (
 				<Layout component="header" aria-label={title} {...rest} align="end">
-					<Cell component={CompactTitle} title={title} titleBelow={titleBelowComponent} marqueeOn={marqueeOn} forceDirection={direction}>
-						<h1 className={css.title}>{title}</h1>
-						{titleBelowComponent}
+					<Cell component={Transition} visible={!collapsed} type="slide">
+						<CompactTitle title={title} titleBelow={titleBelowComponent} marqueeOn={marqueeOn} forceDirection={direction}>
+							<h1 className={css.title}>{title}</h1>
+							{titleBelowComponent}
+						</CompactTitle>
 					</Cell>
 					{children ? <Cell shrink component="nav" className={css.headerComponents}>{children}</Cell> : null}
 				</Layout>
@@ -258,7 +261,9 @@ const HeaderBase = kind({
 			case 'dense':
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
-					{titleOrInput}
+					<Cell component={Transition} visible={!collapsed} type="slide">
+						{titleOrInput}
+					</Cell>
 					<Cell shrink size={96}>
 						<Layout align="end">
 							<Cell className={css.titlesCell}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -215,7 +215,7 @@ const HeaderBase = kind({
 		subTitleBelowComponent: ({centered, marqueeOn, subTitleBelow}) => {
 			return <MarqueeH2 className={css.subTitleBelow} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>{(subTitleBelow != null && subTitleBelow !== '') ? subTitleBelow : ' '}</MarqueeH2>;
 		},
-		titleOrInput: ({centered, headerInput, marqueeOn, title, type}) => {
+		titleOrInput: ({centered, headerInput, marqueeOn, minimized, title, type}) => {
 			if (headerInput && type === 'standard') {
 				return (
 					<Cell className={css.headerInput}>
@@ -228,9 +228,11 @@ const HeaderBase = kind({
 				);
 			} else {
 				return (
-					<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
-						{title}
-					</MarqueeH1>
+					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : '89px'}>
+						<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
+							{title}
+						</MarqueeH1>
+					</Cell>
 				);
 			}
 		}
@@ -247,11 +249,9 @@ const HeaderBase = kind({
 		switch (type) {
 			case 'compact': return (
 				<Layout component="header" aria-label={title} {...rest} align="end">
-					<Cell component={Transition} visible={!minimized} type="slide">
-						<CompactTitle title={title} titleBelow={titleBelowComponent} marqueeOn={marqueeOn} forceDirection={direction}>
-							<h1 className={css.title}>{title}</h1>
-							{titleBelowComponent}
-						</CompactTitle>
+					<Cell component={CompactTitle} title={title} titleBelow={titleBelowComponent} marqueeOn={marqueeOn} forceDirection={direction}>
+						<h1 className={css.title}>{title}</h1>
+						{titleBelowComponent}
 					</Cell>
 					{children ? <Cell shrink component="nav" className={css.headerComponents}>{children}</Cell> : null}
 				</Layout>
@@ -269,9 +269,7 @@ const HeaderBase = kind({
 			case 'dense':
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
-					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : '89px'}>
-						{titleOrInput}
-					</Cell>
+					{titleOrInput}
 					<Cell shrink size={96}>
 						<Layout align="end">
 							<Cell className={css.titlesCell}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -131,6 +131,15 @@ const HeaderBase = kind({
 		marqueeOn: PropTypes.oneOf(['focus', 'hover', 'render']),
 
 		/**
+		 * Minimizes the Header to only show the header-components.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		minimized: PropTypes.bool,
+
+		/**
 		 * Sub-title displayed at the bottom of the panel.
 		 *
 		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
@@ -181,6 +190,7 @@ const HeaderBase = kind({
 	defaultProps: {
 		fullBleed: false,
 		marqueeOn: 'render',
+		minimized: false,
 		// titleAbove: '00',
 		type: 'standard'
 	},
@@ -191,7 +201,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, fullBleed, hideLine, type, styler}) => styler.append({centered, fullBleed, hideLine}, type),
+		className: ({centered, fullBleed, hideLine, minimized, type, styler}) => styler.append({centered, fullBleed, hideLine, minimized}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {
@@ -218,17 +228,15 @@ const HeaderBase = kind({
 				);
 			} else {
 				return (
-					<Cell>
-						<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
-							{title}
-						</MarqueeH1>
-					</Cell>
+					<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
+						{title}
+					</MarqueeH1>
 				);
 			}
 		}
 	},
 
-	render: ({children, collapsed, direction, marqueeOn, subTitleBelowComponent, title, titleOrInput, /* titleAbove, */titleBelowComponent, type, ...rest}) => {
+	render: ({children, minimized, direction, marqueeOn, subTitleBelowComponent, title, titleOrInput, /* titleAbove, */titleBelowComponent, type, ...rest}) => {
 		delete rest.centered;
 		delete rest.fullBleed;
 		delete rest.headerInput;
@@ -239,7 +247,7 @@ const HeaderBase = kind({
 		switch (type) {
 			case 'compact': return (
 				<Layout component="header" aria-label={title} {...rest} align="end">
-					<Cell component={Transition} visible={!collapsed} type="slide">
+					<Cell component={Transition} visible={!minimized} type="slide">
 						<CompactTitle title={title} titleBelow={titleBelowComponent} marqueeOn={marqueeOn} forceDirection={direction}>
 							<h1 className={css.title}>{title}</h1>
 							{titleBelowComponent}
@@ -261,7 +269,7 @@ const HeaderBase = kind({
 			case 'dense':
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
-					<Cell component={Transition} visible={!collapsed} type="slide">
+					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : '89px'}>
 						{titleOrInput}
 					</Cell>
 					<Cell shrink size={96}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -201,7 +201,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, fullBleed, hideLine, minimized, type, styler}) => styler.append({centered, fullBleed, hideLine, minimized}, type),
+		className: ({centered, fullBleed, hideLine, type, styler}) => styler.append({centered, fullBleed, hideLine}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {
@@ -215,7 +215,7 @@ const HeaderBase = kind({
 		subTitleBelowComponent: ({centered, marqueeOn, subTitleBelow}) => {
 			return <MarqueeH2 className={css.subTitleBelow} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>{(subTitleBelow != null && subTitleBelow !== '') ? subTitleBelow : ' '}</MarqueeH2>;
 		},
-		titleOrInput: ({centered, headerInput, marqueeOn, minimized, title, type}) => {
+		titleOrInput: ({centered, headerInput, marqueeOn, title, type}) => {
 			if (headerInput && type === 'standard') {
 				return (
 					<Cell className={css.headerInput}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -132,6 +132,7 @@ const HeaderBase = kind({
 
 		/**
 		 * Minimizes the Header to only show the header-components.
+		 * Has no effect on `type="compact"`.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -2,10 +2,11 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {isRtlText} from '@enact/i18n/util';
+import ComponentOverride from '@enact/ui/ComponentOverride';
 import {Layout, Cell} from '@enact/ui/Layout';
+import ri from '@enact/ui/resolution';
 import Slottable from '@enact/ui/Slottable';
 import Transition from '@enact/ui/Transition';
-import ComponentOverride from '@enact/ui/ComponentOverride';
 
 import {MarqueeDecorator, MarqueeBase} from '../Marquee';
 import Skinnable from '../Skinnable';
@@ -245,7 +246,7 @@ const HeaderBase = kind({
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
 
-		const titleHeight = type === 'dense' ? '69px' : '89px';
+		const titleHeight = ri.unit(ri.scale((type === 'dense') ? 69 : 89), 'rem');
 
 		switch (type) {
 			case 'compact': return (

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -228,11 +228,9 @@ const HeaderBase = kind({
 				);
 			} else {
 				return (
-					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : '89px'}>
-						<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
-							{title}
-						</MarqueeH1>
-					</Cell>
+					<MarqueeH1 className={css.title} css={marqueeCss} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>
+						{title}
+					</MarqueeH1>
 				);
 			}
 		}
@@ -245,6 +243,8 @@ const HeaderBase = kind({
 		delete rest.hideLine;
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
+
+		const titleHeight = type === 'dense' ? '69px' : '89px';
 
 		switch (type) {
 			case 'compact': return (
@@ -269,7 +269,9 @@ const HeaderBase = kind({
 			case 'dense':
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
-					{titleOrInput}
+					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : titleHeight}>
+						{titleOrInput}
+					</Cell>
 					<Cell shrink size={96}>
 						<Layout align="end">
 							<Cell className={css.titlesCell}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -246,7 +246,7 @@ const HeaderBase = kind({
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
 
-		const titleHeight = ri.unit(ri.scale((type === 'dense') ? 69 : 89), 'rem');
+		const titleHeight = ri.unit(ri.scale((type === 'dense') ? 69 : 90), 'rem');
 
 		switch (type) {
 			case 'compact': return (
@@ -270,7 +270,7 @@ const HeaderBase = kind({
 			// );
 			case 'dense':
 			case 'standard': return (
-				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
+				<Layout component="header" aria-label={title} {...rest} css={css.layout} style={{height: 'unset'}} orientation="vertical">
 					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : titleHeight}>
 						{titleOrInput}
 					</Cell>

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -92,7 +92,7 @@
 	// Standard Header
 	&.standard {
 		.titlesCell {
-			margin-bottom: 15px;
+			margin-bottom: 9px;
 		}
 	}
 
@@ -106,7 +106,7 @@
 		}
 
 		.titlesCell {
-			margin-bottom: 9px;
+			margin-bottom: 15px;
 		}
 
 		.titleBelow,

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -65,7 +65,7 @@
 	// Standard and Dense Header
 	&.dense,
 	&.standard {
-		height: @moon-header-standard-height;
+		// height: @moon-header-standard-height;
 
 		.title {
 			// The height is determined by the line-height below, but we want to maintain that as a

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -106,7 +106,7 @@
 		}
 
 		.titlesCell {
-			margin-bottom: 15px;
+			margin-bottom: 9px;
 		}
 
 		.titleBelow,

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -65,7 +65,7 @@
 	// Standard and Dense Header
 	&.dense,
 	&.standard {
-		// height: @moon-header-standard-height;
+		max-height: @moon-header-standard-height;
 
 		.title {
 			// The height is determined by the line-height below, but we want to maintain that as a
@@ -92,26 +92,26 @@
 	// Standard Header
 	&.standard {
 		.titlesCell {
-			margin-bottom: 9px;
+			margin-bottom: 15px;
 		}
 	}
 
 	// Dense Header
 	&.dense {
-		height: @moon-header-dense-height;
+		max-height: @moon-header-dense-height;
 
 		.title {
 			font-size: @moon-header-dense-title-font-size;
 			font-weight: @moon-header-dense-title-font-weight;
 		}
 
-		.titlesCell {
-			margin-bottom: 15px;
-		}
-
 		.titleBelow,
 		.subTitleBelow {
 			font-size: @moon-header-dense-title-below-font-size;
+		}
+
+		.subTitleBelow {
+			line-height: 27px;
 		}
 	}
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -105,13 +105,13 @@
 			font-weight: @moon-header-dense-title-font-weight;
 		}
 
+		.titlesCell {
+			margin-bottom: 15px;
+		}
+
 		.titleBelow,
 		.subTitleBelow {
 			font-size: @moon-header-dense-title-below-font-size;
-		}
-
-		.subTitleBelow {
-			line-height: 27px;
 		}
 	}
 

--- a/packages/sampler/stories/default/Header.js
+++ b/packages/sampler/stories/default/Header.js
@@ -54,6 +54,7 @@ storiesOf('Moonstone', module)
 					headerInput={headerInput}
 					hideLine={boolean('hideLine', Config)}
 					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
+					minimized={boolean('minimized', Config)}
 				>
 					{children}
 				</Header>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add `minimized` prop to hide the title, only showing the header components, subtitles, and title below.
Using `Transition` to animate and then resize the title cell.

![minimizedheader](https://user-images.githubusercontent.com/8940009/68257089-e91c0780-ffe6-11e9-97e8-e39e450648fa.gif)
