### PR TITLE
PLAT-90767: Movable VirtualGridList when scrolling

### DIFF
--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -46,15 +46,6 @@ class ScrollButtons extends Component {
 
 	static propTypes = /** @lends moonstone/Scrollable.ScrollButtons.prototype */ {
 		/**
-		 * The render function for thumb.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		thumbRenderer: PropTypes.func.isRequired,
-
-		/**
 		 * Called to alert the user for accessibility notifications.
 		 *
 		 * @type {Function}
@@ -141,6 +132,15 @@ class ScrollButtons extends Component {
 		 * @private
 		 */
 		rtl: PropTypes.bool,
+
+		/**
+		 * The render function for thumb.
+		 *
+		 * @type {Function}
+		 * @required
+		 * @private
+		 */
+		thumbRenderer: PropTypes.func,
 
 		/**
 		 * The scrollbar will be oriented vertically.
@@ -373,7 +373,7 @@ class ScrollButtons extends Component {
 			>
 				{prevIcon}
 			</ScrollButton>,
-			thumbRenderer(),
+			thumbRenderer ? thumbRenderer() : null,
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -505,10 +505,11 @@ class ScrollableBase extends Component {
 	}
 
 	onFocus = (ev) => {
-		const {isDragging} = this.uiRef.current;
-		const shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
-			this.childRef.current.shouldPreventScrollByFocus() :
-			false;
+		const
+			{isDragging} = this.uiRef.current,
+			shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
+				this.childRef.current.shouldPreventScrollByFocus() :
+				false;
 
 		if (this.isWheeling) {
 			this.uiRef.current.stop();
@@ -990,7 +991,7 @@ class ScrollableBase extends Component {
 					initChildRef: initUiChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
-					overSize,
+					moveDistance,
 					rtl,
 					scrollTo,
 					style,
@@ -1014,9 +1015,9 @@ class ScrollableBase extends Component {
 									initUiChildRef,
 									isHorizontalScrollbarVisible,
 									isVerticalScrollbarVisible,
+									moveDistance,
 									onScroll: handleScroll,
 									onUpdate: this.handleScrollerUpdate,
-									overSize,
 									ref: this.childRef,
 									rtl,
 									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
@@ -1029,9 +1030,9 @@ class ScrollableBase extends Component {
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
+									moveDistance={moveDistance}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
-									overSize={overSize}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -491,7 +491,8 @@ class ScrollableBase extends Component {
 						previousScrollHeight: this.uiRef.current.bounds.scrollHeight,
 						scrollTop: this.uiRef.current.scrollTop
 					};
-				pos = positionFn({item: spotItem, scrollInfo});
+
+				pos = positionFn({item: spotItem, scrollPosition: scrollInfo.scrollTop});
 			}
 
 			if (pos && (pos.left !== this.uiRef.current.scrollLeft || pos.top !== this.uiRef.current.scrollTop)) {
@@ -504,11 +505,10 @@ class ScrollableBase extends Component {
 	}
 
 	onFocus = (ev) => {
-		const
-			{isDragging} = this.uiRef.current,
-			shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
-				this.childRef.current.shouldPreventScrollByFocus() :
-				false;
+		const {isDragging} = this.uiRef.current;
+		const shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
+			this.childRef.current.shouldPreventScrollByFocus() :
+			false;
 
 		if (this.isWheeling) {
 			this.uiRef.current.stop();
@@ -990,6 +990,7 @@ class ScrollableBase extends Component {
 					initChildRef: initUiChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
+					overSize,
 					rtl,
 					scrollTo,
 					style,
@@ -1015,6 +1016,7 @@ class ScrollableBase extends Component {
 									isVerticalScrollbarVisible,
 									onScroll: handleScroll,
 									onUpdate: this.handleScrollerUpdate,
+									overSize,
 									ref: this.childRef,
 									rtl,
 									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
@@ -1029,6 +1031,7 @@ class ScrollableBase extends Component {
 									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
+									overSize={overSize}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
 									previousButtonAriaLabel={upButtonAriaLabel}
 									rtl={rtl}

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -55,7 +55,7 @@ class ScrollbarBase extends Component {
 		/**
 		 * TBD
 		 */
-		overSize: PropTypes.number,
+		moveDistance: PropTypes.number,
 
 		/**
 		 * `true` if rtl, `false` if ltr.
@@ -99,7 +99,7 @@ class ScrollbarBase extends Component {
 
 		this.scrollbarRef = React.createRef();
 		this.scrollButtonsRef = React.createRef();
-		this.overSizeRef = React.createRef();
+		this.moveDistanceRef = React.createRef();
 	}
 
 	componentDidMount () {
@@ -119,28 +119,30 @@ class ScrollbarBase extends Component {
 		};
 		this.focusOnButton = focusOnButton;
 
-		this.syncHeight = (overSize, scrollPosition) => {
-			const
-				height = parseInt(window.getComputedStyle(this.overSizeRef.current).getPropertyValue('height')),
-				thumbRef = this.getContainerRef(),
-				nextButtonRef = this.scrollButtonsRef.current.nextButtonRef;
+		this.syncHeight = (moveDistance, scrollPosition) => {
+			if (this.moveDistanceRef.current && typeof window !== 'undefined') {
+				const
+					height = parseInt(window.getComputedStyle(this.moveDistanceRef.current).getPropertyValue('height')),
+					thumbRef = this.getContainerRef(),
+					nextButtonRef = this.scrollButtonsRef.current.nextButtonRef;
 
-			// To scale the thumb height depending on the VirtualList position
-			thumbRef.current.style.transform =
-				'scale3d(1, ' + (height - overSize + scrollPosition - 120) / (height - overSize - 120) + ', 1)';
+				// To scale the thumb height depending on the VirtualList position
+				thumbRef.current.style.transform =
+					'scale3d(1, ' + (height - moveDistance + scrollPosition - 120) / (height - moveDistance - 120) + ', 1)';
 
-			// To move the next scroll bar button depending on the VirtualList position
-			nextButtonRef.current.style.transform =
-				'translate3d(0, ' + (scrollPosition - overSize) + 'px, 0)';
+				// To move the next scroll bar button depending on the VirtualList position
+				nextButtonRef.current.style.transform =
+					'translate3d(0, ' + (scrollPosition - moveDistance) + 'px, 0)';
+			}
 		};
 	}
 
 	render () {
-		const {cbAlertThumb, clientSize, corner, overSize, vertical, ...rest} = this.props;
+		const {cbAlertThumb, clientSize, corner, moveDistance, vertical, ...rest} = this.props;
 
-		if (overSize) {
+		if (moveDistance) {
 			return (
-				<div className={componentCss.overSize} ref={this.overSizeRef}>
+				<div className={componentCss.moveDistance} ref={this.moveDistanceRef}>
 					<ScrollButtons
 						{...rest}
 						ref={this.scrollButtonsRef}
@@ -151,7 +153,7 @@ class ScrollbarBase extends Component {
 						clientSize={clientSize}
 						css={componentCss}
 						ref={this.scrollbarRef}
-						style={{height: 'calc(100% - ' + (overSize + 120) + 'px)'}}
+						style={{height: 'calc(100% - ' + (moveDistance + 120) + 'px)'}}
 						vertical={vertical}
 						childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
 							<ScrollThumb

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -53,7 +53,10 @@ class ScrollbarBase extends Component {
 		corner: PropTypes.bool,
 
 		/**
-		 * TBD
+		 * The distance that a list should move first when scrolling
+		 *
+		 * @type {Number}
+		 * @public
 		 */
 		moveDistance: PropTypes.number,
 

--- a/packages/moonstone/Scrollable/Scrollbar.module.less
+++ b/packages/moonstone/Scrollable/Scrollbar.module.less
@@ -77,3 +77,30 @@
 		}
 	}
 });
+
+.overSize {
+	position: relative;
+	width: 60px;
+	height: 100%;
+
+	// previous scroll bar button
+	& > div:first-child {
+		position: relative;
+		margin: 0;
+	}
+
+	// next scroll bar button
+	& > div:nth-child(2) {
+		position: absolute;
+		left: 0;
+		margin: 0;
+		bottom: 0;
+	}
+
+	// thumb
+	& > div:nth-child(4) {
+		position: relative;
+		will-change: transform;
+		transform-origin: top
+	}
+}

--- a/packages/moonstone/Scrollable/Scrollbar.module.less
+++ b/packages/moonstone/Scrollable/Scrollbar.module.less
@@ -78,7 +78,7 @@
 	}
 });
 
-.overSize {
+.moveDistance {
 	position: relative;
 	width: 60px;
 	height: 100%;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -145,7 +145,10 @@ const VirtualListBaseFactory = (type) => {
 			itemSizes: PropTypes.array,
 
 			/**
-			 * TBD
+			 * The distance that a list should move first when scrolling
+			 *
+			 * @type {Number}
+			 * @public
 			 */
 			moveDistance: PropTypes.number,
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -145,6 +145,11 @@ const VirtualListBaseFactory = (type) => {
 			itemSizes: PropTypes.array,
 
 			/**
+			 * TBD
+			 */
+			overSize: PropTypes.number,
+
+			/**
 			 * It scrolls by page when `true`, by item when `false`.
 			 *
 			 * @type {Boolean}
@@ -714,10 +719,12 @@ const VirtualListBaseFactory = (type) => {
 
 		calculatePositionOnFocus = ({item, scrollPosition = this.uiRefCurrent.scrollPosition}) => {
 			const
-				{pageScroll} = this.props,
+				{overSize, pageScroll} = this.props,
 				{numOfItems} = this.uiRefCurrent.state,
 				{primary} = this.uiRefCurrent,
-				offsetToClientEnd = primary.clientSize - primary.itemSize,
+				overSizeOffset = overSize - Math.min(overSize, scrollPosition),
+				// The offset varies depending on the VirtualList position.
+				offsetToClientEnd = primary.clientSize - primary.itemSize - overSizeOffset,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
 			if (!isNaN(focusedIndex)) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -147,7 +147,7 @@ const VirtualListBaseFactory = (type) => {
 			/**
 			 * TBD
 			 */
-			overSize: PropTypes.number,
+			moveDistance: PropTypes.number,
 
 			/**
 			 * It scrolls by page when `true`, by item when `false`.
@@ -719,12 +719,12 @@ const VirtualListBaseFactory = (type) => {
 
 		calculatePositionOnFocus = ({item, scrollPosition = this.uiRefCurrent.scrollPosition}) => {
 			const
-				{overSize, pageScroll} = this.props,
+				{moveDistance, pageScroll} = this.props,
 				{numOfItems} = this.uiRefCurrent.state,
 				{primary} = this.uiRefCurrent,
-				overSizeOffset = overSize - Math.min(overSize, scrollPosition),
+				moveDistanceOffset = moveDistance ? (moveDistance - Math.min(moveDistance, scrollPosition)) : 0,
 				// The offset varies depending on the VirtualList position.
-				offsetToClientEnd = primary.clientSize - primary.itemSize - overSizeOffset,
+				offsetToClientEnd = primary.clientSize - primary.itemSize - moveDistanceOffset,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
 			if (!isNaN(focusedIndex)) {

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -354,6 +354,11 @@ class ScrollableBase extends Component {
 		}),
 
 		/**
+		 * TBD
+		 */
+		overSize: PropTypes.number,
+
+		/**
 		 * Called when removing additional event listeners in a themed component.
 		 *
 		 * @type {Function}
@@ -453,6 +458,10 @@ class ScrollableBase extends Component {
 		this.resizeRegistry.parent = this.context;
 		this.addEventListeners();
 		this.updateScrollbars();
+
+		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
+		}
 	}
 
 	componentDidUpdate (prevProps, prevState) {
@@ -493,6 +502,10 @@ class ScrollableBase extends Component {
 		const vertical = isVerticalScrollbarVisible !== prevState.isVerticalScrollbarVisible;
 		if (horizontal || vertical) {
 			this.resizeRegistry.notify({});
+		}
+
+		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
 		}
 	}
 
@@ -1051,6 +1064,13 @@ class ScrollableBase extends Component {
 		}
 
 		this.childRefCurrent.setScrollPosition(this.scrollLeft, this.scrollTop, this.props.rtl, ...rest);
+		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			if (this.scrollTop < this.props.overSize) {
+				this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
+			} else {
+				this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.props.overSize);
+			}
+		}
 		this.forwardScrollEvent('onScroll');
 	}
 
@@ -1323,7 +1343,7 @@ class ScrollableBase extends Component {
 
 	render () {
 		const
-			{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = this.props,
+			{className, containerRenderer, noScrollByDrag, overSize, rtl, style, ...rest} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			scrollableClasses = classNames(css.scrollable, className),
 			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
@@ -1374,6 +1394,7 @@ class ScrollableBase extends Component {
 					initChildRef: this.initChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
+					overSize,
 					rtl,
 					scrollTo: this.scrollTo,
 					style,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -189,6 +189,14 @@ class ScrollableBase extends Component {
 		horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
 
 		/**
+		 * The distance that a list should move first when scrolling
+		 *
+		 * @type {Number}
+		 * @public
+		 */
+		moveDistance: PropTypes.number,
+
+		/**
 		 * Prevents scroll by dragging or flicking on the list or the scroller.
 		 *
 		 * @type {Boolean}
@@ -354,11 +362,6 @@ class ScrollableBase extends Component {
 		}),
 
 		/**
-		 * TBD
-		 */
-		overSize: PropTypes.number,
-
-		/**
 		 * Called when removing additional event listeners in a themed component.
 		 *
 		 * @type {Function}
@@ -455,17 +458,20 @@ class ScrollableBase extends Component {
 	}
 
 	componentDidMount () {
+		const {moveDistance} = this.props;
+
 		this.resizeRegistry.parent = this.context;
 		this.addEventListeners();
 		this.updateScrollbars();
 
-		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
-			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
+		if (moveDistance && this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			this.verticalScrollbarRef.current.syncHeight(moveDistance, this.scrollTop);
 		}
 	}
 
 	componentDidUpdate (prevProps, prevState) {
 		const
+			{moveDistance} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			{hasDataSizeChanged} = this.childRefCurrent;
 
@@ -504,8 +510,8 @@ class ScrollableBase extends Component {
 			this.resizeRegistry.notify({});
 		}
 
-		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
-			this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
+		if (moveDistance && this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			this.verticalScrollbarRef.current.syncHeight(moveDistance, this.scrollTop);
 		}
 	}
 
@@ -1056,6 +1062,8 @@ class ScrollableBase extends Component {
 	}
 
 	scroll = (left, top, ...rest) => {
+		const {moveDistance} = this.props;
+
 		if (left !== this.scrollLeft) {
 			this.setScrollLeft(left);
 		}
@@ -1064,11 +1072,11 @@ class ScrollableBase extends Component {
 		}
 
 		this.childRefCurrent.setScrollPosition(this.scrollLeft, this.scrollTop, this.props.rtl, ...rest);
-		if (this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
-			if (this.scrollTop < this.props.overSize) {
-				this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.scrollTop);
+		if (moveDistance && this.verticalScrollbarRef.current && this.verticalScrollbarRef.current.syncHeight) {
+			if (this.scrollTop < moveDistance) {
+				this.verticalScrollbarRef.current.syncHeight(moveDistance, this.scrollTop);
 			} else {
-				this.verticalScrollbarRef.current.syncHeight(this.props.overSize, this.props.overSize);
+				this.verticalScrollbarRef.current.syncHeight(moveDistance, moveDistance);
 			}
 		}
 		this.forwardScrollEvent('onScroll');
@@ -1343,7 +1351,7 @@ class ScrollableBase extends Component {
 
 	render () {
 		const
-			{className, containerRenderer, noScrollByDrag, overSize, rtl, style, ...rest} = this.props,
+			{className, containerRenderer, moveDistance, noScrollByDrag, rtl, style, ...rest} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			scrollableClasses = classNames(css.scrollable, className),
 			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
@@ -1394,7 +1402,7 @@ class ScrollableBase extends Component {
 					initChildRef: this.initChildRef,
 					isHorizontalScrollbarVisible,
 					isVerticalScrollbarVisible,
-					overSize,
+					moveDistance,
 					rtl,
 					scrollTo: this.scrollTo,
 					style,

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -57,20 +57,20 @@ class ScrollerBase extends Component {
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
-		 * The distance that a list should move first when scrolling
-		 *
-		 * @type {Number}
-		 * @public
-		 */
-		moveDistance: PropTypes.number,
-
-		/**
 		 * Prop to check context value if Scrollbar exists or not.
 		 *
 		 * @type {Boolean}
 		 * @private
 		 */
 		isVerticalScrollbarVisible: PropTypes.bool,
+
+		/**
+		 * The distance that a list should move first when scrolling
+		 *
+		 * @type {Number}
+		 * @public
+		 */
+		moveDistance: PropTypes.number,
 
 		/**
 		 * `true` if RTL, `false` if LTR.

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -57,6 +57,14 @@ class ScrollerBase extends Component {
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
+		 * The distance that a list should move first when scrolling
+		 *
+		 * @type {Number}
+		 * @public
+		 */
+		moveDistance: PropTypes.number,
+
+		/**
 		 * Prop to check context value if Scrollbar exists or not.
 		 *
 		 * @type {Boolean}
@@ -188,6 +196,7 @@ class ScrollerBase extends Component {
 
 		delete rest.cbScrollTo;
 		delete rest.direction;
+		delete rest.moveDistance;
 		delete rest.rtl;
 		delete rest.isHorizontalScrollbarVisible;
 		delete rest.isVerticalScrollbarVisible;

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -193,6 +193,14 @@ const VirtualListBaseFactory = (type) => {
 			itemSizes: PropTypes.arrayOf(PropTypes.number),
 
 			/**
+			 * The distance that a list should move first when scrolling
+			 *
+			 * @type {Number}
+			 * @public
+			 */
+			moveDistance: PropTypes.number,
+
+			/**
 			 * Called when the range of items has updated.
 			 *
 			 * Event payload includes the `firstIndex` and `lastIndex` of the list.
@@ -212,11 +220,6 @@ const VirtualListBaseFactory = (type) => {
 			 * @private
 			 */
 			overhang: PropTypes.number,
-
-			/**
-			 * TBD
-			 */
-			overSize: PropTypes.number,
 
 			/**
 			 * When `true`, the list will scroll by page.  Otherwise the list will scroll by item.
@@ -799,22 +802,24 @@ const VirtualListBaseFactory = (type) => {
 
 		// JS only
 		setScrollPosition (x, y, rtl = this.props.rtl, targetX = 0, targetY = 0) {
-			// if the scrollPosition is less than overSize, then the VirtualList does not scroll.
+			const {moveDistance} = this.props;
+
+			// if the scrollPosition is less than moveDistance, then the VirtualList does not scroll.
 			// But the list generates `onScroll` event so that the list could move upper by an App.
-			if (this.props.overSize && this.isPrimaryDirectionVertical && this.containerRef.current) {
-				if (y < this.props.overSize) {
+			if (moveDistance && this.isPrimaryDirectionVertical && this.containerRef.current) {
+				if (y < moveDistance) {
 					this.containerScrollPosition = y;
 
 					this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, 0, 0)`;
 
 					return;
 				} else {
-					if (y > this.props.overSize && this.containerScrollPosition < this.props.overSize) {
-						this.containerScrollPosition = this.isPrimaryDirectionVertical ? this.props.overSize : x;
+					if (y > moveDistance && this.containerScrollPosition < moveDistance) {
+						this.containerScrollPosition = this.isPrimaryDirectionVertical ? moveDistance : x;
 					}
 
-					if (this.containerScrollPosition > this.props.overSize) {
-						this.containerScrollPosition = this.props.overSize;
+					if (this.containerScrollPosition > moveDistance) {
+						this.containerScrollPosition = moveDistance;
 					}
 				}
 			}
@@ -837,7 +842,7 @@ const VirtualListBaseFactory = (type) => {
 
 		didScroll (x, y) {
 			const
-				{dataSize, spacing, itemSizes} = this.props,
+				{dataSize, moveDistance, spacing, itemSizes} = this.props,
 				{firstIndex} = this.state,
 				{isPrimaryDirectionVertical, threshold, dimensionToExtent, maxFirstIndex, scrollBounds, itemPositions} = this,
 				{clientSize, gridSize} = this.primary,
@@ -915,7 +920,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			this.syncThreshold(maxPos);
-			this.scrollPosition = this.props.overSize ? pos - this.props.overSize : pos;
+			this.scrollPosition = moveDistance ? pos - moveDistance : pos;
 			this.updateMoreInfo(dataSize, pos);
 
 			if (this.shouldUpdateBounds || firstIndex !== newFirstIndex) {
@@ -1195,10 +1200,10 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.isVerticalScrollbarVisible;
 			delete rest.itemRenderer;
 			delete rest.itemSize;
+			delete rest.moveDistance;
 			delete rest.onUpdate;
 			delete rest.onUpdateItems;
 			delete rest.overhang;
-			delete rest.overSize;
 			delete rest.pageScroll;
 			delete rest.rtl;
 			delete rest.spacing;

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -214,6 +214,11 @@ const VirtualListBaseFactory = (type) => {
 			overhang: PropTypes.number,
 
 			/**
+			 * TBD
+			 */
+			overSize: PropTypes.number,
+
+			/**
 			 * When `true`, the list will scroll by page.  Otherwise the list will scroll by item.
 			 *
 			 * @type {Boolean}
@@ -443,6 +448,7 @@ const VirtualListBaseFactory = (type) => {
 		hasDataSizeChanged = false
 		cc = []
 		scrollPosition = 0
+		containerScrollPosition = 0
 		scrollPositionTarget = 0
 
 		// For individually sized item
@@ -793,6 +799,26 @@ const VirtualListBaseFactory = (type) => {
 
 		// JS only
 		setScrollPosition (x, y, rtl = this.props.rtl, targetX = 0, targetY = 0) {
+			// if the scrollPosition is less than overSize, then the VirtualList does not scroll.
+			// But the list generates `onScroll` event so that the list could move upper by an App.
+			if (this.props.overSize && this.isPrimaryDirectionVertical && this.containerRef.current) {
+				if (y < this.props.overSize) {
+					this.containerScrollPosition = y;
+
+					this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, 0, 0)`;
+
+					return;
+				} else {
+					if (y > this.props.overSize && this.containerScrollPosition < this.props.overSize) {
+						this.containerScrollPosition = this.isPrimaryDirectionVertical ? this.props.overSize : x;
+					}
+
+					if (this.containerScrollPosition > this.props.overSize) {
+						this.containerScrollPosition = this.props.overSize;
+					}
+				}
+			}
+
 			if (this.contentRef.current) {
 				this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
 
@@ -889,7 +915,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			this.syncThreshold(maxPos);
-			this.scrollPosition = pos;
+			this.scrollPosition = this.props.overSize ? pos - this.props.overSize : pos;
 			this.updateMoreInfo(dataSize, pos);
 
 			if (this.shouldUpdateBounds || firstIndex !== newFirstIndex) {
@@ -1172,6 +1198,7 @@ const VirtualListBaseFactory = (type) => {
 			delete rest.onUpdate;
 			delete rest.onUpdateItems;
 			delete rest.overhang;
+			delete rest.overSize;
 			delete rest.pageScroll;
 			delete rest.rtl;
 			delete rest.spacing;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

: Add the `moveDistance` prop in the `VirtualGridList` to move the list instead of animating the items in the list when scrolling to that distance.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When starting scrolling the VirtualList, the list moves upper. I expect that behavior would be implemented by a panel or the POC for controller because the VirtualList positions upper naturally if the panel body including the list enlarges and moves upper.  To verify this PR, I implemented that behavior app side. Please use the app described in the JIRA to verify this PR.

### Links
[//]: # (Related issues, references)

PLAT-90767

### Comments
