### PR TITLE
Support VirtualList to have Scroller as an item

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -154,6 +154,15 @@ class ScrollableBase extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
+		 * This is passed onto the wrapped component to allow
+		 * it to be a list item for nested list or scroller use case.
+		 *
+		 * @type {Number}
+		 * @private
+		 */
+		'data-index': PropTypes.number,
+
+		/**
 		 * This is set to `true` by SpotlightContainerDecorator
 		 *
 		 * @type {Boolean}
@@ -945,6 +954,7 @@ class ScrollableBase extends Component {
 		const
 			{
 				childRenderer,
+				'data-index': dataIndex,
 				'data-spotlight-container': spotlightContainer,
 				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
@@ -997,6 +1007,7 @@ class ScrollableBase extends Component {
 				}) => (
 					<div
 						className={classNames(className, overscrollCss.scrollable)}
+						data-index={dataIndex}
 						data-spotlight-container={spotlightContainer}
 						data-spotlight-container-disabled={spotlightContainerDisabled}
 						data-spotlight-id={spotlightId}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -135,6 +135,15 @@ class ScrollableBaseNative extends Component {
 		childRenderer: PropTypes.func.isRequired,
 
 		/**
+		 * This is passed onto the wrapped component to allow
+		 * it to be a list item for nested list or scroller use case.
+		 *
+		 * @type {Number}
+		 * @private
+		 */
+		'data-index': PropTypes.number,
+
+		/**
 		 * This is set to `true` by SpotlightContainerDecorator
 		 *
 		 * @type {Boolean}
@@ -584,6 +593,7 @@ class ScrollableBaseNative extends Component {
 			this.alertThumb();
 		}
 
+
 		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || isDragging)) {
 			const
 				item = ev.target,
@@ -1009,6 +1019,7 @@ class ScrollableBaseNative extends Component {
 		const
 			{
 				childRenderer,
+				'data-index': dataIndex,
 				'data-spotlight-container': spotlightContainer,
 				'data-spotlight-container-disabled': spotlightContainerDisabled,
 				'data-spotlight-id': spotlightId,
@@ -1061,6 +1072,7 @@ class ScrollableBaseNative extends Component {
 				}) => (
 					<div
 						className={classNames(className, overscrollCss.scrollable)}
+						data-index={dataIndex}
 						data-spotlight-container={spotlightContainer}
 						data-spotlight-container-disabled={spotlightContainerDisabled}
 						data-spotlight-id={spotlightId}

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -79,6 +79,14 @@ class ScrollerBase extends Component {
 		scrollAndFocusScrollbarButton: PropTypes.func,
 
 		/**
+		 * Configuration for a spotlight container of Scroller
+		 *
+		 * @type {Object}
+		 * @private
+		 */
+		spotlightContainerConfig: PropTypes.object,
+
+		/**
 		 * The spotlight id for the component.
 		 *
 		 * @type {String}
@@ -109,10 +117,12 @@ class ScrollerBase extends Component {
 	uiRefCurrent = null
 
 	configureSpotlight () {
-		Spotlight.set(this.props.spotlightId, {
-			onLeaveContainer: this.handleLeaveContainer,
-			onLeaveContainerFail: this.handleLeaveContainer
-		});
+		Spotlight.set(this.props.spotlightId,
+			Object.assign({}, this.props.spotlightContainerConfig, {
+				onLeaveContainer: this.handleLeaveContainer,
+				onLeaveContainerFail: this.handleLeaveContainer
+			})
+		);
 	}
 
 	/**
@@ -359,6 +369,7 @@ class ScrollerBase extends Component {
 		delete props.initUiChildRef;
 		delete props.onUpdate;
 		delete props.scrollAndFocusScrollbarButton;
+		delete props.spotlightContainerConfig;
 		delete props.spotlightId;
 
 		return (

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -430,14 +430,28 @@ const VirtualListBaseFactory = (type) => {
 		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
 			const {cbScrollTo, dataSize, spacing, wrap} = this.props;
 			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPositionTarget} = this.uiRefCurrent;
-			const index = getNumberValue(target.dataset.index);
+			let targetIndex = target.dataset.index;
+			let node = target;
+
+			// If `target` is a node inside of an item, we should track up to an item.
+			// FIXME: We need to refine this code to check only inside of this list
+			while (targetIndex === undefined) {
+				node = node.parentElement;
+				if (node) {
+					targetIndex = node.dataset.index;
+				} else {
+					targetIndex = 0;
+					break;
+				}
+			}
+			targetIndex = getNumberValue(targetIndex);
 
 			this.isScrolledBy5way = false;
 			this.isScrolledByJump = false;
 
 			if (nextIndex >= 0) {
 				const
-					row = Math.floor(index / dimensionToExtent),
+					row = Math.floor(targetIndex / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
 					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
 					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + gridSize;
@@ -470,7 +484,7 @@ const VirtualListBaseFactory = (type) => {
 					this.isWrappedBy5way = isWrapped;
 
 					if (isWrapped && (
-						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
+						this.uiRefCurrent.itemContainerRef.current.querySelector(`:scope > [data-index='${nextIndex}']`) == null
 					)) {
 						if (wrap === true) {
 							this.pause.pause();
@@ -486,7 +500,7 @@ const VirtualListBaseFactory = (type) => {
 
 					cbScrollTo({
 						index: nextIndex,
-						stickTo: index < nextIndex ? 'end' : 'start',
+						stickTo: targetIndex < nextIndex ? 'end' : 'start',
 						animate: !(isWrapped && wrap === 'noAnimation')
 					});
 				}
@@ -500,6 +514,14 @@ const VirtualListBaseFactory = (type) => {
 			const direction = getDirection(keyCode);
 
 			if (direction) {
+				const {dimensionToExtent} = this.uiRefCurrent;
+
+				// A non-grid list does not need to handle keys for non-scrollable directions.
+				if (dimensionToExtent === 1 &&
+				(this.props.direction === 'vertical') !== (direction === 'up' || direction === 'down')) {
+					return;
+				}
+
 				Spotlight.setPointerMode(false);
 
 				if (SpotlightAccelerator.processKey(ev, nop)) {
@@ -507,14 +529,25 @@ const VirtualListBaseFactory = (type) => {
 				} else {
 					const {repeat} = ev;
 					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
-					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
-					const targetIndex = target.dataset.index;
-					const isScrollButton = (
-						// if target has an index, it must be an item so can't be a scroll button
-						!targetIndex &&
-						// if it lacks an index and is inside the scroller, it must be a button
-						target.matches(`[data-spotlight-id="${spotlightId}"] *`)
-					);
+					const {isPrimaryDirectionVertical} = this.uiRefCurrent;
+
+					let targetIndex = target.dataset.index;
+					let node = target;
+					// If `target` is a node inside of an item, we should track up to an item.
+					// FIXME: We need to refine this code to check only inside of this list
+					while (targetIndex === undefined) {
+						node = node.parentElement;
+						if (node) {
+							targetIndex = node.dataset.index;
+						} else {
+							targetIndex = 0;
+							break;
+						}
+					}
+					targetIndex = getNumberValue(targetIndex);
+
+					// FIXME: We need to find better way to determind `target` is a scroll button or not
+					const isScrollButton = (target.dataset.spotlightOverflow === 'ignore');
 					const index = !isScrollButton ? getNumberValue(targetIndex) : -1;
 					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
 					const directions = {};
@@ -605,7 +638,7 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		focusByIndex = (index) => {
-			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}']${spottableSelector}`);
+			const item = this.uiRefCurrent.itemContainerRef.current.querySelector(`:scope > [data-index='${index}']`);
 
 			if (!item && index >= 0 && index < this.props.dataSize) {
 				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
@@ -717,8 +750,19 @@ const VirtualListBaseFactory = (type) => {
 				{pageScroll} = this.props,
 				{numOfItems} = this.uiRefCurrent.state,
 				{primary} = this.uiRefCurrent,
-				offsetToClientEnd = primary.clientSize - primary.itemSize,
-				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
+				offsetToClientEnd = primary.clientSize - primary.itemSize;
+			let
+				itemNode = item,
+				focusedIndex = itemNode.getAttribute(dataIndexAttribute);
+
+			while (focusedIndex === null) {
+				itemNode = itemNode.parentElement;
+				if (itemNode && itemNode !== primary) {
+					focusedIndex = itemNode.getAttribute(dataIndexAttribute);
+				} else {
+					break;
+				}
+			}
 
 			if (!isNaN(focusedIndex)) {
 				let gridPosition = this.uiRefCurrent.getGridPosition(focusedIndex);

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -756,14 +756,14 @@ function getContainerNavigableElements (containerId) {
 				const elementRect = getRect(element);
 				if (isContainer(element)) {
 					return intersects(containerRect, elementRect);
+				} else {
+					return contains(containerRect, elementRect);
 				}
-
-				return contains(containerRect, getRect(element));
 			});
 		}
 
 		// otherwise, return all spottables within the container
-		if (!next) {
+		if (!next || next.length === 0) {
 			next = spottables;
 		}
 	}

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1308,16 +1308,19 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	handleScroll = () => {
-		const childRefCurrent = this.childRefCurrent;
+	handleScroll = (ev) => {
+		const containerRefCurrent = this.childRefCurrent.containerRef.current;
+		if (ev.target === containerRefCurrent) {
+			const childRefCurrent = this.childRefCurrent;
 
-		// Prevent scroll by focus.
-		// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
-		// Only Scroller could get `onscroll` event.
-		if (!this.animator.isAnimating() && childRefCurrent && childRefCurrent.containerRef.current && childRefCurrent.getRtlPositionX) {
-			// For Scroller
-			childRefCurrent.containerRef.current.scrollTop = this.scrollTop;
-			childRefCurrent.containerRef.current.scrollLeft = childRefCurrent.getRtlPositionX(this.scrollLeft);
+			// Prevent scroll by focus.
+			// VirtualList and VirtualGridList DO NOT receive `onscroll` event.
+			// Only Scroller could get `onscroll` event.
+			if (!this.animator.isAnimating() && childRefCurrent && containerRefCurrent && childRefCurrent.getRtlPositionX) {
+				// For Scroller
+				containerRefCurrent.scrollTop = this.scrollTop;
+				containerRefCurrent.scrollLeft = childRefCurrent.getRtlPositionX(this.scrollLeft);
+			}
 		}
 	}
 

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -749,32 +749,34 @@ class ScrollableBaseNative extends Component {
 	}
 
 	onScroll = (ev) => {
-		let {scrollLeft, scrollTop} = ev.target;
+		if (ev.target === this.childRefCurrent.containerRef.current) {
+			let {scrollLeft, scrollTop} = ev.target;
 
-		const
-			bounds = this.getScrollBounds(),
-			canScrollHorizontally = this.canScrollHorizontally(bounds);
+			const
+				bounds = this.getScrollBounds(),
+				canScrollHorizontally = this.canScrollHorizontally(bounds);
 
-		if (!this.scrolling) {
-			this.scrollStartOnScroll();
-		}
+			if (!this.scrolling) {
+				this.scrollStartOnScroll();
+			}
 
-		if (this.props.rtl && canScrollHorizontally) {
-			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
-		}
+			if (this.props.rtl && canScrollHorizontally) {
+				scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
+			}
 
-		if (scrollLeft !== this.scrollLeft) {
-			this.setScrollLeft(scrollLeft);
-		}
-		if (scrollTop !== this.scrollTop) {
-			this.setScrollTop(scrollTop);
-		}
+			if (scrollLeft !== this.scrollLeft) {
+				this.setScrollLeft(scrollLeft);
+			}
+			if (scrollTop !== this.scrollTop) {
+				this.setScrollTop(scrollTop);
+			}
 
-		if (this.childRefCurrent.didScroll) {
-			this.childRefCurrent.didScroll(this.scrollLeft, this.scrollTop);
+			if (this.childRefCurrent.didScroll) {
+				this.childRefCurrent.didScroll(this.scrollLeft, this.scrollTop);
+			}
+			this.forwardScrollEvent('onScroll');
+			this.scrollStopJob.start();
 		}
-		this.forwardScrollEvent('onScroll');
-		this.scrollStopJob.start();
 	}
 
 	onKeyDown = (ev) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `Scroller` elements are items of `VirtualList` element, spotlight navigation by 5-way key does not work properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Fixed native scrollable components (that catch `scroll` event to update its contents) to check which scrollable area is actually scrolled in nested cases.
- Fixed lists to get `data-index` attribute value from a node inside of an item on keypress.
- Fixed `Scrollable`s to set `data-index` attribute value to its most outer node to be handled properly when it is an item of a list.
- Added a prop for a container configuration to `Scroller` to support `'last-focused'` rule.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
A list moves spotlight simply to the next item, and the spotlight moves the first child of a scroller if the item is a scroller. Because a scroller's container is a spotlight container, this is expected behavior.

### Links
[//]: # (Related issues, references)
PLAT-97349

### Comments
