### PR TITLE
PLAT-98572: Convert scrollbar and scroll thumb components into functional components

### DIFF
--- a/packages/moonstone/Scrollable/ScrollThumb.js
+++ b/packages/moonstone/Scrollable/ScrollThumb.js
@@ -1,45 +1,44 @@
 import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useEffect, forwardRef} from 'react';
 
 const nop = () => {};
 
 /**
  * A Moonstone-styled scroll thumb with moonstone behavior
  *
- * @class ScrollThumb
+ * @function ScrollThumb
  * @memberof moonstone/Scrollable
  * @extends ui/Scrollable/ScrollThumb
  * @ui
  * @private
  */
-class ScrollThumb extends Component {
-	static propTypes = /** @lends moonstone/Scrollable.ScrollThumb.prototype */ {
-		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		cbAlertThumb: PropTypes.func
-	}
+const ScrollThumb = forwardRef((props, ref) => {
+	const rest = Object.assign({}, props);
+	delete rest.cbAlertThumb;
 
-	static defaultProps = {
-		cbAlertThumb: nop
-	}
+	useEffect (() => {
+		props.cbAlertThumb();
+	});
 
-	componentDidUpdate () {
-		this.props.cbAlertThumb();
-	}
+	return <UiScrollThumb {...rest} ref={ref} />;
+});
 
-	render () {
-		const props = Object.assign({}, this.props);
+ScrollThumb.displayName = 'ScrollThumb';
 
-		delete props.cbAlertThumb;
+ScrollThumb.propTypes = /** @lends moonstone/Scrollable.ScrollThumb.prototype */ {
+	/**
+	 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	cbAlertThumb: PropTypes.func
+};
 
-		return <UiScrollThumb {...props} />;
-	}
-}
+ScrollThumb.defaultProps = {
+	cbAlertThumb: nop
+};
 
 export default ScrollThumb;
 export {

--- a/packages/moonstone/Scrollable/ScrollThumb.js
+++ b/packages/moonstone/Scrollable/ScrollThumb.js
@@ -13,12 +13,9 @@ const nop = () => {};
  * @ui
  * @private
  */
-const ScrollThumb = forwardRef((props, ref) => {
-	const rest = Object.assign({}, props);
-	delete rest.cbAlertThumb;
-
+const ScrollThumb = forwardRef(({cbAlertThumb, ...rest}, ref) => {
 	useEffect (() => {
-		props.cbAlertThumb();
+		cbAlertThumb();
 	});
 
 	return <UiScrollThumb {...rest} ref={ref} />;

--- a/packages/moonstone/Scrollable/ScrollThumb.js
+++ b/packages/moonstone/Scrollable/ScrollThumb.js
@@ -1,6 +1,6 @@
 import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {useEffect, forwardRef} from 'react';
+import React, {forwardRef, useEffect} from 'react';
 
 const nop = () => {};
 

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 // import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {forwardRef, useImperativeHandle, useRef} from 'react';
+import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 
 import ScrollButtons from './ScrollButtons';
 import ScrollThumb from './ScrollThumb';
@@ -18,7 +18,7 @@ import componentCss from './Scrollbar.module.less';
  * @ui
  * @private
  */
-const ScrollbarBase = forwardRef((props, ref) => {
+const ScrollbarBase = memo(forwardRef((props, ref) => {
 	// Refs
 	const scrollbarRef = useRef();
 	const scrollButtonsRef = useRef();
@@ -66,7 +66,7 @@ const ScrollbarBase = forwardRef((props, ref) => {
 			)}
 		/>
 	);
-});
+}));
 
 ScrollbarBase.displayName = 'ScrollbarBase';
 

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -19,8 +19,11 @@ import componentCss from './Scrollbar.module.less';
  * @private
  */
 const ScrollbarBase = forwardRef((props, ref) => {
+	// Refs
 	const scrollbarRef = useRef();
 	const scrollButtonsRef = useRef();
+	// render
+	const {cbAlertThumb, clientSize, corner, vertical, ...rest} = props;
 
 	useImperativeHandle(ref, () => {
 		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = scrollbarRef.current;
@@ -37,9 +40,7 @@ const ScrollbarBase = forwardRef((props, ref) => {
 			},
 			focusOnButton
 		};
-	}, []);
-
-	const {cbAlertThumb, clientSize, corner, vertical, ...rest} = props;
+	}, [scrollbarRef, scrollButtonsRef]);
 
 	return (
 		<UiScrollbarBase

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -27,18 +27,18 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 
 	useImperativeHandle(ref, () => {
 		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = scrollbarRef.current;
-		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = scrollButtonsRef.current;
+		const {focusOnButton, isOneOfScrollButtonsFocused, updateButtons} = scrollButtonsRef.current;
 		return {
+			focusOnButton,
 			getContainerRef,
+			isOneOfScrollButtonsFocused,
 			showThumb,
 			startHidingThumb,
 			uiUpdate,
-			isOneOfScrollButtonsFocused,
 			update: (bounds) => {
 				updateButtons(bounds);
 				uiUpdate(bounds);
-			},
-			focusOnButton
+			}
 		};
 	}, [scrollbarRef, scrollButtonsRef]);
 
@@ -49,21 +49,25 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 			css={componentCss}
 			ref={scrollbarRef}
 			vertical={vertical}
-			childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
-				<ScrollButtons
-					{...rest}
-					ref={scrollButtonsRef}
-					vertical={vertical}
-					thumbRenderer={() => ( // eslint-disable-line react/jsx-no-bind
-						<ScrollThumb
-							cbAlertThumb={cbAlertThumb}
-							key="thumb"
-							ref={thumbRef}
-							vertical={vertical}
-						/>
-					)}
-				/>
-			)}
+			childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
+				return (
+					<ScrollButtons
+						{...rest}
+						ref={scrollButtonsRef}
+						vertical={vertical}
+						thumbRenderer={() => { // eslint-disable-line react/jsx-no-bind
+							return (
+								<ScrollThumb
+									cbAlertThumb={cbAlertThumb}
+									key="thumb"
+									ref={thumbRef}
+									vertical={vertical}
+								/>
+							);
+						}}
+					/>
+				);
+			}}
 		/>
 	);
 }));

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -1,11 +1,11 @@
-import ApiDecorator from '@enact/core/internal/ApiDecorator';
+// import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 
 import ScrollButtons from './ScrollButtons';
 import ScrollThumb from './ScrollThumb';
-import Skinnable from '../Skinnable';
+// import Skinnable from '../Skinnable';
 
 import componentCss from './Scrollbar.module.less';
 
@@ -18,131 +18,120 @@ import componentCss from './Scrollbar.module.less';
  * @ui
  * @private
  */
-class ScrollbarBase extends Component {
-	static displayName = 'ScrollbarBase'
+const ScrollbarBase = forwardRef((props, ref) => {
+	const scrollbarRef = useRef();
+	const scrollButtonsRef = useRef();
 
-	static propTypes = /** @lends moonstone/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		cbAlertThumb: PropTypes.func,
-
-		/**
-		 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
-		 *
-		 * @type {Object}
-		 * @property {Number}    clientHeight    The client height of the list.
-		 * @property {Number}    clientWidth    The client width of the list.
-		 * @public
-		 */
-		clientSize: PropTypes.shape({
-			clientHeight: PropTypes.number.isRequired,
-			clientWidth: PropTypes.number.isRequired
-		}),
-
-		/**
-		 * Adds the corner between vertical and horizontal scrollbars.
-		 *
-		 * @type {Booelan}
-		 * @default false
-		 * @public
-		 */
-		corner: PropTypes.bool,
-
-		/**
-		 * `true` if rtl, `false` if ltr.
-		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		rtl: PropTypes.bool,
-
-		/**
-		 * Registers the ScrollButtons component with an
-		 * {@link core/internal/ApiDecorator.ApiDecorator}.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		setApiProvider: PropTypes.func,
-
-		/**
-		 * The scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
-
-	static defaultProps = {
-		corner: false,
-		vertical: true
-	}
-
-	constructor (props) {
-		super(props);
-
-		if (props.setApiProvider) {
-			props.setApiProvider(this);
-		}
-
-		this.scrollbarRef = React.createRef();
-		this.scrollButtonsRef = React.createRef();
-	}
-
-	componentDidMount () {
-		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = this.scrollbarRef.current;
-
-		this.getContainerRef = getContainerRef;
-		this.showThumb = showThumb;
-		this.startHidingThumb = startHidingThumb;
-		this.uiUpdate = uiUpdate;
-
-		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = this.scrollButtonsRef.current;
-
-		this.isOneOfScrollButtonsFocused = isOneOfScrollButtonsFocused;
-		this.update = (bounds) => {
-			updateButtons(bounds);
-			this.uiUpdate(bounds);
+	useImperativeHandle(ref, () => {
+		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = scrollbarRef.current;
+		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = scrollButtonsRef.current;
+		return {
+			getContainerRef,
+			showThumb,
+			startHidingThumb,
+			uiUpdate,
+			isOneOfScrollButtonsFocused,
+			update: (bounds) => {
+				updateButtons(bounds);
+				uiUpdate(bounds);
+			},
+			focusOnButton
 		};
-		this.focusOnButton = focusOnButton;
-	}
+	}, []);
 
-	render () {
-		const {cbAlertThumb, clientSize, corner, vertical, ...rest} = this.props;
+	const {cbAlertThumb, clientSize, corner, vertical, ...rest} = props;
 
-		return (
-			<UiScrollbarBase
-				corner={corner}
-				clientSize={clientSize}
-				css={componentCss}
-				ref={this.scrollbarRef}
-				vertical={vertical}
-				childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
-					<ScrollButtons
-						{...rest}
-						ref={this.scrollButtonsRef}
-						vertical={vertical}
-						thumbRenderer={() => ( // eslint-disable-line react/jsx-no-bind
-							<ScrollThumb
-								cbAlertThumb={cbAlertThumb}
-								key="thumb"
-								ref={thumbRef}
-								vertical={vertical}
-							/>
-						)}
-					/>
-				)}
-			/>
-		);
-	}
-}
+	return (
+		<UiScrollbarBase
+			corner={corner}
+			clientSize={clientSize}
+			css={componentCss}
+			ref={scrollbarRef}
+			vertical={vertical}
+			childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
+				<ScrollButtons
+					{...rest}
+					ref={scrollButtonsRef}
+					vertical={vertical}
+					thumbRenderer={() => ( // eslint-disable-line react/jsx-no-bind
+						<ScrollThumb
+							cbAlertThumb={cbAlertThumb}
+							key="thumb"
+							ref={thumbRef}
+							vertical={vertical}
+						/>
+					)}
+				/>
+			)}
+		/>
+	);
+});
+
+ScrollbarBase.displayName = 'ScrollbarBase';
+
+ScrollbarBase.propTypes = /** @lends moonstone/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	cbAlertThumb: PropTypes.func,
+
+	/**
+	 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
+	 *
+	 * @type {Object}
+	 * @property {Number}    clientHeight    The client height of the list.
+	 * @property {Number}    clientWidth    The client width of the list.
+	 * @public
+	 */
+	clientSize: PropTypes.shape({
+		clientHeight: PropTypes.number.isRequired,
+		clientWidth: PropTypes.number.isRequired
+	}),
+
+	/**
+	 * Adds the corner between vertical and horizontal scrollbars.
+	 *
+	 * @type {Booelan}
+	 * @default false
+	 * @public
+	 */
+	corner: PropTypes.bool,
+
+	/**
+	 * `true` if rtl, `false` if ltr.
+	 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+	 *
+	 * @type {Boolean}
+	 * @private
+	 */
+	rtl: PropTypes.bool,
+
+	/**
+	 * Registers the ScrollButtons component with an
+	 * {@link core/internal/ApiDecorator.ApiDecorator}.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	// setApiProvider: PropTypes.func,
+
+	/**
+	 * The scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollbarBase.defaultProps = {
+	corner: false,
+	vertical: true
+};
 
 /**
  * A Moonstone-styled scroll bar. It is used in [Scrollable]{@link moonstone/Scrollable.Scrollable}.
@@ -152,6 +141,7 @@ class ScrollbarBase extends Component {
  * @ui
  * @private
  */
+/* TODO: Is it possible to use ApiDecorator?
 const Scrollbar = ApiDecorator(
 	{api: [
 		'focusOnButton',
@@ -162,6 +152,8 @@ const Scrollbar = ApiDecorator(
 		'update'
 	]}, Skinnable(ScrollbarBase)
 );
+*/
+const Scrollbar = ScrollbarBase;
 Scrollbar.displayName = 'Scrollbar';
 
 export default Scrollbar;

--- a/packages/ui/Scrollable/ScrollThumb.js
+++ b/packages/ui/Scrollable/ScrollThumb.js
@@ -1,50 +1,41 @@
-import kind from '@enact/core/kind';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {forwardRef} from 'react';
 
 import css from './ScrollThumb.module.less';
 
 /**
  * An unstyled scroll thumb without any behavior.
  *
- * @class ScrollThumb
+ * @function ScrollThumb
  * @memberof ui/Scrollable
  * @ui
  * @private
  */
-const ScrollThumb = kind({
-	name: 'ui:ScrollThumb',
+const ScrollThumb = forwardRef((props, ref) => {
+	const
+		{vertical, ...rest} = props,
+		className = classNames(css.scrollThumb, vertical ? css.vertical : null);
 
-	propTypes: /** @lends ui/Scrollable.ScrollThumb.prototype */ {
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	},
-
-	defaultProps: {
-		vertical: true
-	},
-
-	styles: {
-		css,
-		className: 'scrollThumb'
-	},
-
-	computed: {
-		className: ({vertical, styler}) => styler.append({vertical})
-	},
-
-	render: (props) => {
-		delete props.vertical;
-
-		return <div {...props} />;
-	}
+	return <div {...rest} className={className} ref={ref} />;
 });
+
+ScrollThumb.displayName = 'ui:ScrollThumb';
+
+ScrollThumb.propTypes = /** @lends ui/Scrollable.ScrollThumb.prototype */ {
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollThumb.defaultProps = {
+	vertical: true
+};
 
 export default ScrollThumb;
 export {

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -46,7 +46,7 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 	// Refs
 	const containerRef = useRef();
 	const thumbRef = useRef();
-	const hideThumbJob = useRef(new Job(hideThumb, thumbHidingDelay));
+	const hideThumbJob = useRef(null);
 	// Render
 	const
 		{childRenderer, className, corner, css, vertical, ...rest} = props,
@@ -58,6 +58,8 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 		);
 
 	delete rest.clientSize;
+
+	hideThumbJob.current = hideThumbJob.current || new Job(hideThumb, thumbHidingDelay);
 
 	function hideThumb () {
 		removeClass(thumbRef.current, css.thumbShown);

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
-import React, {forwardRef, useEffect, useRef, useImperativeHandle} from 'react';
+import React, {forwardRef, useRef, useImperativeHandle} from 'react';
 import ReactDOM from 'react-dom';
 
 import ri from '../resolution';
@@ -20,14 +20,14 @@ function useHidingThumbJob (callback, timeout) {
 
 	React.useEffect(() => {
 		return () => state.job.stop();
-	}, []);
+	}, [state.job]);
 
 	return state.job;
 }
 
 const addRemoveClass = (element, className, operation) => {
 	ReactDOM.findDOMNode(element).classList[operation](className); // eslint-disable-line react/no-find-dom-node
-}
+};
 
 /*
  * Set CSS Varaible value.
@@ -55,23 +55,34 @@ const ScrollbarBase = forwardRef((props, ref) => {
 	const thumbRef = useRef();
 	// Job
 	const hideThumbJob = useHidingThumbJob(hideThumb, thumbHidingDelay);
+	// Render
+	const
+		{childRenderer, className, corner, css, vertical, ...rest} = props,
+		containerClassName = classNames(
+			className,
+			css.scrollbar,
+			corner && css.corner,
+			vertical ? css.vertical : css.horizontal
+		);
+
+	delete rest.clientSize;
 
 	function hideThumb () {
-		addRemoveClass(thumbRef.current, props.css.thumbShown, 'remove');
+		addRemoveClass(thumbRef.current, css.thumbShown, 'remove');
 	}
 
 	useImperativeHandle(ref, () => ({
 		getContainerRef: () => (containerRef),
 		showThumb: () => {
 			hideThumbJob.stop();
-			addRemoveClass(thumbRef.current, props.css.thumbShown, 'add');
+			addRemoveClass(thumbRef.current, css.thumbShown, 'add');
 		},
 		startHidingThumb: () => {
 			hideThumbJob.start();
 		},
 		update: (bounds) => {
 			const
-				{vertical, clientSize} = props,
+				{clientSize} = props,
 				primaryDimenstion = vertical ? 'clientHeight' : 'clientWidth',
 				trackSize = clientSize ? clientSize[primaryDimenstion] : containerRef.current[primaryDimenstion],
 				scrollViewSize = vertical ? bounds.clientHeight : bounds.clientWidth,
@@ -85,17 +96,6 @@ const ScrollbarBase = forwardRef((props, ref) => {
 			setCSSVariable(thumbRef.current, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
 		}
 	}));
-
-	const
-		{childRenderer, className, corner, css, vertical, ...rest} = props,
-		containerClassName = classNames(
-			className,
-			css.scrollbar,
-			corner && css.corner,
-			vertical ? css.vertical : css.horizontal
-		);
-
-	delete rest.clientSize;
 
 	return (
 		<div {...rest} className={containerClassName} ref={containerRef}>

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
-import React, {PureComponent, Component} from 'react';
+import React, {forwardRef, useEffect, useRef, useImperativeHandle} from 'react';
 import ReactDOM from 'react-dom';
 
 import ri from '../resolution';
@@ -29,165 +29,164 @@ const setCSSVariable = (element, variable, value) => {
 /**
  * An unstyled base component for a scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
  *
- * @class ScrollbarBase
+ * @function ScrollbarBase
  * @memberof ui/Scrollable
  * @ui
  * @private
  */
-class ScrollbarBase extends PureComponent {
-	static displayName = 'ui:Scrollbar'
+const ScrollbarBase = forwardRef((props, ref) => {
+	const containerRef = useRef();
+	const thumbRef = useRef();
+	const variables = useRef({
+		hideThumbJob: null,
+		minThumbSizeRatio: 0
+	}).current;
 
-	static propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * The render function for child.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		childRenderer: PropTypes.func.isRequired,
+	useEffect(() => {
+		variables.hideThumbJob = new Job(hideThumb, thumbHidingDelay);
 
-		/**
-		 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
-		 *
-		 * @type {Object}
-		 * @property {Number}    clientHeight    The client height of the list.
-		 * @property {Number}    clientWidth    The client width of the list.
-		 * @public
-		 */
-		clientSize: PropTypes.shape({
-			clientHeight: PropTypes.number.isRequired,
-			clientWidth: PropTypes.number.isRequired
-		}),
+		return () => {
+			variables.hideThumbJob.stop();
+		};
+	}, [variables.hideThumbJob]);
 
-		/**
-		 * If `true`, add the corner between vertical and horizontal scrollbars.
-		 *
-		 * @type {Booelan}
-		 * @default false
-		 * @public
-		 */
-		corner: PropTypes.bool,
+	useEffect(() => {
+		calculateMetrics();
+	});
 
-		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal Elements and states of this component.
-		 *
-		 * The following classes are supported:
-		 *
-		 * * `scrollbar` - The scrollbar component class
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		css: PropTypes.object,
-
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
-
-	static defaultProps = {
-		corner: false,
-		css: componentCss,
-		vertical: true
-	}
-
-	constructor (props) {
-		super(props);
-
-		this.containerRef = React.createRef();
-		this.thumbRef = React.createRef();
-	}
-
-	componentDidMount () {
-		this.calculateMetrics();
-	}
-
-	componentDidUpdate () {
-		this.calculateMetrics();
-	}
-
-	componentWillUnmount () {
-		this.hideThumbJob.stop();
-	}
-
-	minThumbSizeRatio = 0
-	ignoreMode = false
-
-	update = (bounds) => {
-		const
-			{vertical} = this.props,
-			{clientWidth, clientHeight, scrollWidth, scrollHeight, scrollLeft, scrollTop} = bounds,
-			clientSize = vertical ? clientHeight : clientWidth,
-			scrollSize = vertical ? scrollHeight : scrollWidth,
-			scrollOrigin = vertical ? scrollTop : scrollLeft,
-
-			thumbSizeRatioBase = (clientSize / scrollSize),
-			scrollThumbPositionRatio = (scrollOrigin / (scrollSize - clientSize)),
-			scrollThumbSizeRatio = Math.max(this.minThumbSizeRatio, Math.min(1, thumbSizeRatioBase));
-
-		setCSSVariable(this.thumbRef.current, '--scrollbar-size-ratio', scrollThumbSizeRatio);
-		setCSSVariable(this.thumbRef.current, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
-	}
-
-	showThumb = () => {
-		this.hideThumbJob.stop();
-		ReactDOM.findDOMNode(this.thumbRef.current).classList.add(this.props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
-	}
-
-	startHidingThumb = () => {
-		this.hideThumbJob.start();
-	}
-
-	hideThumb = () => {
-		ReactDOM.findDOMNode(this.thumbRef.current).classList.remove(this.props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
-	}
-
-	hideThumbJob = new Job(this.hideThumb.bind(this), thumbHidingDelay);
-
-	calculateMetrics = () => {
-		const primaryDimenstion = this.props.vertical ? 'clientHeight' : 'clientWidth';
+	function calculateMetrics () {
+		const primaryDimenstion = props.vertical ? 'clientHeight' : 'clientWidth';
 		let trackSize;
 
-		if (this.props.clientSize) {
-			trackSize = this.props.clientSize[primaryDimenstion];
+		if (props.clientSize) {
+			trackSize = props.clientSize[primaryDimenstion];
 		} else {
-			trackSize = this.containerRef.current[primaryDimenstion];
+			trackSize = containerRef.current[primaryDimenstion];
 		}
 
-		this.minThumbSizeRatio = ri.scale(minThumbSize) / trackSize;
+		variables.minThumbSizeRatio = ri.scale(minThumbSize) / trackSize;
 	}
 
-	getContainerRef = () => (this.containerRef)
+	function hideThumb () {
+		ReactDOM.findDOMNode(thumbRef.current).classList.remove(props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
+	}
 
-	render () {
-		const
-			{childRenderer, className, corner, css, vertical, ...rest} = this.props,
-			containerClassName = classNames(
-				className,
-				css.scrollbar,
-				corner ? css.corner : null,
-				vertical ? css.vertical : css.horizontal
-			);
+	function getContainerRef () {
+		return containerRef;
+	}
 
-		delete rest.clientSize;
+	useImperativeHandle(ref, () => ({
+		showThumb: () => {
+			if (variables.hideThumbJob) {
+				variables.hideThumbJob.stop();
+			}
+			ReactDOM.findDOMNode(thumbRef.current).classList.add(props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
+		},
+		startHidingThumb: () => {
+			if (variables.hideThumbJob) {
+				variables.hideThumbJob.start();
+			}
+		},
+		update: (bounds) => {
+			const
+				{vertical} = props,
+				{clientWidth, clientHeight, scrollWidth, scrollHeight, scrollLeft, scrollTop} = bounds,
+				clientSize = vertical ? clientHeight : clientWidth,
+				scrollSize = vertical ? scrollHeight : scrollWidth,
+				scrollOrigin = vertical ? scrollTop : scrollLeft,
 
-		return (
-			<div {...rest} className={containerClassName} ref={this.containerRef}>
-				{childRenderer({
-					getContainerRef: this.getContainerRef,
-					thumbRef: this.thumbRef
-				})}
-			</div>
+				thumbSizeRatioBase = (clientSize / scrollSize),
+				scrollThumbPositionRatio = (scrollOrigin / (scrollSize - clientSize)),
+				scrollThumbSizeRatio = Math.max(variables.minThumbSizeRatio, Math.min(1, thumbSizeRatioBase));
+
+			setCSSVariable(thumbRef.current, '--scrollbar-size-ratio', scrollThumbSizeRatio);
+			setCSSVariable(thumbRef.current, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
+		}
+	}));
+
+	const
+		{childRenderer, className, corner, css, vertical, ...rest} = props,
+		containerClassName = classNames(
+			className,
+			css.scrollbar,
+			corner ? css.corner : null,
+			vertical ? css.vertical : css.horizontal
 		);
-	}
-}
+
+	delete rest.clientSize;
+
+	return (
+		<div {...rest} className={containerClassName} ref={containerRef}>
+			{childRenderer({
+				getContainerRef,
+				thumbRef
+			})}
+		</div>
+	);
+});
+
+ScrollbarBase.displayName = 'ui:Scrollbar';
+
+ScrollbarBase.propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * The render function for child.
+	 *
+	 * @type {Function}
+	 * @required
+	 * @private
+	 */
+	childRenderer: PropTypes.func.isRequired,
+
+	/**
+	 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
+	 *
+	 * @type {Object}
+	 * @property {Number}    clientHeight    The client height of the list.
+	 * @property {Number}    clientWidth    The client width of the list.
+	 * @public
+	 */
+	clientSize: PropTypes.shape({
+		clientHeight: PropTypes.number.isRequired,
+		clientWidth: PropTypes.number.isRequired
+	}),
+
+	/**
+	 * If `true`, add the corner between vertical and horizontal scrollbars.
+	 *
+	 * @type {Booelan}
+	 * @default false
+	 * @public
+	 */
+	corner: PropTypes.bool,
+
+	/**
+	 * Customizes the component by mapping the supplied collection of CSS class names to the
+	 * corresponding internal Elements and states of this component.
+	 *
+	 * The following classes are supported:
+	 *
+	 * * `scrollbar` - The scrollbar component class
+	 *
+	 * @type {Object}
+	 * @public
+	 */
+	css: PropTypes.object,
+
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollbarBase.defaultProps = {
+	corner: false,
+	css: componentCss,
+	vertical: true
+};
 
 /**
  * An unstyled scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
@@ -197,53 +196,53 @@ class ScrollbarBase extends PureComponent {
  * @ui
  * @private
  */
-class Scrollbar extends Component {
-	static propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
+const Scrollbar = forwardRef((props, ref) => {
+	const scrollbarBaseRef = useRef(null);
 
-	static defaultProps = {
-		vertical: true
-	}
+	useImperativeHandle(ref, () => {
+		if (scrollbarBaseRef.current) {
+			const {getContainerRef, showThumb, startHidingThumb, update} = scrollbarBaseRef.current;
 
-	setApi = (ref) => {
-		if (ref) {
-			const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = ref;
-
-			this.getContainerRef = getContainerRef;
-			this.showThumb = showThumb;
-			this.startHidingThumb = startHidingThumb;
-			this.update = uiUpdate;
+			return {
+				getContainerRef,
+				showThumb,
+				startHidingThumb,
+				update
+			};
 		}
-	}
+	}, [scrollbarBaseRef]);
 
-	render () {
-		const {vertical} = this.props;
+	return (
+		<ScrollbarBase
+			{...props}
+			ref={scrollbarBaseRef}
+			childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
+				return (
+					<ScrollThumb
+						key="thumb"
+						ref={thumbRef}
+						vertical={props.vertical}
+					/>
+				);
+			}}
+		/>
+	);
+});
 
-		return (
-			<ScrollbarBase
-				{...this.props}
-				ref={this.setApi}
-				childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
-					return (
-						<ScrollThumb
-							key="thumb"
-							ref={thumbRef}
-							vertical={vertical}
-						/>
-					);
-				}}
-			/>
-		);
-	}
-}
+Scrollbar.propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+Scrollbar.defaultProps = {
+	vertical: true
+};
 
 export default Scrollbar;
 export {

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -66,9 +66,8 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 	}
 
 	useEffect(() => {
-		const job = hideThumbJob.current;
 		return () => {
-			job.stop();
+			hideThumbJob.current.stop();
 		};
 	}, []);
 
@@ -180,16 +179,14 @@ const Scrollbar = forwardRef((props, ref) => {
 	const scrollbarBaseRef = useRef(null);
 
 	useImperativeHandle(ref, () => {
-		if (scrollbarBaseRef.current) {
-			const {getContainerRef, showThumb, startHidingThumb, update} = scrollbarBaseRef.current;
+		const {getContainerRef, showThumb, startHidingThumb, update} = scrollbarBaseRef.current;
 
-			return {
-				getContainerRef,
-				showThumb,
-				startHidingThumb,
-				update
-			};
-		}
+		return {
+			getContainerRef,
+			showThumb,
+			startHidingThumb,
+			update
+		};
 	}, [scrollbarBaseRef]);
 
 	return (

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
-import React, {forwardRef, useRef, useImperativeHandle} from 'react';
+import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 import ReactDOM from 'react-dom';
 
 import ri from '../resolution';
@@ -25,8 +25,12 @@ function useHidingThumbJob (callback, timeout) {
 	return state.job;
 }
 
-const addRemoveClass = (element, className, operation) => {
-	ReactDOM.findDOMNode(element).classList[operation](className); // eslint-disable-line react/no-find-dom-node
+const addClass = (element, className) => {
+	ReactDOM.findDOMNode(element).classList.add(className); // eslint-disable-line react/no-find-dom-node
+};
+
+const removeClass = (element, className) => {
+	ReactDOM.findDOMNode(element).classList.remove(className); // eslint-disable-line react/no-find-dom-node
 };
 
 /*
@@ -49,7 +53,7 @@ const setCSSVariable = (element, variable, value) => {
  * @ui
  * @private
  */
-const ScrollbarBase = forwardRef((props, ref) => {
+const ScrollbarBase = memo(forwardRef((props, ref) => {
 	// Refs
 	const containerRef = useRef();
 	const thumbRef = useRef();
@@ -68,14 +72,14 @@ const ScrollbarBase = forwardRef((props, ref) => {
 	delete rest.clientSize;
 
 	function hideThumb () {
-		addRemoveClass(thumbRef.current, css.thumbShown, 'remove');
+		removeClass(thumbRef.current, css.thumbShown);
 	}
 
 	useImperativeHandle(ref, () => ({
 		getContainerRef: () => (containerRef),
 		showThumb: () => {
 			hideThumbJob.stop();
-			addRemoveClass(thumbRef.current, css.thumbShown, 'add');
+			addClass(thumbRef.current, css.thumbShown);
 		},
 		startHidingThumb: () => {
 			hideThumbJob.start();
@@ -99,12 +103,10 @@ const ScrollbarBase = forwardRef((props, ref) => {
 
 	return (
 		<div {...rest} className={containerClassName} ref={containerRef}>
-			{childRenderer({
-				thumbRef
-			})}
+			{childRenderer({thumbRef})}
 		</div>
 	);
-});
+}));
 
 ScrollbarBase.displayName = 'ui:Scrollbar';
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Convert scrollbar and scroll thumb components into functional components

### Links
[//]: # (Related issues, references)
PLAT-98572

### Comments
Note that this PR may not work until all related decoupling works get together.
Note: the target branch/repo may be changed later. This PR is for review for now.