### PR TITLE
PLAT-94532: Prevent double read of marqueeing text

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to not double aria readout for marqueeing contents
+
 ## [3.2.4] - 2019-11-07
 
 ### Fixed
 
-- `ui/Marquee` text aligment when content is centered
+- `ui/Marquee` text alignment when content is centered
 
 ## [3.2.3] - 2019-11-01
 

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -45,6 +45,15 @@ const MarqueeBase = kind({
 		animating: PropTypes.bool,
 
 		/**
+		 * Sets the value of the `aria-label` attribute for the wrapped component.
+		 *
+		 * @memberof ui/Marquee.MarqueeBase.prototype
+		 * @type {String}
+		 * @public
+		 */
+		'aria-label': PropTypes.string,
+
+		/**
 		 * The text or a set of components that should be marqueed
 		 *
 		 * This prop may be empty in some cases, which is OK.
@@ -182,6 +191,8 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
+		'aria-label': ({'aria-label': aria, children}) => aria == null &&
+			typeof children === 'string' ? children : aria,
 		clientClassName: ({animating, willAnimate, styler}) => styler.join({
 			animate: animating,
 			text: true,

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -191,10 +191,15 @@ const MarqueeBase = kind({
 	},
 
 	computed: {
-		'aria-label': ({'aria-label': aria, children}) => aria == null &&
-			React.Children.map(children, c => typeof c === 'string' && c)
-				.filter(Boolean)
-				.join(' ') || aria,	// If aria set or no string children, use aria value
+		'aria-label': ({'aria-label': aria, children, distance, willAnimate}) => {
+			if (aria == null && willAnimate && distance > 0) {
+				return React.Children.map(children, c => typeof c === 'string' && c)
+					.filter(Boolean)
+					.join(' ') || aria;
+			} else {
+				return aria;
+			}
+		},
 		clientClassName: ({animating, willAnimate, styler}) => styler.join({
 			animate: animating,
 			text: true,

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -192,7 +192,9 @@ const MarqueeBase = kind({
 
 	computed: {
 		'aria-label': ({'aria-label': aria, children}) => aria == null &&
-			typeof children === 'string' ? children : aria,
+			React.Children.map(children, c => typeof c === 'string' && c)
+				.filter(Boolean)
+				.join(' ') || aria,	// If aria set or no string children, use aria value
 		clientClassName: ({animating, willAnimate, styler}) => styler.join({
 			animate: animating,
 			text: true,

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -318,4 +318,56 @@ describe('MarqueeBase', () => {
 		const actual = subject.text();
 		expect(actual).toBe('Text');
 	});
+
+	test('should add aria-label with content when promoted and a non-zero distance', () => {
+		const text = 'Text';
+		const subject = mount(
+			<MarqueeBase willAnimate distance={100}>
+				{text}
+			</MarqueeBase>
+		);
+
+		const expected = text;
+		const actual = subject.childAt(0).prop('aria-label');
+		expect(actual).toBe(expected);
+	});
+
+	test('should not override aria-label with content when promoted and a non-zero distance', () => {
+		const aria = 'Custom';
+		const subject = mount(
+			<MarqueeBase willAnimate distance={100} aria-label={aria}>
+				Text
+			</MarqueeBase>
+		);
+
+		const expected = aria;
+		const actual = subject.childAt(0).prop('aria-label');
+		expect(actual).toBe(expected);
+	});
+
+	test('should concatenate string children when promoted and a non-zero distance', () => {
+		const subject = mount(
+			<MarqueeBase willAnimate distance={100} aria-label={aria}>
+				This is {'A'} test
+			</MarqueeBase>
+		);
+
+		const expected = 'This is  A  test';
+		const actual = subject.childAt(0).prop('aria-label');
+		expect(actual).toBe(expected);
+	});
+
+	test('should not concatenate non-string children when promoted and a non-zero distance', () => {
+		const subject = mount(
+			<MarqueeBase willAnimate distance={100} aria-label={aria}>
+				Test
+				<div>Hello</div>
+				World
+			</MarqueeBase>
+		);
+
+		const expected = 'Test World';
+		const actual = subject.childAt(0).prop('aria-label');
+		expect(actual).toBe(expected);
+	});
 });

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -347,7 +347,7 @@ describe('MarqueeBase', () => {
 
 	test('should concatenate string children when promoted and a non-zero distance', () => {
 		const subject = mount(
-			<MarqueeBase willAnimate distance={100} aria-label={aria}>
+			<MarqueeBase willAnimate distance={100}>
 				This is {'A'} test
 			</MarqueeBase>
 		);
@@ -359,7 +359,7 @@ describe('MarqueeBase', () => {
 
 	test('should not concatenate non-string children when promoted and a non-zero distance', () => {
 		const subject = mount(
-			<MarqueeBase willAnimate distance={100} aria-label={aria}>
+			<MarqueeBase willAnimate distance={100}>
 				Test
 				<div>Hello</div>
 				World


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A marqueeing item that needed to read again would read the contents twice

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set an `aria-label` if one was not supplied, the contents (`children`) is plain text and the marquee will animate

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
If the marquee does not contain 'plain' children, the readout could be  unexpected. Developers can override by setting `aria-label` directly in these cases.

### Links
[//]: # (Related issues, references)
PLAT-94352

### Comments
