### PR TITLE
ENYO-6352: Fix Notification to support 3 full-width buttons in one line

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Notification`to support 3 max-width buttons in a single line
+
 ## [3.2.4] - 2019-11-07
 
 ### Fixed

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -470,8 +470,8 @@
 @moon-notification-padding-left-right: 39px;
 @moon-notification-padding-top-bottom: 24px;
 @moon-notification-min-width: 300px;
-@moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)));  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
-@moon-notification-wide-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (3 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)));
+@moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)) + 12px);  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
+@moon-notification-wide-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (3 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)) + 12px);
 
 // Tooltip
 // ---------------------------------------

--- a/packages/moonstone/styles/variables.less
+++ b/packages/moonstone/styles/variables.less
@@ -471,7 +471,7 @@
 @moon-notification-padding-top-bottom: 24px;
 @moon-notification-min-width: 300px;
 @moon-notification-max-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (2 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)));  // Attempt to calculate the width of all of the buttons and the pieces of Notification that influence the width to get the maximum size
-@moon-notification-wide-width: 1287px;
+@moon-notification-wide-width: ((@moon-notification-border-width * 2) + (@moon-notification-padding-left-right * 2) + (3 * ((@moon-button-small-h-margin * 2) + @moon-button-small-max-width)));
 
 // Tooltip
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
3 max-width buttons don't fit in a wide `Notification`.


### Resolution
The width of `Notification`is now based on the size of 3 max-width buttons. (It's wider now.)