### PR TITLE
Fix Marquee to not throw for null children

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,11 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` to not error when passed `null` `children` during an animation.
+
 ## [3.2.5] - 2019-11-14
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -192,7 +192,7 @@ const MarqueeBase = kind({
 
 	computed: {
 		'aria-label': ({'aria-label': aria, children, distance, willAnimate}) => {
-			if (aria == null && willAnimate && distance > 0) {
+			if (children != null && aria == null && willAnimate && distance > 0) {
 				return React.Children.map(children, c => typeof c === 'string' && c)
 					.filter(Boolean)
 					.join(' ') || aria;

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -370,4 +370,14 @@ describe('MarqueeBase', () => {
 		const actual = subject.childAt(0).prop('aria-label');
 		expect(actual).toBe(expected);
 	});
+
+	test('should not throw exception for null children when promoted and a non-zero distance - ENYO-6362', () => {
+		const mountSubject = () => mount(
+			<MarqueeBase willAnimate distance={100}>
+				{null}
+			</MarqueeBase>
+		);
+
+		expect(mountSubject).not.toThrow();
+	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If `children` changes to `null` during an animation an exception is thrown.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Because we must render `children` before we can measure, there can be a window when `Marquee` thinks it should animate but there are no children to render.  Additionally, `React.Children.map()` returns `undefined` or `null` instead of an empty array when passed `undefined` or `null` we must prevent chaining from the return in those cases.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I checked other uses and there appear to be no problems with `React.Children.map()` elsewhere.  Could also have used `React.Children.toArray().map()` instead.

### Links
[//]: # (Related issues, references)
ENYO-6362

### Comments
