### PR TITLE
PLAT-86361: Fix VirtualList with different item sizes to render properly when dataSize is 0

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,8 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Notification`to support 3 max-width buttons in a single line
+- `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
+
 ## [3.2.5] - 2019-11-14
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
+
 ## [3.2.5] - 2019-11-14
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,11 +3,6 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
-
-### Fixed
-
-- `ui/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
-
 ## [3.2.5] - 2019-11-14
 
 ### Fixed

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -471,7 +471,7 @@ const VirtualListBaseFactory = (type) => {
 			const extent = Math.floor(index / dimensionToExtent);
 			let primaryPosition;
 
-			if (this.props.dataSize > index && this.props.itemSizes && typeof this.props.itemSizes[index] !== 'undefined') {
+			if (this.props.itemSizes && typeof this.props.itemSizes[index] !== 'undefined' && this.props.dataSize > index) {
 				const firstIndexInExtent = extent * dimensionToExtent;
 
 				if (!itemPositions[firstIndexInExtent]) {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -466,12 +466,14 @@ const VirtualListBaseFactory = (type) => {
 		getMoreInfo = () => this.moreInfo
 
 		getGridPosition (index) {
-			const {dimensionToExtent, itemPositions, primary, secondary} = this;
-			const secondaryPosition = (index % dimensionToExtent) * secondary.gridSize;
-			const extent = Math.floor(index / dimensionToExtent);
+			const
+				{dataSize, itemSizes} = this.props,
+				{dimensionToExtent, itemPositions, primary, secondary} = this,
+				secondaryPosition = (index % dimensionToExtent) * secondary.gridSize,
+				extent = Math.floor(index / dimensionToExtent);
 			let primaryPosition;
 
-			if (this.props.itemSizes && typeof this.props.itemSizes[index] !== 'undefined' && this.props.dataSize > index) {
+			if (itemSizes && typeof itemSizes[index] !== 'undefined' && dataSize > index) {
 				const firstIndexInExtent = extent * dimensionToExtent;
 
 				if (!itemPositions[firstIndexInExtent]) {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -471,7 +471,7 @@ const VirtualListBaseFactory = (type) => {
 			const extent = Math.floor(index / dimensionToExtent);
 			let primaryPosition;
 
-			if (this.props.itemSizes) {
+			if (this.props.dataSize > index && this.props.itemSizes && typeof this.props.itemSizes[index] !== 'undefined') {
 				const firstIndexInExtent = extent * dimensionToExtent;
 
 				if (!itemPositions[firstIndexInExtent]) {
@@ -481,7 +481,11 @@ const VirtualListBaseFactory = (type) => {
 					}
 				}
 
-				primaryPosition = itemPositions[firstIndexInExtent].position;
+				if (itemPositions[firstIndexInExtent]) {
+					primaryPosition = itemPositions[firstIndexInExtent].position;
+				} else {
+					primaryPosition = extent * primary.gridSize;
+				}
 			} else {
 				primaryPosition = extent * primary.gridSize;
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a bug to access a member property of `undefined` if `VirtualList` has no item when `itemSizes` prop is given. This PR adds conditions to avoid invalid access.
Even if there is no item inside a list, a hidden placeholder item for spotlight management gets focus and a list try to get/calculate the position of the item has index 0. This makes access to an invalid `undefined` object.
Also, a new potential risk is found in a case that `itemSIzes` does not have sizing info for a target index.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added conditions to avoid invalid access.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The fix assumes that `itemSizes` has no empty element between the first and the last elements.

### Links
[//]: # (Related issues, references)
PLAT-86361

### Comments
