### PR TITLE
PLAT-95353:  Avoid unsafe access to unprovided position info

### DIFF
--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 ### Fixed
 
 - `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes` is given and `dataSize` is 0
+- `moonstone/VirtualList.VirtualList` to render properly without error when `itemSizes`'s value is missing
 
 ## [3.2.5] - 2019-11-14
 

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -440,12 +440,11 @@ const VirtualListBaseFactory = (type) => {
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
 					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
-					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + gridSize;
+					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + spacing;
 				let isNextItemInView = false;
 
 				if (this.props.itemSizes) {
-					isNextItemInView = this.uiRefCurrent.itemPositions[nextIndex].position >= scrollPositionTarget &&
-						this.uiRefCurrent.getItemBottomPosition(nextIndex) <= scrollPositionTarget + clientSize;
+					isNextItemInView = start >= scrollPositionTarget && end <= scrollPositionTarget + clientSize;
 				} else {
 					const
 						firstFullyVisibleIndex = Math.ceil(scrollPositionTarget / gridSize) * dimensionToExtent,
@@ -463,7 +462,7 @@ const VirtualListBaseFactory = (type) => {
 					this.isScrolledBy5way = true;
 					this.focusByIndex(nextIndex);
 					this.isScrolledBy5way = false;
-				} else if (row === nextRow && (start < scrollPositionTarget || end > scrollPositionTarget + clientSize)) {
+				} else if (row === nextRow) {
 					this.focusByIndex(nextIndex);
 				} else {
 					this.isScrolledBy5way = true;

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -429,7 +429,7 @@ const VirtualListBaseFactory = (type) => {
 
 		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
 			const {cbScrollTo, dataSize, spacing, wrap} = this.props;
-			const {dimensionToExtent, primary: {clientSize, gridSize}, scrollPositionTarget} = this.uiRefCurrent;
+			const {dimensionToExtent, primary: {clientSize, gridSize, itemSize}, scrollPositionTarget} = this.uiRefCurrent;
 			const index = getNumberValue(target.dataset.index);
 
 			this.isScrolledBy5way = false;
@@ -440,7 +440,7 @@ const VirtualListBaseFactory = (type) => {
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
 					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
-					end = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition + spacing;
+					end = this.uiRefCurrent.getItemBottomPosition(nextIndex);
 				let isNextItemInView = false;
 
 				if (this.props.itemSizes) {

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -428,8 +428,8 @@ const VirtualListBaseFactory = (type) => {
 		 */
 
 		onAcceleratedKeyDown = ({isWrapped, keyCode, nextIndex, repeat, target}) => {
-			const {cbScrollTo, dataSize, spacing, wrap} = this.props;
-			const {dimensionToExtent, primary: {clientSize, gridSize, itemSize}, scrollPositionTarget} = this.uiRefCurrent;
+			const {cbScrollTo, wrap} = this.props;
+			const {dimensionToExtent, primary: {clientSize, itemSize}, scrollPositionTarget} = this.uiRefCurrent;
 			const index = getNumberValue(target.dataset.index);
 
 			this.isScrolledBy5way = false;
@@ -440,24 +440,10 @@ const VirtualListBaseFactory = (type) => {
 					row = Math.floor(index / dimensionToExtent),
 					nextRow = Math.floor(nextIndex / dimensionToExtent),
 					start = this.uiRefCurrent.getGridPosition(nextIndex).primaryPosition,
-					end = this.uiRefCurrent.getItemBottomPosition(nextIndex);
-				let isNextItemInView = false;
-
-				if (this.props.itemSizes) {
-					isNextItemInView = start >= scrollPositionTarget && end <= scrollPositionTarget + clientSize;
-				} else {
-					const
-						firstFullyVisibleIndex = Math.ceil(scrollPositionTarget / gridSize) * dimensionToExtent,
-						lastFullyVisibleIndex = Math.min(
-							dataSize - 1,
-							Math.floor((scrollPositionTarget + clientSize + spacing) / gridSize) * dimensionToExtent - 1
-						);
-					isNextItemInView = nextIndex >= firstFullyVisibleIndex && nextIndex <= lastFullyVisibleIndex;
-				}
-
+					end = this.props.itemSizes ? this.uiRefCurrent.getItemBottomPosition(nextIndex) : start + itemSize;
 				this.lastFocusedIndex = nextIndex;
 
-				if (isNextItemInView) {
+				if (start >= scrollPositionTarget && end <= scrollPositionTarget + clientSize) {
 					// The next item could be still out of viewport. So we need to prevent scrolling into view with `isScrolledBy5way` flag.
 					this.isScrolledBy5way = true;
 					this.focusByIndex(nextIndex);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If an app setup an _empty_ item size array for a list, a script error occurs due to unguarded access to internal position info that is based on the item size from the app.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Refined related logic to access position info safely;
- Changed to access position info through guarded getter function
- Merged logics for different sized items and single sized items into a unified logic

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This fix just to avoid script errors during 5-way key inputs and does not mean that the behavior of a list will be fine with _empty_ size info. Proper size info should be provided by an app to make a list working properly.

### Links
[//]: # (Related issues, references)
PLAT-95353

### Comments
