### PR TITLE
PLAT-87249: Add noLockPointer config to InputSpotlightDecorator

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,6 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Input.InputSpotlightDecorator` to add unLockedPointer config
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
 
 ## [3.2.5] - 2019-11-14

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
+- `moonstone/Input.InputSpotlightDecorator` to add unLockedPointer config
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
 
 ## [3.2.5] - 2019-11-14

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -31,7 +31,7 @@ const handleKeyDown = handle(
 /**
  * Default config for [InputSpotlightDecorator]{@link moonstone/Input.InputSpotlightDecorator}
  *
- * @memberof moonstone/Input.InputSpotlightDecorator
+ * @memberof moonstone/Input/InputSpotlightDecorator.InputSpotlightDecorator
  * @hocconfig
  */
 const defaultConfig = {
@@ -40,7 +40,7 @@ const defaultConfig = {
 	 *
 	 * @type {Boolean}
 	 * @default false
-	 * @memberof moonstone/Input.InputSpotlightDecorator.defaultConfig
+	 * @memberof moonstone/Input/InputSpotlightDecorator.InputSpotlightDecorator.defaultConfig
 	*/
 	unlockedPointer: false
 };
@@ -50,7 +50,7 @@ const defaultConfig = {
  * spotlight behavior for an {@link moonstone/Input.Input}
  *
  * @class InputSpotlightDecorator
- * @memberof moonstone/Input.InputSpotlightDecorator
+ * @memberof moonstone/Input/InputSpotlightDecorator
  * @hoc
  * @private
  */

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -30,8 +30,9 @@ const handleKeyDown = handle(
 
 /**
  * Default config for {@link moonstone/Input.InputSpotlightDecorator}
- * @hocconfig
+ *
  * @memberof moonstone/Input.InputSpotlightDecorator
+ * @hocconfig
  */
 const defaultConfig = {
 	/**

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -29,7 +29,7 @@ const handleKeyDown = handle(
 
 
 /**
- * Default config for {@link moonstone/Input.InputSpotlightDecorator}
+ * Default config for [InputSpotlightDecorator]{@link moonstone/Input.InputSpotlightDecorator}
  *
  * @memberof moonstone/Input.InputSpotlightDecorator
  * @hocconfig
@@ -39,8 +39,7 @@ const defaultConfig = {
 	 * Suppress the pointer lock behavior of moonstone input
 	 *
 	 * @type {Boolean}
-	 * default false
-	 * @public
+	 * @default false
 	 * @memberof moonstone/Input.InputSpotlightDecorator.defaultConfig
 	*/
 	unlockedPointer: false
@@ -51,7 +50,7 @@ const defaultConfig = {
  * spotlight behavior for an {@link moonstone/Input.Input}
  *
  * @class InputSpotlightDecorator
- * @memberof moonstone/Input/InputSpotlightDecorator
+ * @memberof moonstone/Input.InputSpotlightDecorator
  * @hoc
  * @private
  */

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -27,6 +27,24 @@ const handleKeyDown = handle(
 	call('onKeyDown')
 );
 
+
+/**
+ * Default config for {@link moonstone/Input.InputSpotlightDecorator}
+ * @hocconfig
+ * @memberof moonstone/Input.InputSpotlightDecorator
+ */
+const defaultConfig = {
+	/**
+	 * Suppress the pointer lock behavior of moonstone input
+	 *
+	 * @type {Boolean}
+	 * default false
+	 * @public
+	 * @memberof moonstone/Input.InputSpotlightDecorator.defaultConfig
+	*/
+	unLockedPointer: false
+};
+
 /**
  * A higher-order component that manages the
  * spotlight behavior for an {@link moonstone/Input.Input}
@@ -36,7 +54,8 @@ const handleKeyDown = handle(
  * @hoc
  * @private
  */
-const InputSpotlightDecorator = hoc((config, Wrapped) => {
+const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
+	const {unLockedPointer} = config;
 	const Component = Spottable({emulateMouse: false}, Wrapped);
 	const forwardBlur = forward('onBlur');
 	const forwardMouseDown = forward('onMouseDown');
@@ -137,7 +156,9 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 					onSpotlightDisappear();
 				}
 
-				releasePointer(this.state.node);
+				if (!unLockedPointer) {
+					releasePointer(this.state.node);
+				}
 			}
 		}
 
@@ -155,11 +176,15 @@ const InputSpotlightDecorator = hoc((config, Wrapped) => {
 			if (focusChanged) {
 				if (this.state.focused === 'input') {
 					forward('onActivate', {type: 'onActivate'}, this.props);
-					lockPointer(this.state.node);
+					if (!unLockedPointer) {
+						lockPointer(this.state.node);
+					}
 					this.paused.pause();
 				} else if (prevState.focused === 'input') {
 					forward('onDeactivate', {type: 'onDeactivate'}, this.props);
-					releasePointer(prevState.node);
+					if (!unLockedPointer) {
+						releasePointer(prevState.node);
+					}
 					this.paused.resume();
 				}
 			}

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -42,7 +42,7 @@ const defaultConfig = {
 	 * @default false
 	 * @memberof moonstone/Input/InputSpotlightDecorator.InputSpotlightDecorator.defaultConfig
 	*/
-	unlockedPointer: false
+	noLockPointer: false
 };
 
 /**
@@ -55,7 +55,7 @@ const defaultConfig = {
  * @private
  */
 const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {unlockedPointer} = config;
+	const {noLockPointer} = config;
 	const Component = Spottable({emulateMouse: false}, Wrapped);
 	const forwardBlur = forward('onBlur');
 	const forwardMouseDown = forward('onMouseDown');
@@ -156,7 +156,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onSpotlightDisappear();
 				}
 
-				if (!unlockedPointer) {
+				if (!noLockPointer) {
 					releasePointer(this.state.node);
 				}
 			}
@@ -176,13 +176,13 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (focusChanged) {
 				if (this.state.focused === 'input') {
 					forward('onActivate', {type: 'onActivate'}, this.props);
-					if (!unlockedPointer) {
+					if (!noLockPointer) {
 						lockPointer(this.state.node);
 					}
 					this.paused.pause();
 				} else if (prevState.focused === 'input') {
 					forward('onDeactivate', {type: 'onDeactivate'}, this.props);
-					if (!unlockedPointer) {
+					if (!noLockPointer) {
 						releasePointer(prevState.node);
 					}
 					this.paused.resume();

--- a/packages/moonstone/Input/InputSpotlightDecorator.js
+++ b/packages/moonstone/Input/InputSpotlightDecorator.js
@@ -42,7 +42,7 @@ const defaultConfig = {
 	 * @public
 	 * @memberof moonstone/Input.InputSpotlightDecorator.defaultConfig
 	*/
-	unLockedPointer: false
+	unlockedPointer: false
 };
 
 /**
@@ -55,7 +55,7 @@ const defaultConfig = {
  * @private
  */
 const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {unLockedPointer} = config;
+	const {unlockedPointer} = config;
 	const Component = Spottable({emulateMouse: false}, Wrapped);
 	const forwardBlur = forward('onBlur');
 	const forwardMouseDown = forward('onMouseDown');
@@ -156,7 +156,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onSpotlightDisappear();
 				}
 
-				if (!unLockedPointer) {
+				if (!unlockedPointer) {
 					releasePointer(this.state.node);
 				}
 			}
@@ -176,13 +176,13 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (focusChanged) {
 				if (this.state.focused === 'input') {
 					forward('onActivate', {type: 'onActivate'}, this.props);
-					if (!unLockedPointer) {
+					if (!unlockedPointer) {
 						lockPointer(this.state.node);
 					}
 					this.paused.pause();
 				} else if (prevState.focused === 'input') {
 					forward('onDeactivate', {type: 'onDeactivate'}, this.props);
-					if (!unLockedPointer) {
+					if (!unlockedPointer) {
 						releasePointer(prevState.node);
 					}
 					this.paused.resume();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
1) One of `moonstone/Input` requirements is that users should not be able to click on other components while focusing on an input field. It caused confusing user interaction on touchable devices by a user have to tap twice to click any components.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
By adding `unlockedPointer` config to InputSpotlightDecorator, we provide an optional way to avoid a pointer locked which block click and tap actions when the input has focus.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We set the default value of `unlockedPointer` config to follow the UX requirement. The application developer can apply the config to the exceptional cases selectively.

### Links
[//]: # (Related issues, references)
 PLAT-87249

### Comments
