### PR TITLE
Uses simpler scaling and styling

### DIFF
--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -294,7 +294,7 @@ const HeaderBase = kind({
 			case 'standard': return (
 				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
 					{titleOrInput}
-					<Cell shrink size={96}>
+					<Cell shrink size={96} className={css.info}>
 						<Layout align="end">
 							<Cell className={css.titlesCell}>
 								{titleBelowComponent}

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import {isRtlText} from '@enact/i18n/util';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 import {Layout, Cell} from '@enact/ui/Layout';
-import ri from '@enact/ui/resolution';
 import Slottable from '@enact/ui/Slottable';
 import Transition from '@enact/ui/Transition';
 

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -203,7 +203,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, fullBleed, hideLine, type, styler}) => styler.append({centered, fullBleed, hideLine}, type),
+		className: ({centered, fullBleed, hideLine, minimized, type, styler}) => styler.append({centered, fullBleed, hideLine, minimized}, type),
 		direction: ({title, titleBelow}) => isRtlText(title) || isRtlText(titleBelow) ? 'rtl' : 'ltr',
 		titleBelowComponent: ({centered, marqueeOn, titleBelow, type}) => {
 			switch (type) {
@@ -246,7 +246,7 @@ const HeaderBase = kind({
 		delete rest.subTitleBelow;
 		delete rest.titleBelow;
 
-		const titleHeight = ri.unit(ri.scale((type === 'dense') ? 69 : 90), 'rem');
+		const titleHeight = (type === 'dense') ? 69 : 90;
 
 		switch (type) {
 			case 'compact': return (
@@ -270,8 +270,8 @@ const HeaderBase = kind({
 			// );
 			case 'dense':
 			case 'standard': return (
-				<Layout component="header" aria-label={title} {...rest} css={css.layout} style={{height: 'unset'}} orientation="vertical">
-					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? '0' : titleHeight}>
+				<Layout component="header" aria-label={title} {...rest} orientation="vertical">
+					<Cell component={Transition} type="slide" visible={!minimized} size={minimized ? 0 : titleHeight}>
 						{titleOrInput}
 					</Cell>
 					<Cell shrink size={96}>

--- a/packages/moonstone/Panels/Header.js
+++ b/packages/moonstone/Panels/Header.js
@@ -4,7 +4,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {isRtlText} from '@enact/i18n/util';
 import {Layout, Cell} from '@enact/ui/Layout';
-import Measurable from '@enact/ui/Measurable';
 import Slottable from '@enact/ui/Slottable';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 
@@ -234,10 +233,6 @@ const HeaderBase = kind({
 					return <MarqueeH2 className={css.titleBelow} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>{(titleBelow != null && titleBelow !== '') ? titleBelow : ' '}</MarqueeH2>;
 			}
 		},
-		style: ({style, titleMeasurements}) => ({
-			...style,
-			'--header-title-height': titleMeasurements && titleMeasurements.height + 'px' || 'auto'
-		}),
 		subTitleBelowComponent: ({centered, marqueeOn, subTitleBelow}) => {
 			return <MarqueeH2 className={css.subTitleBelow} marqueeOn={marqueeOn} alignment={centered ? 'center' : null}>{(subTitleBelow != null && subTitleBelow !== '') ? subTitleBelow : ' '}</MarqueeH2>;
 		},
@@ -317,7 +312,6 @@ const HeaderBase = kind({
 // Note that we only export this (even as HeaderBase). HeaderBase is not useful on its own.
 const HeaderDecorator = compose(
 	Slottable({slots: ['headerInput', 'subTitleBelow', 'title', 'titleBelow']}),
-	Measurable({refProp: 'titleRef', measurementProp: 'titleMeasurements'}),
 	Skinnable
 );
 

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -68,14 +68,22 @@
 		transition: transform 600ms ease-in-out;
 		will-change: transform;
 
+		.info,
+		.titleCells,
+		.headerComponents {
+			// Static positioning removes the repaint these cells cells issue when the layout changes during the animation.
+			position: static;
+		}
+
 		.title {
 			// The height is determined by the line-height below, but we want to maintain that as a
 			// relative unit (`em`) rather than dictate specific pixels to automatically accomodate
 			// font size changes.
 			line-height: @moon-header-standard-title-line-height;
 			margin-left: -3px; // Negative 3px here to allow the title text to horizontally align with the rest of the header text
-			transition: transform 500ms ease-in-out;
-			will-change: transform;
+			transition: transform 500ms ease-in-out, opacity 500ms ease;
+			opacity: 1;
+			will-change: transform, opacity;
 
 			.moon-locale-non-latin({line-height: @moon-non-latin-header-standard-title-line-height;});
 		}
@@ -95,6 +103,7 @@
 
 			.title {
 				transform: translateY(-50%);
+				opacity: 0.3;
 			}
 		}
 	}

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -87,6 +87,9 @@
 			max-width: 100%;
 		}
 
+		&.minimized {
+			height: auto;
+		}
 	}
 
 	// Standard Header

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -65,7 +65,8 @@
 	// Standard and Dense Header
 	&.dense,
 	&.standard {
-		max-height: @moon-header-standard-height;
+		transition: transform 600ms ease-in-out;
+		will-change: transform;
 
 		.title {
 			// The height is determined by the line-height below, but we want to maintain that as a
@@ -73,6 +74,8 @@
 			// font size changes.
 			line-height: @moon-header-standard-title-line-height;
 			margin-left: -3px; // Negative 3px here to allow the title text to horizontally align with the rest of the header text
+			transition: transform 500ms ease-in-out;
+			will-change: transform;
 
 			.moon-locale-non-latin({line-height: @moon-non-latin-header-standard-title-line-height;});
 		}
@@ -88,12 +91,18 @@
 		}
 
 		&.minimized {
-			height: auto;
+			transform: translateY(calc(var(--header-title-height, 0) * -1));
+
+			.title {
+				transform: translateY(-50%);
+			}
 		}
 	}
 
 	// Standard Header
 	&.standard {
+		height: @moon-header-standard-height;
+
 		.titlesCell {
 			margin-bottom: 9px;
 		}
@@ -101,7 +110,7 @@
 
 	// Dense Header
 	&.dense {
-		max-height: @moon-header-dense-height;
+		height: @moon-header-dense-height;
 
 		.title {
 			font-size: @moon-header-dense-title-font-size;

--- a/packages/moonstone/Panels/Header.module.less
+++ b/packages/moonstone/Panels/Header.module.less
@@ -91,7 +91,7 @@
 		}
 
 		&.minimized {
-			transform: translateY(calc(var(--header-title-height, 0) * -1));
+			transform: translateY(-12px);
 
 			.title {
 				transform: translateY(-50%);

--- a/packages/moonstone/Panels/Panel.module.less
+++ b/packages/moonstone/Panels/Panel.module.less
@@ -11,10 +11,12 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	transition: 700ms transform ease-in-out;
+	transition: 700ms transform ease-in-out, 700ms height ease-in-out;
+	will-change: transform, height;
 
 	&.minimized {
 		transform: translateY(calc(var(--panel-header-title-height) * -1));
+		height: calc(100% + var(--panel-header-title-height));
 	}
 
 	&:global(.enact-fit) {

--- a/packages/moonstone/Panels/Panel.module.less
+++ b/packages/moonstone/Panels/Panel.module.less
@@ -11,6 +11,11 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
+	transition: 700ms transform ease-in-out;
+
+	&.minimized {
+		transform: translateY(calc(var(--panel-header-title-height) * -1));
+	}
 
 	&:global(.enact-fit) {
 		height: auto;

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -66,7 +66,10 @@ const CellBase = kind({
 		 * @type {Function}
 		 * @private
 		 */
-		componentRef: PropTypes.func,
+		componentRef: PropTypes.oneOfType([
+			PropTypes.func,
+			PropTypes.shape({current: PropTypes.any})
+		]),
 
 		/**
 		 * Sizes `Cell` to its contents.

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -211,7 +211,10 @@ const LayoutBase = kind({
 		 * @type {Function}
 		 * @private
 		 */
-		componentRef: PropTypes.func,
+		componentRef: PropTypes.oneOfType([
+			PropTypes.func,
+			PropTypes.shape({current: PropTypes.any})
+		]),
 
 		/**
 		 * Allows this `Layout` to have following siblings drawn on the same line as itself


### PR DESCRIPTION
### Issue Resolved / Feature Added
Simplified the sizing even further (forgot that Layout automatically adjusts to rem calculation if you just supply a number, rather than a size string).
Removed unnecessary `css` prop
Removed `style` prop since it would clobber external values and could be assigned from within the module's LESS file.
Added `.minimized` class to inform CSS of our state.


### Additional Considerations
* Using this approach means that subtile changes in line-height can affect the size of the Header component (since it's now auto-sizing), which may have detremental effects on app layout if they weren't expecting the body area to change dimensions.
* Setting `auto` or `unset` height means that we can no longer smoothly transition, since animating from `x` to `auto` isn't a valid change. Transitions must always be to known values.