### PR TITLE
ENYO-6372: Add MoonstoneDecorator documentation

### DIFF
--- a/docs/creating-components.md
+++ b/docs/creating-components.md
@@ -108,7 +108,7 @@ behaviors across components. All of these HOCs were created using the `hoc()` fa
 * HOCs can be configurable by passing an object with parameters to the HOC function. This object is
   merged with a set of default configuration parameters.
 * HOCs are flexible in their usage. They can:
-  * Accept a configuration object and a component 
+  * Accept a configuration object and a component
     ```javascript
     const ToggleableWidget = Toggleable({toggle: 'onClick', prop: 'selected'}, Widget);
     ```

--- a/packages/moonstone/BodyText/BodyText.js
+++ b/packages/moonstone/BodyText/BodyText.js
@@ -54,7 +54,7 @@ const BodyTextBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Button/Button.js
+++ b/packages/moonstone/Button/Button.js
@@ -69,7 +69,7 @@ const ButtonBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/CheckboxItem/CheckboxItem.js
+++ b/packages/moonstone/CheckboxItem/CheckboxItem.js
@@ -49,7 +49,7 @@ const CheckboxItemBase = kind({
 	propTypes: /** @lends moonstone/CheckboxItem.CheckboxItem.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
+++ b/packages/moonstone/ContextualPopupDecorator/ContextualPopup.js
@@ -52,7 +52,8 @@ const ContextualPopupRoot = Skinnable(
 /**
  * A popup component used by
  * [ContextualPopupDecorator]{@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator} to
- * wrap its [popupComponent]{@link moonstone/ContextualPopupDecorator.popupComponent}.
+ * wrap its
+ * [popupComponent]{@link moonstone/ContextualPopupDecorator.ContextualPopupDecorator.popupComponent}.
  *
  * `ContextualPopup` is usually not used directly but is made available for unique application use
  * cases.

--- a/packages/moonstone/Dialog/Dialog.js
+++ b/packages/moonstone/Dialog/Dialog.js
@@ -59,7 +59,7 @@ const DialogBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/FormCheckbox/FormCheckbox.js
+++ b/packages/moonstone/FormCheckbox/FormCheckbox.js
@@ -38,7 +38,7 @@ const FormCheckboxBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link ui/Icon.IconBase.iconList},
+		 * * A string that represents an icon from the [iconList]{@link ui/Icon.Icon.iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution}).

--- a/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
+++ b/packages/moonstone/FormCheckboxItem/FormCheckboxItem.js
@@ -34,7 +34,7 @@ const FormCheckboxItemBase = kind({
 	propTypes: /** @lends moonstone/FormCheckboxItem.FormCheckboxItem.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/GridListImageItem/GridListImageItem.js
+++ b/packages/moonstone/GridListImageItem/GridListImageItem.js
@@ -53,7 +53,7 @@ const GridListImageItemBase = kind({
 	propTypes: /** @lends moonstone/GridListImageItem.GridListImageItemBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Icon/Icon.js
+++ b/packages/moonstone/Icon/Icon.js
@@ -139,7 +139,7 @@ const IconBase = kind({
  * view360
  * view360off
  * info
- * cycle
+ * repeattrack
  * bluetoothoff
  * verticalellipsis
  * arrowcurveright

--- a/packages/moonstone/IconButton/IconButton.js
+++ b/packages/moonstone/IconButton/IconButton.js
@@ -69,7 +69,7 @@ const IconButtonBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Image/Image.js
+++ b/packages/moonstone/Image/Image.js
@@ -38,7 +38,7 @@ const ImageBase = kind({
 	propTypes: /** @lends moonstone/Image.ImageBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/IncrementSlider/IncrementSlider.js
+++ b/packages/moonstone/IncrementSlider/IncrementSlider.js
@@ -108,7 +108,7 @@ const IncrementSliderBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * @type {Object}
 		 * @private

--- a/packages/moonstone/Input/Input.js
+++ b/packages/moonstone/Input/Input.js
@@ -45,7 +45,7 @@ const InputBase = kind({
 	propTypes: /** @lends moonstone/Input.InputBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Item/Item.js
+++ b/packages/moonstone/Item/Item.js
@@ -38,7 +38,7 @@ const ItemBase = kind({
 	propTypes: /** @lends moonstone/Item.ItemBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Item/Item.js
+++ b/packages/moonstone/Item/Item.js
@@ -72,9 +72,9 @@ const ItemBase = kind({
  * @class ItemDecorator
  * @hoc
  * @memberof moonstone/Item
- * @mixes spotlight.Spottable
+ * @mixes spotlight/Spottable.Spottable
  * @mixes moonstone/Marquee.MarqueeDecorator
- * @mixes moonstone/Skinnable
+ * @mixes moonstone/Skinnable.Skinnable
  * @ui
  * @public
  */

--- a/packages/moonstone/LabeledIcon/LabeledIcon.js
+++ b/packages/moonstone/LabeledIcon/LabeledIcon.js
@@ -43,7 +43,7 @@ const LabeledIconBase = kind({
 	propTypes: /** @lends moonstone/LabeledIcon.LabeledIconBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/LabeledIconButton/LabeledIconButton.js
+++ b/packages/moonstone/LabeledIconButton/LabeledIconButton.js
@@ -51,7 +51,7 @@ const LabeledIconButtonBase = kind({
 	propTypes: /** @lends moonstone/LabeledIconButton.LabeledIconButtonBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/LabeledItem/LabeledItem.js
+++ b/packages/moonstone/LabeledItem/LabeledItem.js
@@ -60,7 +60,7 @@ const LabeledItemBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/MediaOverlay/MediaOverlay.js
+++ b/packages/moonstone/MediaOverlay/MediaOverlay.js
@@ -191,7 +191,7 @@ const MediaOverlayDecorator = compose(
  *
  * @class MediaOverlay
  * @memberof moonstone/MediaOverlay
- * @extends moonstone/mediaOverlay.MediaOverlayBase
+ * @extends moonstone/MediaOverlay.MediaOverlayBase
  * @mixes moonstone/MediaOverlay.MediaOverlayDecorator
  * @ui
  * @public

--- a/packages/moonstone/MediaOverlay/MediaOverlay.js
+++ b/packages/moonstone/MediaOverlay/MediaOverlay.js
@@ -52,7 +52,7 @@ const MediaOverlayBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/MoonstoneDecorator/AccessibilityDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/AccessibilityDecorator.js
@@ -26,6 +26,7 @@ const AccessibilityDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			 * the components' contrast to this preset.
 			 *
 			 * @type {Boolean}
+			 * @default false
 			 * @public
 			 */
 			highContrast: PropTypes.bool,
@@ -37,7 +38,7 @@ const AccessibilityDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			 * information to adjust the components' text sizes to this preset.
 			 * Current presets are `'normal'` (default), and `'large'`.
 			 *
-			 * @type {String}
+			 * @type {('normal'|'large')}
 			 * @default 'normal'
 			 * @public
 			 */

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -65,9 +65,10 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
 	/**
 	 * Options for I18nDecorator.
 	 *
-	 * If not applied, app will be responsible for applying the decorator.
+	 * My be `false` to prevent applying the decorator. If not applied, app will be responsible for
+	 * applying the decorator.
 	 *
-	 * @type {Object}
+	 * @type {Object|false}
 	 * @default {sync: true}
 	 * @see {@link i18n/I18nDecorator}
 	 * @public
@@ -98,7 +99,7 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
 	 * Override the resolution independence settings.
 	 *
 	 * @type {Object}
-	 * @see {@link moonstone/resolution}
+	 * @see {@link ui/resolution}
 	 * @public
 	 */
 	ri: {

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -28,20 +28,104 @@ import {configure} from '@enact/ui/Touchable';
  * @memberof moonstone/MoonstoneDecorator.MoonstoneDecorator
  * @hocconfig
  */
-const defaultConfig = {
+const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator.defaultConfig */ {
+	/**
+	 * Applies AccessibilityDecorator.
+	 *
+	 * If not applied, app will not support accessibility options.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @see {@link moonstone/MoonstoneDecorator.AccessibilityDecorator}
+	 * @public
+	 */
+	accessible: true,
+
+	/**
+	 * Disables use of full screen.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
 	disableFullscreen: false,
+
+	/**
+	 * Enables a floating layer for popup components.
+	 *
+	 * If not applied, app will be responsible for applying the decorator.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @see {@link ui/FloatingLayer.FloatingLayerDecorator}
+	 * @public
+	 */
 	float: true,
+
+	/**
+	 * Options for I18nDecorator.
+	 *
+	 * If not applied, app will be responsible for applying the decorator.
+	 *
+	 * @type {Object}
+	 * @default {sync: true}
+	 * @see {@link i18n/I18nDecorator}
+	 * @public
+	 */
 	i18n: {
 		sync: true
 	},
+
+	/**
+	 * Disables setting spotlight focus on first render.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
 	noAutoFocus: false,
+
+	/**
+	 * Enables overlay mode (no background color will be applied).
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
 	overlay: false,
+
+	/**
+	 * Override the resolution independence settings.
+	 *
+	 * @type {Object}
+	 * @see {@link moonstone/resolution}
+	 * @public
+	 */
 	ri: {
 		screenTypes
 	},
+
+	/**
+	 * Applies skinning support.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @see {@link moonstone/Skinnable}
+	 * @public
+	 */
 	skin: true,
-	spotlight: true,
-	textSize: true
+
+	/**
+	 * Applies spotlight decorator.
+	 *
+	 * If not applied, app will be responsible for applying the decorator.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @see {@link spotlight/SpotlightRootDecorator}
+	 * @public
+	 */
+	spotlight: true
 };
 
 /**
@@ -62,12 +146,17 @@ const defaultConfig = {
  *
  * @class MoonstoneDecorator
  * @memberof moonstone/MoonstoneDecorator
+ * @mixes ui/FloatingLayer.FloatingLayerDecorator
+ * @mixes ui/resolution.ResolutionDecorator
+ * @mixes spotlight/SpotlightRootDecorator.SpotlightRootDecorator
+ * @mixes moonstone/Skinnable.Skinnable
+ * @mixes moonstone/MoonstoneDecorator.AccessibilityDecorator
  * @hoc
  * @public
  */
 const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {ri, i18n, spotlight, float, noAutoFocus, overlay,
-		textSize, skin, highContrast, disableFullscreen} = config;
+	const {accessible, ri, i18n, spotlight, float, noAutoFocus, overlay,
+		skin, disableFullscreen} = config;
 
 	// Apply classes depending on screen type (overlay / fullscreen)
 	const bgClassName = classNames({
@@ -98,7 +187,7 @@ const MoonstoneDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	}
 	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
 	if (skin) App = Skinnable({defaultSkin: 'dark'}, App);
-	if (textSize || highContrast) App = AccessibilityDecorator(App);
+	if (accessible) App = AccessibilityDecorator(App);
 
 	// add webOS-specific key maps
 	addAll({

--- a/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
+++ b/packages/moonstone/MoonstoneDecorator/MoonstoneDecorator.js
@@ -65,7 +65,7 @@ const defaultConfig = /** @lends moonstone/MoonstoneDecorator.MoonstoneDecorator
 	/**
 	 * Options for I18nDecorator.
 	 *
-	 * My be `false` to prevent applying the decorator. If not applied, app will be responsible for
+	 * May be `false` to prevent applying the decorator. If not applied, app will be responsible for
 	 * applying the decorator.
 	 *
 	 * @type {Object|false}

--- a/packages/moonstone/Notification/Notification.js
+++ b/packages/moonstone/Notification/Notification.js
@@ -69,7 +69,7 @@ const NotificationBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -119,7 +119,7 @@ const PickerBase = kind({
 		 * Disables marqueeing of items.
 		 *
 		 * By default, each picker item is wrapped by a
-		 * [`MarqueeText`]{@link moonstone/Marquee.MarqueeText}. When this is set, the items will
+		 * [`Marquee`]{@link moonstone/Marquee.Marquee}. When this is set, the items will
 		 * not be wrapped.
 		 *
 		 * @type {Boolean}

--- a/packages/moonstone/Picker/Picker.js
+++ b/packages/moonstone/Picker/Picker.js
@@ -249,12 +249,13 @@ const PickerBase = kind({
 /**
  * A Picker component that allows selecting values from a list of values.
  *
- * By default, `RangePicker` maintains the state of its `value` property. Supply the `defaultValue`
+ * By default, `Picker` maintains the state of its `value` property. Supply the `defaultValue`
  * property to control its initial value. If you wish to directly control updates to the component,
  * supply a value to `value` at creation time and update it in response to `onChange` events.
  *
  * @class Picker
  * @memberof moonstone/Picker
+ * @extends moonstone/Picker.PickerBase
  * @mixes ui/Changeable.Changeable
  * @mixes moonstone/Marquee.MarqueeController
  * @ui

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -275,7 +275,6 @@ const OpenState = {
  * @class Popup
  * @memberof moonstone/Popup
  * @extends moonstone/Popup.PopupBase
- * @mixes moonstone/Popup.PopupDecorator
  * @ui
  * @public
  */

--- a/packages/moonstone/Popup/Popup.js
+++ b/packages/moonstone/Popup/Popup.js
@@ -1,11 +1,12 @@
 /**
  * Modal component that appears at the bottom of the screen and takes up the full screen width.
  *
+ * @example
+ * <Popup open>Hello!</Popup>
+ *
  * @module moonstone/Popup
  * @exports Popup
  * @exports PopupBase
- * @example
- * <Popup open>Hello!</Popup>
  */
 
 import {is} from '@enact/core/keymap';
@@ -73,7 +74,7 @@ const PopupBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *
@@ -273,6 +274,8 @@ const OpenState = {
  *
  * @class Popup
  * @memberof moonstone/Popup
+ * @extends moonstone/Popup.PopupBase
+ * @mixes moonstone/Popup.PopupDecorator
  * @ui
  * @public
  */

--- a/packages/moonstone/ProgressBar/ProgressBar.js
+++ b/packages/moonstone/ProgressBar/ProgressBar.js
@@ -39,7 +39,7 @@ const ProgressBarBase = kind({
 	propTypes: /** @lends moonstone/ProgressBar.ProgressBarBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/RadioItem/RadioItem.js
+++ b/packages/moonstone/RadioItem/RadioItem.js
@@ -34,7 +34,7 @@ const RadioItemBase = kind({
 	propTypes: /** @lends moonstone/RadioItem.RadioItem.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/SelectableItem/SelectableItem.js
+++ b/packages/moonstone/SelectableItem/SelectableItem.js
@@ -36,7 +36,7 @@ const SelectableItemBase = kind({
 	propTypes: /** @lends moonstone/SelectableItem.SelectableItemBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Slider/Slider.js
+++ b/packages/moonstone/Slider/Slider.js
@@ -76,7 +76,7 @@ const SliderBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -87,10 +87,10 @@ const SlotItemBase = kind({
  * @class SlotItemDecorator
  * @memberof moonstone/SlotItem
  * @mixes ui/SlotItem.SlotItemDecorator
- * @mixes ui/Toggleable
- * @mixes spotlight.Spottable
+ * @mixes ui/Toggleable.Toggleable
+ * @mixes spotlight/Spottable.Spottable
  * @mixes moonstone/Marquee.MarqueeDecorator
- * @mixes moonstone/Skinnable
+ * @mixes moonstone/Skinnable.Skinnable
  * @hoc
  * @public
  */

--- a/packages/moonstone/SlotItem/SlotItem.js
+++ b/packages/moonstone/SlotItem/SlotItem.js
@@ -53,7 +53,7 @@ const SlotItemBase = kind({
 	propTypes: /** @lends moonstone/SlotItem.SlotItemBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/Spinner/Spinner.js
+++ b/packages/moonstone/Spinner/Spinner.js
@@ -92,7 +92,7 @@ const SpinnerBase = kind({
 	propTypes: /** @lends moonstone/Spinner.SpinnerBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/SwitchItem/SwitchItem.js
+++ b/packages/moonstone/SwitchItem/SwitchItem.js
@@ -38,7 +38,7 @@ const SwitchItemBase = kind({
 	propTypes: /** @lends moonstone/SwitchItem.SwitchItem.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/ToggleButton/ToggleButton.js
+++ b/packages/moonstone/ToggleButton/ToggleButton.js
@@ -183,7 +183,7 @@ const ToggleButtonBase = kind({
  * @memberof moonstone/ToggleButton
  * @extends moonstone/ToggleButton.ToggleButtonBase
  * @ui
- * @mixes ui/Toggleable
+ * @mixes ui/Toggleable.Toggleable
  * @public
  */
 const ToggleButton = Pure(

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -70,7 +70,7 @@ const ToggleItemBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/moonstone/ToggleItem/ToggleItem.js
+++ b/packages/moonstone/ToggleItem/ToggleItem.js
@@ -136,7 +136,7 @@ const defaultConfig = {
  * @mixes ui/ToggleItem.ToggleItemDecorator
  * @mixes spotlight/Spottable.Spottable
  * @mixes moonstone/Marquee.MarqueeDecorator
- * @mixes moonstone/Skinnable
+ * @mixes moonstone/Skinnable.Skinnable
  * @hoc
  * @public
  */

--- a/packages/moonstone/VideoPlayer/Video.js
+++ b/packages/moonstone/VideoPlayer/Video.js
@@ -275,7 +275,7 @@ const VideoDecorator = compose(
  * ```
  *
  * @class Video
- * @mixes ui/Slottable
+ * @mixes ui/Slottable.Slottable
  * @memberof moonstone/VideoPlayer
  * @ui
  * @public

--- a/packages/moonstone/VideoPlayer/Video.js
+++ b/packages/moonstone/VideoPlayer/Video.js
@@ -59,7 +59,7 @@ const VideoBase = class extends React.Component {
 		 * * `pause()` - pause video
 		 * * `load()` - load video
 		 *
-		 * The [`source`]{@link moonstone/VideoPlayer.VideoBase.source} property is passed to
+		 * The [`source`]{@link moonstone/VideoPlayer.Video.source} property is passed to
 		 * the video component as a child node.
 		 *
 		 * @type {String|Component|Element}

--- a/packages/moonstone/VideoPlayer/VideoPlayer.js
+++ b/packages/moonstone/VideoPlayer/VideoPlayer.js
@@ -610,7 +610,7 @@ const VideoPlayerBase = class extends React.Component {
 		 * * `pause()` - pause video
 		 * * `load()` - load video
 		 *
-		 * The [`source`]{@link moonstone/VideoPlayer.VideoBase.source} property is passed to
+		 * The [`source`]{@link moonstone/VideoPlayer.Video.source} property is passed to
 		 * the video component as a child node.
 		 *
 		 * @type {Component|Element}

--- a/packages/ui/BodyText/BodyText.js
+++ b/packages/ui/BodyText/BodyText.js
@@ -58,7 +58,7 @@ const BodyTextBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -30,7 +30,7 @@ const ButtonBase = kind({
 	propTypes: /** @lends ui/Button.ButtonBase.prototype */ {
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -46,7 +46,7 @@ const GridListImageItem = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Heading/Heading.js
+++ b/packages/ui/Heading/Heading.js
@@ -38,7 +38,7 @@ const Heading = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -77,7 +77,7 @@ const Icon = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -68,7 +68,7 @@ const IconButtonBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -75,7 +75,7 @@ const ImageBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Item/Item.js
+++ b/packages/ui/Item/Item.js
@@ -60,7 +60,7 @@ const ItemBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/LabeledIcon/LabeledIcon.js
+++ b/packages/ui/LabeledIcon/LabeledIcon.js
@@ -44,7 +44,7 @@ const LabeledIconBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -73,7 +73,7 @@ const MarqueeBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -67,7 +67,7 @@ const ProgressBar = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -71,7 +71,7 @@ class ScrollbarBase extends PureComponent {
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Slider/Slider.js
+++ b/packages/ui/Slider/Slider.js
@@ -68,7 +68,7 @@ const SliderBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/SlotItem/SlotItem.js
+++ b/packages/ui/SlotItem/SlotItem.js
@@ -76,7 +76,7 @@ const SlotItemBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Spinner/Spinner.js
+++ b/packages/ui/Spinner/Spinner.js
@@ -87,7 +87,7 @@ const SpinnerBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/ToggleIcon/ToggleIcon.js
+++ b/packages/ui/ToggleIcon/ToggleIcon.js
@@ -45,7 +45,7 @@ const ToggleIconBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -119,7 +119,7 @@ const ToggleItemBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -87,7 +87,7 @@ const TransitionBase = kind({
 
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
+		 * corresponding internal elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`MoonstoneDecorator` config was not documented

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add documentation for config and add `@mixes` for the hocs that could be applied.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I renamed the pair of config options `textSize` and `highContrast` to be `accessible`.  Since this API is private and the default is to enable, this _should_ be safe.  Apps that may have intended to disable this shouldn't be passing the props that control this anyhow.

### Links
[//]: # (Related issues, references)
ENYO-6372

### Comments
