### PR TITLE
PLAT-98204: Resolve dependency problem between Moonstone Scroller React components

### DIFF
--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -194,6 +194,30 @@ const ScrollableBase = (props) => {
 	} = props;
 
 	useEffect(() => {
+		const pageKeyHandlerObj = {scrollByPageOnPointerMode};
+		function createOverscrollJob (orientation, edge) {
+			if (!variables.current.overscrollJobs[orientation][edge]) {
+				// TODO : check side-effect about this binding
+				// origin-code : `applyOverscrollEffect.bind(this)`
+				variables.current.overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect, overscrollTimeout);
+			}
+		}
+
+		// Only intended to be used within componentDidMount, this method will fetch the last stored
+		// scroll position from SharedState and scroll (without animation) to that position
+		function restoreScrollPosition () {
+			const {id} = props;
+			if (id && context && context.get) {
+				const scrollPosition = context.get(`${id}.scrollPosition`);
+				if (scrollPosition) {
+					uiRef.current.scrollTo({
+						position: scrollPosition,
+						animate: false
+					});
+				}
+			}
+		}
+
 		// componentDidMount
 		createOverscrollJob('horizontal', 'before');
 		createOverscrollJob('horizontal', 'after');
@@ -203,13 +227,11 @@ const ScrollableBase = (props) => {
 
 		restoreScrollPosition();
 
-		// TODO: Replace `this` to something.
-		scrollables.set(/* this */null, uiRef.current.containerRef.current);
+		scrollables.set(pageKeyHandlerObj, uiRef.current.containerRef.current);
 
 		// componentWillUnmount
 		return () => {
-			// TODO: Replace `this` to something.
-			scrollables.delete(/* this */ null);
+			scrollables.delete(pageKeyHandlerObj);
 
 			stopOverscrollJob('horizontal', 'before');
 			stopOverscrollJob('horizontal', 'after');
@@ -222,21 +244,6 @@ const ScrollableBase = (props) => {
 		configureSpotlightContainer(props);
 	}, [props['data-spotlight-id'], props.focusableScrollbar]);	// TODO : Handle exhaustive-deps ESLint rule.
 
-
-	// Only intended to be used within componentDidMount, this method will fetch the last stored
-	// scroll position from SharedState and scroll (without animation) to that position
-	function restoreScrollPosition () {
-		const {id} = props;
-		if (id && context && context.get) {
-			const scrollPosition = context.get(`${id}.scrollPosition`);
-			if (scrollPosition) {
-				uiRef.current.scrollTo({
-					position: scrollPosition,
-					animate: false
-				});
-			}
-		}
-	}
 
 	function isScrollButtonFocused () {
 		const {horizontalScrollbarRef: h, verticalScrollbarRef: v} = uiRef.current;
@@ -683,14 +690,6 @@ const ScrollableBase = (props) => {
 			if (type === overscrollTypeOnce) {
 				variables.current.overscrollJobs[orientation][edge].start(orientation, edge, overscrollTypeDone, 0);
 			}
-		}
-	}
-
-	function createOverscrollJob (orientation, edge) {
-		if (!variables.current.overscrollJobs[orientation][edge]) {
-			// TODO : check side-effect about this binding
-			// origin-code : `applyOverscrollEffect.bind(this)`
-			variables.current.overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect, overscrollTimeout);
 		}
 	}
 

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -195,6 +195,7 @@ const ScrollableBase = (props) => {
 
 	useEffect(() => {
 		const pageKeyHandlerObj = {scrollByPageOnPointerMode};
+
 		function createOverscrollJob (orientation, edge) {
 			if (!variables.current.overscrollJobs[orientation][edge]) {
 				// TODO : check side-effect about this binding

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -7,7 +7,7 @@
  */
 
 import classNames from 'classnames';
-import handle, {forward} from '@enact/core/handle';
+import {forward} from '@enact/core/handle';
 import platform from '@enact/core/platform';
 import {onWindowReady} from '@enact/core/snapshot';
 import {clamp, Job} from '@enact/core/util';
@@ -364,6 +364,11 @@ const ScrollableBase = (props) => {
 	}
 
 	function onFocus (ev) {
+		if (!childRef.current) {
+			// TODO : On initial load,`childRef.current` is null
+			return;
+		}
+
 		const
 			{isDragging} = uiRef.current,
 			shouldPreventScrollByFocus = childRef.current.shouldPreventScrollByFocus ?
@@ -463,7 +468,6 @@ const ScrollableBase = (props) => {
 		}
 	}
 
-	// TODO PLAT-98204.
 	function scrollByPageOnPointerMode (ev) {
 		const {keyCode, repeat} = ev;
 		forward('onKeyDown', ev, props);
@@ -684,7 +688,9 @@ const ScrollableBase = (props) => {
 
 	function createOverscrollJob (orientation, edge) {
 		if (!variables.current.overscrollJobs[orientation][edge]) {
-			variables.current.overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect.bind(this), overscrollTimeout);
+			// TODO : check side-effect about this binding
+			// origin-code : `applyOverscrollEffect.bind(this)`
+			variables.current.overscrollJobs[orientation][edge] = new Job(applyOverscrollEffect, overscrollTimeout);
 		}
 	}
 
@@ -792,13 +798,15 @@ const ScrollableBase = (props) => {
 		}
 	}
 
-	const handleScroll = handle(
-		forward('onScroll'),
-		(ev, {id}, context) => id && context && context.set,
-		({scrollLeft: x, scrollTop: y}, {id}, context) => {
+	function handleScroll (ev) {
+		const {scrollLeft: x, scrollTop: y} = ev;
+		const {id} = props;
+		forward('onScroll', ev, props);
+		if (id && context && context.set) {
+			context.set(ev, props);
 			context.set(`${id}.scrollPosition`, {x, y});
 		}
-	);
+	}
 
 	// render
 	const

--- a/packages/moonstone/Scroller/Scroller.js
+++ b/packages/moonstone/Scroller/Scroller.js
@@ -21,7 +21,7 @@ import {getRect} from '@enact/spotlight/src/utils';
 import ri from '@enact/ui/resolution';
 import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useImperativeHandle, useRef} from 'react';
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useRef} from 'react';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -323,7 +323,7 @@ let ScrollerBase = (props, reference) => {
 	);
 };
 
-ScrollerBase = React.forwardRef(ScrollerBase);
+ScrollerBase = forwardRef(ScrollerBase);
 ScrollerBase.displayName = 'ScrollerBase';
 ScrollerBase.propTypes = /** @lends moonstone/Scroller.ScrollerBase.prototype */ {
 	/**

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,7 +7,7 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useImperativeHandle, useRef} from 'react';
 import warning from 'warning';
 
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
@@ -44,7 +44,7 @@ const
 const VirtualListBaseFactory = (type) => {
 	const UiBase = (type === JS) ? UiVirtualListBase : UiVirtualListBaseNative;
 
-	const VirtualListCore = (props) => {
+	let VirtualListCore = (props, refernce) => {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
 		// Instance variables
@@ -64,6 +64,15 @@ const VirtualListBaseFactory = (type) => {
 		if (variables.current.pause === null) {
 			variables.current.pause = new Pause('VirtualListBase');
 		}
+
+		useImperativeHandle(refernce, () => ({
+			calculatePositionOnFocus,
+			shouldPreventScrollByFocus,
+			shouldPreventOverscrollEffect,
+			setLastFocusedNode,
+			getScrollBounds,
+			setContainerDisabled
+		}));
 
 		// Constructor
 		const {spotlightId} = props;
@@ -543,8 +552,6 @@ const VirtualListBaseFactory = (type) => {
 		/**
 		 * calculator
 		 */
-
-		// TODO PLAT-98204.
 		function calculatePositionOnFocus ({item, scrollPosition = variables.current.uiRefCurrent.scrollPosition}) {
 			const
 				{pageScroll} = props,
@@ -590,17 +597,14 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		// TODO PLAT-98204.
 		function shouldPreventScrollByFocus () {
 			return ((type === JS) ? (variables.current.isScrolledBy5way) : (variables.current.isScrolledBy5way || variables.current.isScrolledByJump));
 		}
 
-		// TODO PLAT-98204.
 		function shouldPreventOverscrollEffect () {
 			return variables.current.isWrappedBy5way;
 		}
 
-		// TODO PLAT-98204.
 		function setLastFocusedNode (node) {
 			variables.current.lastFocusedIndex = node.dataset && getNumberValue(node.dataset.index);
 		}
@@ -614,7 +618,6 @@ const VirtualListBaseFactory = (type) => {
 			));
 		}
 
-		// TODO PLAT-98204.
 		function getScrollBounds () {
 			return variables.current.uiRefCurrent.getScrollBounds();
 		}
@@ -668,6 +671,7 @@ const VirtualListBaseFactory = (type) => {
 		);
 	};
 
+	VirtualListCore = React.forwardRef(VirtualListCore);
 	VirtualListCore.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
 		/**
 		 * The `render` function called for each item in the list.

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -44,7 +44,7 @@ const
 const VirtualListBaseFactory = (type) => {
 	const UiBase = (type === JS) ? UiVirtualListBase : UiVirtualListBaseNative;
 
-	let VirtualListCore = (props, refernce) => {
+	let VirtualListCore = (props, reference) => {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
 		// Instance variables
@@ -64,9 +64,11 @@ const VirtualListBaseFactory = (type) => {
 		if (variables.current.pause === null) {
 			variables.current.pause = new Pause('VirtualListBase');
 		}
+		const pause = variables.current.pause;
 
-		useImperativeHandle(refernce, () => ({
+		useImperativeHandle(reference, () => ({
 			calculatePositionOnFocus,
+			focusByIndex,
 			shouldPreventScrollByFocus,
 			shouldPreventOverscrollEffect,
 			setLastFocusedNode,
@@ -81,6 +83,7 @@ const VirtualListBaseFactory = (type) => {
 			// componentDidMount
 			const containerNode = variables.current.uiRefCurrent.containerRef.current;
 			const scrollerNode = document.querySelector(`[data-spotlight-id="${props.spotlightId}"]`);
+			const preventScrollHandler = variables.current.preventScroll;
 
 			if (type === JS) {
 				// prevent native scrolling by Spotlight
@@ -90,7 +93,7 @@ const VirtualListBaseFactory = (type) => {
 				};
 
 				if (containerNode && containerNode.addEventListener) {
-					containerNode.addEventListener('scroll', variables.current.preventScroll);
+					containerNode.addEventListener('scroll', preventScrollHandler);
 				}
 			}
 
@@ -104,7 +107,7 @@ const VirtualListBaseFactory = (type) => {
 				if (type === JS) {
 					// remove a function for preventing native scrolling by Spotlight
 					if (containerNode && containerNode.removeEventListener) {
-						containerNode.removeEventListener('scroll', variables.current.preventScroll);
+						containerNode.removeEventListener('scroll', preventScrollHandler);
 					}
 				}
 
@@ -113,7 +116,7 @@ const VirtualListBaseFactory = (type) => {
 					scrollerNode.removeEventListener('keyup', onKeyUp, {capture: true});
 				}
 
-				variables.current.pause.resume();
+				pause.resume();
 				SpotlightAccelerator.reset();
 
 				setContainerDisabled(false);
@@ -125,7 +128,7 @@ const VirtualListBaseFactory = (type) => {
 			configureSpotlight();
 		}, [props.spotlightId]);	// TODO : Handle exhaustive-deps ESLint rule.
 
-		useEffect(restoreFocus);	// TODO : Handle exhaustive-deps ESLint rule.
+		useEffect(restoreFocus);
 
 		function setContainerDisabled (bool) {
 			const containerNode = document.querySelector(`[data-spotlight-id="${spotlightId}"]`);
@@ -314,7 +317,7 @@ const VirtualListBaseFactory = (type) => {
 						variables.current.uiRefCurrent.containerRef.current.querySelector(`[data-index='${nextIndex}']${spottableSelector}`) == null
 					)) {
 						if (wrap === true) {
-							variables.current.pause.pause();
+							pause.pause();
 							target.blur();
 						} else {
 							focusByIndex(nextIndex);

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -7,7 +7,7 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import {VirtualListBase as UiVirtualListBase, VirtualListBaseNative as UiVirtualListBaseNative} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
-import React, {useEffect, useImperativeHandle, useRef} from 'react';
+import React, {forwardRef, useEffect, useImperativeHandle, useRef} from 'react';
 import warning from 'warning';
 
 import {Scrollable, dataIndexAttribute} from '../Scrollable';
@@ -529,7 +529,7 @@ const VirtualListBaseFactory = (type) => {
 				!isPlaceholderFocused()
 			) {
 				const node = variables.current.uiRefCurrent.containerRef.current.querySelector(
-						`[data-spotlight-id="${spotlightId}"] [data-index="${variables.current.preservedIndex}"]`
+					`[data-spotlight-id="${spotlightId}"] [data-index="${variables.current.preservedIndex}"]`
 				);
 
 				if (node) {
@@ -674,7 +674,7 @@ const VirtualListBaseFactory = (type) => {
 		);
 	};
 
-	VirtualListCore = React.forwardRef(VirtualListCore);
+	VirtualListCore = forwardRef(VirtualListCore);
 	VirtualListCore.propTypes = /** @lends moonstone/VirtualList.VirtualListBase.prototype */ {
 		/**
 		 * The `render` function called for each item in the list.

--- a/packages/moonstone/VirtualList/VirtualListBase.js
+++ b/packages/moonstone/VirtualList/VirtualListBase.js
@@ -69,6 +69,7 @@ const VirtualListBaseFactory = (type) => {
 		useImperativeHandle(reference, () => ({
 			calculatePositionOnFocus,
 			focusByIndex,
+			focusOnNode,
 			shouldPreventScrollByFocus,
 			shouldPreventOverscrollEffect,
 			setLastFocusedNode,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Resolve a problem about component method accessing using ref.
This problem cause by PLAT-98201.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

We have converted 4 moonstone React components to functional component on PLAT-98201.
But there was many dependency on class instance. 
(ex, Scrollable call shouldPreventScrollByFocus() in  virtualListBase class using childRef.current.shouldPreventScrollByFocus())
It cause many console error, and some operations did not work.
I  used `useImperativeHandle` to access to functional component method on Moonstone functional component.

1. Use `useImperativeHandle`
2. Solve binding problem on `Scrollable`. 
3. Avoid a error of empty ref on initial loading. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I avoid initial empty ref problem by checking null on Scrollable.
Operation seems there is no error now, but I left a annotation using TODO.

### Links
[//]: # (Related issues, references)


### Comments
