### PR TITLE
Alternate approach using "clip"

### DIFF
--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import {isRtlText} from '@enact/i18n/util';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 import {Layout, Cell} from '@enact/ui/Layout';
-import ri from '@enact/ui/resolution';
 import Slottable from '@enact/ui/Slottable';
 import Transition from '@enact/ui/Transition';
 
@@ -203,7 +202,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, fullBleed, hideLine, type, styler}) => styler.append({centered, fullBleed, hideLine}, type),
+		className: ({centered, fullBleed, hideLine, minimized, type, styler}) => styler.append({centered, fullBleed, hideLine, minimized}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {
@@ -246,8 +245,6 @@ const HeaderBase = kind({
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
 
-		const titleHeight = ri.unit(ri.scale((type === 'dense') ? 69 : 90), 'rem');
-
 		switch (type) {
 			case 'compact': return (
 				<Layout component="header" aria-label={title} {...rest} align="end">
@@ -270,9 +267,11 @@ const HeaderBase = kind({
 			// );
 			case 'dense':
 			case 'standard': return (
-				<Layout component="header" aria-label={title} {...rest} css={css.layout} style={{height: 'unset'}} orientation="vertical">
-					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : titleHeight}>
-						{titleOrInput}
+				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
+					<Cell shrink>
+						<Transition type="clip" direction="down" visible={!minimized}>
+							{titleOrInput}
+						</Transition>
 					</Cell>
 					<Cell shrink size={96}>
 						<Layout align="end">

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -65,7 +65,8 @@
 	// Standard and Dense Header
 	&.dense,
 	&.standard {
-		max-height: @moon-header-standard-height;
+		transition: height 600ms ease-in-out;  // Intentionally slightly longer than the transition for an inertial effect
+		will-change: height;
 
 		.title {
 			// The height is determined by the line-height below, but we want to maintain that as a
@@ -86,19 +87,24 @@
 		.inputHighlight {
 			max-width: 100%;
 		}
-
 	}
 
 	// Standard Header
 	&.standard {
+		height: @moon-header-standard-height;
+
 		.titlesCell {
 			margin-bottom: 9px;
+		}
+
+		&.minimized {
+			height: (@moon-header-standard-height - 89px);  // Must subtract the height of the header element. Considering changing the `em` line-height to a px value to make this more straightforward.
 		}
 	}
 
 	// Dense Header
 	&.dense {
-		max-height: @moon-header-dense-height;
+		height: @moon-header-dense-height;
 
 		.title {
 			font-size: @moon-header-dense-title-font-size;
@@ -112,6 +118,10 @@
 		.titleBelow,
 		.subTitleBelow {
 			font-size: @moon-header-dense-title-below-font-size;
+		}
+
+		&.minimized {
+			height: (@moon-header-standard-height - 69px);  // Must subtract the height of the header element. Considering changing the `em` line-height to a px value to make this more straightforward.
 		}
 	}
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -98,7 +98,7 @@
 		}
 
 		&.minimized {
-			height: (@moon-header-standard-height - 89px);  // Must subtract the height of the header element. Considering changing the `em` line-height to a px value to make this more straightforward.
+			height: (@moon-header-standard-height - 90px);  // Must subtract the height of the header element. Considering changing the `em` line-height to a px value to make this more straightforward.
 		}
 	}
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
Setting the title height in the JS is not ideal.
The CSS should be informed when minimized is true.
"slide" Transition type doesn't adjust layout, which we need this to affect.

### Resolution
Switched to "clip" (same transition `Expandable` uses) to facilitate the layout change.
Moved all measurements into the CSS.
Added an inertial delay animation of the content to more closely match the model video.
Added a `.minimized` class to inform the CSS of our current state.