### PR TITLE
PLAT-98572: Converted ui scrollbar components into function components

### DIFF
--- a/packages/ui/Scrollable/ScrollThumb.js
+++ b/packages/ui/Scrollable/ScrollThumb.js
@@ -1,50 +1,41 @@
-import kind from '@enact/core/kind';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {forwardRef} from 'react';
 
 import css from './ScrollThumb.module.less';
 
 /**
  * An unstyled scroll thumb without any behavior.
  *
- * @class ScrollThumb
+ * @function ScrollThumb
  * @memberof ui/Scrollable
  * @ui
  * @private
  */
-const ScrollThumb = kind({
-	name: 'ui:ScrollThumb',
+const ScrollThumb = forwardRef((props, ref) => {
+	const
+		{vertical, ...rest} = props,
+		className = classNames(css.scrollThumb, vertical ? css.vertical : null);
 
-	propTypes: /** @lends ui/Scrollable.ScrollThumb.prototype */ {
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	},
-
-	defaultProps: {
-		vertical: true
-	},
-
-	styles: {
-		css,
-		className: 'scrollThumb'
-	},
-
-	computed: {
-		className: ({vertical, styler}) => styler.append({vertical})
-	},
-
-	render: (props) => {
-		delete props.vertical;
-
-		return <div {...props} />;
-	}
+	return <div {...rest} className={className} ref={ref} />;
 });
+
+ScrollThumb.displayName = 'ui:ScrollThumb';
+
+ScrollThumb.propTypes = /** @lends ui/Scrollable.ScrollThumb.prototype */ {
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollThumb.defaultProps = {
+	vertical: true
+};
 
 export default ScrollThumb;
 export {

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
-import React, {PureComponent, Component} from 'react';
+import React, {forwardRef, memo, useEffect, useImperativeHandle, useRef} from 'react';
 import ReactDOM from 'react-dom';
 
 import ri from '../resolution';
@@ -13,6 +13,14 @@ import componentCss from './Scrollbar.module.less';
 const
 	minThumbSize = 18, // Size in pixels
 	thumbHidingDelay = 400; // in milliseconds
+
+const addClass = (element, className) => {
+	ReactDOM.findDOMNode(element).classList.add(className); // eslint-disable-line react/no-find-dom-node
+};
+
+const removeClass = (element, className) => {
+	ReactDOM.findDOMNode(element).classList.remove(className); // eslint-disable-line react/no-find-dom-node
+};
 
 /*
  * Set CSS Varaible value.
@@ -29,165 +37,135 @@ const setCSSVariable = (element, variable, value) => {
 /**
  * An unstyled base component for a scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
  *
- * @class ScrollbarBase
+ * @function ScrollbarBase
  * @memberof ui/Scrollable
  * @ui
  * @private
  */
-class ScrollbarBase extends PureComponent {
-	static displayName = 'ui:Scrollbar'
-
-	static propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * The render function for child.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		childRenderer: PropTypes.func.isRequired,
-
-		/**
-		 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
-		 *
-		 * @type {Object}
-		 * @property {Number}    clientHeight    The client height of the list.
-		 * @property {Number}    clientWidth    The client width of the list.
-		 * @public
-		 */
-		clientSize: PropTypes.shape({
-			clientHeight: PropTypes.number.isRequired,
-			clientWidth: PropTypes.number.isRequired
-		}),
-
-		/**
-		 * If `true`, add the corner between vertical and horizontal scrollbars.
-		 *
-		 * @type {Booelan}
-		 * @default false
-		 * @public
-		 */
-		corner: PropTypes.bool,
-
-		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal elements and states of this component.
-		 *
-		 * The following classes are supported:
-		 *
-		 * * `scrollbar` - The scrollbar component class
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		css: PropTypes.object,
-
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
-
-	static defaultProps = {
-		corner: false,
-		css: componentCss,
-		vertical: true
-	}
-
-	constructor (props) {
-		super(props);
-
-		this.containerRef = React.createRef();
-		this.thumbRef = React.createRef();
-	}
-
-	componentDidMount () {
-		this.calculateMetrics();
-	}
-
-	componentDidUpdate () {
-		this.calculateMetrics();
-	}
-
-	componentWillUnmount () {
-		this.hideThumbJob.stop();
-	}
-
-	minThumbSizeRatio = 0
-	ignoreMode = false
-
-	update = (bounds) => {
-		const
-			{vertical} = this.props,
-			{clientWidth, clientHeight, scrollWidth, scrollHeight, scrollLeft, scrollTop} = bounds,
-			clientSize = vertical ? clientHeight : clientWidth,
-			scrollSize = vertical ? scrollHeight : scrollWidth,
-			scrollOrigin = vertical ? scrollTop : scrollLeft,
-
-			thumbSizeRatioBase = (clientSize / scrollSize),
-			scrollThumbPositionRatio = (scrollOrigin / (scrollSize - clientSize)),
-			scrollThumbSizeRatio = Math.max(this.minThumbSizeRatio, Math.min(1, thumbSizeRatioBase));
-
-		setCSSVariable(this.thumbRef.current, '--scrollbar-size-ratio', scrollThumbSizeRatio);
-		setCSSVariable(this.thumbRef.current, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
-	}
-
-	showThumb = () => {
-		this.hideThumbJob.stop();
-		ReactDOM.findDOMNode(this.thumbRef.current).classList.add(this.props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
-	}
-
-	startHidingThumb = () => {
-		this.hideThumbJob.start();
-	}
-
-	hideThumb = () => {
-		ReactDOM.findDOMNode(this.thumbRef.current).classList.remove(this.props.css.thumbShown); // eslint-disable-line react/no-find-dom-node
-	}
-
-	hideThumbJob = new Job(this.hideThumb.bind(this), thumbHidingDelay);
-
-	calculateMetrics = () => {
-		const primaryDimenstion = this.props.vertical ? 'clientHeight' : 'clientWidth';
-		let trackSize;
-
-		if (this.props.clientSize) {
-			trackSize = this.props.clientSize[primaryDimenstion];
-		} else {
-			trackSize = this.containerRef.current[primaryDimenstion];
-		}
-
-		this.minThumbSizeRatio = ri.scale(minThumbSize) / trackSize;
-	}
-
-	getContainerRef = () => (this.containerRef)
-
-	render () {
-		const
-			{childRenderer, className, corner, css, vertical, ...rest} = this.props,
-			containerClassName = classNames(
-				className,
-				css.scrollbar,
-				corner ? css.corner : null,
-				vertical ? css.vertical : css.horizontal
-			);
-
-		delete rest.clientSize;
-
-		return (
-			<div {...rest} className={containerClassName} ref={this.containerRef}>
-				{childRenderer({
-					getContainerRef: this.getContainerRef,
-					thumbRef: this.thumbRef
-				})}
-			</div>
+const ScrollbarBase = memo(forwardRef((props, ref) => {
+	// Refs
+	const containerRef = useRef();
+	const thumbRef = useRef();
+	const hideThumbJob = useRef(null);
+	// Render
+	const
+		{childRenderer, className, corner, css, vertical, ...rest} = props,
+		containerClassName = classNames(
+			className,
+			css.scrollbar,
+			corner && css.corner,
+			vertical ? css.vertical : css.horizontal
 		);
+
+	delete rest.clientSize;
+
+	hideThumbJob.current = hideThumbJob.current || new Job(hideThumb, thumbHidingDelay);
+
+	function hideThumb () {
+		removeClass(thumbRef.current, css.thumbShown);
 	}
-}
+
+	useEffect(() => {
+		return () => {
+			hideThumbJob.current.stop();
+		};
+	}, []);
+
+	useImperativeHandle(ref, () => ({
+		getContainerRef: () => (containerRef),
+		showThumb: () => {
+			hideThumbJob.current.stop();
+			addClass(thumbRef.current, css.thumbShown);
+		},
+		startHidingThumb: () => {
+			hideThumbJob.current.start();
+		},
+		update: (bounds) => {
+			const
+				{clientSize} = props,
+				primaryDimenstion = vertical ? 'clientHeight' : 'clientWidth',
+				trackSize = clientSize ? clientSize[primaryDimenstion] : containerRef.current[primaryDimenstion],
+				scrollViewSize = vertical ? bounds.clientHeight : bounds.clientWidth,
+				scrollContentSize = vertical ? bounds.scrollHeight : bounds.scrollWidth,
+				scrollOrigin = vertical ? bounds.scrollTop : bounds.scrollLeft,
+				thumbSizeRatioBase = (scrollViewSize / scrollContentSize),
+				scrollThumbPositionRatio = (scrollOrigin / (scrollContentSize - scrollViewSize)),
+				scrollThumbSizeRatio = Math.max(ri.scale(minThumbSize) / trackSize, Math.min(1, thumbSizeRatioBase));
+
+			setCSSVariable(thumbRef.current, '--scrollbar-size-ratio', scrollThumbSizeRatio);
+			setCSSVariable(thumbRef.current, '--scrollbar-progress-ratio', scrollThumbPositionRatio);
+		}
+	}));
+
+	return (
+		<div {...rest} className={containerClassName} ref={containerRef}>
+			{childRenderer({thumbRef})}
+		</div>
+	);
+}));
+
+ScrollbarBase.displayName = 'ui:Scrollbar';
+
+ScrollbarBase.propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * The render function for child.
+	 *
+	 * @type {Function}
+	 * @required
+	 * @private
+	 */
+	childRenderer: PropTypes.func.isRequired,
+
+	/**
+	 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
+	 *
+	 * @type {Object}
+	 * @property {Number}    clientHeight    The client height of the list.
+	 * @property {Number}    clientWidth    The client width of the list.
+	 * @public
+	 */
+	clientSize: PropTypes.shape({
+		clientHeight: PropTypes.number.isRequired,
+		clientWidth: PropTypes.number.isRequired
+	}),
+
+	/**
+	 * If `true`, add the corner between vertical and horizontal scrollbars.
+	 *
+	 * @type {Booelan}
+	 * @default false
+	 * @public
+	 */
+	corner: PropTypes.bool,
+
+	/**
+	 * Customizes the component by mapping the supplied collection of CSS class names to the
+	 * corresponding internal elements and states of this component.
+	 *
+	 * The following classes are supported:
+	 *
+	 * * `scrollbar` - The scrollbar component class
+	 *
+	 * @type {Object}
+	 * @public
+	 */
+	css: PropTypes.object,
+
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
+
+ScrollbarBase.defaultProps = {
+	corner: false,
+	css: componentCss,
+	vertical: true
+};
 
 /**
  * An unstyled scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
@@ -197,53 +175,51 @@ class ScrollbarBase extends PureComponent {
  * @ui
  * @private
  */
-class Scrollbar extends Component {
-	static propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
-		/**
-		 * If `true`, the scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	}
+const Scrollbar = forwardRef((props, ref) => {
+	const scrollbarBaseRef = useRef(null);
 
-	static defaultProps = {
-		vertical: true
-	}
+	useImperativeHandle(ref, () => {
+		const {getContainerRef, showThumb, startHidingThumb, update} = scrollbarBaseRef.current;
 
-	setApi = (ref) => {
-		if (ref) {
-			const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = ref;
+		return {
+			getContainerRef,
+			showThumb,
+			startHidingThumb,
+			update
+		};
+	}, [scrollbarBaseRef]);
 
-			this.getContainerRef = getContainerRef;
-			this.showThumb = showThumb;
-			this.startHidingThumb = startHidingThumb;
-			this.update = uiUpdate;
-		}
-	}
+	return (
+		<ScrollbarBase
+			{...props}
+			ref={scrollbarBaseRef}
+			childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
+				return (
+					<ScrollThumb
+						key="thumb"
+						ref={thumbRef}
+						vertical={props.vertical}
+					/>
+				);
+			}}
+		/>
+	);
+});
 
-	render () {
-		const {vertical} = this.props;
+Scrollbar.propTypes = /** @lends ui/Scrollable.Scrollbar.prototype */ {
+	/**
+	 * If `true`, the scrollbar will be oriented vertically.
+	 *
+	 * @type {Boolean}
+	 * @default true
+	 * @public
+	 */
+	vertical: PropTypes.bool
+};
 
-		return (
-			<ScrollbarBase
-				{...this.props}
-				ref={this.setApi}
-				childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind
-					return (
-						<ScrollThumb
-							key="thumb"
-							ref={thumbRef}
-							vertical={vertical}
-						/>
-					);
-				}}
-			/>
-		);
-	}
-}
+Scrollbar.defaultProps = {
+	vertical: true
+};
 
 export default Scrollbar;
 export {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Convert scrollbar and scroll thumb components into functional components

### Links
[//]: # (Related issues, references)
PLAT-98572
#2676 (for moonstone)

### Comments
This PR is for ui components only