### PR TITLE
PLAT-90767: Scale the VirtualGridList while scrolling to the `moveDistance` distance

### DIFF
--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -53,7 +53,7 @@ class ScrollbarBase extends Component {
 		corner: PropTypes.bool,
 
 		/**
-		 * The distance that a list should move first when scrolling
+		 * The distance that a list should scale first when scrolling
 		 *
 		 * @type {Number}
 		 * @public

--- a/packages/moonstone/VirtualList/VirtualList.js
+++ b/packages/moonstone/VirtualList/VirtualList.js
@@ -17,6 +17,8 @@ import React from 'react';
 
 import {ScrollableVirtualList, ScrollableVirtualListNative, VirtualListBase, VirtualListBaseNative} from './VirtualListBase';
 
+import css from './VirtualList.module.less';
+
 /**
  * A Moonstone-styled scrollable and spottable virtual list component.
  *
@@ -72,10 +74,8 @@ const VirtualList = kind({
  * @ui
  * @public
  */
-const VirtualGridList = kind({
-	name: 'VirtualGridList',
-
-	propTypes: /** @lends moonstone/VirtualList.VirtualGridList.prototype */ {
+class VirtualGridList extends React.Component {
+	static propTypes = /** @lends moonstone/VirtualList.VirtualGridList.prototype */ {
 		/**
 		 * Size of an item for the VirtualGridList; valid value is an object that has `minWidth`
 		 * and `minHeight` as properties.
@@ -95,12 +95,50 @@ const VirtualGridList = kind({
 		 * @public
 		 */
 		itemSize: gridListItemSizeShape.isRequired
-	},
+	}
 
-	render: (props) => (
-		<ScrollableVirtualList {...props} />
-	)
-});
+	constructor (props) {
+		super(props);
+
+		this.listContainer = React.createRef();
+		this.listReverseScaleContainer = React.createRef();
+	}
+
+	listPosition = 0
+
+	scale = (ev) => {
+		let listPosition = ev.scrollTop;
+
+		if (ev.scrollTop > 118 && this.listPosition < 118) {
+			listPosition = 118;
+		}
+
+		this.listContainer.current.style.transform =
+			'scaleY(' + ((listPosition + 722) / 722) + ')';
+		this.listReverseScaleContainer.current.style.transform =
+			'scaleY(' + (722 / (listPosition + 722)) + ')';
+
+		this.listPosition = listPosition;
+	}
+
+	render () {
+		const {moveDistance} = this.props;
+
+		if (moveDistance) {
+			return (
+				<div ref={this.listContainer} className={css.virtualListContainer} style={{height: 'calc(100% - ' + moveDistance + 'px)'}}>
+					<div ref={this.listReverseScaleContainer} className={css.virtualListReverseScaleContainer}>
+						<div style={{width: '100%', height: 'calc(100% + ' + moveDistance + 'px)'}}>
+							<ScrollableVirtualList {...this.props} scale={this.scale} />
+						</div>
+					</div>
+				</div>
+			);
+		} else {
+			return (<ScrollableVirtualList {...this.props} />);
+		}
+	}
+}
 
 /**
  * A Moonstone-styled scrollable and spottable virtual native list component.

--- a/packages/moonstone/VirtualList/VirtualList.js
+++ b/packages/moonstone/VirtualList/VirtualList.js
@@ -94,7 +94,15 @@ class VirtualGridList extends React.Component {
 		 * @required
 		 * @public
 		 */
-		itemSize: gridListItemSizeShape.isRequired
+		itemSize: gridListItemSizeShape.isRequired,
+
+		/**
+		 * The distance that a list should scale first when scrolling
+		 *
+		 * @type {Number}
+		 * @public
+		 */
+		moveDistance: PropTypes.number
 	}
 
 	constructor (props) {

--- a/packages/moonstone/VirtualList/VirtualList.module.less
+++ b/packages/moonstone/VirtualList/VirtualList.module.less
@@ -1,0 +1,14 @@
+.virtualListContainer {
+    overflow: hidden;
+	width: 100%;
+    height: 100%;
+    will-change: transform;
+    transform-origin: top;
+}
+
+.virtualListReverseScaleContainer {
+    width: 100%;
+    height: 100%;
+    will-change: transform;
+    transform-origin: top;
+}

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -145,7 +145,7 @@ const VirtualListBaseFactory = (type) => {
 			itemSizes: PropTypes.array,
 
 			/**
-			 * The distance that a list should move first when scrolling
+			 * The distance that a list should scale first when scrolling
 			 *
 			 * @type {Number}
 			 * @public

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -378,6 +378,11 @@ class ScrollableBase extends Component {
 		rtl: PropTypes.bool,
 
 		/**
+		 * The scale to enlarge the list.
+		 */
+		scale: PropTypes.func,
+
+		/**
 		 * Called to execute additional logic in a themed component when scrollTo is called.
 		 *
 		 * @type {Function}
@@ -1080,6 +1085,10 @@ class ScrollableBase extends Component {
 			}
 		}
 		this.forwardScrollEvent('onScroll');
+
+		if (moveDistance) {
+			this.props.scale({scrollTop: this.scrollTop});
+		}
 	}
 
 	stop () {
@@ -1382,6 +1391,7 @@ class ScrollableBase extends Component {
 		delete rest.onWheel;
 		delete rest.overscrollEffectOn;
 		delete rest.removeEventListeners;
+		delete rest.scale;
 		delete rest.scrollTo;
 		delete rest.stop;
 		delete rest.verticalScrollbar;

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -189,7 +189,7 @@ class ScrollableBase extends Component {
 		horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
 
 		/**
-		 * The distance that a list should move first when scrolling
+		 * The distance that a list should scale first when scrolling
 		 *
 		 * @type {Number}
 		 * @public

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -65,7 +65,7 @@ class ScrollerBase extends Component {
 		isVerticalScrollbarVisible: PropTypes.bool,
 
 		/**
-		 * The distance that a list should move first when scrolling
+		 * The distance that a list should scale first when scrolling
 		 *
 		 * @type {Number}
 		 * @public

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -193,7 +193,7 @@ const VirtualListBaseFactory = (type) => {
 			itemSizes: PropTypes.arrayOf(PropTypes.number),
 
 			/**
-			 * The distance that a list should move first when scrolling
+			 * The distance that a list should scale first when scrolling
 			 *
 			 * @type {Number}
 			 * @public


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

: Scale the VirtualGridList while scrolling to the `moveDistance` distance

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When starting scrolling the VirtualList, the list moves upper. I expect that behavior would be implemented by a panel or the POC for controller because the VirtualList positions upper naturally if the panel body including the list enlarges and moves upper.  To verify this PR, I implemented that behavior app side. Please use the app described in the JIRA to verify this PR.

### Links
[//]: # (Related issues, references)

PLAT-90767

### Comments
