### PR TITLE
ENYO-6364: Upgraded ui/Button to leverage ComponentOverride for iconComponent

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -94,10 +94,12 @@ const ButtonBase = kind({
 		/**
 		 * The component used to render the [icon]{@link ui/Button.ButtonBase.icon}.
 		 *
-		 * This component will receive the `size` and `spriteCount` properties and should them.
-		 * This coomponent will also receive the `icon` class to customize its styling.
-		 * If [icon]{@link ui/Button.ButtonBase.icon} is not assigned, this component will not be
-		 * rendered.
+		 * This component will receive the `icon` class to customize its styling.
+		 * If [icon]{@link ui/Button.ButtonBase.icon} is not assigned or is false, this component
+		 * will not be rendered.
+		 *
+		 * If this is a component rather than an HTML element string, this component will also
+		 * receive the `size` property and should be configured to handle it.
 		 *
 		 * @type {Component}
 		 * @public
@@ -175,32 +177,25 @@ const ButtonBase = kind({
 		}, size),
 		icon: ({css, icon, iconComponent, size}) => {
 			if (icon == null || icon === false) return;
-			// If the iconComponent is a string, we exclude the obviously unsupported props
-			// (non-HTML) from the component to simplify the usage of plain HTML elements as the
-			// component. Ex: 'div', 'span', etc.
-			if (typeof iconComponent === 'string') {
-				return (
-					<ComponentOverride
-						component={iconComponent}
-						className={css.icon}
-					>
-						{icon}
-					</ComponentOverride>
-				);
-			} else {
-				// Relay the full compliment of props to the iconComponent. Full Enact components
-				// should be responsible for handling these additional props themselves.
-				// console.log('Rendering %s as a %s icon:', icon, size);
-				return (
-					<ComponentOverride
-						component={iconComponent}
-						size={size}
-						className={css.icon}
-					>
-						{icon}
-					</ComponentOverride>
-				);
+
+			// Establish the base collection of props for the moost basic `iconComponent` type, an
+			// HTML element string.
+			const props = {
+				className: css.icon,
+				component: iconComponent
+			};
+
+			// Add in additional props that any Component supplied to `iconComponent` should be
+			// configured to handle.
+			if (typeof iconComponent !== 'string') {
+				props.size = size;
 			}
+
+			return (
+				<ComponentOverride {...props}>
+					{icon}
+				</ComponentOverride>
+			);
 		}
 	},
 

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -101,10 +101,10 @@ const ButtonBase = kind({
 		 * If this is a component rather than an HTML element string, this component will also
 		 * receive the `size` property and should be configured to handle it.
 		 *
-		 * @type {Component}
+		 * @type {Component|Node}
 		 * @public
 		 */
-		iconComponent: EnactPropTypes.component,
+		iconComponent: EnactPropTypes.componentOverride,
 
 		/**
 		 * Enforces a minimum width for the component.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee` to not error when passed `null` `children` during an animation.
+- `ui/Button` to have more robust support for a customized `iconComponent` prop
 
 ## [3.2.5] - 2019-11-14
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Customization the `iconComponent` of `ui/Button` don't behave as expected.

Example error:
```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
```

### Resolution
When using the `iconComponent` prop of `ui/Button`, the expectation is that it behaves the same way (supports the same features and capabilities) as other overridable components. `ui/Button` used a legacy approach to supporting custom component overrides and this proved to be problematic for customization.

The new code not only updates the approach to the modern Enact standard (`ComponentOverride`) but also now supports simpler usage of HTML elements, as now, you're no longer required to prune out unsupported non-HTML-safe props off your component.