### PR TITLE
PLAT-98572: Converted moonstone scrollbar components into function components

### DIFF
--- a/packages/moonstone/Scrollable/ScrollThumb.js
+++ b/packages/moonstone/Scrollable/ScrollThumb.js
@@ -1,45 +1,41 @@
 import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {forwardRef, useEffect} from 'react';
 
 const nop = () => {};
 
 /**
  * A Moonstone-styled scroll thumb with moonstone behavior
  *
- * @class ScrollThumb
+ * @function ScrollThumb
  * @memberof moonstone/Scrollable
  * @extends ui/Scrollable/ScrollThumb
  * @ui
  * @private
  */
-class ScrollThumb extends Component {
-	static propTypes = /** @lends moonstone/Scrollable.ScrollThumb.prototype */ {
-		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		cbAlertThumb: PropTypes.func
-	}
+const ScrollThumb = forwardRef(({cbAlertThumb, ...rest}, ref) => {
+	useEffect (() => {
+		cbAlertThumb();
+	});
 
-	static defaultProps = {
-		cbAlertThumb: nop
-	}
+	return <UiScrollThumb {...rest} ref={ref} />;
+});
 
-	componentDidUpdate () {
-		this.props.cbAlertThumb();
-	}
+ScrollThumb.displayName = 'ScrollThumb';
 
-	render () {
-		const props = Object.assign({}, this.props);
+ScrollThumb.propTypes = /** @lends moonstone/Scrollable.ScrollThumb.prototype */ {
+	/**
+	 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	cbAlertThumb: PropTypes.func
+};
 
-		delete props.cbAlertThumb;
-
-		return <UiScrollThumb {...props} />;
-	}
-}
+ScrollThumb.defaultProps = {
+	cbAlertThumb: nop
+};
 
 export default ScrollThumb;
 export {

--- a/packages/moonstone/Scrollable/Scrollbar.js
+++ b/packages/moonstone/Scrollable/Scrollbar.js
@@ -1,11 +1,11 @@
-import ApiDecorator from '@enact/core/internal/ApiDecorator';
+// import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 
 import ScrollButtons from './ScrollButtons';
 import ScrollThumb from './ScrollThumb';
-import Skinnable from '../Skinnable';
+// import Skinnable from '../Skinnable';
 
 import componentCss from './Scrollbar.module.less';
 
@@ -18,131 +18,125 @@ import componentCss from './Scrollbar.module.less';
  * @ui
  * @private
  */
-class ScrollbarBase extends Component {
-	static displayName = 'ScrollbarBase'
+const ScrollbarBase = memo(forwardRef((props, ref) => {
+	// Refs
+	const scrollbarRef = useRef();
+	const scrollButtonsRef = useRef();
+	// render
+	const {cbAlertThumb, clientSize, corner, vertical, ...rest} = props;
 
-	static propTypes = /** @lends moonstone/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		cbAlertThumb: PropTypes.func,
-
-		/**
-		 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
-		 *
-		 * @type {Object}
-		 * @property {Number}    clientHeight    The client height of the list.
-		 * @property {Number}    clientWidth    The client width of the list.
-		 * @public
-		 */
-		clientSize: PropTypes.shape({
-			clientHeight: PropTypes.number.isRequired,
-			clientWidth: PropTypes.number.isRequired
-		}),
-
-		/**
-		 * Adds the corner between vertical and horizontal scrollbars.
-		 *
-		 * @type {Booelan}
-		 * @default false
-		 * @public
-		 */
-		corner: PropTypes.bool,
-
-		/**
-		 * `true` if rtl, `false` if ltr.
-		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		rtl: PropTypes.bool,
-
-		/**
-		 * Registers the ScrollButtons component with an
-		 * {@link core/internal/ApiDecorator.ApiDecorator}.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		setApiProvider: PropTypes.func,
-
-		/**
-		 * The scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
-
-	static defaultProps = {
-		corner: false,
-		vertical: true
-	}
-
-	constructor (props) {
-		super(props);
-
-		if (props.setApiProvider) {
-			props.setApiProvider(this);
-		}
-
-		this.scrollbarRef = React.createRef();
-		this.scrollButtonsRef = React.createRef();
-	}
-
-	componentDidMount () {
-		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = this.scrollbarRef.current;
-
-		this.getContainerRef = getContainerRef;
-		this.showThumb = showThumb;
-		this.startHidingThumb = startHidingThumb;
-		this.uiUpdate = uiUpdate;
-
-		const {isOneOfScrollButtonsFocused, updateButtons, focusOnButton} = this.scrollButtonsRef.current;
-
-		this.isOneOfScrollButtonsFocused = isOneOfScrollButtonsFocused;
-		this.update = (bounds) => {
-			updateButtons(bounds);
-			this.uiUpdate(bounds);
+	useImperativeHandle(ref, () => {
+		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = scrollbarRef.current;
+		const {focusOnButton, isOneOfScrollButtonsFocused, updateButtons} = scrollButtonsRef.current;
+		return {
+			focusOnButton,
+			getContainerRef,
+			isOneOfScrollButtonsFocused,
+			showThumb,
+			startHidingThumb,
+			uiUpdate,
+			update: (bounds) => {
+				updateButtons(bounds);
+				uiUpdate(bounds);
+			}
 		};
-		this.focusOnButton = focusOnButton;
-	}
+	}, [scrollbarRef, scrollButtonsRef]);
 
-	render () {
-		const {cbAlertThumb, clientSize, corner, vertical, ...rest} = this.props;
-
-		return (
-			<UiScrollbarBase
-				corner={corner}
-				clientSize={clientSize}
-				css={componentCss}
-				ref={this.scrollbarRef}
-				vertical={vertical}
-				childRenderer={({thumbRef}) => ( // eslint-disable-line react/jsx-no-bind
+	return (
+		<UiScrollbarBase
+			corner={corner}
+			clientSize={clientSize}
+			css={componentCss}
+			ref={scrollbarRef}
+			vertical={vertical}
+			childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
+				return (
 					<ScrollButtons
 						{...rest}
-						ref={this.scrollButtonsRef}
+						ref={scrollButtonsRef}
 						vertical={vertical}
-						thumbRenderer={() => ( // eslint-disable-line react/jsx-no-bind
-							<ScrollThumb
-								cbAlertThumb={cbAlertThumb}
-								key="thumb"
-								ref={thumbRef}
-								vertical={vertical}
-							/>
-						)}
+						thumbRenderer={() => { // eslint-disable-line react/jsx-no-bind
+							return (
+								<ScrollThumb
+									cbAlertThumb={cbAlertThumb}
+									key="thumb"
+									ref={thumbRef}
+									vertical={vertical}
+								/>
+							);
+						}}
 					/>
-				)}
-			/>
-		);
-	}
-}
+				);
+			}}
+		/>
+	);
+}));
+
+ScrollbarBase.displayName = 'ScrollbarBase';
+
+ScrollbarBase.propTypes = /** @lends moonstone/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * Called when [ScrollThumb]{@link moonstone/Scrollable.ScrollThumb} is updated.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	cbAlertThumb: PropTypes.func,
+
+	/**
+	 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
+	 *
+	 * @type {Object}
+	 * @property {Number}    clientHeight    The client height of the list.
+	 * @property {Number}    clientWidth    The client width of the list.
+	 * @public
+	 */
+	clientSize: PropTypes.shape({
+		clientHeight: PropTypes.number.isRequired,
+		clientWidth: PropTypes.number.isRequired
+	}),
+
+	/**
+	 * Adds the corner between vertical and horizontal scrollbars.
+	 *
+	 * @type {Booelan}
+	 * @default false
+	 * @public
+	 */
+	corner: PropTypes.bool,
+
+	/**
+	 * `true` if rtl, `false` if ltr.
+	 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+	 *
+	 * @type {Boolean}
+	 * @private
+	 */
+	rtl: PropTypes.bool,
+
+	/**
+	 * Registers the ScrollButtons component with an
+	 * {@link core/internal/ApiDecorator.ApiDecorator}.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	// setApiProvider: PropTypes.func,
+
+	/**
+	 * The scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollbarBase.defaultProps = {
+	corner: false,
+	vertical: true
+};
 
 /**
  * A Moonstone-styled scroll bar. It is used in [Scrollable]{@link moonstone/Scrollable.Scrollable}.
@@ -152,6 +146,7 @@ class ScrollbarBase extends Component {
  * @ui
  * @private
  */
+/* TODO: Is it possible to use ApiDecorator?
 const Scrollbar = ApiDecorator(
 	{api: [
 		'focusOnButton',
@@ -162,6 +157,8 @@ const Scrollbar = ApiDecorator(
 		'update'
 	]}, Skinnable(ScrollbarBase)
 );
+*/
+const Scrollbar = ScrollbarBase;
 Scrollbar.displayName = 'Scrollbar';
 
 export default Scrollbar;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Convert scrollbar and scroll thumb components into functional components

### Links
[//]: # (Related issues, references)
PLAT-98572
#2677 (for ui)

### Comments
This PR is for moonstone components only and will be applied to the new repo along with the target branch later.