### PR TITLE
Update a list item style for horizontal lists

### DIFF
--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -17,17 +17,26 @@ const
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
 	prop = {
+		direction: {horizontal: 'horizontal', vertical: 'vertical'},
 		scrollbarOption: ['auto', 'hidden', 'visible']
 	},
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
-	uiRenderItem = (size) => ({index, ...rest}) => {
-		const itemStyle = {
-			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-			boxSizing: 'border-box',
-			height: size + 'px'
-		};
+	uiRenderItem = (direction, size) => ({index, ...rest}) => {
+		const
+			sizePx = size + 'px',
+			itemStyle = {
+				borderBottom: ri.unit(3, 'rem') + ' solid #202328',
+				boxSizing: 'border-box'
+			};
+
+		if (direction !== 'horizontal') {
+			itemStyle.height = sizePx;
+		} else {
+			itemStyle.width = sizePx;
+			itemStyle.writingMode = 'vertical-lr';
+		}
 
 		return (
 			<UiItem {...rest} style={itemStyle}>
@@ -36,12 +45,20 @@ const
 		);
 	},
 	// eslint-disable-next-line enact/prop-types, enact/display-name
-	renderItem = (size) => ({index, ...rest}) => {
-		const itemStyle = {
-			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-			boxSizing: 'border-box',
-			height: size + 'px'
-		};
+	renderItem = (direction, size) => ({index, ...rest}) => {
+		const
+			sizePx = size + 'px',
+			itemStyle = {
+				borderBottom: ri.unit(3, 'rem') + ' solid #202328',
+				boxSizing: 'border-box',
+			};
+
+		if (direction !== 'horizontal') {
+			itemStyle.height = sizePx;
+		} else {
+			itemStyle.width = sizePx;
+			itemStyle.writingMode = 'vertical-lr';
+		}
 
 		return (
 			<Item {...rest} style={itemStyle}>
@@ -76,8 +93,9 @@ storiesOf('UI', module)
 			return (
 				<UiVirtualList
 					dataSize={updateDataSize(number('dataSize', UiVirtualListConfig, defaultDataSize))}
+					direction={select('direction', prop.direction, UiVirtualListConfig)}
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, UiVirtualListConfig)}
-					itemRenderer={uiRenderItem(ri.scale(number('itemSize', UiVirtualListConfig, 72)))}
+					itemRenderer={uiRenderItem(select('direction', prop.direction, VirtualListConfig), ri.scale(number('itemSize', UiVirtualListConfig, 72)))}
 					itemSize={ri.scale(number('itemSize', UiVirtualListConfig, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', UiVirtualListConfig)}
 					onScrollStart={action('onScrollStart')}
@@ -102,9 +120,10 @@ storiesOf('Moonstone', module)
 			return (
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
+					direction={select('direction', prop.direction, VirtualListConfig)}
 					focusableScrollbar={boolean('focusableScrollbar', VirtualListConfig)}
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualListConfig)}
-					itemRenderer={renderItem(ri.scale(number('itemSize', VirtualListConfig, 72)))}
+					itemRenderer={renderItem(select('direction', prop.direction, VirtualListConfig), ri.scale(number('itemSize', VirtualListConfig, 72)))}
 					itemSize={ri.scale(number('itemSize', VirtualListConfig, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', VirtualListConfig)}
 					onScrollStart={action('onScrollStart')}

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -3,27 +3,28 @@
 	height: 100%;
 	width: 100%;
 	overflow: hidden;
-
-	&.vertical {
-		overflow-y: scroll;
-	}
-
-	&.horizontal {
-		overflow-x: scroll;
-	}
-
-	.listItem {
-		overflow: hidden;
-		width: 100%;
-
-		will-change: transform;
-	}
-	
-	.content {
-		will-change: transform;
-	}
 }
 
 .virtualList::-webkit-scrollbar {
 	display: none;
+}
+
+.native {
+	&.vertical {
+		overflow-y: scroll;
+	}
+	&.horizontal {
+		overflow-x: scroll;
+	}
+}
+
+.listItem {
+	height: 100%;
+	width: 100%;
+	overflow: hidden;
+	will-change: transform;
+}
+
+.content {
+	will-change: transform;
 }

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1145,13 +1145,12 @@ const VirtualListBaseFactory = (type) => {
 		// render
 
 		getContainerClasses (className) {
-			let containerClass = null;
-
-			if (type === Native) {
-				containerClass = this.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
-			}
-
-			return classNames(css.virtualList, containerClass, className);
+			return classNames(
+				css.virtualList,
+				this.isPrimaryDirectionVertical ? css.vertical : css.horizontal,
+				(type === Native) ? css.native : null,
+				className
+			);
 		}
 
 		getContentClasses () {


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A virtual list sets a CSS class for its item internally and the CSS covers a vertical list only.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update CSS to cover an item of a horizontal list also.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
A list sets a selector of two CSS classes for an item currently and it blocks an app side single CSS class for an item by higher specificity. We are using modular CSS now, so we actually don't need to put such a complex CSS selector for a list item. To make apps easy to override item sizes, needs to be flattened.

### Links
[//]: # (Related issues, references)
PLAT-86356

### Comments
