### PR TITLE
PLAT-98876: Change `ui/Button` of ARIA structure to support touch accessibility

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -161,6 +161,9 @@ const ButtonBase = kind({
 	},
 
 	computed: {
+		ariaLabel: ({children}) => {
+			return typeof children === 'string' ? children : null;
+		},
 		className: ({icon, minWidth, pressed, selected, size, styler}) => styler.append({
 			hasIcon: (!!icon),
 			minWidth,
@@ -174,7 +177,7 @@ const ButtonBase = kind({
 		}
 	},
 
-	render: ({children, css, decoration, disabled, icon, ...rest}) => {
+	render: ({ariaLabel, children, css, decoration, disabled, icon, ...rest}) => {
 		delete rest.iconComponent;
 		delete rest.minWidth;
 		delete rest.pressed;
@@ -182,12 +185,12 @@ const ButtonBase = kind({
 		delete rest.size;
 
 		return (
-			<div role="button" {...rest} aria-disabled={disabled} disabled={disabled}>
+			<div role="button" aria-label={ariaLabel} {...rest} aria-disabled={disabled} disabled={disabled}>
 				{decoration ? (
 					<div className={css.decoration}>{decoration}</div>
 				) : null}
 				<div className={css.bg} />
-				<div className={css.client}>{icon}{children}</div>
+				<div className={css.client} aria-hidden={!!ariaLabel}>{icon}{children}</div>
 			</div>
 		);
 	}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Marquee` to not double aria readout for marqueeing contents
 
+### Changed
+
+- `ui/Button` of ARIA structure to support touch accessibility
+
 ## [3.2.4] - 2019-11-07
 
 ### Fixed


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- Touching the content area of the button ignores the button role and only reads the content.
- Clicking the button (double tap for GMRSI VVO) reads the button's contents.


### Resolution
- Put aria-hidden in the button's content area, and put the content in aria-label. If there is a react element other than string in the content like Moonstone, it is excluded(Line 165).


### Additional Considerations