### PR TITLE
PLAT-98201: [VirtualList and Scroller] Convert from Moonstone React component to functional component

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -19,7 +19,7 @@ import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from 
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useContext, useDebugValue, useRef} from 'react';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';
@@ -132,247 +132,106 @@ const getTargetInViewByDirectionFromPosition = (direction, position, container) 
 /**
  * A Moonstone-styled component that provides horizontal and vertical scrollbars.
  *
- * @class ScrollableBase
+ * @function ScrollableBase
  * @memberof moonstone/Scrollable
  * @extends ui/Scrollable.ScrollableBase
  * @ui
  * @public
  */
-class ScrollableBase extends Component {
-	static displayName = 'Scrollable'
+const ScrollableBase = (props) => {
+	useDebugValue('Scrollable');
+	const context = useContext(SharedState);
 
-	static contextType = SharedState
-
-	static propTypes = /** @lends moonstone/Scrollable.Scrollable.prototype */ {
-		/**
-		 * Render function.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		childRenderer: PropTypes.func.isRequired,
-
-		/**
-		 * This is set to `true` by SpotlightContainerDecorator
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		'data-spotlight-container': PropTypes.bool,
-
-		/**
-		 * `false` if the content of the list or the scroller could get focus
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		'data-spotlight-container-disabled': PropTypes.bool,
-
-		/**
-		 * This is passed onto the wrapped component to allow
-		 * it to customize the spotlight container for its use case.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		'data-spotlight-id': PropTypes.string,
-
-		/**
-		 * Direction of the list or the scroller.
-		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
-		 *
-		 * Valid values are:
-		 * * `'both'`,
-		 * * `'horizontal'`, and
-		 * * `'vertical'`.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
-
-		/**
-		 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
-		 * not move focus to the scrollbar controls.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		focusableScrollbar: PropTypes.bool,
-
-		/**
-		 * A unique identifier for the scrollable component.
-		 *
-		 * When specified and when the scrollable is within a SharedStateDecorator, the scroll
-		 * position will be shared and restored on mount if the component is destroyed and
-		 * recreated.
-		 *
-		 * @type {String}
-		 * @public
-		 */
-		id: PropTypes.string,
-
-		/**
-		 * Specifies overscroll effects shows on which type of inputs.
-		 *
-		 * @type {Object}
-		 * @default {
-		 *	arrowKey: false,
-		 *	drag: false,
-		 *	pageKey: false,
-		 *	scrollbarButton: false,
-		 *	wheel: true
-		 * }
-		 * @private
-		 */
-		overscrollEffectOn: PropTypes.shape({
-			arrowKey: PropTypes.bool,
-			drag: PropTypes.bool,
-			pageKey: PropTypes.bool,
-			scrollbarButton: PropTypes.bool,
-			wheel: PropTypes.bool
-		}),
-
-		/**
-		 * Specifies preventing keydown events from bubbling up to applications.
-		 * Valid values are `'none'`, and `'programmatic'`.
-		 *
-		 * When it is `'none'`, every keydown event is bubbled.
-		 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
-		 * which invokes programmatic spotlight moving.
-		 *
-		 * @type {String}
-		 * @default 'none'
-		 * @private
-		 */
-		preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
-
-		/**
-		 * Sets the hint string read when focusing the next button in the vertical scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll down')
-		 * @public
-		 */
-		scrollDownAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll left')
-		 * @public
-		 */
-		scrollLeftAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the next button in the horizontal scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll right')
-		 * @public
-		 */
-		scrollRightAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the previous button in the vertical scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll up')
-		 * @public
-		 */
-		scrollUpAriaLabel: PropTypes.string
-	}
-
-	static defaultProps = {
-		'data-spotlight-container-disabled': false,
-		focusableScrollbar: false,
-		overscrollEffectOn: {
-			arrowKey: false,
-			drag: false,
-			pageKey: false,
-			scrollbarButton: false,
-			wheel: true
+	// constructor
+	// Instance variables
+	let variables = useRef({
+		scrollbarProps: {
+			cbAlertThumb: alertThumbAfterRendered,
+			onNextScroll: onScrollbarButtonClick,
+			onPrevScroll: onScrollbarButtonClick
 		},
-		preventBubblingOnKeyDown: 'none'
-	}
-
-	constructor (props) {
-		super(props);
-
-		this.scrollbarProps = {
-			cbAlertThumb: this.alertThumbAfterRendered,
-			onNextScroll: this.onScrollbarButtonClick,
-			onPrevScroll: this.onScrollbarButtonClick
-		};
-
-		this.overscrollRefs = {
+		overscrollRefs: {
 			horizontal: React.createRef(),
 			vertical: React.createRef()
-		};
-		this.childRef = React.createRef();
-		this.uiRef = React.createRef();
+		},
+		childRef: React.createRef(),
+		uiRef: React.createRef(),
+		animateOnFocus: false
+	});
+	configureSpotlightContainer(props);
 
-		configureSpotlightContainer(props);
+	// Destructuring for render
+	const {
+		childRenderer,
+		'data-spotlight-container': spotlightContainer,
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
+		'data-spotlight-id': spotlightId,
+		focusableScrollbar,
+		preventBubblingOnKeyDown,
+		scrollDownAriaLabel,
+		scrollLeftAriaLabel,
+		scrollRightAriaLabel,
+		scrollUpAriaLabel,
+		...rest
+	} = props;
+
+	// TODO : Change to useEffect
+	function componentDidMount () {
+		createOverscrollJob('horizontal', 'before');
+		createOverscrollJob('horizontal', 'after');
+
+		createOverscrollJob('vertical', 'before');
+		createOverscrollJob('vertical', 'after');
+
+		restoreScrollPosition();
+		scrollables.set(this, variables.current.uiRef.current.containerRef.current);
 	}
 
-	componentDidMount () {
-		this.createOverscrollJob('horizontal', 'before');
-		this.createOverscrollJob('horizontal', 'after');
-
-		this.createOverscrollJob('vertical', 'before');
-		this.createOverscrollJob('vertical', 'after');
-
-		this.restoreScrollPosition();
-		scrollables.set(this, this.uiRef.current.containerRef.current);
-	}
-
-	componentDidUpdate (prevProps) {
-		if (prevProps['data-spotlight-id'] !== this.props['data-spotlight-id'] ||
-				prevProps.focusableScrollbar !== this.props.focusableScrollbar) {
-			configureSpotlightContainer(this.props);
+	// TODO : Change to useEffect
+	function componentDidUpdate (prevProps) {
+		if (prevProps['data-spotlight-id'] !== props['data-spotlight-id'] ||
+				prevProps.focusableScrollbar !== props.focusableScrollbar) {
+			configureSpotlightContainer(props);
 		}
 	}
 
-	componentWillUnmount () {
+	// TODO : Change to useEffect
+	function componentWillUnmount () {
 		scrollables.delete(this);
 
-		this.stopOverscrollJob('horizontal', 'before');
-		this.stopOverscrollJob('horizontal', 'after');
-		this.stopOverscrollJob('vertical', 'before');
-		this.stopOverscrollJob('vertical', 'after');
+		stopOverscrollJob('horizontal', 'before');
+		stopOverscrollJob('horizontal', 'after');
+		stopOverscrollJob('vertical', 'before');
+		stopOverscrollJob('vertical', 'after');
 	}
 
 	// status
-	isWheeling = false
+	let isWheeling = false;
 
 	// spotlight
-	lastScrollPositionOnFocus = null
-	indexToFocus = null
-	nodeToFocus = null
-	pointToFocus = null
+	let lastScrollPositionOnFocus = null;
+	let indexToFocus = null;
+	let nodeToFocus = null;
+	let pointToFocus = null;
 
 	// voice control
-	isVoiceControl = false
-	voiceControlDirection = 'vertical'
+	let isVoiceControl = false;
+	let voiceControlDirection = 'vertical';
 
 	// overscroll
-	overscrollJobs = {
+	let overscrollJobs = {
 		horizontal: {before: null, after: null},
 		vertical: {before: null, after: null}
-	}
+	};
 
 	// Only intended to be used within componentDidMount, this method will fetch the last stored
 	// scroll position from SharedState and scroll (without animation) to that position
-	restoreScrollPosition () {
-		const {id} = this.props;
-		if (id && this.context && this.context.get) {
-			const scrollPosition = this.context.get(`${id}.scrollPosition`);
+	function restoreScrollPosition () {
+		const {id} = props;
+		if (id && context && context.get) {
+			const scrollPosition = context.get(`${id}.scrollPosition`);
 			if (scrollPosition) {
-				this.uiRef.current.scrollTo({
+				variables.current.uiRef.current.scrollTo({
 					position: scrollPosition,
 					animate: false
 				});
@@ -380,8 +239,8 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	isScrollButtonFocused () {
-		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = this.uiRef.current;
+	function isScrollButtonFocused () {
+		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = variables.current.uiRef.current;
 
 		return (
 			h.current && h.current.isOneOfScrollButtonsFocused() ||
@@ -389,8 +248,8 @@ class ScrollableBase extends Component {
 		);
 	}
 
-	onFlick = ({direction}) => {
-		const bounds = this.uiRef.current.getScrollBounds();
+	function onFlick ({direction}) {
+		const bounds = variables.current.uiRef.current.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
@@ -398,88 +257,90 @@ class ScrollableBase extends Component {
 		}
 
 		if ((
-			direction === 'vertical' && this.uiRef.current.canScrollVertically(bounds) ||
-			direction === 'horizontal' && this.uiRef.current.canScrollHorizontally(bounds)
-		) && !this.props['data-spotlight-container-disabled']) {
-			this.childRef.current.setContainerDisabled(true);
+			direction === 'vertical' && variables.current.uiRef.current.canScrollVertically(bounds) ||
+			direction === 'horizontal' && variables.current.uiRef.current.canScrollHorizontally(bounds)
+		) && !props['data-spotlight-container-disabled']) {
+			variables.current.childRef.current.setContainerDisabled(true);
 		}
 	}
 
-	onMouseDown = (ev) => {
-		if (this.isScrollButtonFocused()) {
+	function onMouseDown (ev) {
+		if (isScrollButtonFocused()) {
 			ev.preventDefault();
 		}
 
-		if (this.props['data-spotlight-container-disabled']) {
+		if (props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
 		}
 	}
 
-	onTouchStart = () => {
+	function onTouchStart () {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (!Spotlight.isPaused() && focusedItem && !this.isScrollButtonFocused()) {
+		if (!Spotlight.isPaused() && focusedItem && !isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 	}
 
-	onWheel = ({delta}) => {
+	function onWheel ({delta}) {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem && !this.isScrollButtonFocused()) {
+		if (focusedItem && !isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 
 		if (delta !== 0) {
-			this.isWheeling = true;
-			if (!this.props['data-spotlight-container-disabled']) {
-				this.childRef.current.setContainerDisabled(true);
+			isWheeling = true;
+			if (!props['data-spotlight-container-disabled']) {
+				variables.current.childRef.current.setContainerDisabled(true);
 			}
 		}
 	}
 
-	isContent = (element) => (element && this.uiRef.current && this.uiRef.current.childRefCurrent.containerRef.current.contains(element))
+	function isContent (element) {
+		return (element && variables.current.uiRef.current && variables.current.uiRef.current.childRefCurrent.containerRef.current.contains(element));
+	}
 
-	startScrollOnFocus = (pos) => {
+	function startScrollOnFocus (pos) {
 		if (pos) {
 			const
 				{top, left} = pos,
-				bounds = this.uiRef.current.getScrollBounds(),
-				scrollHorizontally = bounds.maxLeft > 0 && left !== this.uiRef.current.scrollLeft,
-				scrollVertically = bounds.maxTop > 0 && top !== this.uiRef.current.scrollTop;
+				bounds = variables.current.uiRef.current.getScrollBounds(),
+				scrollHorizontally = bounds.maxLeft > 0 && left !== variables.current.uiRef.current.scrollLeft,
+				scrollVertically = bounds.maxTop > 0 && top !== variables.current.uiRef.current.scrollTop;
 
 			if (scrollHorizontally || scrollVertically) {
-				this.uiRef.current.start({
+				variables.current.uiRef.current.start({
 					targetX: left,
 					targetY: top,
-					animate: (animationDuration > 0) && this.animateOnFocus,
-					overscrollEffect: this.props.overscrollEffectOn[this.uiRef.current.lastInputType] && (!this.childRef.current.shouldPreventOverscrollEffect || !this.childRef.current.shouldPreventOverscrollEffect())
+					animate: (animationDuration > 0) && variables.current.animateOnFocus,
+					overscrollEffect: props.overscrollEffectOn[variables.current.uiRef.current.lastInputType] && (!variables.current.childRef.current.shouldPreventOverscrollEffect || !variables.current.childRef.current.shouldPreventOverscrollEffect())
 				});
-				this.lastScrollPositionOnFocus = pos;
+				lastScrollPositionOnFocus = pos;
 			}
 		}
 	}
 
-	calculateAndScrollTo = () => {
+	function calculateAndScrollTo () {
 		const
 			spotItem = Spotlight.getCurrent(),
-			positionFn = this.childRef.current.calculatePositionOnFocus,
-			containerNode = this.uiRef.current.childRefCurrent.containerRef.current;
+			positionFn = variables.current.childRef.current.calculatePositionOnFocus,
+			containerNode = variables.current.uiRef.current.childRefCurrent.containerRef.current;
 
 		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
-			const lastPos = this.lastScrollPositionOnFocus;
+			const lastPos = lastScrollPositionOnFocus;
 			let pos;
 
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
-			if (this.uiRef.current.animator.isAnimating() && lastPos) {
+			if (variables.current.uiRef.current.animator.isAnimating() && lastPos) {
 				const containerRect = getRect(containerNode);
 				const itemRect = getRect(spotItem);
 				let scrollPosition;
 
-				if (this.props.direction === 'horizontal' || this.props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
+				if (props.direction === 'horizontal' || props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
 					scrollPosition = lastPos.left;
-				} else if (this.props.direction === 'vertical' || this.props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
+				} else if (props.direction === 'vertical' || props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
 					scrollPosition = lastPos.top;
 				}
 
@@ -488,35 +349,35 @@ class ScrollableBase extends Component {
 				// scrollInfo passes in current `scrollHeight` and `scrollTop` before calculations
 				const
 					scrollInfo = {
-						previousScrollHeight: this.uiRef.current.bounds.scrollHeight,
-						scrollTop: this.uiRef.current.scrollTop
+						previousScrollHeight: variables.current.uiRef.current.bounds.scrollHeight,
+						scrollTop: variables.current.uiRef.current.scrollTop
 					};
 				pos = positionFn({item: spotItem, scrollInfo});
 			}
 
-			if (pos && (pos.left !== this.uiRef.current.scrollLeft || pos.top !== this.uiRef.current.scrollTop)) {
-				this.startScrollOnFocus(pos);
+			if (pos && (pos.left !== variables.current.uiRef.current.scrollLeft || pos.top !== variables.current.uiRef.current.scrollTop)) {
+				startScrollOnFocus(pos);
 			}
 
 			// update `scrollHeight`
-			this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+			variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
 		}
 	}
 
-	onFocus = (ev) => {
+	function onFocus (ev) {
 		const
-			{isDragging} = this.uiRef.current,
-			shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
-				this.childRef.current.shouldPreventScrollByFocus() :
+			{isDragging} = variables.current.uiRef.current,
+			shouldPreventScrollByFocus = variables.current.childRef.current.shouldPreventScrollByFocus ?
+				variables.current.childRef.current.shouldPreventScrollByFocus() :
 				false;
 
-		if (this.isWheeling) {
-			this.uiRef.current.stop();
-			this.animateOnFocus = false;
+		if (isWheeling) {
+			variables.current.uiRef.current.stop();
+			variables.current.animateOnFocus = false;
 		}
 
 		if (!Spotlight.getPointerMode()) {
-			this.alertThumb();
+			alertThumb();
 		}
 
 		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || isDragging)) {
@@ -525,28 +386,28 @@ class ScrollableBase extends Component {
 				spotItem = Spotlight.getCurrent();
 
 			if (item && item === spotItem) {
-				this.calculateAndScrollTo();
+				calculateAndScrollTo();
 			}
-		} else if (this.childRef.current.setLastFocusedNode) {
-			this.childRef.current.setLastFocusedNode(ev.target);
+		} else if (variables.current.childRef.current.setLastFocusedNode) {
+			variables.current.childRef.current.setLastFocusedNode(ev.target);
 		}
 	}
 
-	scrollByPage = (direction) => {
+	function scrollByPage (direction) {
 		const
-			{childRefCurrent, scrollTop} = this.uiRef.current,
+			{childRefCurrent, scrollTop} = variables.current.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
-			bounds = this.uiRef.current.getScrollBounds(),
+			bounds = variables.current.uiRef.current.getScrollBounds(),
 			isUp = direction === 'up',
 			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier,
 			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop > scrollTop;
 
-		this.uiRef.current.lastInputType = 'pageKey';
+		variables.current.uiRef.current.lastInputType = 'pageKey';
 
-		if (directionFactor !== this.uiRef.current.wheelDirection) {
-			this.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			this.uiRef.current.wheelDirection = directionFactor;
+		if (directionFactor !== variables.current.uiRef.current.wheelDirection) {
+			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
+			variables.current.uiRef.current.wheelDirection = directionFactor;
 		}
 
 		if (scrollPossible) {
@@ -564,57 +425,59 @@ class ScrollableBase extends Component {
 							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();
-					if (!this.props['data-spotlight-container-disabled']) {
-						this.childRef.current.setContainerDisabled(true);
+					if (!props['data-spotlight-container-disabled']) {
+						variables.current.childRef.current.setContainerDisabled(true);
 					}
-					this.pointToFocus = {direction, x, y};
+					pointToFocus = {direction, x, y};
 				}
 			} else {
-				this.pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
+				pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
 			}
 
-			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
+			variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);
 		}
 	}
 
-	hasFocus () {
+	function hasFocus () {
 		let current = Spotlight.getCurrent();
 
 		if (!current) {
-			const spotlightId = Spotlight.getActiveContainer();
+			// TODO : Remove.
+			// const spotlightId = Spotlight.getActiveContainer();
 			current = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 		}
 
-		return current && this.uiRef.current && this.uiRef.current.containerRef.current.contains(current);
+		return current && variables.current.uiRef.current && variables.current.uiRef.current.containerRef.current.contains(current);
 	}
 
-	checkAndApplyOverscrollEffectByDirection = (direction) => {
+	function checkAndApplyOverscrollEffectByDirection (direction) {
 		const
 			orientation = (direction === 'up' || direction === 'down') ? 'vertical' : 'horizontal',
-			bounds = this.uiRef.current.getScrollBounds(),
-			scrollability = orientation === 'vertical' ? this.uiRef.current.canScrollVertically(bounds) : this.uiRef.current.canScrollHorizontally(bounds);
+			bounds = variables.current.uiRef.current.getScrollBounds(),
+			scrollability = orientation === 'vertical' ? variables.current.uiRef.current.canScrollVertically(bounds) : variables.current.uiRef.current.canScrollHorizontally(bounds);
 
 		if (scrollability) {
 			const
-				isRtl = this.uiRef.current.props.rtl,
+				isRtl = variables.current.uiRef.current.props.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
-			this.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
+			variables.current.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 
-	scrollByPageOnPointerMode = (ev) => {
+	// TODO PLAT-98204.
+	function scrollByPageOnPointerMode (ev) {
 		const {keyCode, repeat} = ev;
-		forward('onKeyDown', ev, this.props);
+		forward('onKeyDown', ev, props);
 		ev.preventDefault();
 
-		this.animateOnFocus = true;
+		variables.current.animateOnFocus = true;
 
-		if (!repeat && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
+		if (!repeat && (props.direction === 'vertical' || props.direction === 'both')) {
 			const direction = isPageUp(keyCode) ? 'up' : 'down';
 
-			this.scrollByPage(direction);
-			if (this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-				this.checkAndApplyOverscrollEffectByDirection(direction);
+			scrollByPage(direction);
+			if (props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+				checkAndApplyOverscrollEffectByDirection(direction);
 			}
 
 			return true; // means consumed
@@ -623,78 +486,78 @@ class ScrollableBase extends Component {
 		return false; // means to be propagated
 	}
 
-	onKeyDown = (ev) => {
+	function onKeyDown (ev) {
 		const {keyCode, repeat, target} = ev;
 
-		forward('onKeyDown', ev, this.props);
+		forward('onKeyDown', ev, props);
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			ev.preventDefault();
 		}
 
-		this.animateOnFocus = true;
+		variables.current.animateOnFocus = true;
 
-		if (!repeat && this.hasFocus()) {
-			const {overscrollEffectOn} = this.props;
+		if (!repeat && hasFocus()) {
+			const {overscrollEffectOn} = props;
 			let direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+				if (props.direction === 'vertical' || props.direction === 'both') {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 
-					if (this.isContent(target)) {
+					if (isContent(target)) {
 						ev.stopPropagation();
-						this.scrollByPage(direction);
+						scrollByPage(direction);
 					}
 					if (overscrollEffectOn.pageKey) {
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+						checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
 			} else if (getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 
-				this.uiRef.current.lastInputType = 'arrowKey';
+				variables.current.uiRef.current.lastInputType = 'arrowKey';
 
 				direction = getDirection(keyCode);
 				if (overscrollEffectOn.arrowKey && !(element ? getTargetByDirectionFromElement(direction, element) : null)) {
-					const {horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef.current;
+					const {horizontalScrollbarRef, verticalScrollbarRef} = variables.current.uiRef.current;
 
 					if (!(horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(element)) &&
 						!(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(element))) {
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+						checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
 			}
 		}
 	}
 
-	onScrollbarButtonClick = ({isPreviousScrollButton, isVerticalScrollBar}) => {
+	function onScrollbarButtonClick ({isPreviousScrollButton, isVerticalScrollBar}) {
 		const
-			bounds = this.uiRef.current.getScrollBounds(),
+			bounds = variables.current.uiRef.current.getScrollBounds(),
 			direction = isPreviousScrollButton ? -1 : 1,
 			pageDistance = direction * (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
-		this.uiRef.current.lastInputType = 'scrollbarButton';
+		variables.current.uiRef.current.lastInputType = 'scrollbarButton';
 
-		if (direction !== this.uiRef.current.wheelDirection) {
-			this.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			this.uiRef.current.wheelDirection = direction;
+		if (direction !== variables.current.uiRef.current.wheelDirection) {
+			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
+			variables.current.uiRef.current.wheelDirection = direction;
 		}
 
-		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
+		variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, props.overscrollEffectOn.scrollbarButton);
 	}
 
-	focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
+	function focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
 		if (scrollbarRef.current) {
 			scrollbarRef.current.focusOnButton(isPreviousScrollButton);
 		}
 	}
 
-	scrollAndFocusScrollbarButton = (direction) => {
-		if (this.uiRef.current) {
+	function scrollAndFocusScrollbarButton (direction) {
+		if (variables.current.uiRef.current) {
 			const
-				{focusableScrollbar, direction: directionProp} = this.props,
-				uiRefCurrent = this.uiRef.current,
+				{direction: directionProp} = props,
+				uiRefCurrent = variables.current.uiRef.current,
 				isRtl = uiRefCurrent.props.rtl,
 				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 				isHorizontalDirection = direction === 'left' || direction === 'right',
@@ -703,13 +566,13 @@ class ScrollableBase extends Component {
 				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
 			if (canScrollHorizontally || canScrollingVertically) {
-				this.onScrollbarButtonClick({
+				onScrollbarButtonClick({
 					isPreviousScrollButton,
 					isVerticalScrollBar: canScrollingVertically
 				});
 
 				if (focusableScrollbar) {
-					this.focusOnScrollButton(
+					focusOnScrollButton(
 						canScrollingVertically ? uiRefCurrent.verticalScrollbarRef : uiRefCurrent.horizontalScrollbarRef,
 						isPreviousScrollButton
 					);
@@ -718,37 +581,34 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	stop = () => {
-		if (!this.props['data-spotlight-container-disabled']) {
-			this.childRef.current.setContainerDisabled(false);
+	function stop () {
+		if (!props['data-spotlight-container-disabled']) {
+			variables.current.childRef.current.setContainerDisabled(false);
 		}
-
-		this.focusOnItem();
-		this.lastScrollPositionOnFocus = null;
-		this.isWheeling = false;
-		if (this.isVoiceControl) {
-			this.isVoiceControl = false;
-			this.updateFocusAfterVoiceControl();
+		focusOnItem();
+		lastScrollPositionOnFocus = null;
+		isWheeling = false;
+		if (isVoiceControl) {
+			isVoiceControl = false;
+			updateFocusAfterVoiceControl();
 		}
 	}
 
-	focusOnItem () {
-		const childRef = this.childRef;
-
-		if (this.indexToFocus !== null && typeof childRef.current.focusByIndex === 'function') {
-			childRef.current.focusByIndex(this.indexToFocus);
-			this.indexToFocus = null;
+	function focusOnItem () {
+		if (indexToFocus !== null && typeof variables.current.childRef.current.focusByIndex === 'function') {
+			variables.current.childRef.current.focusByIndex(indexToFocus);
+			indexToFocus = null;
 		}
-		if (this.nodeToFocus !== null && typeof childRef.current.focusOnNode === 'function') {
-			childRef.current.focusOnNode(this.nodeToFocus);
-			this.nodeToFocus = null;
+		if (nodeToFocus !== null && typeof variables.current.childRef.current.focusOnNode === 'function') {
+			variables.current.childRef.current.focusOnNode(nodeToFocus);
+			nodeToFocus = null;
 		}
-		if (this.pointToFocus !== null) {
+		if (pointToFocus !== null) {
 			// no need to focus on pointer mode
 			if (!Spotlight.getPointerMode()) {
-				const {direction, x, y} = this.pointToFocus;
+				const {direction, x, y} = pointToFocus;
 				const position = {x, y};
-				const {current: {containerRef: {current}}} = this.uiRef;
+				const {current: {containerRef: {current}}} = variables.current.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
 				const target =
 					elemFromPoint && elemFromPoint.closest && getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
@@ -759,31 +619,31 @@ class ScrollableBase extends Component {
 					Spotlight.focus(target);
 				}
 			}
-			this.pointToFocus = null;
+			pointToFocus = null;
 		}
 	}
 
-	scrollTo = (opt) => {
-		this.indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
-		this.nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
+	function scrollTo (opt) {
+		indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
+		nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
 	}
 
-	alertThumb = () => {
-		const bounds = this.uiRef.current.getScrollBounds();
+	function alertThumb () {
+		const bounds = variables.current.uiRef.current.getScrollBounds();
 
-		this.uiRef.current.showThumb(bounds);
-		this.uiRef.current.startHidingThumb();
+		variables.current.uiRef.current.showThumb(bounds);
+		variables.current.uiRef.current.startHidingThumb();
 	}
 
-	alertThumbAfterRendered = () => {
+	function alertThumbAfterRendered () {
 		const spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && this.isContent(spotItem) && this.uiRef.current.isUpdatedScrollThumb) {
-			this.alertThumb();
+		if (!Spotlight.getPointerMode() && isContent(spotItem) && variables.current.uiRef.current.isUpdatedScrollThumb) {
+			alertThumb();
 		}
 	}
 
-	handleResizeWindow = () => {
+	function handleResizeWindow () {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
@@ -792,45 +652,45 @@ class ScrollableBase extends Component {
 	}
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
-	handleScrollerUpdate = () => {
-		if (this.uiRef.current.scrollToInfo === null) {
-			const scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
-			if (scrollHeight !== this.uiRef.current.bounds.scrollHeight) {
-				this.calculateAndScrollTo();
+	function handleScrollerUpdate () {
+		if (variables.current.uiRef.current.scrollToInfo === null) {
+			const scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
+			if (scrollHeight !== variables.current.uiRef.current.bounds.scrollHeight) {
+				calculateAndScrollTo();
 			}
 		}
 
-		// oddly, Scroller manages this.uiRef.current.bounds so if we don't update it here (it is also
+		// oddly, Scroller manages uiRef.current.bounds so if we don't update it here (it is also
 		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
 		// out of date when we land back in this method next time.
-		this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+		variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
 	}
 
-	clearOverscrollEffect = (orientation, edge) => {
-		this.overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
-		this.uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
+	function clearOverscrollEffect (orientation, edge) {
+		overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
+		variables.current.uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
 	}
 
-	applyOverscrollEffect = (orientation, edge, type, ratio) => {
-		const nodeRef = this.overscrollRefs[orientation].current;
+	function applyOverscrollEffect (orientation, edge, type, ratio) {
+		const nodeRef = variables.current.overscrollRefs[orientation].current;
 
 		if (nodeRef) {
 			nodeRef.style.setProperty(overscrollRatioPrefix + orientation + edge, ratio);
 
 			if (type === overscrollTypeOnce) {
-				this.overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
+				overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
 			}
 		}
 	}
 
-	createOverscrollJob = (orientation, edge) => {
-		if (!this.overscrollJobs[orientation][edge]) {
-			this.overscrollJobs[orientation][edge] = new Job(this.applyOverscrollEffect.bind(this), overscrollTimeout);
+	function createOverscrollJob (orientation, edge) {
+		if (!overscrollJobs[orientation][edge]) {
+			overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect.bind(this), overscrollTimeout);
 		}
 	}
 
-	stopOverscrollJob = (orientation, edge) => {
-		const job = this.overscrollJobs[orientation][edge];
+	function stopOverscrollJob (orientation, edge) {
+		const job = overscrollJobs[orientation][edge];
 
 		if (job) {
 			job.stop();
@@ -838,36 +698,36 @@ class ScrollableBase extends Component {
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	addEventListeners = (childContainerRef) => {
+	function addEventListeners (childContainerRef) {
 		if (childContainerRef.current && childContainerRef.current.addEventListener) {
-			childContainerRef.current.addEventListener('focusin', this.onFocus);
+			childContainerRef.current.addEventListener('focusin', onFocus);
 			if (platform.webos) {
-				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
+				childContainerRef.current.addEventListener('webOSVoice', onVoice);
 				childContainerRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
 			}
 		}
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	removeEventListeners = (childContainerRef) => {
+	function removeEventListeners (childContainerRef) {
 		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
-			childContainerRef.current.removeEventListener('focusin', this.onFocus);
+			childContainerRef.current.removeEventListener('focusin', onFocus);
 			if (platform.webos) {
-				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);
+				childContainerRef.current.removeEventListener('webOSVoice', onVoice);
 				childContainerRef.current.removeAttribute('data-webos-voice-intent');
 			}
 		}
 	}
 
-	updateFocusAfterVoiceControl = () => {
+	function updateFocusAfterVoiceControl () {
 		const spotItem = Spotlight.getCurrent();
-		if (spotItem && this.uiRef.current.containerRef.current.contains(spotItem)) {
+		if (spotItem && variables.current.uiRef.current.containerRef.current.contains(spotItem)) {
 			const
-				viewportBounds = this.uiRef.current.containerRef.current.getBoundingClientRect(),
+				viewportBounds = variables.current.uiRef.current.containerRef.current.getBoundingClientRect(),
 				spotItemBounds = spotItem.getBoundingClientRect(),
-				nodes = Spotlight.getSpottableDescendants(this.uiRef.current.containerRef.current.dataset.spotlightId),
-				first = this.voiceControlDirection === 'vertical' ? 'top' : 'left',
-				last = this.voiceControlDirection === 'vertical' ? 'bottom' : 'right';
+				nodes = Spotlight.getSpottableDescendants(variables.current.uiRef.current.containerRef.current.dataset.spotlightId),
+				first = voiceControlDirection === 'vertical' ? 'top' : 'left',
+				last = voiceControlDirection === 'vertical' ? 'bottom' : 'right';
 
 			if (spotItemBounds[last] < viewportBounds[first] || spotItemBounds[first] > viewportBounds[last]) {
 				for (let i = 0; i < nodes.length; i++) {
@@ -881,17 +741,17 @@ class ScrollableBase extends Component {
 		}
 	}
 
-	isReachedEdge = (scrollPos, ltrBound, rtlBound, isRtl = false) => {
+	function isReachedEdge (scrollPos, ltrBound, rtlBound, isRtl = false) {
 		const bound = isRtl ? rtlBound : ltrBound;
 		return (bound === 0 && scrollPos === 0) || (bound > 0 && scrollPos >= bound - 1);
 	}
 
-	onVoice = (e) => {
+	function onVoice (e) {
 		const
-			isHorizontal = this.props.direction === 'horizontal',
-			isRtl = this.uiRef.current.props.rtl,
-			{scrollTop, scrollLeft} = this.uiRef.current,
-			{maxLeft, maxTop} = this.uiRef.current.getScrollBounds(),
+			isHorizontal = props.direction === 'horizontal',
+			isRtl = variables.current.uiRef.current.props.rtl,
+			{scrollTop, scrollLeft} = variables.current.uiRef.current,
+			{maxLeft, maxTop} = variables.current.uiRef.current.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
 			horizontalDirection = isRtl ? ['right', 'left', 'rightmost', 'leftmost'] : ['left', 'right', 'leftmost', 'rightmost'],
 			movement = ['previous', 'next', 'first', 'last'];
@@ -904,17 +764,17 @@ class ScrollableBase extends Component {
 			scroll = isHorizontal ? horizontalDirection[index] : verticalDirection[index];
 		}
 
-		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
+		voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
 
 		// Case 1. Invalid direction
-		if (this.voiceControlDirection === null) {
-			this.isVoiceControl = false;
+		if (voiceControlDirection === null) {
+			isVoiceControl = false;
 		// Case 2. Cannot scroll
 		} else if (
-			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
-			(['down', 'bottom'].includes(scroll) && this.isReachedEdge(scrollTop, maxTop)) ||
-			(['left', 'leftmost'].includes(scroll) && this.isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
-			(['right', 'rightmost'].includes(scroll) && this.isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
+			(['up', 'top'].includes(scroll) && isReachedEdge(scrollTop, 0)) ||
+			(['down', 'bottom'].includes(scroll) && isReachedEdge(scrollTop, maxTop)) ||
+			(['left', 'leftmost'].includes(scroll) && isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
+			(['right', 'rightmost'].includes(scroll) && isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
 		) {
 			if (window.webOSVoiceReportActionResult) {
 				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
@@ -922,141 +782,286 @@ class ScrollableBase extends Component {
 			}
 		// Case 3. Can scroll
 		} else {
-			this.isVoiceControl = true;
+			isVoiceControl = true;
 			if (['up', 'down', 'left', 'right'].includes(scroll)) {
 				const isPreviousScrollButton = (scroll === 'up') || (scroll === 'left' && !isRtl) || (scroll === 'right' && isRtl);
-				this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
+				onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
 			} else { // ['top', 'bottom', 'leftmost', 'rightmost'].includes(scroll)
-				this.uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
+				variables.current.uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
 			}
 			e.preventDefault();
 		}
 	}
 
-	handleScroll = handle(
+	const handleScroll = handle(
 		forward('onScroll'),
 		(ev, {id}, context) => id && context && context.set,
 		({scrollLeft: x, scrollTop: y}, {id}, context) => {
 			context.set(`${id}.scrollPosition`, {x, y});
 		}
-	).bindAs(this, 'handleScroll')
+	);
 
-	render () {
-		const
-			{
-				childRenderer,
-				'data-spotlight-container': spotlightContainer,
-				'data-spotlight-container-disabled': spotlightContainerDisabled,
-				'data-spotlight-id': spotlightId,
-				focusableScrollbar,
-				preventBubblingOnKeyDown,
-				scrollDownAriaLabel,
-				scrollLeftAriaLabel,
-				scrollRightAriaLabel,
-				scrollUpAriaLabel,
-				...rest
-			} = this.props,
-			downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
-			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
-			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
-			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
+	// render
+	const
+		downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
+		upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
+		rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
+		leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
-		return (
-			<UiScrollableBase
-				noScrollByDrag={!platform.touchscreen}
-				{...rest}
-				addEventListeners={this.addEventListeners}
-				applyOverscrollEffect={this.applyOverscrollEffect}
-				clearOverscrollEffect={this.clearOverscrollEffect}
-				handleResizeWindow={this.handleResizeWindow}
-				onFlick={this.onFlick}
-				onKeyDown={this.onKeyDown}
-				onMouseDown={this.onMouseDown}
-				onScroll={this.handleScroll}
-				onWheel={this.onWheel}
-				ref={this.uiRef}
-				removeEventListeners={this.removeEventListeners}
-				scrollTo={this.scrollTo}
-				stop={this.stop}
-				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
-					childWrapper: ChildWrapper,
-					childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
-					className,
-					componentCss,
-					containerRef: uiContainerRef,
-					handleScroll,
-					horizontalScrollbarProps,
-					initChildRef: initUiChildRef,
-					isHorizontalScrollbarVisible,
-					isVerticalScrollbarVisible,
-					rtl,
-					scrollTo,
-					style,
-					verticalScrollbarProps
-				}) => (
-					<div
-						className={classNames(className, overscrollCss.scrollable)}
-						data-spotlight-container={spotlightContainer}
-						data-spotlight-container-disabled={spotlightContainerDisabled}
-						data-spotlight-id={spotlightId}
-						onTouchStart={this.onTouchStart}
-						ref={uiContainerRef}
-						style={style}
-					>
-						<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={this.overscrollRefs.vertical}>
-							<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={this.overscrollRefs.horizontal} {...restChildWrapperProps}>
-								{childRenderer({
-									...childComponentProps,
-									cbScrollTo: scrollTo,
-									className: componentCss.scrollableFill,
-									initUiChildRef,
-									isHorizontalScrollbarVisible,
-									isVerticalScrollbarVisible,
-									onScroll: handleScroll,
-									onUpdate: this.handleScrollerUpdate,
-									ref: this.childRef,
-									rtl,
-									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
-									spotlightId
-								})}
-							</ChildWrapper>
-							{isVerticalScrollbarVisible ?
-								<Scrollbar
-									{...verticalScrollbarProps}
-									{...this.scrollbarProps}
-									disabled={!isVerticalScrollbarVisible}
-									focusableScrollButtons={focusableScrollbar}
-									nextButtonAriaLabel={downButtonAriaLabel}
-									onKeyDownButton={this.onKeyDown}
-									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
-									previousButtonAriaLabel={upButtonAriaLabel}
-									rtl={rtl}
-								/> :
-								null
-							}
-						</div>
-						{isHorizontalScrollbarVisible ?
+	return (
+		<UiScrollableBase
+			noScrollByDrag={!platform.touchscreen}
+			{...rest}
+			addEventListeners={addEventListeners}
+			applyOverscrollEffect={applyOverscrollEffect}
+			clearOverscrollEffect={clearOverscrollEffect}
+			handleResizeWindow={handleResizeWindow}
+			onFlick={onFlick}
+			onKeyDown={onKeyDown}
+			onMouseDown={onMouseDown}
+			onScroll={handleScroll}
+			onWheel={onWheel}
+			ref={variables.current.uiRef}
+			removeEventListeners={removeEventListeners}
+			scrollTo={scrollTo}
+			stop={stop}
+			containerRenderer={({ // eslint-disable-line react/jsx-no-bind
+				childComponentProps,
+				childWrapper: ChildWrapper,
+				childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
+				className,
+				componentCss,
+				containerRef: uiContainerRef,
+				// TODO : change name "handleScrollInContainer"
+				handleScroll: handleScrollInContainer,
+				horizontalScrollbarProps,
+				initChildRef: initUiChildRef,
+				isHorizontalScrollbarVisible,
+				isVerticalScrollbarVisible,
+				rtl,
+				// TODO : change name "scrollToInContainer"
+				scrollTo: scrollToInContainer,
+				style,
+				verticalScrollbarProps
+			}) => (
+				<div
+					className={classNames(className, overscrollCss.scrollable)}
+					data-spotlight-container={spotlightContainer}
+					data-spotlight-container-disabled={spotlightContainerDisabled}
+					data-spotlight-id={spotlightId}
+					onTouchStart={onTouchStart}
+					ref={uiContainerRef}
+					style={style}
+				>
+					<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={variables.current.overscrollRefs.vertical}>
+						<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={variables.current.overscrollRefs.horizontal} {...restChildWrapperProps}>
+							{childRenderer({
+								...childComponentProps,
+								cbScrollTo: scrollToInContainer,
+								className: componentCss.scrollableFill,
+								initUiChildRef,
+								isHorizontalScrollbarVisible,
+								isVerticalScrollbarVisible,
+								onScroll: handleScrollInContainer,
+								onUpdate: handleScrollerUpdate,
+								ref: variables.current.childRef,
+								rtl,
+								scrollAndFocusScrollbarButton: scrollAndFocusScrollbarButton,
+								spotlightId
+							})}
+						</ChildWrapper>
+						{isVerticalScrollbarVisible ?
 							<Scrollbar
-								{...horizontalScrollbarProps}
-								{...this.scrollbarProps}
-								corner={isVerticalScrollbarVisible}
-								disabled={!isHorizontalScrollbarVisible}
+								{...verticalScrollbarProps}
+								{...variables.current.scrollbarProps}
+								disabled={!isVerticalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
-								nextButtonAriaLabel={rightButtonAriaLabel}
-								onKeyDownButton={this.onKeyDown}
+								nextButtonAriaLabel={downButtonAriaLabel}
+								onKeyDownButton={onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}
-								previousButtonAriaLabel={leftButtonAriaLabel}
+								previousButtonAriaLabel={upButtonAriaLabel}
 								rtl={rtl}
 							/> :
 							null
 						}
 					</div>
-				)}
-			/>
-		);
-	}
-}
+					{isHorizontalScrollbarVisible ?
+						<Scrollbar
+							{...horizontalScrollbarProps}
+							{...variables.current.scrollbarProps}
+							corner={isVerticalScrollbarVisible}
+							disabled={!isHorizontalScrollbarVisible}
+							focusableScrollButtons={focusableScrollbar}
+							nextButtonAriaLabel={rightButtonAriaLabel}
+							onKeyDownButton={onKeyDown}
+							preventBubblingOnKeyDown={preventBubblingOnKeyDown}
+							previousButtonAriaLabel={leftButtonAriaLabel}
+							rtl={rtl}
+						/> :
+						null
+					}
+				</div>
+			)}
+		/>
+	);
+};
+
+ScrollableBase.propTypes = /** @lends moonstone/Scrollable.Scrollable.prototype */ {
+	/**
+	 * Render function.
+	 *
+	 * @type {Function}
+	 * @required
+	 * @private
+	 */
+	childRenderer: PropTypes.func.isRequired,
+
+	/**
+	 * This is set to `true` by SpotlightContainerDecorator
+	 *
+	 * @type {Boolean}
+	 * @private
+	 */
+	'data-spotlight-container': PropTypes.bool,
+
+	/**
+	 * `false` if the content of the list or the scroller could get focus
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @private
+	 */
+	'data-spotlight-container-disabled': PropTypes.bool,
+
+	/**
+	 * This is passed onto the wrapped component to allow
+	 * it to customize the spotlight container for its use case.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	'data-spotlight-id': PropTypes.string,
+
+	/**
+	 * Direction of the list or the scroller.
+	 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
+
+	/**
+	 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+	 * not move focus to the scrollbar controls.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	focusableScrollbar: PropTypes.bool,
+
+	/**
+	 * A unique identifier for the scrollable component.
+	 *
+	 * When specified and when the scrollable is within a SharedStateDecorator, the scroll
+	 * position will be shared and restored on mount if the component is destroyed and
+	 * recreated.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	id: PropTypes.string,
+
+	/**
+	 * Specifies overscroll effects shows on which type of inputs.
+	 *
+	 * @type {Object}
+	 * @default {
+	 *	arrowKey: false,
+	 *	drag: false,
+	 *	pageKey: false,
+	 *	scrollbarButton: false,
+	 *	wheel: true
+	 * }
+	 * @private
+	 */
+	overscrollEffectOn: PropTypes.shape({
+		arrowKey: PropTypes.bool,
+		drag: PropTypes.bool,
+		pageKey: PropTypes.bool,
+		scrollbarButton: PropTypes.bool,
+		wheel: PropTypes.bool
+	}),
+
+	/**
+	 * Specifies preventing keydown events from bubbling up to applications.
+	 * Valid values are `'none'`, and `'programmatic'`.
+	 *
+	 * When it is `'none'`, every keydown event is bubbled.
+	 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
+	 * which invokes programmatic spotlight moving.
+	 *
+	 * @type {String}
+	 * @default 'none'
+	 * @private
+	 */
+	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
+
+	/**
+	 * Sets the hint string read when focusing the next button in the vertical scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll down')
+	 * @public
+	 */
+	scrollDownAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll left')
+	 * @public
+	 */
+	scrollLeftAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the next button in the horizontal scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll right')
+	 * @public
+	 */
+	scrollRightAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the previous button in the vertical scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll up')
+	 * @public
+	 */
+	scrollUpAriaLabel: PropTypes.string
+};
+
+ScrollableBase.defaultProps = {
+	'data-spotlight-container-disabled': false,
+	focusableScrollbar: false,
+	overscrollEffectOn: {
+		arrowKey: false,
+		drag: false,
+		pageKey: false,
+		scrollbarButton: false,
+		wheel: true
+	},
+	preventBubblingOnKeyDown: 'none'
+};
 
 /**
  * A Moonstone-styled component that provides horizontal and vertical scrollbars.

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -178,8 +178,6 @@ const ScrollableBase = (props) => {
 	const childRef = React.useRef();
 	const uiRef = React.useRef();
 
-	configureSpotlightContainer(props);
-
 	// Destructuring for render
 	const {
 		childRenderer,

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -19,7 +19,7 @@ import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from 
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
-import React, {useContext, useRef} from 'react';
+import React, {useContext, useEffect, useRef} from 'react';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';
@@ -195,8 +195,8 @@ const ScrollableBase = (props) => {
 		...rest
 	} = props;
 
-	// TODO : Change to useEffect
-	function componentDidMount () {
+	useEffect(() => {
+		// componentDidMount
 		createOverscrollJob('horizontal', 'before');
 		createOverscrollJob('horizontal', 'after');
 
@@ -204,26 +204,25 @@ const ScrollableBase = (props) => {
 		createOverscrollJob('vertical', 'after');
 
 		restoreScrollPosition();
-		scrollables.set(this, uiRef.current.containerRef.current);
-	}
 
-	// TODO : Change to useEffect
-	function componentDidUpdate (prevProps) {
-		if (prevProps['data-spotlight-id'] !== props['data-spotlight-id'] ||
-				prevProps.focusableScrollbar !== props.focusableScrollbar) {
-			configureSpotlightContainer(props);
-		}
-	}
+		// TODO: Replace `this` to something.
+		scrollables.set(/* this */null, uiRef.current.containerRef.current);
 
-	// TODO : Change to useEffect
-	function componentWillUnmount () {
-		scrollables.delete(this);
+		// componentWillUnmount
+		return () => {
+			// TODO: Replace `this` to something.
+			scrollables.delete(/* this */ null);
 
-		stopOverscrollJob('horizontal', 'before');
-		stopOverscrollJob('horizontal', 'after');
-		stopOverscrollJob('vertical', 'before');
-		stopOverscrollJob('vertical', 'after');
-	}
+			stopOverscrollJob('horizontal', 'before');
+			stopOverscrollJob('horizontal', 'after');
+			stopOverscrollJob('vertical', 'before');
+			stopOverscrollJob('vertical', 'after');
+		};
+	}, []);	// TODO : Handle exhaustive-deps ESLint rule.
+
+	useEffect(() => {
+		configureSpotlightContainer(props);
+	}, [props['data-spotlight-id'], props.focusableScrollbar]);	// TODO : Handle exhaustive-deps ESLint rule.
 
 
 	// Only intended to be used within componentDidMount, this method will fetch the last stored

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -157,8 +157,6 @@ const ScrollableBaseNative = (props) => {
 	const childRef = React.useRef();
 	const uiRef = React.useRef();
 
-	configureSpotlightContainer(props);
-
 	const {
 			childRenderer,
 			'data-spotlight-container': spotlightContainer,
@@ -962,7 +960,7 @@ const ScrollableBaseNative = (props) => {
 	);
 };
 
-ScrollableBaseNative.displayName  = 'ScrollableNative';
+ScrollableBaseNative.displayName = 'ScrollableNative';
 ScrollableBaseNative.propTypes = /** @lends moonstone/ScrollableNative.ScrollableNative.prototype */ {
 	/**
 	 * Render function.

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -11,7 +11,7 @@ import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from 
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useContext, useDebugValue, useRef} from 'react';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';
@@ -113,248 +113,112 @@ const getTargetInViewByDirectionFromPosition = (direction, position, container) 
 /**
  * A Moonstone-styled native component that provides horizontal and vertical scrollbars.
  *
- * @class ScrollableBaseNative
+ * @function ScrollableBaseNative
  * @memberof moonstone/ScrollableNative
  * @extends ui/Scrollable.ScrollableBaseNative
  * @ui
  * @private
  */
-class ScrollableBaseNative extends Component {
-	static displayName = 'ScrollableNative'
+const ScrollableBaseNative = (props) => {
+	useDebugValue('ScrollableNative');
+	const context = useContext(SharedState);
 
-	static contextType = SharedState
-
-	static propTypes = /** @lends moonstone/ScrollableNative.ScrollableNative.prototype */ {
-		/**
-		 * Render function.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		childRenderer: PropTypes.func.isRequired,
-
-		/**
-		 * This is set to `true` by SpotlightContainerDecorator
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		'data-spotlight-container': PropTypes.bool,
-
-		/**
-		 * `false` if the content of the list or the scroller could get focus
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		'data-spotlight-container-disabled': PropTypes.bool,
-
-		/**
-		 * This is passed onto the wrapped component to allow
-		 * it to customize the spotlight container for its use case.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		'data-spotlight-id': PropTypes.string,
-
-		/**
-		 * Direction of the list or the scroller.
-		 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
-		 *
-		 * Valid values are:
-		 * * `'both'`,
-		 * * `'horizontal'`, and
-		 * * `'vertical'`.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
-
-		/**
-		 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
-		 * not move focus to the scrollbar controls.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		focusableScrollbar: PropTypes.bool,
-
-		/**
-		 * A unique identifier for the scrollable component.
-		 *
-		 * When specified and when the scrollable is within a SharedStateDecorator, the scroll
-		 * position will be shared and restored on mount if the component is destroyed and
-		 * recreated.
-		 *
-		 * @type {String}
-		 * @public
-		 */
-		id: PropTypes.string,
-
-		/**
-		 * Specifies overscroll effects shows on which type of inputs.
-		 *
-		 * @type {Object}
-		 * @default {
-		 *	arrowKey: false,
-		 *	drag: false,
-		 *	pageKey: false,
-		 *	scrollbarButton: false,
-		 *	wheel: true
-		 * }
-		 * @private
-		 */
-		overscrollEffectOn: PropTypes.shape({
-			arrowKey: PropTypes.bool,
-			drag: PropTypes.bool,
-			pageKey: PropTypes.bool,
-			scrollbarButton: PropTypes.bool,
-			wheel: PropTypes.bool
-		}),
-
-		/**
-		 * Specifies preventing keydown events from bubbling up to applications.
-		 * Valid values are `'none'`, and `'programmatic'`.
-		 *
-		 * When it is `'none'`, every keydown event is bubbled.
-		 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
-		 * which invokes programmatic spotlight moving.
-		 *
-		 * @type {String}
-		 * @default 'none'
-		 * @private
-		 */
-		preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
-
-		/**
-		 * Sets the hint string read when focusing the next button in the vertical scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll down')
-		 * @public
-		 */
-		scrollDownAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll left')
-		 * @public
-		 */
-		scrollLeftAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the next button in the horizontal scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll right')
-		 * @public
-		 */
-		scrollRightAriaLabel: PropTypes.string,
-
-		/**
-		 * Sets the hint string read when focusing the previous button in the vertical scroll bar.
-		 *
-		 * @type {String}
-		 * @default $L('scroll up')
-		 * @public
-		 */
-		scrollUpAriaLabel: PropTypes.string
-	}
-
-	static defaultProps = {
-		'data-spotlight-container-disabled': false,
-		focusableScrollbar: false,
-		overscrollEffectOn: {
-			arrowKey: false,
-			drag: false,
-			pageKey: false,
-			scrollbarButton: false,
-			wheel: true
+	// constructor (props)
+	// Instance variables
+	let variables = useRef({
+		scrollbarProps: {
+			cbAlertThumb: alertThumbAfterRendered,
+			onNextScroll: onScrollbarButtonClick,
+			onPrevScroll: onScrollbarButtonClick
 		},
-		preventBubblingOnKeyDown: 'none'
-	}
-
-	constructor (props) {
-		super(props);
-
-		this.scrollbarProps = {
-			cbAlertThumb: this.alertThumbAfterRendered,
-			onNextScroll: this.onScrollbarButtonClick,
-			onPrevScroll: this.onScrollbarButtonClick
-		};
-
-		this.overscrollRefs = {
+		overscrollRefs: {
 			horizontal: React.createRef(),
 			vertical: React.createRef()
-		};
-		this.childRef = React.createRef();
-		this.uiRef = React.createRef();
+		},
+		childRef: React.createRef(),
+		uiRef: React.createRef(),
+		animateOnFocus: false
+	});
 
-		configureSpotlightContainer(props);
+	configureSpotlightContainer(props);
+
+	const
+		{
+			childRenderer,
+			'data-spotlight-container': spotlightContainer,
+			'data-spotlight-container-disabled': spotlightContainerDisabled,
+			'data-spotlight-id': spotlightId,
+			focusableScrollbar,
+			preventBubblingOnKeyDown,
+			scrollDownAriaLabel,
+			scrollLeftAriaLabel,
+			scrollRightAriaLabel,
+			scrollUpAriaLabel,
+			...rest
+		} = props,
+		downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
+		upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
+		rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
+		leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
+
+	// TODO : Change to useEffect
+	function componentDidMount () {
+		createOverscrollJob('horizontal', 'before');
+		createOverscrollJob('horizontal', 'after');
+
+		createOverscrollJob('vertical', 'before');
+		createOverscrollJob('vertical', 'after');
+
+		scrollables.set(this, variables.current.uiRef.current.containerRef.current);
+
+		restoreScrollPosition();
 	}
 
-	componentDidMount () {
-		this.createOverscrollJob('horizontal', 'before');
-		this.createOverscrollJob('horizontal', 'after');
-
-		this.createOverscrollJob('vertical', 'before');
-		this.createOverscrollJob('vertical', 'after');
-
-		scrollables.set(this, this.uiRef.current.containerRef.current);
-
-		this.restoreScrollPosition();
-	}
-
-	componentDidUpdate (prevProps) {
-		if (prevProps['data-spotlight-id'] !== this.props['data-spotlight-id'] ||
-				prevProps.focusableScrollbar !== this.props.focusableScrollbar) {
-			configureSpotlightContainer(this.props);
+	// TODO : Change to useEffect
+	function componentDidUpdate (prevProps) {
+		if (prevProps['data-spotlight-id'] !== props['data-spotlight-id'] ||
+				prevProps.focusableScrollbar !== props.focusableScrollbar) {
+			configureSpotlightContainer(props);
 		}
 	}
 
-	componentWillUnmount () {
+	// TODO : Change to useEffect
+	function componentWillUnmount () {
 		scrollables.delete(this);
 
-		this.stopOverscrollJob('horizontal', 'before');
-		this.stopOverscrollJob('horizontal', 'after');
-		this.stopOverscrollJob('vertical', 'before');
-		this.stopOverscrollJob('vertical', 'after');
+		stopOverscrollJob('horizontal', 'before');
+		stopOverscrollJob('horizontal', 'after');
+		stopOverscrollJob('vertical', 'before');
+		stopOverscrollJob('vertical', 'after');
 	}
 
 	// status
-	isWheeling = false
+	let isWheeling = false;
 
 	// spotlight
-	lastScrollPositionOnFocus = null
-	indexToFocus = null
-	nodeToFocus = null
-	pointToFocus = null
+	let lastScrollPositionOnFocus = null;
+	let indexToFocus = null;
+	let nodeToFocus = null;
+	let pointToFocus = null;
 
 	// voice control
-	isVoiceControl = false
-	voiceControlDirection = 'vertical'
+	let isVoiceControl = false;
+	let voiceControlDirection = 'vertical';
 
 	// overscroll
-	overscrollJobs = {
+	let overscrollJobs = {
 		horizontal: {before: null, after: null},
 		vertical: {before: null, after: null}
-	}
+	};
 
 	// Only intended to be used within componentDidMount, this method will fetch the last stored
 	// scroll position from SharedState and scroll (without animation) to that position
-	restoreScrollPosition () {
-		const {id} = this.props;
-		if (id && this.context && this.context.get) {
-			const scrollPosition = this.context.get(`${id}.scrollPosition`);
+	function restoreScrollPosition () {
+		const {id} = props;
+		if (id && context && context.get) {
+			const scrollPosition = context.get(`${id}.scrollPosition`);
 			if (scrollPosition) {
-				this.uiRef.current.scrollTo({
+				variables.current.uiRef.current.scrollTo({
 					position: scrollPosition,
 					animate: false
 				});
@@ -362,9 +226,8 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-
-	isScrollButtonFocused () {
-		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = this.uiRef.current;
+	function isScrollButtonFocused () {
+		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = variables.current.uiRef.current;
 
 		return (
 			h.current && h.current.isOneOfScrollButtonsFocused() ||
@@ -372,8 +235,8 @@ class ScrollableBaseNative extends Component {
 		);
 	}
 
-	onFlick = ({direction}) => {
-		const bounds = this.uiRef.current.getScrollBounds();
+	function onFlick ({direction}) {
+		const bounds = variables.current.uiRef.current.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
@@ -381,29 +244,29 @@ class ScrollableBaseNative extends Component {
 		}
 
 		if ((
-			direction === 'vertical' && this.uiRef.current.canScrollVertically(bounds) ||
-			direction === 'horizontal' && this.uiRef.current.canScrollHorizontally(bounds)
-		) && !this.props['data-spotlight-container-disabled']) {
-			this.childRef.current.setContainerDisabled(true);
+			direction === 'vertical' && variables.current.uiRef.current.canScrollVertically(bounds) ||
+			direction === 'horizontal' && variables.current.uiRef.current.canScrollHorizontally(bounds)
+		) && !props['data-spotlight-container-disabled']) {
+			variables.current.childRef.current.setContainerDisabled(true);
 		}
 	}
 
-	onMouseDown = (ev) => {
-		if (this.isScrollButtonFocused()) {
+	function onMouseDown (ev) {
+		if (isScrollButtonFocused()) {
 			ev.preventDefault();
 		}
 
-		if (this.props['data-spotlight-container-disabled']) {
+		if (props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
 		} else {
-			this.childRef.current.setContainerDisabled(false);
+			variables.current.childRef.current.setContainerDisabled(false);
 		}
 	}
 
-	onTouchStart = () => {
+	function onTouchStart () {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (!Spotlight.isPaused() && focusedItem && !this.isScrollButtonFocused()) {
+		if (!Spotlight.isPaused() && focusedItem && !isScrollButtonFocused()) {
 			focusedItem.blur();
 		}
 	}
@@ -413,12 +276,12 @@ class ScrollableBaseNative extends Component {
 	 * - for horizontal scroll, supports wheel action on any children nodes since web engine cannot support this
 	 * - for vertical scroll, supports wheel action on scrollbars only
 	 */
-	onWheel = (ev) => {
+	function onWheel (ev) {
 		const
-			overscrollEffectRequired = this.props.overscrollEffectOn.wheel,
-			bounds = this.uiRef.current.getScrollBounds(),
-			canScrollHorizontally = this.uiRef.current.canScrollHorizontally(bounds),
-			canScrollVertically = this.uiRef.current.canScrollVertically(bounds),
+			overscrollEffectRequired = props.overscrollEffectOn.wheel,
+			bounds = variables.current.uiRef.current.getScrollBounds(),
+			canScrollHorizontally = variables.current.uiRef.current.canScrollHorizontally(bounds),
+			canScrollVertically = variables.current.uiRef.current.canScrollVertically(bounds),
 			eventDeltaMode = ev.deltaMode,
 			eventDelta = (-ev.wheelDeltaY || ev.deltaY);
 		let
@@ -429,55 +292,55 @@ class ScrollableBaseNative extends Component {
 			window.document.activeElement.blur();
 		}
 
-		this.uiRef.current.showThumb(bounds);
+		variables.current.uiRef.current.showThumb(bounds);
 
 		// FIXME This routine is a temporary support for horizontal wheel scroll.
 		// FIXME If web engine supports horizontal wheel, this routine should be refined or removed.
 		if (canScrollVertically) { // This routine handles wheel events on scrollbars for vertical scroll.
-			if (eventDelta < 0 && this.uiRef.current.scrollTop > 0 || eventDelta > 0 && this.uiRef.current.scrollTop < bounds.maxTop) {
-				const {horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef.current;
+			if (eventDelta < 0 && variables.current.uiRef.current.scrollTop > 0 || eventDelta > 0 && variables.current.uiRef.current.scrollTop < bounds.maxTop) {
+				const {horizontalScrollbarRef, verticalScrollbarRef} = variables.current.uiRef.current;
 
-				if (!this.isWheeling) {
-					if (!this.props['data-spotlight-container-disabled']) {
-						this.childRef.current.setContainerDisabled(true);
+				if (!isWheeling) {
+					if (!props['data-spotlight-container-disabled']) {
+						variables.current.childRef.current.setContainerDisabled(true);
 					}
-					this.isWheeling = true;
+					isWheeling = true;
 				}
 
 				// Not to check if ev.target is a descendant of a wrapped component which may have a lot of nodes in it.
 				if ((horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(ev.target)) ||
 					(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(ev.target))) {
-					delta = this.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+					delta = variables.current.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
 
 					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
-					this.uiRef.current.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
+					variables.current.uiRef.current.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 				}
 
 				ev.stopPropagation();
 			} else {
-				if (overscrollEffectRequired && (eventDelta < 0 && this.uiRef.current.scrollTop <= 0 || eventDelta > 0 && this.uiRef.current.scrollTop >= bounds.maxTop)) {
-					this.uiRef.current.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+				if (overscrollEffectRequired && (eventDelta < 0 && variables.current.uiRef.current.scrollTop <= 0 || eventDelta > 0 && variables.current.uiRef.current.scrollTop >= bounds.maxTop)) {
+					variables.current.uiRef.current.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
 			}
 		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
-			if (eventDelta < 0 && this.uiRef.current.scrollLeft > 0 || eventDelta > 0 && this.uiRef.current.scrollLeft < bounds.maxLeft) {
-				if (!this.isWheeling) {
-					if (!this.props['data-spotlight-container-disabled']) {
-						this.childRef.current.setContainerDisabled(true);
+			if (eventDelta < 0 && variables.current.uiRef.current.scrollLeft > 0 || eventDelta > 0 && variables.current.uiRef.current.scrollLeft < bounds.maxLeft) {
+				if (!isWheeling) {
+					if (!props['data-spotlight-container-disabled']) {
+						variables.current.childRef.current.setContainerDisabled(true);
 					}
-					this.isWheeling = true;
+					isWheeling = true;
 				}
-				delta = this.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+				delta = variables.current.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				needToHideThumb = !delta;
 
 				ev.preventDefault();
 				ev.stopPropagation();
 			} else {
-				if (overscrollEffectRequired && (eventDelta < 0 && this.uiRef.current.scrollLeft <= 0 || eventDelta > 0 && this.uiRef.current.scrollLeft >= bounds.maxLeft)) {
-					this.uiRef.current.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+				if (overscrollEffectRequired && (eventDelta < 0 && variables.current.uiRef.current.scrollLeft <= 0 || eventDelta > 0 && variables.current.uiRef.current.scrollLeft >= bounds.maxLeft)) {
+					variables.current.uiRef.current.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
 			}
@@ -488,68 +351,70 @@ class ScrollableBaseNative extends Component {
 			ev.preventDefault();
 			const direction = Math.sign(delta);
 			// Not to accumulate scroll position if wheel direction is different from hold direction
-			if (direction !== this.uiRef.current.wheelDirection) {
-				this.uiRef.current.isScrollAnimationTargetAccumulated = false;
-				this.uiRef.current.wheelDirection = direction;
+			if (direction !== variables.current.uiRef.current.wheelDirection) {
+				variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
+				variables.current.uiRef.current.wheelDirection = direction;
 			}
-			this.uiRef.current.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
+			variables.current.uiRef.current.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
 		}
 
 		if (needToHideThumb) {
-			this.uiRef.current.startHidingThumb();
+			variables.current.uiRef.current.startHidingThumb();
 		}
 	}
 
-	start = (animate) => {
+	function start (animate) {
 		if (!animate) {
-			this.focusOnItem();
+			focusOnItem();
 		}
 	}
 
-	isContent = (element) => (element && this.uiRef.current && this.uiRef.current.childRefCurrent.containerRef.current.contains(element))
+	function isContent (element) {
+		return (element && variables.current.uiRef.current && variables.current.uiRef.current.childRefCurrent.containerRef.current.contains(element));
+	}
 
 	// event handlers for Spotlight support
 
-	startScrollOnFocus = (pos) => {
+	function startScrollOnFocus (pos) {
 		if (pos) {
 			const
 				{top, left} = pos,
-				bounds = this.uiRef.current.getScrollBounds(),
-				scrollHorizontally = bounds.maxLeft > 0 && Math.abs(left - this.uiRef.current.scrollLeft) > epsilon,
-				scrollVertically = bounds.maxTop > 0 && Math.abs(top - this.uiRef.current.scrollTop) > epsilon;
+				bounds = variables.current.uiRef.current.getScrollBounds(),
+				scrollHorizontally = bounds.maxLeft > 0 && Math.abs(left - variables.current.uiRef.current.scrollLeft) > epsilon,
+				scrollVertically = bounds.maxTop > 0 && Math.abs(top - variables.current.uiRef.current.scrollTop) > epsilon;
 
 			if (scrollHorizontally || scrollVertically) {
-				this.uiRef.current.start({
+				variables.current.uiRef.current.start({
 					targetX: left,
 					targetY: top,
-					animate: this.animateOnFocus,
-					overscrollEffect: this.props.overscrollEffectOn[this.uiRef.current.lastInputType] && (!this.childRef.current.shouldPreventOverscrollEffect || !this.childRef.current.shouldPreventOverscrollEffect())
+					animate: variables.current.animateOnFocus,
+					overscrollEffect: props.overscrollEffectOn[variables.current.uiRef.current.lastInputType] && (!variables.current.childRef.current.shouldPreventOverscrollEffect || !variables.current.childRef.current.shouldPreventOverscrollEffect())
 				});
-				this.lastScrollPositionOnFocus = pos;
+				lastScrollPositionOnFocus = pos;
 			}
 		}
 	}
 
-	calculateAndScrollTo = () => {
+	function calculateAndScrollTo () {
 		const
 			spotItem = Spotlight.getCurrent(),
-			positionFn = this.childRef.current.calculatePositionOnFocus,
-			containerNode = this.uiRef.current.childRefCurrent.containerRef.current;
+			positionFn = variables.current.childRef.current.calculatePositionOnFocus,
+			containerNode = variables.current.uiRef.current.childRefCurrent.containerRef.current;
 
 		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
-			const lastPos = this.lastScrollPositionOnFocus;
+			const lastPos = lastScrollPositionOnFocus;
 			let pos;
 
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
-			if (this.uiRef.current.scrolling && lastPos) {
+			if (variables.current.uiRef.current.scrolling && lastPos) {
 				const containerRect = getRect(containerNode);
 				const itemRect = getRect(spotItem);
 				let scrollPosition;
 
-				if (this.props.direction === 'horizontal' || this.props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
+				if (props.direction === 'horizontal' || props.direction === 'both' && !(itemRect.left >= containerRect.left && itemRect.right <= containerRect.right)) {
 					scrollPosition = lastPos.left;
-				} else if (this.props.direction === 'vertical' || this.props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
+				} else if (props.direction === 'vertical' || props.direction === 'both' && !(itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom)) {
 					scrollPosition = lastPos.top;
 				}
 
@@ -558,30 +423,30 @@ class ScrollableBaseNative extends Component {
 				// scrollInfo passes in current `scrollHeight` and `scrollTop` before calculations
 				const
 					scrollInfo = {
-						previousScrollHeight: this.uiRef.current.bounds.scrollHeight,
-						scrollTop: this.uiRef.current.scrollTop
+						previousScrollHeight: variables.current.uiRef.current.bounds.scrollHeight,
+						scrollTop: variables.current.uiRef.current.scrollTop
 					};
 				pos = positionFn({item: spotItem, scrollInfo});
 			}
 
-			if (pos && (pos.left !== this.uiRef.current.scrollLeft || pos.top !== this.uiRef.current.scrollTop)) {
-				this.startScrollOnFocus(pos);
+			if (pos && (pos.left !== variables.current.uiRef.current.scrollLeft || pos.top !== variables.current.uiRef.current.scrollTop)) {
+				startScrollOnFocus(pos);
 			}
 
 			// update `scrollHeight`
-			this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+			variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
 		}
 	}
 
-	onFocus = (ev) => {
+	function onFocus (ev) {
 		const
-			{isDragging} = this.uiRef.current,
-			shouldPreventScrollByFocus = this.childRef.current.shouldPreventScrollByFocus ?
-				this.childRef.current.shouldPreventScrollByFocus() :
+			{isDragging} = variables.current.uiRef.current,
+			shouldPreventScrollByFocus = variables.current.childRef.current.shouldPreventScrollByFocus ?
+				variables.current.childRef.current.shouldPreventScrollByFocus() :
 				false;
 
 		if (!Spotlight.getPointerMode()) {
-			this.alertThumb();
+			alertThumb();
 		}
 
 		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || isDragging)) {
@@ -590,28 +455,28 @@ class ScrollableBaseNative extends Component {
 				spotItem = Spotlight.getCurrent();
 
 			if (item && item === spotItem) {
-				this.calculateAndScrollTo();
+				calculateAndScrollTo();
 			}
-		} else if (this.childRef.current.setLastFocusedNode) {
-			this.childRef.current.setLastFocusedNode(ev.target);
+		} else if (variables.current.childRef.current.setLastFocusedNode) {
+			variables.current.childRef.current.setLastFocusedNode(ev.target);
 		}
 	}
 
-	scrollByPage = (direction) => {
+	function scrollByPage (direction) {
 		const
-			{childRefCurrent, scrollTop} = this.uiRef.current,
+			{childRefCurrent, scrollTop} = variables.current.uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
-			bounds = this.uiRef.current.getScrollBounds(),
+			bounds = variables.current.uiRef.current.getScrollBounds(),
 			isUp = direction === 'up',
 			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier,
 			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop - scrollTop > epsilon;
 
-		this.uiRef.current.lastInputType = 'pageKey';
+		variables.current.uiRef.current.lastInputType = 'pageKey';
 
-		if (directionFactor !== this.uiRef.current.wheelDirection) {
-			this.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			this.uiRef.current.wheelDirection = directionFactor;
+		if (directionFactor !== variables.current.uiRef.current.wheelDirection) {
+			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
+			variables.current.uiRef.current.wheelDirection = directionFactor;
 		}
 
 		if (scrollPossible) {
@@ -629,57 +494,58 @@ class ScrollableBaseNative extends Component {
 							clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 
 					focusedItem.blur();
-					if (!this.props['data-spotlight-container-disabled']) {
-						this.childRef.current.setContainerDisabled(true);
+					if (!props['data-spotlight-container-disabled']) {
+						variables.current.childRef.current.setContainerDisabled(true);
 					}
-					this.pointToFocus = {direction, x, y};
+					pointToFocus = {direction, x, y};
 				}
 			} else {
-				this.pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
+				pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
 			}
 
-			this.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, this.props.overscrollEffectOn.pageKey);
+			variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);
 		}
 	}
 
-	hasFocus () {
+	function hasFocus () {
 		let current = Spotlight.getCurrent();
 
 		if (!current) {
-			const spotlightId = Spotlight.getActiveContainer();
-			current = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
+			const activeContainerId = Spotlight.getActiveContainer();
+			current = document.querySelector(`[data-spotlight-id="${activeContainerId}"]`);
 		}
 
-		return current && this.uiRef.current.containerRef.current.contains(current);
+		return current && variables.current.uiRef.current.containerRef.current.contains(current);
 	}
 
-	checkAndApplyOverscrollEffectByDirection = (direction) => {
+	function checkAndApplyOverscrollEffectByDirection (direction) {
 		const
 			orientation = (direction === 'up' || direction === 'down') ? 'vertical' : 'horizontal',
-			bounds = this.uiRef.current.getScrollBounds(),
-			scrollability = orientation === 'vertical' ? this.uiRef.current.canScrollVertically(bounds) : this.uiRef.current.canScrollHorizontally(bounds);
+			bounds = variables.current.uiRef.current.getScrollBounds(),
+			scrollability = orientation === 'vertical' ? variables.current.uiRef.current.canScrollVertically(bounds) : variables.current.uiRef.current.canScrollHorizontally(bounds);
 
 		if (scrollability) {
 			const
-				isRtl = this.uiRef.current.props.rtl,
+				isRtl = variables.current.uiRef.current.props.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
-			this.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
+			variables.current.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 
-	scrollByPageOnPointerMode = (ev) => {
+	// TODO PLAT-98204.
+	function scrollByPageOnPointerMode (ev) {
 		const {keyCode, repeat} = ev;
-		forward('onKeyDown', ev, this.props);
+		forward('onKeyDown', ev, props);
 		ev.preventDefault();
 
-		this.animateOnFocus = true;
+		variables.current.animateOnFocus = true;
 
-		if (!repeat && (this.props.direction === 'vertical' || this.props.direction === 'both')) {
+		if (!repeat && (props.direction === 'vertical' || props.direction === 'both')) {
 			const direction = isPageUp(keyCode) ? 'up' : 'down';
 
-			this.scrollByPage(direction);
-			if (this.props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
-				this.checkAndApplyOverscrollEffectByDirection(direction);
+			scrollByPage(direction);
+			if (props.overscrollEffectOn.pageKey) { /* if the spotlight focus will not move */
+				checkAndApplyOverscrollEffectByDirection(direction);
 			}
 
 			return true; // means consumed
@@ -688,78 +554,78 @@ class ScrollableBaseNative extends Component {
 		return false; // means to be propagated
 	}
 
-	onKeyDown = (ev) => {
+	function onKeyDown (ev) {
 		const {keyCode, repeat, target} = ev;
 
-		forward('onKeyDown', ev, this.props);
+		forward('onKeyDown', ev, props);
 
 		if (isPageUp(keyCode) || isPageDown(keyCode)) {
 			ev.preventDefault();
 		}
 
-		this.animateOnFocus = true;
+		variables.current.animateOnFocus = true;
 
-		if (!repeat && this.hasFocus()) {
-			const {overscrollEffectOn} = this.props;
+		if (!repeat && hasFocus()) {
+			const {overscrollEffectOn} = props;
 			let direction = null;
 
 			if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				if (this.props.direction === 'vertical' || this.props.direction === 'both') {
+				if (props.direction === 'vertical' || props.direction === 'both') {
 					direction = isPageUp(keyCode) ? 'up' : 'down';
 
-					if (this.isContent(target)) {
+					if (isContent(target)) {
 						ev.stopPropagation();
-						this.scrollByPage(direction);
+						scrollByPage(direction);
 					}
 					if (overscrollEffectOn.pageKey) {
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+						checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
 			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 
-				this.uiRef.current.lastInputType = 'arrowKey';
+				variables.current.uiRef.current.lastInputType = 'arrowKey';
 
 				direction = getDirection(keyCode);
 				if (overscrollEffectOn.arrowKey && !(element ? getTargetByDirectionFromElement(direction, element) : null)) {
-					const {horizontalScrollbarRef, verticalScrollbarRef} = this.uiRef.current;
+					const {horizontalScrollbarRef, verticalScrollbarRef} = variables.current.uiRef.current;
 
 					if (!(horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(element)) &&
 						!(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(element))) {
-						this.checkAndApplyOverscrollEffectByDirection(direction);
+						checkAndApplyOverscrollEffectByDirection(direction);
 					}
 				}
 			}
 		}
 	}
 
-	onScrollbarButtonClick = ({isPreviousScrollButton, isVerticalScrollBar}) => {
+	function onScrollbarButtonClick ({isPreviousScrollButton, isVerticalScrollBar}) {
 		const
-			bounds = this.uiRef.current.getScrollBounds(),
+			bounds = variables.current.uiRef.current.getScrollBounds(),
 			direction = isPreviousScrollButton ? -1 : 1,
 			pageDistance = direction * (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
-		this.uiRef.current.lastInputType = 'scrollbarButton';
+		variables.current.uiRef.current.lastInputType = 'scrollbarButton';
 
-		if (direction !== this.uiRef.current.wheelDirection) {
-			this.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			this.uiRef.current.wheelDirection = direction;
+		if (direction !== variables.current.uiRef.current.wheelDirection) {
+			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
+			variables.current.uiRef.current.wheelDirection = direction;
 		}
 
-		this.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, this.props.overscrollEffectOn.scrollbarButton);
+		variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, props.overscrollEffectOn.scrollbarButton);
 	}
 
-	focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
+	function focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
 		if (scrollbarRef.current) {
 			scrollbarRef.current.focusOnButton(isPreviousScrollButton);
 		}
 	}
 
-	scrollAndFocusScrollbarButton = (direction) => {
-		if (this.uiRef.current) {
+	function scrollAndFocusScrollbarButton (direction) {
+		if (variables.current.uiRef.current) {
 			const
-				{focusableScrollbar, direction: directionProp} = this.props,
-				uiRefCurrent = this.uiRef.current,
+				{direction: directionProp} = props,
+				uiRefCurrent = variables.current.uiRef.current,
 				isRtl = uiRefCurrent.props.rtl,
 				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 				isHorizontalDirection = direction === 'left' || direction === 'right',
@@ -768,13 +634,13 @@ class ScrollableBaseNative extends Component {
 				canScrollingVertically = isVerticalDirection && (directionProp === 'vertical' || directionProp === 'both');
 
 			if (canScrollHorizontally || canScrollingVertically) {
-				this.onScrollbarButtonClick({
+				onScrollbarButtonClick({
 					isPreviousScrollButton,
 					isVerticalScrollBar: canScrollingVertically
 				});
 
 				if (focusableScrollbar) {
-					this.focusOnScrollButton(
+					focusOnScrollButton(
 						canScrollingVertically ? uiRefCurrent.verticalScrollbarRef : uiRefCurrent.horizontalScrollbarRef,
 						isPreviousScrollButton
 					);
@@ -783,36 +649,34 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	scrollStopOnScroll = () => {
-		if (!this.props['data-spotlight-container-disabled']) {
-			this.childRef.current.setContainerDisabled(false);
+	function scrollStopOnScroll () {
+		if (!props['data-spotlight-container-disabled']) {
+			variables.current.childRef.current.setContainerDisabled(false);
 		}
-		this.focusOnItem();
-		this.lastScrollPositionOnFocus = null;
-		this.isWheeling = false;
-		if (this.isVoiceControl) {
-			this.isVoiceControl = false;
-			this.updateFocusAfterVoiceControl();
+		focusOnItem();
+		lastScrollPositionOnFocus = null;
+		isWheeling = false;
+		if (isVoiceControl) {
+			isVoiceControl = false;
+			updateFocusAfterVoiceControl();
 		}
 	}
 
-	focusOnItem () {
-		const childRef = this.childRef;
-
-		if (this.indexToFocus !== null && typeof childRef.current.focusByIndex === 'function') {
-			childRef.current.focusByIndex(this.indexToFocus);
-			this.indexToFocus = null;
+	function focusOnItem () {
+		if (indexToFocus !== null && typeof variables.current.childRef.current.focusByIndex === 'function') {
+			variables.current.childRef.current.focusByIndex(indexToFocus);
+			indexToFocus = null;
 		}
-		if (this.nodeToFocus !== null && typeof childRef.current.focusOnNode === 'function') {
-			childRef.current.focusOnNode(this.nodeToFocus);
-			this.nodeToFocus = null;
+		if (nodeToFocus !== null && typeof variables.current.childRef.current.focusOnNode === 'function') {
+			variables.current.childRef.current.focusOnNode(nodeToFocus);
+			nodeToFocus = null;
 		}
-		if (this.pointToFocus !== null) {
+		if (pointToFocus !== null) {
 			// no need to focus on pointer mode
 			if (!Spotlight.getPointerMode()) {
-				const {direction, x, y} = this.pointToFocus;
+				const {direction, x, y} = pointToFocus;
 				const position = {x, y};
-				const {current: {containerRef: {current}}} = this.uiRef;
+				const {current: {containerRef: {current}}} = variables.current.uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
 				const target =
 					elemFromPoint && elemFromPoint.closest && getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
@@ -823,31 +687,31 @@ class ScrollableBaseNative extends Component {
 					Spotlight.focus(target);
 				}
 			}
-			this.pointToFocus = null;
+			pointToFocus = null;
 		}
 	}
 
-	scrollTo = (opt) => {
-		this.indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
-		this.nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
+	function scrollTo (opt) {
+		indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
+		nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
 	}
 
-	alertThumb = () => {
-		const bounds = this.uiRef.current.getScrollBounds();
+	function alertThumb () {
+		const bounds = variables.current.uiRef.current.getScrollBounds();
 
-		this.uiRef.current.showThumb(bounds);
-		this.uiRef.current.startHidingThumb();
+		variables.current.uiRef.current.showThumb(bounds);
+		variables.current.uiRef.current.startHidingThumb();
 	}
 
-	alertThumbAfterRendered = () => {
+	function alertThumbAfterRendered () {
 		const spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && this.isContent(spotItem) && this.uiRef.current.isUpdatedScrollThumb) {
-			this.alertThumb();
+		if (!Spotlight.getPointerMode() && isContent(spotItem) && variables.current.uiRef.current.isUpdatedScrollThumb) {
+			alertThumb();
 		}
 	}
 
-	handleResizeWindow = () => {
+	function handleResizeWindow () {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
@@ -856,45 +720,45 @@ class ScrollableBaseNative extends Component {
 	}
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
-	handleScrollerUpdate = () => {
-		if (this.uiRef.current.scrollToInfo === null) {
-			const scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
-			if (scrollHeight !== this.uiRef.current.bounds.scrollHeight) {
-				this.calculateAndScrollTo();
+	function handleScrollerUpdate () {
+		if (variables.current.uiRef.current.scrollToInfo === null) {
+			const scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
+			if (scrollHeight !== variables.current.uiRef.current.bounds.scrollHeight) {
+				calculateAndScrollTo();
 			}
 		}
 
-		// oddly, Scroller manages this.uiRef.current.bounds so if we don't update it here (it is also
+		// oddly, Scroller manages uiRef.current.bounds so if we don't update it here (it is also
 		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
 		// out of date when we land back in this method next time.
-		this.uiRef.current.bounds.scrollHeight = this.uiRef.current.getScrollBounds().scrollHeight;
+		variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
 	}
 
-	clearOverscrollEffect = (orientation, edge) => {
-		this.overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
-		this.uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
+	function clearOverscrollEffect (orientation, edge) {
+		overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
+		variables.current.uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
 	}
 
-	applyOverscrollEffect = (orientation, edge, type, ratio) => {
-		const nodeRef = this.overscrollRefs[orientation].current;
+	function applyOverscrollEffect (orientation, edge, type, ratio) {
+		const nodeRef = variables.current.overscrollRefs[orientation].current;
 
 		if (nodeRef) {
 			nodeRef.style.setProperty(overscrollRatioPrefix + orientation + edge, ratio);
 
 			if (type === overscrollTypeOnce) {
-				this.overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
+				overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
 			}
 		}
 	}
 
-	createOverscrollJob = (orientation, edge) => {
-		if (!this.overscrollJobs[orientation][edge]) {
-			this.overscrollJobs[orientation][edge] = new Job(this.applyOverscrollEffect.bind(this), overscrollTimeout);
+	function createOverscrollJob (orientation, edge) {
+		if (!overscrollJobs[orientation][edge]) {
+			overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect.bind(this), overscrollTimeout);
 		}
 	}
 
-	stopOverscrollJob = (orientation, edge) => {
-		const job = this.overscrollJobs[orientation][edge];
+	function stopOverscrollJob (orientation, edge) {
+		const job = overscrollJobs[orientation][edge];
 
 		if (job) {
 			job.stop();
@@ -902,36 +766,36 @@ class ScrollableBaseNative extends Component {
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	addEventListeners = (childContainerRef) => {
+	function addEventListeners (childContainerRef) {
 		if (childContainerRef.current && childContainerRef.current.addEventListener) {
-			childContainerRef.current.addEventListener('focusin', this.onFocus);
+			childContainerRef.current.addEventListener('focusin', onFocus);
 			if (platform.webos) {
-				childContainerRef.current.addEventListener('webOSVoice', this.onVoice);
+				childContainerRef.current.addEventListener('webOSVoice', onVoice);
 				childContainerRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
 			}
 		}
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	removeEventListeners = (childContainerRef) => {
+	function removeEventListeners (childContainerRef) {
 		if (childContainerRef.current && childContainerRef.current.removeEventListener) {
-			childContainerRef.current.removeEventListener('focusin', this.onFocus);
+			childContainerRef.current.removeEventListener('focusin', onFocus);
 			if (platform.webos) {
-				childContainerRef.current.removeEventListener('webOSVoice', this.onVoice);
+				childContainerRef.current.removeEventListener('webOSVoice', onVoice);
 				childContainerRef.current.removeAttribute('data-webos-voice-intent');
 			}
 		}
 	}
 
-	updateFocusAfterVoiceControl = () => {
+	function updateFocusAfterVoiceControl () {
 		const spotItem = Spotlight.getCurrent();
-		if (spotItem && this.uiRef.current.containerRef.current.contains(spotItem)) {
+		if (spotItem && variables.current.uiRef.current.containerRef.current.contains(spotItem)) {
 			const
-				viewportBounds = this.uiRef.current.containerRef.current.getBoundingClientRect(),
+				viewportBounds = variables.current.uiRef.current.containerRef.current.getBoundingClientRect(),
 				spotItemBounds = spotItem.getBoundingClientRect(),
-				nodes = Spotlight.getSpottableDescendants(this.uiRef.current.containerRef.current.dataset.spotlightId),
-				first = this.voiceControlDirection === 'vertical' ? 'top' : 'left',
-				last = this.voiceControlDirection === 'vertical' ? 'bottom' : 'right';
+				nodes = Spotlight.getSpottableDescendants(variables.current.uiRef.current.containerRef.current.dataset.spotlightId),
+				first = voiceControlDirection === 'vertical' ? 'top' : 'left',
+				last = voiceControlDirection === 'vertical' ? 'bottom' : 'right';
 
 			if (spotItemBounds[last] < viewportBounds[first] || spotItemBounds[first] > viewportBounds[last]) {
 				for (let i = 0; i < nodes.length; i++) {
@@ -945,17 +809,17 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	isReachedEdge = (scrollPos, ltrBound, rtlBound, isRtl = false) => {
+	function isReachedEdge (scrollPos, ltrBound, rtlBound, isRtl = false) {
 		const bound = isRtl ? rtlBound : ltrBound;
 		return (bound === 0 && scrollPos === 0) || (bound > 0 && scrollPos >= bound - 1);
 	}
 
-	onVoice = (e) => {
+	function onVoice (e) {
 		const
-			isHorizontal = this.props.direction === 'horizontal',
-			isRtl = this.uiRef.current.props.rtl,
-			{scrollTop, scrollLeft} = this.uiRef.current,
-			{maxLeft, maxTop} = this.uiRef.current.getScrollBounds(),
+			isHorizontal = props.direction === 'horizontal',
+			isRtl = variables.current.uiRef.current.props.rtl,
+			{scrollTop, scrollLeft} = variables.current.uiRef.current,
+			{maxLeft, maxTop} = variables.current.uiRef.current.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
 			horizontalDirection = isRtl ? ['right', 'left', 'rightmost', 'leftmost'] : ['left', 'right', 'leftmost', 'rightmost'],
 			movement = ['previous', 'next', 'first', 'last'];
@@ -968,17 +832,17 @@ class ScrollableBaseNative extends Component {
 			scroll = isHorizontal ? horizontalDirection[index] : verticalDirection[index];
 		}
 
-		this.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
+		voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
 
 		// Case 1. Invalid direction
-		if (this.voiceControlDirection === null) {
-			this.isVoiceControl = false;
+		if (voiceControlDirection === null) {
+			isVoiceControl = false;
 		// Case 2. Cannot scroll
 		} else if (
-			(['up', 'top'].includes(scroll) && this.isReachedEdge(scrollTop, 0)) ||
-			(['down', 'bottom'].includes(scroll) && this.isReachedEdge(scrollTop, maxTop)) ||
-			(['left', 'leftmost'].includes(scroll) && this.isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
-			(['right', 'rightmost'].includes(scroll) && this.isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
+			(['up', 'top'].includes(scroll) && isReachedEdge(scrollTop, 0)) ||
+			(['down', 'bottom'].includes(scroll) && isReachedEdge(scrollTop, maxTop)) ||
+			(['left', 'leftmost'].includes(scroll) && isReachedEdge(scrollLeft, 0, maxLeft, isRtl)) ||
+			(['right', 'rightmost'].includes(scroll) && isReachedEdge(scrollLeft, maxLeft, 0, isRtl))
 		) {
 			if (window.webOSVoiceReportActionResult) {
 				window.webOSVoiceReportActionResult({voiceUi: {exception: 'alreadyCompleted'}});
@@ -986,140 +850,278 @@ class ScrollableBaseNative extends Component {
 			}
 		// Case 3. Can scroll
 		} else {
-			this.isVoiceControl = true;
+			isVoiceControl = true;
 			if (['up', 'down', 'left', 'right'].includes(scroll)) {
 				const isPreviousScrollButton = (scroll === 'up') || (scroll === 'left' && !isRtl) || (scroll === 'right' && isRtl);
-				this.onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
+				onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
 			} else { // ['top', 'bottom', 'leftmost', 'rightmost'].includes(scroll)
-				this.uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
+				variables.current.uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
 			}
 			e.preventDefault();
 		}
 	}
 
-	handleScroll = handle(
+	let handleScroll = handle(
 		forward('onScroll'),
 		(ev, {id}, context) => id && context && context.set,
 		({scrollLeft: x, scrollTop: y}, {id}, context) => {
 			context.set(`${id}.scrollPosition`, {x, y});
 		}
-	).bindAs(this, 'handleScroll')
+	);
 
-	render () {
-		const
-			{
-				childRenderer,
-				'data-spotlight-container': spotlightContainer,
-				'data-spotlight-container-disabled': spotlightContainerDisabled,
-				'data-spotlight-id': spotlightId,
-				focusableScrollbar,
-				preventBubblingOnKeyDown,
-				scrollDownAriaLabel,
-				scrollLeftAriaLabel,
-				scrollRightAriaLabel,
-				scrollUpAriaLabel,
-				...rest
-			} = this.props,
-			downButtonAriaLabel = scrollDownAriaLabel == null ? $L('scroll down') : scrollDownAriaLabel,
-			upButtonAriaLabel = scrollUpAriaLabel == null ? $L('scroll up') : scrollUpAriaLabel,
-			rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
-			leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
-
-		return (
-			<UiScrollableBaseNative
-				noScrollByDrag={!platform.touchscreen}
-				{...rest}
-				addEventListeners={this.addEventListeners}
-				applyOverscrollEffect={this.applyOverscrollEffect}
-				clearOverscrollEffect={this.clearOverscrollEffect}
-				handleResizeWindow={this.handleResizeWindow}
-				onFlick={this.onFlick}
-				onKeyDown={this.onKeyDown}
-				onMouseDown={this.onMouseDown}
-				onScroll={this.handleScroll}
-				onWheel={this.onWheel}
-				ref={this.uiRef}
-				removeEventListeners={this.removeEventListeners}
-				scrollStopOnScroll={this.scrollStopOnScroll}
-				scrollTo={this.scrollTo}
-				start={this.start}
-				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
-					childWrapper: ChildWrapper,
-					childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
-					className,
-					componentCss,
-					containerRef: uiContainerRef,
-					horizontalScrollbarProps,
-					initChildRef: initUiChildRef,
-					isHorizontalScrollbarVisible,
-					isVerticalScrollbarVisible,
-					rtl,
-					scrollTo,
-					style,
-					verticalScrollbarProps
-				}) => (
-					<div
-						className={classNames(className, overscrollCss.scrollable)}
-						data-spotlight-container={spotlightContainer}
-						data-spotlight-container-disabled={spotlightContainerDisabled}
-						data-spotlight-id={spotlightId}
-						onTouchStart={this.onTouchStart}
-						ref={uiContainerRef}
-						style={style}
-					>
-						<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={this.overscrollRefs.vertical}>
-							<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={this.overscrollRefs.horizontal} {...restChildWrapperProps}>
-								{childRenderer({
-									...childComponentProps,
-									cbScrollTo: scrollTo,
-									className: componentCss.scrollableFill,
-									initUiChildRef,
-									isHorizontalScrollbarVisible,
-									isVerticalScrollbarVisible,
-									onUpdate: this.handleScrollerUpdate,
-									ref: this.childRef,
-									rtl,
-									scrollAndFocusScrollbarButton: this.scrollAndFocusScrollbarButton,
-									spotlightId
-								})}
-							</ChildWrapper>
-							{isVerticalScrollbarVisible ?
-								<Scrollbar
-									{...verticalScrollbarProps}
-									{...this.scrollbarProps}
-									disabled={!isVerticalScrollbarVisible}
-									focusableScrollButtons={focusableScrollbar}
-									nextButtonAriaLabel={downButtonAriaLabel}
-									onKeyDownButton={this.onKeyDown}
-									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
-									previousButtonAriaLabel={upButtonAriaLabel}
-									rtl={rtl}
-								/> :
-								null
-							}
-						</div>
-						{isHorizontalScrollbarVisible ?
+	// render
+	return (
+		<UiScrollableBaseNative
+			noScrollByDrag={!platform.touchscreen}
+			{...rest}
+			addEventListeners={addEventListeners}
+			applyOverscrollEffect={applyOverscrollEffect}
+			clearOverscrollEffect={clearOverscrollEffect}
+			handleResizeWindow={handleResizeWindow}
+			onFlick={onFlick}
+			onKeyDown={onKeyDown}
+			onMouseDown={onMouseDown}
+			onScroll={handleScroll}
+			onWheel={onWheel}
+			ref={variables.current.uiRef}
+			removeEventListeners={removeEventListeners}
+			scrollStopOnScroll={scrollStopOnScroll}
+			scrollTo={scrollTo}
+			start={start}
+			containerRenderer={({ // eslint-disable-line react/jsx-no-bind
+				childComponentProps,
+				childWrapper: ChildWrapper,
+				childWrapperProps: {className: contentClassName, ...restChildWrapperProps},
+				className,
+				componentCss,
+				containerRef: uiContainerRef,
+				horizontalScrollbarProps,
+				initChildRef: initUiChildRef,
+				isHorizontalScrollbarVisible,
+				isVerticalScrollbarVisible,
+				rtl,
+				// TODO : change name "scrollToInContainer"
+				scrollTo: scrollToInContainer,
+				style,
+				verticalScrollbarProps
+			}) => (
+				<div
+					className={classNames(className, overscrollCss.scrollable)}
+					data-spotlight-container={spotlightContainer}
+					data-spotlight-container-disabled={spotlightContainerDisabled}
+					data-spotlight-id={spotlightId}
+					onTouchStart={onTouchStart}
+					ref={uiContainerRef}
+					style={style}
+				>
+					<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={variables.current.overscrollRefs.vertical}>
+						<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={variables.current.overscrollRefs.horizontal} {...restChildWrapperProps}>
+							{childRenderer({
+								...childComponentProps,
+								cbScrollTo: scrollToInContainer,
+								className: componentCss.scrollableFill,
+								initUiChildRef,
+								isHorizontalScrollbarVisible,
+								isVerticalScrollbarVisible,
+								onUpdate: handleScrollerUpdate,
+								ref: variables.current.childRef,
+								rtl,
+								scrollAndFocusScrollbarButton: scrollAndFocusScrollbarButton,
+								spotlightId
+							})}
+						</ChildWrapper>
+						{isVerticalScrollbarVisible ?
 							<Scrollbar
-								{...horizontalScrollbarProps}
-								{...this.scrollbarProps}
-								corner={isVerticalScrollbarVisible}
-								disabled={!isHorizontalScrollbarVisible}
+								{...verticalScrollbarProps}
+								{...variables.current.scrollbarProps}
+								disabled={!isVerticalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
-								nextButtonAriaLabel={rightButtonAriaLabel}
-								onKeyDownButton={this.onKeyDown}
+								nextButtonAriaLabel={downButtonAriaLabel}
+								onKeyDownButton={onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}
-								previousButtonAriaLabel={leftButtonAriaLabel}
+								previousButtonAriaLabel={upButtonAriaLabel}
 								rtl={rtl}
 							/> :
 							null
 						}
 					</div>
-				)}
-			/>
-		);
-	}
-}
+					{isHorizontalScrollbarVisible ?
+						<Scrollbar
+							{...horizontalScrollbarProps}
+							{...variables.current.scrollbarProps}
+							corner={isVerticalScrollbarVisible}
+							disabled={!isHorizontalScrollbarVisible}
+							focusableScrollButtons={focusableScrollbar}
+							nextButtonAriaLabel={rightButtonAriaLabel}
+							onKeyDownButton={onKeyDown}
+							preventBubblingOnKeyDown={preventBubblingOnKeyDown}
+							previousButtonAriaLabel={leftButtonAriaLabel}
+							rtl={rtl}
+						/> :
+						null
+					}
+				</div>
+			)}
+		/>
+	);
+};
+
+ScrollableBaseNative.propTypes = /** @lends moonstone/ScrollableNative.ScrollableNative.prototype */ {
+	/**
+	 * Render function.
+	 *
+	 * @type {Function}
+	 * @required
+	 * @private
+	 */
+	childRenderer: PropTypes.func.isRequired,
+
+	/**
+	 * This is set to `true` by SpotlightContainerDecorator
+	 *
+	 * @type {Boolean}
+	 * @private
+	 */
+	'data-spotlight-container': PropTypes.bool,
+
+	/**
+	 * `false` if the content of the list or the scroller could get focus
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @private
+	 */
+	'data-spotlight-container-disabled': PropTypes.bool,
+
+	/**
+	 * This is passed onto the wrapped component to allow
+	 * it to customize the spotlight container for its use case.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	'data-spotlight-id': PropTypes.string,
+
+	/**
+	 * Direction of the list or the scroller.
+	 * `'both'` could be only used for[Scroller]{@link moonstone/Scroller.Scroller}.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
+
+	/**
+	 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+	 * not move focus to the scrollbar controls.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	focusableScrollbar: PropTypes.bool,
+
+	/**
+	 * A unique identifier for the scrollable component.
+	 *
+	 * When specified and when the scrollable is within a SharedStateDecorator, the scroll
+	 * position will be shared and restored on mount if the component is destroyed and
+	 * recreated.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	id: PropTypes.string,
+
+	/**
+	 * Specifies overscroll effects shows on which type of inputs.
+	 *
+	 * @type {Object}
+	 * @default {
+	 *	arrowKey: false,
+	 *	drag: false,
+	 *	pageKey: false,
+	 *	scrollbarButton: false,
+	 *	wheel: true
+	 * }
+	 * @private
+	 */
+	overscrollEffectOn: PropTypes.shape({
+		arrowKey: PropTypes.bool,
+		drag: PropTypes.bool,
+		pageKey: PropTypes.bool,
+		scrollbarButton: PropTypes.bool,
+		wheel: PropTypes.bool
+	}),
+
+	/**
+	 * Specifies preventing keydown events from bubbling up to applications.
+	 * Valid values are `'none'`, and `'programmatic'`.
+	 *
+	 * When it is `'none'`, every keydown event is bubbled.
+	 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
+	 * which invokes programmatic spotlight moving.
+	 *
+	 * @type {String}
+	 * @default 'none'
+	 * @private
+	 */
+	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
+
+	/**
+	 * Sets the hint string read when focusing the next button in the vertical scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll down')
+	 * @public
+	 */
+	scrollDownAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll left')
+	 * @public
+	 */
+	scrollLeftAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the next button in the horizontal scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll right')
+	 * @public
+	 */
+	scrollRightAriaLabel: PropTypes.string,
+
+	/**
+	 * Sets the hint string read when focusing the previous button in the vertical scroll bar.
+	 *
+	 * @type {String}
+	 * @default $L('scroll up')
+	 * @public
+	 */
+	scrollUpAriaLabel: PropTypes.string
+};
+
+ScrollableBaseNative.defaultProps = {
+	'data-spotlight-container-disabled': false,
+	focusableScrollbar: false,
+	overscrollEffectOn: {
+		arrowKey: false,
+		drag: false,
+		pageKey: false,
+		scrollbarButton: false,
+		wheel: true
+	},
+	preventBubblingOnKeyDown: 'none'
+};
 
 /**
  * A Moonstone-styled component that provides horizontal and vertical scrollbars.

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -11,7 +11,7 @@ import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from 
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
-import React, {useContext, useRef} from 'react';
+import React, {useContext, useEffect, useRef} from 'react';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';
@@ -177,36 +177,35 @@ const ScrollableBaseNative = (props) => {
 		rightButtonAriaLabel = scrollRightAriaLabel == null ? $L('scroll right') : scrollRightAriaLabel,
 		leftButtonAriaLabel = scrollLeftAriaLabel == null ? $L('scroll left') : scrollLeftAriaLabel;
 
-	// TODO : Change to useEffect
-	function componentDidMount () {
+	useEffect(() => {
+		// componentDidMount
 		createOverscrollJob('horizontal', 'before');
 		createOverscrollJob('horizontal', 'after');
 
 		createOverscrollJob('vertical', 'before');
 		createOverscrollJob('vertical', 'after');
 
-		scrollables.set(this, uiRef.current.containerRef.current);
+		// TODO: Replace `this` to something.
+		scrollables.set(/* this */ null, uiRef.current.containerRef.current);
 
 		restoreScrollPosition();
-	}
 
-	// TODO : Change to useEffect
-	function componentDidUpdate (prevProps) {
-		if (prevProps['data-spotlight-id'] !== props['data-spotlight-id'] ||
-				prevProps.focusableScrollbar !== props.focusableScrollbar) {
-			configureSpotlightContainer(props);
-		}
-	}
+		// componentWillUnmount
+		return () => {
+			// TODO: Replace `this` to something.
+			scrollables.delete(/* this */ null);
 
-	// TODO : Change to useEffect
-	function componentWillUnmount () {
-		scrollables.delete(this);
+			stopOverscrollJob('horizontal', 'before');
+			stopOverscrollJob('horizontal', 'after');
+			stopOverscrollJob('vertical', 'before');
+			stopOverscrollJob('vertical', 'after');
+		};
+	}, []);	// TODO : Handle exhaustive-deps ESLint rule.
 
-		stopOverscrollJob('horizontal', 'before');
-		stopOverscrollJob('horizontal', 'after');
-		stopOverscrollJob('vertical', 'before');
-		stopOverscrollJob('vertical', 'after');
-	}
+	useEffect(() => {
+		// componentDidUpdate
+		configureSpotlightContainer(props);
+	}, [props['data-spotlight-id'], props.focusableScrollbar]);	// TODO : Handle exhaustive-deps ESLint rule.
 
 	// Only intended to be used within componentDidMount, this method will fetch the last stored
 	// scroll position from SharedState and scroll (without animation) to that position

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -11,7 +11,7 @@ import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from 
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import PropTypes from 'prop-types';
-import React, {useContext, useDebugValue, useRef} from 'react';
+import React, {useContext, useRef} from 'react';
 
 import $L from '../internal/$L';
 import {SharedState} from '../internal/SharedStateDecorator';
@@ -120,30 +120,46 @@ const getTargetInViewByDirectionFromPosition = (direction, position, container) 
  * @private
  */
 const ScrollableBaseNative = (props) => {
-	useDebugValue('ScrollableNative');
 	const context = useContext(SharedState);
 
 	// constructor (props)
 	// Instance variables
-	let variables = useRef({
+	const variables = useRef({
 		scrollbarProps: {
 			cbAlertThumb: alertThumbAfterRendered,
 			onNextScroll: onScrollbarButtonClick,
 			onPrevScroll: onScrollbarButtonClick
 		},
-		overscrollRefs: {
-			horizontal: React.createRef(),
-			vertical: React.createRef()
-		},
-		childRef: React.createRef(),
-		uiRef: React.createRef(),
-		animateOnFocus: false
+		animateOnFocus: false,
+
+		// status
+		isWheeling: false,
+
+		// spotlight
+		lastScrollPositionOnFocus: null,
+		indexToFocus: null,
+		nodeToFocus: null,
+		pointToFocus: null,
+
+		// voice control
+		isVoiceControl: false,
+		voiceControlDirection: 'vertical',
+		overscrollJobs: {
+			horizontal: {before: null, after: null},
+			vertical: {before: null, after: null}
+		}
 	});
+
+	const overscrollRefs = {
+		horizontal: React.useRef(),
+		vertical: React.useRef()
+	};
+	const childRef = React.useRef();
+	const uiRef = React.useRef();
 
 	configureSpotlightContainer(props);
 
-	const
-		{
+	const {
 			childRenderer,
 			'data-spotlight-container': spotlightContainer,
 			'data-spotlight-container-disabled': spotlightContainerDisabled,
@@ -169,7 +185,7 @@ const ScrollableBaseNative = (props) => {
 		createOverscrollJob('vertical', 'before');
 		createOverscrollJob('vertical', 'after');
 
-		scrollables.set(this, variables.current.uiRef.current.containerRef.current);
+		scrollables.set(this, uiRef.current.containerRef.current);
 
 		restoreScrollPosition();
 	}
@@ -192,25 +208,6 @@ const ScrollableBaseNative = (props) => {
 		stopOverscrollJob('vertical', 'after');
 	}
 
-	// status
-	let isWheeling = false;
-
-	// spotlight
-	let lastScrollPositionOnFocus = null;
-	let indexToFocus = null;
-	let nodeToFocus = null;
-	let pointToFocus = null;
-
-	// voice control
-	let isVoiceControl = false;
-	let voiceControlDirection = 'vertical';
-
-	// overscroll
-	let overscrollJobs = {
-		horizontal: {before: null, after: null},
-		vertical: {before: null, after: null}
-	};
-
 	// Only intended to be used within componentDidMount, this method will fetch the last stored
 	// scroll position from SharedState and scroll (without animation) to that position
 	function restoreScrollPosition () {
@@ -218,7 +215,7 @@ const ScrollableBaseNative = (props) => {
 		if (id && context && context.get) {
 			const scrollPosition = context.get(`${id}.scrollPosition`);
 			if (scrollPosition) {
-				variables.current.uiRef.current.scrollTo({
+				uiRef.current.scrollTo({
 					position: scrollPosition,
 					animate: false
 				});
@@ -227,7 +224,7 @@ const ScrollableBaseNative = (props) => {
 	}
 
 	function isScrollButtonFocused () {
-		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = variables.current.uiRef.current;
+		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = uiRef.current;
 
 		return (
 			h.current && h.current.isOneOfScrollButtonsFocused() ||
@@ -236,7 +233,7 @@ const ScrollableBaseNative = (props) => {
 	}
 
 	function onFlick ({direction}) {
-		const bounds = variables.current.uiRef.current.getScrollBounds();
+		const bounds = uiRef.current.getScrollBounds();
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
@@ -244,10 +241,10 @@ const ScrollableBaseNative = (props) => {
 		}
 
 		if ((
-			direction === 'vertical' && variables.current.uiRef.current.canScrollVertically(bounds) ||
-			direction === 'horizontal' && variables.current.uiRef.current.canScrollHorizontally(bounds)
+			direction === 'vertical' && uiRef.current.canScrollVertically(bounds) ||
+			direction === 'horizontal' && uiRef.current.canScrollHorizontally(bounds)
 		) && !props['data-spotlight-container-disabled']) {
-			variables.current.childRef.current.setContainerDisabled(true);
+			childRef.current.setContainerDisabled(true);
 		}
 	}
 
@@ -259,7 +256,7 @@ const ScrollableBaseNative = (props) => {
 		if (props['data-spotlight-container-disabled']) {
 			ev.preventDefault();
 		} else {
-			variables.current.childRef.current.setContainerDisabled(false);
+			childRef.current.setContainerDisabled(false);
 		}
 	}
 
@@ -279,9 +276,9 @@ const ScrollableBaseNative = (props) => {
 	function onWheel (ev) {
 		const
 			overscrollEffectRequired = props.overscrollEffectOn.wheel,
-			bounds = variables.current.uiRef.current.getScrollBounds(),
-			canScrollHorizontally = variables.current.uiRef.current.canScrollHorizontally(bounds),
-			canScrollVertically = variables.current.uiRef.current.canScrollVertically(bounds),
+			bounds = uiRef.current.getScrollBounds(),
+			canScrollHorizontally = uiRef.current.canScrollHorizontally(bounds),
+			canScrollVertically = uiRef.current.canScrollVertically(bounds),
 			eventDeltaMode = ev.deltaMode,
 			eventDelta = (-ev.wheelDeltaY || ev.deltaY);
 		let
@@ -292,55 +289,55 @@ const ScrollableBaseNative = (props) => {
 			window.document.activeElement.blur();
 		}
 
-		variables.current.uiRef.current.showThumb(bounds);
+		uiRef.current.showThumb(bounds);
 
 		// FIXME This routine is a temporary support for horizontal wheel scroll.
 		// FIXME If web engine supports horizontal wheel, this routine should be refined or removed.
 		if (canScrollVertically) { // This routine handles wheel events on scrollbars for vertical scroll.
-			if (eventDelta < 0 && variables.current.uiRef.current.scrollTop > 0 || eventDelta > 0 && variables.current.uiRef.current.scrollTop < bounds.maxTop) {
-				const {horizontalScrollbarRef, verticalScrollbarRef} = variables.current.uiRef.current;
+			if (eventDelta < 0 && uiRef.current.scrollTop > 0 || eventDelta > 0 && uiRef.current.scrollTop < bounds.maxTop) {
+				const {horizontalScrollbarRef, verticalScrollbarRef} = uiRef.current;
 
-				if (!isWheeling) {
+				if (!variables.current.isWheeling) {
 					if (!props['data-spotlight-container-disabled']) {
-						variables.current.childRef.current.setContainerDisabled(true);
+						childRef.current.setContainerDisabled(true);
 					}
-					isWheeling = true;
+					variables.current.isWheeling = true;
 				}
 
 				// Not to check if ev.target is a descendant of a wrapped component which may have a lot of nodes in it.
 				if ((horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(ev.target)) ||
 					(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(ev.target))) {
-					delta = variables.current.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+					delta = uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
 
 					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
-					variables.current.uiRef.current.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
+					uiRef.current.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 				}
 
 				ev.stopPropagation();
 			} else {
-				if (overscrollEffectRequired && (eventDelta < 0 && variables.current.uiRef.current.scrollTop <= 0 || eventDelta > 0 && variables.current.uiRef.current.scrollTop >= bounds.maxTop)) {
-					variables.current.uiRef.current.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+				if (overscrollEffectRequired && (eventDelta < 0 && uiRef.current.scrollTop <= 0 || eventDelta > 0 && uiRef.current.scrollTop >= bounds.maxTop)) {
+					uiRef.current.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
 			}
 		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
-			if (eventDelta < 0 && variables.current.uiRef.current.scrollLeft > 0 || eventDelta > 0 && variables.current.uiRef.current.scrollLeft < bounds.maxLeft) {
-				if (!isWheeling) {
+			if (eventDelta < 0 && uiRef.current.scrollLeft > 0 || eventDelta > 0 && uiRef.current.scrollLeft < bounds.maxLeft) {
+				if (!variables.current.isWheeling) {
 					if (!props['data-spotlight-container-disabled']) {
-						variables.current.childRef.current.setContainerDisabled(true);
+						childRef.current.setContainerDisabled(true);
 					}
-					isWheeling = true;
+					variables.current.isWheeling = true;
 				}
-				delta = variables.current.uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+				delta = uiRef.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				needToHideThumb = !delta;
 
 				ev.preventDefault();
 				ev.stopPropagation();
 			} else {
-				if (overscrollEffectRequired && (eventDelta < 0 && variables.current.uiRef.current.scrollLeft <= 0 || eventDelta > 0 && variables.current.uiRef.current.scrollLeft >= bounds.maxLeft)) {
-					variables.current.uiRef.current.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+				if (overscrollEffectRequired && (eventDelta < 0 && uiRef.current.scrollLeft <= 0 || eventDelta > 0 && uiRef.current.scrollLeft >= bounds.maxLeft)) {
+					uiRef.current.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 				}
 				needToHideThumb = true;
 			}
@@ -351,15 +348,15 @@ const ScrollableBaseNative = (props) => {
 			ev.preventDefault();
 			const direction = Math.sign(delta);
 			// Not to accumulate scroll position if wheel direction is different from hold direction
-			if (direction !== variables.current.uiRef.current.wheelDirection) {
-				variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
-				variables.current.uiRef.current.wheelDirection = direction;
+			if (direction !== uiRef.current.wheelDirection) {
+				uiRef.current.isScrollAnimationTargetAccumulated = false;
+				uiRef.current.wheelDirection = direction;
 			}
-			variables.current.uiRef.current.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
+			uiRef.current.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
 		}
 
 		if (needToHideThumb) {
-			variables.current.uiRef.current.startHidingThumb();
+			uiRef.current.startHidingThumb();
 		}
 	}
 
@@ -370,7 +367,7 @@ const ScrollableBaseNative = (props) => {
 	}
 
 	function isContent (element) {
-		return (element && variables.current.uiRef.current && variables.current.uiRef.current.childRefCurrent.containerRef.current.contains(element));
+		return (element && uiRef.current && uiRef.current.childRefCurrent.containerRef.current.contains(element));
 	}
 
 	// event handlers for Spotlight support
@@ -379,18 +376,18 @@ const ScrollableBaseNative = (props) => {
 		if (pos) {
 			const
 				{top, left} = pos,
-				bounds = variables.current.uiRef.current.getScrollBounds(),
-				scrollHorizontally = bounds.maxLeft > 0 && Math.abs(left - variables.current.uiRef.current.scrollLeft) > epsilon,
-				scrollVertically = bounds.maxTop > 0 && Math.abs(top - variables.current.uiRef.current.scrollTop) > epsilon;
+				bounds = uiRef.current.getScrollBounds(),
+				scrollHorizontally = bounds.maxLeft > 0 && Math.abs(left - uiRef.current.scrollLeft) > epsilon,
+				scrollVertically = bounds.maxTop > 0 && Math.abs(top - uiRef.current.scrollTop) > epsilon;
 
 			if (scrollHorizontally || scrollVertically) {
-				variables.current.uiRef.current.start({
+				uiRef.current.start({
 					targetX: left,
 					targetY: top,
 					animate: variables.current.animateOnFocus,
-					overscrollEffect: props.overscrollEffectOn[variables.current.uiRef.current.lastInputType] && (!variables.current.childRef.current.shouldPreventOverscrollEffect || !variables.current.childRef.current.shouldPreventOverscrollEffect())
+					overscrollEffect: props.overscrollEffectOn[uiRef.current.lastInputType] && (!childRef.current.shouldPreventOverscrollEffect || !childRef.current.shouldPreventOverscrollEffect())
 				});
-				lastScrollPositionOnFocus = pos;
+				variables.current.lastScrollPositionOnFocus = pos;
 			}
 		}
 	}
@@ -398,16 +395,16 @@ const ScrollableBaseNative = (props) => {
 	function calculateAndScrollTo () {
 		const
 			spotItem = Spotlight.getCurrent(),
-			positionFn = variables.current.childRef.current.calculatePositionOnFocus,
-			containerNode = variables.current.uiRef.current.childRefCurrent.containerRef.current;
+			positionFn = childRef.current.calculatePositionOnFocus,
+			containerNode = uiRef.current.childRefCurrent.containerRef.current;
 
 		if (spotItem && positionFn && containerNode && containerNode.contains(spotItem)) {
-			const lastPos = lastScrollPositionOnFocus;
+			const lastPos = variables.current.lastScrollPositionOnFocus;
 			let pos;
 
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
-			if (variables.current.uiRef.current.scrolling && lastPos) {
+			if (uiRef.current.scrolling && lastPos) {
 				const containerRect = getRect(containerNode);
 				const itemRect = getRect(spotItem);
 				let scrollPosition;
@@ -423,26 +420,26 @@ const ScrollableBaseNative = (props) => {
 				// scrollInfo passes in current `scrollHeight` and `scrollTop` before calculations
 				const
 					scrollInfo = {
-						previousScrollHeight: variables.current.uiRef.current.bounds.scrollHeight,
-						scrollTop: variables.current.uiRef.current.scrollTop
+						previousScrollHeight: uiRef.current.bounds.scrollHeight,
+						scrollTop: uiRef.current.scrollTop
 					};
 				pos = positionFn({item: spotItem, scrollInfo});
 			}
 
-			if (pos && (pos.left !== variables.current.uiRef.current.scrollLeft || pos.top !== variables.current.uiRef.current.scrollTop)) {
+			if (pos && (pos.left !== uiRef.current.scrollLeft || pos.top !== uiRef.current.scrollTop)) {
 				startScrollOnFocus(pos);
 			}
 
 			// update `scrollHeight`
-			variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
+			uiRef.current.bounds.scrollHeight = uiRef.current.getScrollBounds().scrollHeight;
 		}
 	}
 
 	function onFocus (ev) {
 		const
-			{isDragging} = variables.current.uiRef.current,
-			shouldPreventScrollByFocus = variables.current.childRef.current.shouldPreventScrollByFocus ?
-				variables.current.childRef.current.shouldPreventScrollByFocus() :
+			{isDragging} = uiRef.current,
+			shouldPreventScrollByFocus = childRef.current.shouldPreventScrollByFocus ?
+				childRef.current.shouldPreventScrollByFocus() :
 				false;
 
 		if (!Spotlight.getPointerMode()) {
@@ -457,26 +454,26 @@ const ScrollableBaseNative = (props) => {
 			if (item && item === spotItem) {
 				calculateAndScrollTo();
 			}
-		} else if (variables.current.childRef.current.setLastFocusedNode) {
-			variables.current.childRef.current.setLastFocusedNode(ev.target);
+		} else if (childRef.current.setLastFocusedNode) {
+			childRef.current.setLastFocusedNode(ev.target);
 		}
 	}
 
 	function scrollByPage (direction) {
 		const
-			{childRefCurrent, scrollTop} = variables.current.uiRef.current,
+			{childRefCurrent, scrollTop} = uiRef.current,
 			focusedItem = Spotlight.getCurrent(),
-			bounds = variables.current.uiRef.current.getScrollBounds(),
+			bounds = uiRef.current.getScrollBounds(),
 			isUp = direction === 'up',
 			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier,
 			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop - scrollTop > epsilon;
 
-		variables.current.uiRef.current.lastInputType = 'pageKey';
+		uiRef.current.lastInputType = 'pageKey';
 
-		if (directionFactor !== variables.current.uiRef.current.wheelDirection) {
-			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			variables.current.uiRef.current.wheelDirection = directionFactor;
+		if (directionFactor !== uiRef.current.wheelDirection) {
+			uiRef.current.isScrollAnimationTargetAccumulated = false;
+			uiRef.current.wheelDirection = directionFactor;
 		}
 
 		if (scrollPossible) {
@@ -495,15 +492,15 @@ const ScrollableBaseNative = (props) => {
 
 					focusedItem.blur();
 					if (!props['data-spotlight-container-disabled']) {
-						variables.current.childRef.current.setContainerDisabled(true);
+						childRef.current.setContainerDisabled(true);
 					}
-					pointToFocus = {direction, x, y};
+					variables.current.pointToFocus = {direction, x, y};
 				}
 			} else {
-				pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
+				variables.current.pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
 			}
 
-			variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);
+			uiRef.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);
 		}
 	}
 
@@ -515,20 +512,20 @@ const ScrollableBaseNative = (props) => {
 			current = document.querySelector(`[data-spotlight-id="${activeContainerId}"]`);
 		}
 
-		return current && variables.current.uiRef.current.containerRef.current.contains(current);
+		return current && uiRef.current.containerRef.current.contains(current);
 	}
 
 	function checkAndApplyOverscrollEffectByDirection (direction) {
 		const
 			orientation = (direction === 'up' || direction === 'down') ? 'vertical' : 'horizontal',
-			bounds = variables.current.uiRef.current.getScrollBounds(),
-			scrollability = orientation === 'vertical' ? variables.current.uiRef.current.canScrollVertically(bounds) : variables.current.uiRef.current.canScrollHorizontally(bounds);
+			bounds = uiRef.current.getScrollBounds(),
+			scrollability = orientation === 'vertical' ? uiRef.current.canScrollVertically(bounds) : uiRef.current.canScrollHorizontally(bounds);
 
 		if (scrollability) {
 			const
-				isRtl = variables.current.uiRef.current.props.rtl,
+				isRtl = uiRef.current.props.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
-			variables.current.uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
+			uiRef.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 
@@ -584,11 +581,11 @@ const ScrollableBaseNative = (props) => {
 			} else if (!Spotlight.getPointerMode() && getDirection(keyCode)) {
 				const element = Spotlight.getCurrent();
 
-				variables.current.uiRef.current.lastInputType = 'arrowKey';
+				uiRef.current.lastInputType = 'arrowKey';
 
 				direction = getDirection(keyCode);
 				if (overscrollEffectOn.arrowKey && !(element ? getTargetByDirectionFromElement(direction, element) : null)) {
-					const {horizontalScrollbarRef, verticalScrollbarRef} = variables.current.uiRef.current;
+					const {horizontalScrollbarRef, verticalScrollbarRef} = uiRef.current;
 
 					if (!(horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(element)) &&
 						!(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(element))) {
@@ -601,18 +598,18 @@ const ScrollableBaseNative = (props) => {
 
 	function onScrollbarButtonClick ({isPreviousScrollButton, isVerticalScrollBar}) {
 		const
-			bounds = variables.current.uiRef.current.getScrollBounds(),
+			bounds = uiRef.current.getScrollBounds(),
 			direction = isPreviousScrollButton ? -1 : 1,
 			pageDistance = direction * (isVerticalScrollBar ? bounds.clientHeight : bounds.clientWidth) * paginationPageMultiplier;
 
-		variables.current.uiRef.current.lastInputType = 'scrollbarButton';
+		uiRef.current.lastInputType = 'scrollbarButton';
 
-		if (direction !== variables.current.uiRef.current.wheelDirection) {
-			variables.current.uiRef.current.isScrollAnimationTargetAccumulated = false;
-			variables.current.uiRef.current.wheelDirection = direction;
+		if (direction !== uiRef.current.wheelDirection) {
+			uiRef.current.isScrollAnimationTargetAccumulated = false;
+			uiRef.current.wheelDirection = direction;
 		}
 
-		variables.current.uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, props.overscrollEffectOn.scrollbarButton);
+		uiRef.current.scrollToAccumulatedTarget(pageDistance, isVerticalScrollBar, props.overscrollEffectOn.scrollbarButton);
 	}
 
 	function focusOnScrollButton (scrollbarRef, isPreviousScrollButton) {
@@ -622,10 +619,10 @@ const ScrollableBaseNative = (props) => {
 	}
 
 	function scrollAndFocusScrollbarButton (direction) {
-		if (variables.current.uiRef.current) {
+		if (uiRef.current) {
 			const
 				{direction: directionProp} = props,
-				uiRefCurrent = variables.current.uiRef.current,
+				uiRefCurrent = uiRef.current,
 				isRtl = uiRefCurrent.props.rtl,
 				isPreviousScrollButton = direction === 'up' || (isRtl ? direction === 'right' : direction === 'left'),
 				isHorizontalDirection = direction === 'left' || direction === 'right',
@@ -651,32 +648,32 @@ const ScrollableBaseNative = (props) => {
 
 	function scrollStopOnScroll () {
 		if (!props['data-spotlight-container-disabled']) {
-			variables.current.childRef.current.setContainerDisabled(false);
+			childRef.current.setContainerDisabled(false);
 		}
 		focusOnItem();
-		lastScrollPositionOnFocus = null;
-		isWheeling = false;
-		if (isVoiceControl) {
-			isVoiceControl = false;
+		variables.current.lastScrollPositionOnFocus = null;
+		variables.current.isWheeling = false;
+		if (variables.current.isVoiceControl) {
+			variables.current.isVoiceControl = false;
 			updateFocusAfterVoiceControl();
 		}
 	}
 
 	function focusOnItem () {
-		if (indexToFocus !== null && typeof variables.current.childRef.current.focusByIndex === 'function') {
-			variables.current.childRef.current.focusByIndex(indexToFocus);
-			indexToFocus = null;
+		if (variables.current.indexToFocus !== null && typeof childRef.current.focusByIndex === 'function') {
+			childRef.current.focusByIndex(variables.current.indexToFocus);
+			variables.current.indexToFocus = null;
 		}
-		if (nodeToFocus !== null && typeof variables.current.childRef.current.focusOnNode === 'function') {
-			variables.current.childRef.current.focusOnNode(nodeToFocus);
-			nodeToFocus = null;
+		if (variables.current.nodeToFocus !== null && typeof childRef.current.focusOnNode === 'function') {
+			childRef.current.focusOnNode(variables.current.nodeToFocus);
+			variables.current.nodeToFocus = null;
 		}
-		if (pointToFocus !== null) {
+		if (variables.current.pointToFocus !== null) {
 			// no need to focus on pointer mode
 			if (!Spotlight.getPointerMode()) {
-				const {direction, x, y} = pointToFocus;
+				const {direction, x, y} = variables.current.pointToFocus;
 				const position = {x, y};
-				const {current: {containerRef: {current}}} = variables.current.uiRef;
+				const {current: {containerRef: {current}}} = uiRef;
 				const elemFromPoint = document.elementFromPoint(x, y);
 				const target =
 					elemFromPoint && elemFromPoint.closest && getIntersectingElement(elemFromPoint.closest(`.${spottableClass}`), current) ||
@@ -687,26 +684,26 @@ const ScrollableBaseNative = (props) => {
 					Spotlight.focus(target);
 				}
 			}
-			pointToFocus = null;
+			variables.current.pointToFocus = null;
 		}
 	}
 
 	function scrollTo (opt) {
-		indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
-		nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
+		variables.current.indexToFocus = (opt.focus && typeof opt.index === 'number') ? opt.index : null;
+		variables.current.nodeToFocus = (opt.focus && opt.node instanceof Object && opt.node.nodeType === 1) ? opt.node : null;
 	}
 
 	function alertThumb () {
-		const bounds = variables.current.uiRef.current.getScrollBounds();
+		const bounds = uiRef.current.getScrollBounds();
 
-		variables.current.uiRef.current.showThumb(bounds);
-		variables.current.uiRef.current.startHidingThumb();
+		uiRef.current.showThumb(bounds);
+		uiRef.current.startHidingThumb();
 	}
 
 	function alertThumbAfterRendered () {
 		const spotItem = Spotlight.getCurrent();
 
-		if (!Spotlight.getPointerMode() && isContent(spotItem) && variables.current.uiRef.current.isUpdatedScrollThumb) {
+		if (!Spotlight.getPointerMode() && isContent(spotItem) && uiRef.current.isUpdatedScrollThumb) {
 			alertThumb();
 		}
 	}
@@ -721,9 +718,9 @@ const ScrollableBaseNative = (props) => {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	function handleScrollerUpdate () {
-		if (variables.current.uiRef.current.scrollToInfo === null) {
-			const scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
-			if (scrollHeight !== variables.current.uiRef.current.bounds.scrollHeight) {
+		if (uiRef.current.scrollToInfo === null) {
+			const scrollHeight = uiRef.current.getScrollBounds().scrollHeight;
+			if (scrollHeight !== uiRef.current.bounds.scrollHeight) {
 				calculateAndScrollTo();
 			}
 		}
@@ -731,34 +728,34 @@ const ScrollableBaseNative = (props) => {
 		// oddly, Scroller manages uiRef.current.bounds so if we don't update it here (it is also
 		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
 		// out of date when we land back in this method next time.
-		variables.current.uiRef.current.bounds.scrollHeight = variables.current.uiRef.current.getScrollBounds().scrollHeight;
+		uiRef.current.bounds.scrollHeight = uiRef.current.getScrollBounds().scrollHeight;
 	}
 
 	function clearOverscrollEffect (orientation, edge) {
-		overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
-		variables.current.uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
+		variables.current.overscrollJobs[orientation][edge].startAfter(overscrollTimeout, orientation, edge, overscrollTypeNone, 0);
+		uiRef.current.setOverscrollStatus(orientation, edge, overscrollTypeNone, 0);
 	}
 
 	function applyOverscrollEffect (orientation, edge, type, ratio) {
-		const nodeRef = variables.current.overscrollRefs[orientation].current;
+		const nodeRef = overscrollRefs[orientation].current;
 
 		if (nodeRef) {
 			nodeRef.style.setProperty(overscrollRatioPrefix + orientation + edge, ratio);
 
 			if (type === overscrollTypeOnce) {
-				overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
+				variables.current.overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
 			}
 		}
 	}
 
 	function createOverscrollJob (orientation, edge) {
-		if (!overscrollJobs[orientation][edge]) {
-			overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect.bind(this), overscrollTimeout);
+		if (!variables.current.overscrollJobs[orientation][edge]) {
+			variables.current.overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect.bind(this), overscrollTimeout);
 		}
 	}
 
 	function stopOverscrollJob (orientation, edge) {
-		const job = overscrollJobs[orientation][edge];
+		const job = variables.current.overscrollJobs[orientation][edge];
 
 		if (job) {
 			job.stop();
@@ -789,13 +786,13 @@ const ScrollableBaseNative = (props) => {
 
 	function updateFocusAfterVoiceControl () {
 		const spotItem = Spotlight.getCurrent();
-		if (spotItem && variables.current.uiRef.current.containerRef.current.contains(spotItem)) {
+		if (spotItem && uiRef.current.containerRef.current.contains(spotItem)) {
 			const
-				viewportBounds = variables.current.uiRef.current.containerRef.current.getBoundingClientRect(),
+				viewportBounds = uiRef.current.containerRef.current.getBoundingClientRect(),
 				spotItemBounds = spotItem.getBoundingClientRect(),
-				nodes = Spotlight.getSpottableDescendants(variables.current.uiRef.current.containerRef.current.dataset.spotlightId),
-				first = voiceControlDirection === 'vertical' ? 'top' : 'left',
-				last = voiceControlDirection === 'vertical' ? 'bottom' : 'right';
+				nodes = Spotlight.getSpottableDescendants(uiRef.current.containerRef.current.dataset.spotlightId),
+				first = variables.current.voiceControlDirection === 'vertical' ? 'top' : 'left',
+				last = variables.current.voiceControlDirection === 'vertical' ? 'bottom' : 'right';
 
 			if (spotItemBounds[last] < viewportBounds[first] || spotItemBounds[first] > viewportBounds[last]) {
 				for (let i = 0; i < nodes.length; i++) {
@@ -817,9 +814,9 @@ const ScrollableBaseNative = (props) => {
 	function onVoice (e) {
 		const
 			isHorizontal = props.direction === 'horizontal',
-			isRtl = variables.current.uiRef.current.props.rtl,
-			{scrollTop, scrollLeft} = variables.current.uiRef.current,
-			{maxLeft, maxTop} = variables.current.uiRef.current.getScrollBounds(),
+			isRtl = uiRef.current.props.rtl,
+			{scrollTop, scrollLeft} = uiRef.current,
+			{maxLeft, maxTop} = uiRef.current.getScrollBounds(),
 			verticalDirection = ['up', 'down', 'top', 'bottom'],
 			horizontalDirection = isRtl ? ['right', 'left', 'rightmost', 'leftmost'] : ['left', 'right', 'leftmost', 'rightmost'],
 			movement = ['previous', 'next', 'first', 'last'];
@@ -832,11 +829,11 @@ const ScrollableBaseNative = (props) => {
 			scroll = isHorizontal ? horizontalDirection[index] : verticalDirection[index];
 		}
 
-		voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
+		variables.current.voiceControlDirection = verticalDirection.includes(scroll) && 'vertical' || horizontalDirection.includes(scroll) && 'horizontal' || null;
 
 		// Case 1. Invalid direction
-		if (voiceControlDirection === null) {
-			isVoiceControl = false;
+		if (variables.current.voiceControlDirection === null) {
+			variables.current.isVoiceControl = false;
 		// Case 2. Cannot scroll
 		} else if (
 			(['up', 'top'].includes(scroll) && isReachedEdge(scrollTop, 0)) ||
@@ -850,12 +847,12 @@ const ScrollableBaseNative = (props) => {
 			}
 		// Case 3. Can scroll
 		} else {
-			isVoiceControl = true;
+			variables.current.isVoiceControl = true;
 			if (['up', 'down', 'left', 'right'].includes(scroll)) {
 				const isPreviousScrollButton = (scroll === 'up') || (scroll === 'left' && !isRtl) || (scroll === 'right' && isRtl);
 				onScrollbarButtonClick({isPreviousScrollButton, isVerticalScrollBar: verticalDirection.includes(scroll)});
 			} else { // ['top', 'bottom', 'leftmost', 'rightmost'].includes(scroll)
-				variables.current.uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
+				uiRef.current.scrollTo({align: verticalDirection.includes(scroll) && scroll || (scroll === 'leftmost' && isRtl || scroll === 'rightmost' && !isRtl) && 'right' || 'left'});
 			}
 			e.preventDefault();
 		}
@@ -883,7 +880,7 @@ const ScrollableBaseNative = (props) => {
 			onMouseDown={onMouseDown}
 			onScroll={handleScroll}
 			onWheel={onWheel}
-			ref={variables.current.uiRef}
+			ref={uiRef}
 			removeEventListeners={removeEventListeners}
 			scrollStopOnScroll={scrollStopOnScroll}
 			scrollTo={scrollTo}
@@ -914,8 +911,8 @@ const ScrollableBaseNative = (props) => {
 					ref={uiContainerRef}
 					style={style}
 				>
-					<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={variables.current.overscrollRefs.vertical}>
-						<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={variables.current.overscrollRefs.horizontal} {...restChildWrapperProps}>
+					<div className={classNames(componentCss.container, overscrollCss.overscrollFrame, overscrollCss.vertical, isHorizontalScrollbarVisible ? overscrollCss.horizontalScrollbarVisible : null)} ref={overscrollRefs.vertical}>
+						<ChildWrapper className={classNames(contentClassName, overscrollCss.overscrollFrame, overscrollCss.horizontal)} ref={overscrollRefs.horizontal} {...restChildWrapperProps}>
 							{childRenderer({
 								...childComponentProps,
 								cbScrollTo: scrollToInContainer,
@@ -924,7 +921,7 @@ const ScrollableBaseNative = (props) => {
 								isHorizontalScrollbarVisible,
 								isVerticalScrollbarVisible,
 								onUpdate: handleScrollerUpdate,
-								ref: variables.current.childRef,
+								ref: childRef,
 								rtl,
 								scrollAndFocusScrollbarButton: scrollAndFocusScrollbarButton,
 								spotlightId
@@ -966,6 +963,7 @@ const ScrollableBaseNative = (props) => {
 	);
 };
 
+ScrollableBaseNative.displayName  = 'ScrollableNative';
 ScrollableBaseNative.propTypes = /** @lends moonstone/ScrollableNative.ScrollableNative.prototype */ {
 	/**
 	 * Render function.

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -53,7 +53,7 @@ const ScrollerBase = (props) => {
 	useEffect(() => {
 		const {onUpdate} = props;
 		if (onUpdate) {
-		//	onUpdate();		// TODO: Invoking onUpdate() has error. Fix it.
+		//	onUpdate();		// TODO: Invoking onUpdate() has error. Fix it on PLAT-98204.
 		}
 	});	// TODO : Handle exhaustive-deps ESLint rule.
 

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -42,12 +42,9 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  */
 const ScrollerBase = (props) => {
 	useEffect(() => {
-		// componentDidMount
-		configureSpotlight();
-
 		// componentWillUnmount
 		return () => setContainerDisabled(false);
-	}, [configureSpotlight, setContainerDisabled]);	// TODO : Handle exhaustive-deps ESLint rule.
+	}, [setContainerDisabled]);	// TODO : Handle exhaustive-deps ESLint rule.
 
 	useEffect(configureSpotlight, [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
 	useEffect(() => {
@@ -320,7 +317,7 @@ const ScrollerBase = (props) => {
 	);
 };
 
-ScrollerBase.displayName  = 'ScrollerBase';
+ScrollerBase.displayName = 'ScrollerBase';
 ScrollerBase.propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 	/**
 	 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -21,7 +21,7 @@ import {getRect} from '@enact/spotlight/src/utils';
 import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
-import React, {useDebugValue, useRef} from 'react';
+import React, {useRef} from 'react';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -41,8 +41,6 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  * @public
  */
 const ScrollerBase = (props) => {
-	useDebugValue('ScrollerBase');
-
 	// TODO : Change to useEffect
 	function componentDidMount () {
 		configureSpotlight();
@@ -66,7 +64,7 @@ const ScrollerBase = (props) => {
 	}
 
 	// Instance variables
-	let uiRefCurrent = useRef({});
+	const uiRefCurrent = useRef({});
 
 	function configureSpotlight () {
 		Spotlight.set(props.spotlightId, {
@@ -328,6 +326,7 @@ const ScrollerBase = (props) => {
 	);
 };
 
+	ScrollerBase.displayName  = 'ScrollerBase';
 ScrollerBase.propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 	/**
 	 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -47,13 +47,13 @@ const ScrollerBase = (props) => {
 
 		// componentWillUnmount
 		return () => setContainerDisabled(false);
-	}, []);	// TODO : Handle exhaustive-deps ESLint rule.
+	}, [configureSpotlight, setContainerDisabled]);	// TODO : Handle exhaustive-deps ESLint rule.
 
-	useEffect(configureSpotlight(), [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
+	useEffect(configureSpotlight, [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
 	useEffect(() => {
 		const {onUpdate} = props;
 		if (onUpdate) {
-			onUpdate();
+		//	onUpdate();		// TODO: Invoking onUpdate() has error. Fix it.
 		}
 	});	// TODO : Handle exhaustive-deps ESLint rule.
 
@@ -320,7 +320,7 @@ const ScrollerBase = (props) => {
 	);
 };
 
-	ScrollerBase.displayName  = 'ScrollerBase';
+ScrollerBase.displayName  = 'ScrollerBase';
 ScrollerBase.propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 	/**
 	 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -21,7 +21,7 @@ import {getRect} from '@enact/spotlight/src/utils';
 import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -41,27 +41,21 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  * @public
  */
 const ScrollerBase = (props) => {
-	// TODO : Change to useEffect
-	function componentDidMount () {
+	useEffect(() => {
+		// componentDidMount
 		configureSpotlight();
-	}
 
-	// TODO : Change to useEffect
-	function componentDidUpdate (prevProps) {
+		// componentWillUnmount
+		return () => setContainerDisabled(false);
+	}, []);	// TODO : Handle exhaustive-deps ESLint rule.
+
+	useEffect(configureSpotlight(), [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
+	useEffect(() => {
 		const {onUpdate} = props;
 		if (onUpdate) {
 			onUpdate();
 		}
-
-		if (prevProps.spotlightId !== props.spotlightId) {
-			configureSpotlight();
-		}
-	}
-
-	// TODO : Change to useEffect
-	function componentWillUnmount () {
-		setContainerDisabled(false);
-	}
+	});	// TODO : Handle exhaustive-deps ESLint rule.
 
 	// Instance variables
 	const uiRefCurrent = useRef({});

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -59,8 +59,12 @@ const VirtualListBaseFactory = (type) => {
 			restoreLastFocused:  false,
 			uiRefCurrent:  null,
 			preventScroll:  null,
-			pause: new Pause('VirtualListBase')
+			pause: null
 		});
+
+		if (variables.current.pause === null) {
+			variables.current.pause = new Pause('VirtualListBase');
+		}
 
 		// Constructor
 		const {spotlightId} = props;
@@ -305,7 +309,7 @@ const VirtualListBaseFactory = (type) => {
 						variables.current.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
 					)) {
 						if (wrap === true) {
-							pause.pause();
+							variables.current.pause.pause();
 							target.blur();
 						} else {
 							focusByIndex(nextIndex);
@@ -449,7 +453,7 @@ const VirtualListBaseFactory = (type) => {
 					variables.current.isWrappedBy5way = false;
 				}
 
-				pause.resume();
+				variables.current.pause.resume();
 				focusOnNode(item);
 				variables.current.nodeIndexToBeFocused = null;
 				variables.current.isScrolledByJump = false;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -58,7 +58,8 @@ const VirtualListBaseFactory = (type) => {
 			preservedIndex:  null,
 			restoreLastFocused:  false,
 			uiRefCurrent:  null,
-			preventScroll:  null
+			preventScroll:  null,
+			pause: new Pause('VirtualListBase')
 		});
 
 		// Constructor
@@ -66,8 +67,6 @@ const VirtualListBaseFactory = (type) => {
 		if (spotlightId) {
 			configureSpotlight();
 		}
-
-		let pause = new Pause('VirtualListBase');
 
 		useEffect(() => {
 			// componentDidMount
@@ -105,7 +104,7 @@ const VirtualListBaseFactory = (type) => {
 					scrollerNode.removeEventListener('keyup', onKeyUp, {capture: true});
 				}
 
-				pause.resume();
+				variables.current.pause.resume();
 				SpotlightAccelerator.reset();
 
 				setContainerDisabled(false);
@@ -114,7 +113,7 @@ const VirtualListBaseFactory = (type) => {
 
 		// componentDidUpdate
 		useEffect(() => {
-			configureSpotlight(props.spotlightId);
+			configureSpotlight();
 		}, [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
 
 		useEffect(restoreFocus);	// TODO : Handle exhaustive-deps ESLint rule.

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -10,7 +10,6 @@ import clamp from 'ramda/src/clamp';
 import React, {useEffect, useRef} from 'react';
 import warning from 'warning';
 
-
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
 
@@ -51,14 +50,14 @@ const VirtualListBaseFactory = (type) => {
 		// Instance variables
 		const variables = useRef({
 			isScrolledBy5way: false,
-			isScrolledByJump:  false,
-			isWrappedBy5way:  false,
-			lastFocusedIndex:  null,
-			nodeIndexToBeFocused:  null,
-			preservedIndex:  null,
-			restoreLastFocused:  false,
-			uiRefCurrent:  null,
-			preventScroll:  null,
+			isScrolledByJump: false,
+			isWrappedBy5way: false,
+			lastFocusedIndex: null,
+			nodeIndexToBeFocused: null,
+			preservedIndex: null,
+			restoreLastFocused: false,
+			uiRefCurrent: null,
+			preventScroll: null,
 			pause: null
 		});
 
@@ -68,9 +67,6 @@ const VirtualListBaseFactory = (type) => {
 
 		// Constructor
 		const {spotlightId} = props;
-		if (spotlightId) {
-			configureSpotlight();
-		}
 
 		useEffect(() => {
 			// componentDidMount

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -49,7 +49,7 @@ const VirtualListBaseFactory = (type) => {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
 		// Instance variables
-		let variables = useRef({
+		const variables = useRef({
 			isScrolledBy5way: false,
 			isScrolledByJump:  false,
 			isWrappedBy5way:  false,

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,8 +7,9 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
-import React, {Component} from 'react';
+import React, {useRef} from 'react';
 import warning from 'warning';
+
 
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -36,7 +37,7 @@ const
  * The base version of [VirtualListBase]{@link moonstone/VirtualList.VirtualListBase} and
  * [VirtualListBaseNative]{@link moonstone/VirtualList.VirtualListBaseNative}.
  *
- * @class VirtualListCore
+ * @function VirtualListCore
  * @memberof moonstone/VirtualList
  * @ui
  * @private
@@ -44,276 +45,115 @@ const
 const VirtualListBaseFactory = (type) => {
 	const UiBase = (type === JS) ? UiVirtualListBase : UiVirtualListBaseNative;
 
-	return class VirtualListCore extends Component {
+	const VirtualListCore = (props) => {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
-		static propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
-			/**
-			 * The `render` function called for each item in the list.
-			 *
-			 * > NOTE: The list does NOT always render a component whenever its render function is called
-			 * due to performance optimization.
-			 *
-			 * Usage:
-			 * ```
-			 * renderItem = ({index, ...rest}) => {
-			 * 	return (
-			 * 		<MyComponent index={index} {...rest} />
-			 * 	);
-			 * }
-			 * ```
-			 *
-			 * @type {Function}
-			 * @param {Object} event
-			 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
-			 * @param {Number} event.index The index number of the component to render
-			 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.
-			 *
-			 * @required
-			 * @public
-			 */
-			itemRenderer: PropTypes.func.isRequired,
+		// Instance variables
+		let variables = useRef({
+			isScrolledBy5way: false,
+			isScrolledByJump:  false,
+			isWrappedBy5way:  false,
+			lastFocusedIndex:  null,
+			nodeIndexToBeFocused:  null,
+			preservedIndex:  null,
+			restoreLastFocused:  false,
+			uiRefCurrent:  null,
+			preventScroll:  null
+		});
 
-			/**
-			 * The render function for the items.
-			 *
-			 * @type {Function}
-			 * @required
-			 * @private
-			 */
-			itemsRenderer: PropTypes.func.isRequired,
-
-			/**
-			 * Callback method of scrollTo.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
-			 *
-			 * @type {Function}
-			 * @private
-			 */
-			cbScrollTo: PropTypes.func,
-
-			/**
-			 * Size of the data.
-			 *
-			 * @type {Number}
-			 * @default 0
-			 * @public
-			 */
-			dataSize: PropTypes.number,
-
-			/**
-			 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
-			 * not move focus to the scrollbar controls.
-			 *
-			 * @type {Boolean}
-			 * @default false
-			 * @public
-			 */
-			focusableScrollbar: PropTypes.bool,
-
-			/**
-			 * Passes the instance of [VirtualList]{@link ui/VirtualList.VirtualList}.
-			 *
-			 * @type {Object}
-			 * @param {Object} ref
-			 * @private
-			 */
-			initUiChildRef: PropTypes.func,
-
-			/**
-			 * Prop to check if horizontal Scrollbar exists or not.
-			 *
-			 * @type {Boolean}
-			 * @private
-			 */
-			isHorizontalScrollbarVisible: PropTypes.bool,
-
-			/**
-			 * Prop to check if vertical Scrollbar exists or not.
-			 *
-			 * @type {Boolean}
-			 * @private
-			 */
-			isVerticalScrollbarVisible: PropTypes.bool,
-
-			/**
-			 * The array for individually sized items.
-			 *
-			 * @type {Number[]}
-			 * @private
-			 */
-			itemSizes: PropTypes.array,
-
-			/**
-			 * It scrolls by page when `true`, by item when `false`.
-			 *
-			 * @type {Boolean}
-			 * @default false
-			 * @private
-			 */
-			pageScroll: PropTypes.bool,
-
-			/**
-			 * The ARIA role for the list.
-			 *
-			 * @type {String}
-			 * @default 'list'
-			 * @public
-			 */
-			role: PropTypes.string,
-
-			/**
-			 * `true` if rtl, `false` if ltr.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
-			 *
-			 * @type {Boolean}
-			 * @private
-			 */
-			rtl: PropTypes.bool,
-
-			/**
-			 * Spacing between items.
-			 *
-			 * @type {Number}
-			 * @default 0
-			 * @public
-			 */
-			spacing: PropTypes.number,
-
-			/**
-			 * Spotlight Id. It would be the same with [Scrollable]{@link ui/Scrollable.Scrollable}'s.
-			 *
-			 * @type {String}
-			 * @private
-			 */
-			spotlightId: PropTypes.string,
-
-			/**
-			 * When it's `true` and the spotlight focus cannot move to the given direction anymore by 5-way keys,
-			 * a list is scrolled with an animation to the other side and the spotlight focus moves in wraparound manner.
-			 *
-			 * When it's `'noAnimation'`, the spotlight focus moves in wraparound manner as same as when it's `true`
-			 * except that a list is scrolled without an animation.
-			 *
-			 * @type {Boolean|String}
-			 * @default false
-			 * @public
-			 */
-			wrap: PropTypes.oneOfType([
-				PropTypes.bool,
-				PropTypes.oneOf(['noAnimation'])
-			])
+		// Constructor
+		const {spotlightId} = props;
+		if (spotlightId) {
+			configureSpotlight();
 		}
 
-		static defaultProps = {
-			dataSize: 0,
-			focusableScrollbar: false,
-			pageScroll: false,
-			spacing: 0,
-			wrap: false
-		}
+		let pause = new Pause('VirtualListBase');
 
-		constructor (props) {
-			super(props);
-
-			const {spotlightId} = props;
-			if (spotlightId) {
-				this.configureSpotlight(spotlightId);
-			}
-
-			this.pause = new Pause('VirtualListBase');
-		}
-
-		componentDidMount () {
-			const containerNode = this.uiRefCurrent.containerRef.current;
-			const scrollerNode = document.querySelector(`[data-spotlight-id="${this.props.spotlightId}"]`);
+		// ComponentDidMount
+		// TODO : Change to useEffect
+		function componentDidMount () {
+			const containerNode = variables.current.uiRefCurrent.containerRef.current;
+			const scrollerNode = document.querySelector(`[data-spotlight-id="${props.spotlightId}"]`);
 
 			if (type === JS) {
 				// prevent native scrolling by Spotlight
-				this.preventScroll = () => {
+				variables.current.preventScroll = () => {
 					containerNode.scrollTop = 0;
-					containerNode.scrollLeft = this.props.rtl ? containerNode.scrollWidth : 0;
+					containerNode.scrollLeft = props.rtl ? containerNode.scrollWidth : 0;
 				};
 
 				if (containerNode && containerNode.addEventListener) {
-					containerNode.addEventListener('scroll', this.preventScroll);
+					containerNode.addEventListener('scroll', variables.current.preventScroll);
 				}
 			}
 
 			if (scrollerNode && scrollerNode.addEventListener) {
-				scrollerNode.addEventListener('keydown', this.onKeyDown, {capture: true});
-				scrollerNode.addEventListener('keyup', this.onKeyUp, {capture: true});
+				scrollerNode.addEventListener('keydown', onKeyDown, {capture: true});
+				scrollerNode.addEventListener('keyup', onKeyUp, {capture: true});
 			}
 		}
 
-		componentDidUpdate (prevProps) {
-			if (prevProps.spotlightId !== this.props.spotlightId) {
-				this.configureSpotlight(this.props.spotlightId);
+		// ComponentDidUpdate
+		// TODO : Change to useEffect
+		function componentDidUpdate (prevProps) {
+			if (prevProps.spotlightId !== props.spotlightId) {
+				configureSpotlight(props.spotlightId);
 			}
-			this.restoreFocus();
+			restoreFocus();
 		}
 
-		componentWillUnmount () {
-			const containerNode = this.uiRefCurrent.containerRef.current;
-			const scrollerNode = document.querySelector(`[data-spotlight-id="${this.props.spotlightId}"]`);
+		// ComponentWillUnmount
+		// TODO : Change to useEffect
+		function componentWillUnmount () {
+			const containerNode = variables.current.uiRefCurrent.containerRef.current;
+			const scrollerNode = document.querySelector(`[data-spotlight-id="${props.spotlightId}"]`);
 
 			if (type === JS) {
 				// remove a function for preventing native scrolling by Spotlight
 				if (containerNode && containerNode.removeEventListener) {
-					containerNode.removeEventListener('scroll', this.preventScroll);
+					containerNode.removeEventListener('scroll', variables.current.preventScroll);
 				}
 			}
 
 			if (scrollerNode && scrollerNode.removeEventListener) {
-				scrollerNode.removeEventListener('keydown', this.onKeyDown, {capture: true});
-				scrollerNode.removeEventListener('keyup', this.onKeyUp, {capture: true});
+				scrollerNode.removeEventListener('keydown', onKeyDown, {capture: true});
+				scrollerNode.removeEventListener('keyup', onKeyUp, {capture: true});
 			}
 
-			this.pause.resume();
+			pause.resume();
 			SpotlightAccelerator.reset();
 
-			this.setContainerDisabled(false);
+			setContainerDisabled(false);
 		}
 
-		isScrolledBy5way = false
-		isScrolledByJump = false
-		isWrappedBy5way = false
-		lastFocusedIndex = null
-		nodeIndexToBeFocused = null
-		preservedIndex = null
-		restoreLastFocused = false
-		uiRefCurrent = null
-
-		setContainerDisabled = (bool) => {
-			const
-				{spotlightId} = this.props,
-				containerNode = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
+		function setContainerDisabled (bool) {
+			const containerNode = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
 
 			if (containerNode) {
 				containerNode.setAttribute(dataContainerDisabledAttribute, bool);
 
 				if (bool) {
-					document.addEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
+					document.addEventListener('keydown', handleGlobalKeyDown, {capture: true});
 				} else {
-					document.removeEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
+					document.removeEventListener('keydown', handleGlobalKeyDown, {capture: true});
 				}
 			}
 		}
 
-		configureSpotlight = (spotlightId) => {
-			const {spacing} = this.props;
+		function configureSpotlight () {
+			const {spacing} = props;
 
 			Spotlight.set(spotlightId, {
 				enterTo: 'last-focused',
 				/*
 				 * Returns the data-index as the key for last focused
 				 */
-				lastFocusedPersist: this.lastFocusedPersist,
+				lastFocusedPersist: lastFocusedPersist,
 				/*
 				 * Restores the data-index into the placeholder if its the only element. Tries to find a
 				 * matching child otherwise.
 				 */
-				lastFocusedRestore: this.lastFocusedRestore,
+				lastFocusedRestore: lastFocusedRestore,
 				/*
 				 * Directs spotlight focus to favor straight elements that are within range of `spacing`
 				 * over oblique elements, like scroll buttons.
@@ -322,12 +162,12 @@ const VirtualListBaseFactory = (type) => {
 			});
 		}
 
-		lastFocusedPersist = () => {
-			if (this.lastFocusedIndex != null) {
+		function lastFocusedPersist () {
+			if (variables.current.lastFocusedIndex != null) {
 				return {
 					container: false,
 					element: true,
-					key: this.lastFocusedIndex
+					key: variables.current.lastFocusedIndex
 				};
 			}
 		}
@@ -336,7 +176,7 @@ const VirtualListBaseFactory = (type) => {
 		 * Restores the data-index into the placeholder if it exists. Tries to find a matching child
 		 * otherwise.
 		 */
-		lastFocusedRestore = ({key}, all) => {
+		function lastFocusedRestore ({key}, all) {
 			const placeholder = all.find(el => 'vlPlaceholder' in el.dataset);
 			if (placeholder) {
 				placeholder.dataset.index = key;
@@ -349,8 +189,8 @@ const VirtualListBaseFactory = (type) => {
 			}, null);
 		}
 
-		findSpottableItem = (indexFrom, indexTo) => {
-			const {dataSize} = this.props;
+		function findSpottableItem (indexFrom, indexTo) {
+			const {dataSize} = props;
 
 			if (indexFrom < 0 && indexTo < 0 || indexFrom >= dataSize && indexTo >= dataSize) {
 				return -1;
@@ -359,9 +199,9 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		getNextIndex = ({index, keyCode, repeat}) => {
-			const {dataSize, rtl, wrap} = this.props;
-			const {isPrimaryDirectionVertical, dimensionToExtent} = this.uiRefCurrent;
+		function getNextIndex ({index, keyCode, repeat}) {
+			const {dataSize, rtl, wrap} = props;
+			const {isPrimaryDirectionVertical, dimensionToExtent} = variables.current.uiRefCurrent;
 			const column = index % dimensionToExtent;
 			const row = (index - column) % dataSize / dimensionToExtent;
 			const isDownKey = isDown(keyCode);
@@ -411,11 +251,11 @@ const VirtualListBaseFactory = (type) => {
 			}
 
 			if (!repeat && nextIndex === -1 && wrap) {
-				if (isForward && this.findSpottableItem((row + 1) * dimensionToExtent, dataSize) < 0) {
-					nextIndex = this.findSpottableItem(0, index);
+				if (isForward && findSpottableItem((row + 1) * dimensionToExtent, dataSize) < 0) {
+					nextIndex = findSpottableItem(0, index);
 					isWrapped = true;
-				} else if (isBackward && this.findSpottableItem(-1, row * dimensionToExtent - 1) < 0) {
-					nextIndex = this.findSpottableItem(dataSize, index);
+				} else if (isBackward && findSpottableItem(-1, row * dimensionToExtent - 1) < 0) {
+					nextIndex = findSpottableItem(dataSize, index);
 					isWrapped = true;
 				}
 			}
@@ -427,25 +267,25 @@ const VirtualListBaseFactory = (type) => {
 		 * Handle `onKeyDown` event
 		 */
 
-		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
-			const {cbScrollTo, dataSize, spacing, wrap} = this.props;
-			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPositionTarget} = this.uiRefCurrent;
+		function onAcceleratedKeyDown ({isWrapped, keyCode, nextIndex, repeat, target}) {
+			const {cbScrollTo, dataSize, spacing, wrap} = props;
+			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPositionTarget} = variables.current.uiRefCurrent;
 			const index = getNumberValue(target.dataset.index);
 
-			this.isScrolledBy5way = false;
-			this.isScrolledByJump = false;
+			variables.current.isScrolledBy5way = false;
+			variables.current.isScrolledByJump = false;
 
 			if (nextIndex >= 0) {
 				const
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
-					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
-					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + gridSize;
+					start = variables.current.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
+					end = variables.current.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + gridSize;
 				let isNextItemInView = false;
 
-				if (this.props.itemSizes) {
-					isNextItemInView = this.uiRefCurrent.itemPositions[nextIndex].position >= scrollPositionTarget &&
-						this.uiRefCurrent.getItemBottomPosition(nextIndex) <= scrollPositionTarget + clientSize;
+				if (props.itemSizes) {
+					isNextItemInView = variables.current.uiRefCurrent.itemPositions[nextIndex].position >= scrollPositionTarget &&
+						variables.current.uiRefCurrent.getItemBottomPosition(nextIndex) <= scrollPositionTarget + clientSize;
 				} else {
 					const
 						firstFullyVisibleIndex = Math.ceil(scrollPositionTarget / gridSize) * dimensionToExtent,
@@ -456,32 +296,32 @@ const VirtualListBaseFactory = (type) => {
 					isNextItemInView = nextIndex >= firstFullyVisibleIndex && nextIndex <= lastFullyVisibleIndex;
 				}
 
-				this.lastFocusedIndex = nextIndex;
+				variables.current.lastFocusedIndex = nextIndex;
 
 				if (isNextItemInView) {
 					// The next item could be still out of viewport. So we need to prevent scrolling into view with `isScrolledBy5way` flag.
-					this.isScrolledBy5way = true;
-					this.focusByIndex(nextIndex);
-					this.isScrolledBy5way = false;
+					variables.current.isScrolledBy5way = true;
+					focusByIndex(nextIndex);
+					variables.current.isScrolledBy5way = false;
 				} else if (row === nextRow && (start < scrollPositionTarget || end > scrollPositionTarget + clientSize)) {
-					this.focusByIndex(nextIndex);
+					focusByIndex(nextIndex);
 				} else {
-					this.isScrolledBy5way = true;
-					this.isWrappedBy5way = isWrapped;
+					variables.current.isScrolledBy5way = true;
+					variables.current.isWrappedBy5way = isWrapped;
 
 					if (isWrapped && (
-						this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
+						variables.current.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
 					)) {
 						if (wrap === true) {
-							this.pause.pause();
+							pause.pause();
 							target.blur();
 						} else {
-							this.focusByIndex(nextIndex);
+							focusByIndex(nextIndex);
 						}
 
-						this.nodeIndexToBeFocused = nextIndex;
+						variables.current.nodeIndexToBeFocused = nextIndex;
 					} else {
-						this.focusByIndex(nextIndex);
+						focusByIndex(nextIndex);
 					}
 
 					cbScrollTo({
@@ -495,7 +335,7 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		onKeyDown = (ev) => {
+		function onKeyDown (ev) {
 			const {keyCode, target} = ev;
 			const direction = getDirection(keyCode);
 
@@ -506,8 +346,8 @@ const VirtualListBaseFactory = (type) => {
 					ev.stopPropagation();
 				} else {
 					const {repeat} = ev;
-					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = this.props;
-					const {dimensionToExtent, isPrimaryDirectionVertical} = this.uiRefCurrent;
+					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = props;
+					const {dimensionToExtent, isPrimaryDirectionVertical} = variables.current.uiRefCurrent;
 					const targetIndex = target.dataset.index;
 					const isScrollButton = (
 						// if target has an index, it must be an item so can't be a scroll button
@@ -516,7 +356,7 @@ const VirtualListBaseFactory = (type) => {
 						target.matches(`[data-spotlight-id="${spotlightId}"] *`)
 					);
 					const index = !isScrollButton ? getNumberValue(targetIndex) : -1;
-					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = this.getNextIndex({index, keyCode, repeat});
+					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = getNextIndex({index, keyCode, repeat});
 					const directions = {};
 					let isLeaving = false;
 					let isScrollbarVisible;
@@ -539,9 +379,9 @@ const VirtualListBaseFactory = (type) => {
 						if (nextIndex >= 0) {
 							ev.preventDefault();
 							ev.stopPropagation();
-							this.onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
+							onAcceleratedKeyDown({isWrapped, keyCode, nextIndex, repeat, target});
 						} else {
-							const {dataSize} = this.props;
+							const {dataSize} = props;
 							const column = index % dimensionToExtent;
 							const row = (index - column) % dataSize / dimensionToExtent;
 							isLeaving = directions.up && row === 0 ||
@@ -559,7 +399,7 @@ const VirtualListBaseFactory = (type) => {
 								ev.stopPropagation();
 
 								if (typeof nextTargetIndex === 'string') {
-									this.onAcceleratedKeyDown({keyCode, nextIndex: getNumberValue(nextTargetIndex), repeat, target});
+									onAcceleratedKeyDown({keyCode, nextIndex: getNumberValue(nextTargetIndex), repeat, target});
 								}
 							}
 
@@ -576,11 +416,11 @@ const VirtualListBaseFactory = (type) => {
 					}
 				}
 			} else if (isPageUp(keyCode) || isPageDown(keyCode)) {
-				this.isScrolledBy5way = false;
+				variables.current.isScrolledBy5way = false;
 			}
 		}
 
-		onKeyUp = ({keyCode}) => {
+		function onKeyUp ({keyCode}) {
 			if (getDirection(keyCode) || isEnter(keyCode)) {
 				SpotlightAccelerator.reset();
 			}
@@ -590,50 +430,50 @@ const VirtualListBaseFactory = (type) => {
 		 * Handle global `onKeyDown` event
 		 */
 
-		handleGlobalKeyDown = () => {
-			this.setContainerDisabled(false);
+		function handleGlobalKeyDown () {
+			setContainerDisabled(false);
 		}
 
 		/**
 		 * Focus on the Node of the VirtualList item
 		 */
 
-		focusOnNode = (node) => {
+		function focusOnNode (node) {
 			if (node) {
 				Spotlight.focus(node);
 			}
 		}
 
-		focusByIndex = (index) => {
-			const item = this.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}']${spottableSelector}`);
+		function focusByIndex (index) {
+			const item = variables.current.uiRefCurrent.containerRef.current.querySelector(`[data-index='${index}']${spottableSelector}`);
 
-			if (!item && index >= 0 && index < this.props.dataSize) {
+			if (!item && index >= 0 && index < props.dataSize) {
 				// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
-				this.preservedIndex = index;
-				this.restoreLastFocused = true;
+				variables.current.preservedIndex = index;
+				variables.current.restoreLastFocused = true;
 			} else {
-				if (this.isWrappedBy5way) {
+				if (variables.current.isWrappedBy5way) {
 					SpotlightAccelerator.reset();
-					this.isWrappedBy5way = false;
+					variables.current.isWrappedBy5way = false;
 				}
 
-				this.pause.resume();
-				this.focusOnNode(item);
-				this.nodeIndexToBeFocused = null;
-				this.isScrolledByJump = false;
+				pause.resume();
+				focusOnNode(item);
+				variables.current.nodeIndexToBeFocused = null;
+				variables.current.isScrolledByJump = false;
 			}
 		}
 
-		initItemRef = (ref, index) => {
+		function initItemRef (ref, index) {
 			if (ref) {
 				if (type === JS) {
-					this.focusByIndex(index);
+					focusByIndex(index);
 				} else {
 					// If focusing the item of VirtuallistNative, `onFocus` in Scrollable will be called.
 					// Then VirtualListNative tries to scroll again differently from VirtualList.
 					// So we would like to skip `focus` handling when focusing the item as a workaround.
-					this.isScrolledByJump = true;
-					this.focusByIndex(index);
+					variables.current.isScrolledByJump = true;
+					focusByIndex(index);
 				}
 			}
 		}
@@ -642,24 +482,26 @@ const VirtualListBaseFactory = (type) => {
 		 * Manage a placeholder
 		 */
 
-		isNeededScrollingPlaceholder = () => this.nodeIndexToBeFocused != null && Spotlight.isPaused();
+		function isNeededScrollingPlaceholder () {
+			return variables.current.nodeIndexToBeFocused != null && Spotlight.isPaused();
+		}
 
-		handlePlaceholderFocus = (ev) => {
+		function handlePlaceholderFocus (ev) {
 			const placeholder = ev.currentTarget;
 
 			if (placeholder) {
 				const index = placeholder.dataset.index;
 
 				if (index) {
-					this.preservedIndex = getNumberValue(index);
-					this.restoreLastFocused = true;
+					variables.current.preservedIndex = getNumberValue(index);
+					variables.current.restoreLastFocused = true;
 				}
 			}
 		}
 
-		handleUpdateItems = ({firstIndex, lastIndex}) => {
-			if (this.restoreLastFocused && this.preservedIndex >= firstIndex && this.preservedIndex <= lastIndex) {
-				this.restoreFocus();
+		function handleUpdateItems ({firstIndex, lastIndex}) {
+			if (variables.current.restoreLastFocused && variables.current.preservedIndex >= firstIndex && variables.current.preservedIndex <= lastIndex) {
+				restoreFocus();
 			}
 		}
 
@@ -667,41 +509,39 @@ const VirtualListBaseFactory = (type) => {
 		 * Restore the focus of VirtualList
 		 */
 
-		isPlaceholderFocused = () => {
+		function isPlaceholderFocused () {
 			const current = Spotlight.getCurrent();
 
-			if (current && current.dataset.vlPlaceholder && this.uiRefCurrent.containerRef.current.contains(current)) {
+			if (current && current.dataset.vlPlaceholder && variables.current.uiRefCurrent.containerRef.current.contains(current)) {
 				return true;
 			}
 
 			return false;
 		}
 
-		restoreFocus = () => {
+		function restoreFocus () {
 			if (
-				this.restoreLastFocused &&
-				!this.isPlaceholderFocused()
+				variables.current.restoreLastFocused &&
+				!isPlaceholderFocused()
 			) {
-				const
-					{spotlightId} = this.props,
-					node = this.uiRefCurrent.containerRef.current.querySelector(
-						`[data-spotlight-id="${spotlightId}"] [data-index="${this.preservedIndex}"]`
-					);
+				const node = variables.current.uiRefCurrent.containerRef.current.querySelector(
+						`[data-spotlight-id="${spotlightId}"] [data-index="${variables.current.preservedIndex}"]`
+				);
 
 				if (node) {
 					// if we're supposed to restore focus and virtual list has positioned a set of items
 					// that includes lastFocusedIndex, clear the indicator
-					this.restoreLastFocused = false;
+					variables.current.restoreLastFocused = false;
 
 					// try to focus the last focused item
-					this.isScrolledByJump = true;
+					variables.current.isScrolledByJump = true;
 					const foundLastFocused = Spotlight.focus(node);
-					this.isScrolledByJump = false;
+					variables.current.isScrolledByJump = false;
 
 					// but if that fails (because it isn't found or is disabled), focus the container so
 					// spotlight isn't lost
 					if (!foundLastFocused) {
-						this.restoreLastFocused = true;
+						variables.current.restoreLastFocused = true;
 						Spotlight.focus(spotlightId);
 					}
 				}
@@ -712,26 +552,27 @@ const VirtualListBaseFactory = (type) => {
 		 * calculator
 		 */
 
-		calculatePositionOnFocus = ({item, scrollPosition = this.uiRefCurrent.scrollPosition}) => {
+		// TODO PLAT-98204.
+		function calculatePositionOnFocus ({item, scrollPosition = variables.current.uiRefCurrent.scrollPosition}) {
 			const
-				{pageScroll} = this.props,
-				{numOfItems} = this.uiRefCurrent.state,
-				{primary} = this.uiRefCurrent,
+				{pageScroll} = props,
+				{numOfItems} = variables.current.uiRefCurrent.state,
+				{primary} = variables.current.uiRefCurrent,
 				offsetToClientEnd = primary.clientSize - primary.itemSize,
 				focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
 			if (!isNaN(focusedIndex)) {
-				let gridPosition = this.uiRefCurrent.getGridPosition(focusedIndex);
+				let gridPosition = variables.current.uiRefCurrent.getGridPosition(focusedIndex);
 
-				if (numOfItems > 0 && focusedIndex % numOfItems !== this.lastFocusedIndex % numOfItems) {
-					const node = this.uiRefCurrent.getItemNode(this.lastFocusedIndex);
+				if (numOfItems > 0 && focusedIndex % numOfItems !== variables.current.lastFocusedIndex % numOfItems) {
+					const node = variables.current.uiRefCurrent.getItemNode(variables.current.lastFocusedIndex);
 
 					if (node) {
 						node.blur();
 					}
 				}
-				this.nodeIndexToBeFocused = null;
-				this.lastFocusedIndex = focusedIndex;
+				variables.current.nodeIndexToBeFocused = null;
+				variables.current.lastFocusedIndex = focusedIndex;
 
 				if (primary.clientSize >= primary.itemSize) {
 					if (gridPosition.primaryPosition > scrollPosition + offsetToClientEnd) { // forward over
@@ -742,7 +583,7 @@ const VirtualListBaseFactory = (type) => {
 						} else {
 							// This code uses the trick to change the target position slightly which will not affect the actual result
 							// since a browser ignore `scrollTo` method if the target position is same as the current position.
-							gridPosition.primaryPosition = scrollPosition + (this.uiRefCurrent.scrollPosition === scrollPosition ? 0.1 : 0);
+							gridPosition.primaryPosition = scrollPosition + (variables.current.uiRefCurrent.scrollPosition === scrollPosition ? 0.1 : 0);
 						}
 					} else { // backward over
 						gridPosition.primaryPosition -= pageScroll ? offsetToClientEnd : 0;
@@ -753,77 +594,255 @@ const VirtualListBaseFactory = (type) => {
 				// scrondaryPosition should be 0 here.
 				gridPosition.secondaryPosition = 0;
 
-				return this.uiRefCurrent.gridPositionToItemPosition(gridPosition);
+				return variables.current.uiRefCurrent.gridPositionToItemPosition(gridPosition);
 			}
 		}
 
-		shouldPreventScrollByFocus = () => ((type === JS) ? (this.isScrolledBy5way) : (this.isScrolledBy5way || this.isScrolledByJump))
-
-		shouldPreventOverscrollEffect = () => (this.isWrappedBy5way)
-
-		setLastFocusedNode = (node) => {
-			this.lastFocusedIndex = node.dataset && getNumberValue(node.dataset.index);
+		// TODO PLAT-98204.
+		function shouldPreventScrollByFocus () {
+			return ((type === JS) ? (variables.current.isScrolledBy5way) : (variables.current.isScrolledBy5way || variables.current.isScrolledByJump));
 		}
 
-		updateStatesAndBounds = ({dataSize, moreInfo, numOfItems}) => {
-			const {preservedIndex} = this;
+		// TODO PLAT-98204.
+		function shouldPreventOverscrollEffect () {
+			return variables.current.isWrappedBy5way;
+		}
 
-			return (this.restoreLastFocused && numOfItems > 0 && preservedIndex < dataSize && (
-				preservedIndex < moreInfo.firstVisibleIndex || preservedIndex > moreInfo.lastVisibleIndex
+		// TODO PLAT-98204.
+		function setLastFocusedNode (node) {
+			variables.current.lastFocusedIndex = node.dataset && getNumberValue(node.dataset.index);
+		}
+
+		function updateStatesAndBounds ({dataSize, moreInfo, numOfItems}) {
+			// TODO check preservedIndex
+			// const {preservedIndex} = this;
+
+			return (variables.current.restoreLastFocused && numOfItems > 0 && variables.current.preservedIndex < dataSize && (
+				variables.current.preservedIndex < moreInfo.firstVisibleIndex || variables.current.preservedIndex > moreInfo.lastVisibleIndex
 			));
 		}
 
-		getScrollBounds = () => this.uiRefCurrent.getScrollBounds()
+		// TODO PLAT-98204.
+		function getScrollBounds () {
+			return variables.current.uiRefCurrent.getScrollBounds();
+		}
 
-		getComponentProps = (index) => (
-			(index === this.nodeIndexToBeFocused) ? {ref: (ref) => this.initItemRef(ref, index)} : {}
-		)
+		function getComponentProps (index) {
+			return (index === variables.current.nodeIndexToBeFocused) ? {ref: (ref) => initItemRef(ref, index)} : {};
+		}
 
-		initUiRef = (ref) => {
+		function initUiRef (ref) {
 			if (ref) {
-				this.uiRefCurrent = ref;
-				this.props.initUiChildRef(ref);
+				variables.current.uiRefCurrent = ref;
+				props.initUiChildRef(ref);
 			}
 		}
 
-		render () {
-			const
-				{itemRenderer, itemsRenderer, role, ...rest} = this.props,
-				needsScrollingPlaceholder = this.isNeededScrollingPlaceholder();
+		// Render
+		const
+			{itemRenderer, itemsRenderer, role, ...rest} = props,
+			needsScrollingPlaceholder = isNeededScrollingPlaceholder();
 
-			delete rest.initUiChildRef;
-			// not used by VirtualList
-			delete rest.focusableScrollbar;
-			delete rest.scrollAndFocusScrollbarButton;
-			delete rest.spotlightId;
-			delete rest.wrap;
+		delete rest.initUiChildRef;
+		// not used by VirtualList
+		delete rest.focusableScrollbar;
+		delete rest.scrollAndFocusScrollbarButton;
+		delete rest.spotlightId;
+		delete rest.wrap;
 
-			return (
-				<UiBase
-					{...rest}
-					getComponentProps={this.getComponentProps}
-					itemRenderer={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
-						itemRenderer({
-							...itemRest,
-							[dataIndexAttribute]: index,
-							index
-						})
-					)}
-					onUpdateItems={this.handleUpdateItems}
-					ref={this.initUiRef}
-					updateStatesAndBounds={this.updateStatesAndBounds}
-					itemsRenderer={(props) => { // eslint-disable-line react/jsx-no-bind
-						return itemsRenderer({
-							...props,
-							handlePlaceholderFocus: this.handlePlaceholderFocus,
-							needsScrollingPlaceholder,
-							role
-						});
-					}}
-				/>
-			);
-		}
+		return (
+			<UiBase
+				{...rest}
+				getComponentProps={getComponentProps}
+				itemRenderer={({index, ...itemRest}) => ( // eslint-disable-line react/jsx-no-bind
+					itemRenderer({
+						...itemRest,
+						[dataIndexAttribute]: index,
+						index
+					})
+				)}
+				onUpdateItems={handleUpdateItems}
+				ref={initUiRef}
+				updateStatesAndBounds={updateStatesAndBounds}
+				itemsRenderer={(itemsRendererProps) => { // eslint-disable-line react/jsx-no-bind
+					return itemsRenderer({
+						...itemsRendererProps,
+						handlePlaceholderFocus: handlePlaceholderFocus,
+						needsScrollingPlaceholder,
+						role
+					});
+				}}
+			/>
+		);
 	};
+
+	VirtualListCore.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
+		/**
+		 * The `render` function called for each item in the list.
+		 *
+		 * > NOTE: The list does NOT always render a component whenever its render function is called
+		 * due to performance optimization.
+		 *
+		 * Usage:
+		 * ```
+		 * renderItem = ({index, ...rest}) => {
+		 * 	return (
+		 * 		<MyComponent index={index} {...rest} />
+		 * 	);
+		 * }
+		 * ```
+		 *
+		 * @type {Function}
+		 * @param {Object} event
+		 * @param {Number} event.data-index It is required for Spotlight 5-way navigation. Pass to the root element in the component.
+		 * @param {Number} event.index The index number of the component to render
+		 * @param {Number} event.key It MUST be passed as a prop to the root element in the component for DOM recycling.
+		 *
+		 * @required
+		 * @public
+		 */
+		itemRenderer: PropTypes.func.isRequired,
+
+		/**
+		 * The render function for the items.
+		 *
+		 * @type {Function}
+		 * @required
+		 * @private
+		 */
+		itemsRenderer: PropTypes.func.isRequired,
+
+		/**
+		 * Callback method of scrollTo.
+		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		cbScrollTo: PropTypes.func,
+
+		/**
+		 * Size of the data.
+		 *
+		 * @type {Number}
+		 * @default 0
+		 * @public
+		 */
+		dataSize: PropTypes.number,
+
+		/**
+		 * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
+		 * not move focus to the scrollbar controls.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		focusableScrollbar: PropTypes.bool,
+
+		/**
+		 * Passes the instance of [VirtualList]{@link ui/VirtualList.VirtualList}.
+		 *
+		 * @type {Object}
+		 * @param {Object} ref
+		 * @private
+		 */
+		initUiChildRef: PropTypes.func,
+
+		/**
+		 * Prop to check if horizontal Scrollbar exists or not.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		isHorizontalScrollbarVisible: PropTypes.bool,
+
+		/**
+		 * Prop to check if vertical Scrollbar exists or not.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		isVerticalScrollbarVisible: PropTypes.bool,
+
+		/**
+		 * The array for individually sized items.
+		 *
+		 * @type {Number[]}
+		 * @private
+		 */
+		itemSizes: PropTypes.array,
+
+		/**
+		 * It scrolls by page when `true`, by item when `false`.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		pageScroll: PropTypes.bool,
+
+		/**
+		 * The ARIA role for the list.
+		 *
+		 * @type {String}
+		 * @default 'list'
+		 * @public
+		 */
+		role: PropTypes.string,
+
+		/**
+		 * `true` if rtl, `false` if ltr.
+		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		rtl: PropTypes.bool,
+
+		/**
+		 * Spacing between items.
+		 *
+		 * @type {Number}
+		 * @default 0
+		 * @public
+		 */
+		spacing: PropTypes.number,
+
+		/**
+		 * Spotlight Id. It would be the same with [Scrollable]{@link ui/Scrollable.Scrollable}'s.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		spotlightId: PropTypes.string,
+
+		/**
+		 * When it's `true` and the spotlight focus cannot move to the given direction anymore by 5-way keys,
+		 * a list is scrolled with an animation to the other side and the spotlight focus moves in wraparound manner.
+		 *
+		 * When it's `'noAnimation'`, the spotlight focus moves in wraparound manner as same as when it's `true`
+		 * except that a list is scrolled without an animation.
+		 *
+		 * @type {Boolean|String}
+		 * @default false
+		 * @public
+		 */
+		wrap: PropTypes.oneOfType([
+			PropTypes.bool,
+			PropTypes.oneOf(['noAnimation'])
+		])
+	};
+
+	VirtualListCore.defaultProps = {
+		dataSize: 0,
+		focusableScrollbar: false,
+		pageScroll: false,
+		spacing: 0,
+		wrap: false
+	};
+
+	return VirtualListCore;
 };
 
 /**

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,7 +7,7 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import warning from 'warning';
 
 
@@ -69,9 +69,8 @@ const VirtualListBaseFactory = (type) => {
 
 		let pause = new Pause('VirtualListBase');
 
-		// ComponentDidMount
-		// TODO : Change to useEffect
-		function componentDidMount () {
+		useEffect(() => {
+			// componentDidMount
 			const containerNode = variables.current.uiRefCurrent.containerRef.current;
 			const scrollerNode = document.querySelector(`[data-spotlight-id="${props.spotlightId}"]`);
 
@@ -91,40 +90,34 @@ const VirtualListBaseFactory = (type) => {
 				scrollerNode.addEventListener('keydown', onKeyDown, {capture: true});
 				scrollerNode.addEventListener('keyup', onKeyUp, {capture: true});
 			}
-		}
 
-		// ComponentDidUpdate
-		// TODO : Change to useEffect
-		function componentDidUpdate (prevProps) {
-			if (prevProps.spotlightId !== props.spotlightId) {
-				configureSpotlight(props.spotlightId);
-			}
-			restoreFocus();
-		}
-
-		// ComponentWillUnmount
-		// TODO : Change to useEffect
-		function componentWillUnmount () {
-			const containerNode = variables.current.uiRefCurrent.containerRef.current;
-			const scrollerNode = document.querySelector(`[data-spotlight-id="${props.spotlightId}"]`);
-
-			if (type === JS) {
-				// remove a function for preventing native scrolling by Spotlight
-				if (containerNode && containerNode.removeEventListener) {
-					containerNode.removeEventListener('scroll', variables.current.preventScroll);
+			// componentWillUnmount
+			return () => {
+				if (type === JS) {
+					// remove a function for preventing native scrolling by Spotlight
+					if (containerNode && containerNode.removeEventListener) {
+						containerNode.removeEventListener('scroll', variables.current.preventScroll);
+					}
 				}
-			}
 
-			if (scrollerNode && scrollerNode.removeEventListener) {
-				scrollerNode.removeEventListener('keydown', onKeyDown, {capture: true});
-				scrollerNode.removeEventListener('keyup', onKeyUp, {capture: true});
-			}
+				if (scrollerNode && scrollerNode.removeEventListener) {
+					scrollerNode.removeEventListener('keydown', onKeyDown, {capture: true});
+					scrollerNode.removeEventListener('keyup', onKeyUp, {capture: true});
+				}
 
-			pause.resume();
-			SpotlightAccelerator.reset();
+				pause.resume();
+				SpotlightAccelerator.reset();
 
-			setContainerDisabled(false);
-		}
+				setContainerDisabled(false);
+			};
+		}, []);	// TODO : Handle exhaustive-deps ESLint rule.
+
+		// componentDidUpdate
+		useEffect(() => {
+			configureSpotlight(props.spotlightId);
+		}, [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
+
+		useEffect(restoreFocus);	// TODO : Handle exhaustive-deps ESLint rule.
 
 		function setContainerDisabled (bool) {
 			const containerNode = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We want to migrate HoC and render props to hooks for all VirtualList and Scroller.
As the first step, I converted 4 moonstone scroller components defined by class to functional component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

4 moonstone scroller components have been converted to functional component.
* Target component
Moonstone/VirtualListBase
Moonstone/Scrollable
Moonstone/ScollableNative
Moonstone/Scroller

1) Change `class NameOfComponent extends Component` to `const NameOfComponent => (props){`
2) Change `defaultProp`, `propTypes` to `NameOfComponent.defaultProp`,  `NameOfComponent.propTypes`. 
3) Remove the constructor
4) Remove the render() method, keep the return
5) Convert all methods to `function` for hoisting.
6) Use `useRef` for all instance variables. 
7) Replace all lifecycle functnion to `useEffect`. 
8) Use `useRef` or `useContext` As needed.
9) Remove all references to ‘this’ throughout the component
10) Set initial state with `useState()`. ie…
11) Declare some undeclared member variables. (this.variable)
12) Adjust duplicated variable names.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* When I use useEffect,  I got lint warning from exhaustive-deps ESLint rule
(https://github.com/facebook/react/issues/14920).
I checked the operation, but lint-warning is occurring.
More discussion is needed to solve this problem.

* There are some issues found while testing samples. W'll fix them later 
: Issue 1> Now, some error is occurring on some part to access class instance method using ref.
 Function component doesn't have instance, so I will solve the problem on  PLAT-98204.
That means, current operation accompany some errors yet.
: Issue 2> Can not launch perf-enact-virtualgridlist sample
: Issue 3> Need to fix travis fail
: Issue 4> Can not wheel
```
Step1> Launch the VirtualGridList sampler
Step2> Wheel over the list
```

### Links
[//]: # (Related issues, references)
PLAT-98201
