### PR TITLE
PLAT-98506: [VirtualList and Scroller] Convert from UI React component to functional component

### DIFF
--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -6,7 +6,7 @@ import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import clamp from 'ramda/src/clamp';
-import React, {Component} from 'react';
+import React, {useContext, useState, useReducer, useRef, useEffect} from 'react';
 
 import {ResizeContext} from '../Resizable';
 import ri from '../resolution';
@@ -50,603 +50,336 @@ const TouchableDiv = Touchable('div');
 /**
  * An unstyled native component that passes scrollable behavior information as its render prop's arguments.
  *
- * @class ScrollableBaseNative
+ * @function ScrollableBaseNative
  * @memberof ui/ScrollableNative
  * @ui
  * @private
  */
-class ScrollableBaseNative extends Component {
-	static displayName = 'ui:ScrollableBaseNative'
+const ScrollableBaseNative = (props) => {
+	const [, forceUpdate] = useReducer(x => x + 1, 0);
 
-	static propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
-		/**
-		 * Render function.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		containerRenderer: PropTypes.func.isRequired,
+	const context = useContext(ResizeContext);
+	const [remeasure, setRemeasure] = useState(false);
+	const [isHorizontalScrollbarVisible, setIsHorizontalScrollbarVisible] = useState(props.horizontalScrollbar === 'visible');
+	const [isVerticalScrollbarVisible, setIsVerticalScrollbarVisible] = useState(props.verticalScrollbar === 'visible');
 
-		/**
-		 * Called when adding additional event listeners in a themed component.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		addEventListeners: PropTypes.func,
+	const containerRef = useRef();
+	const horizontalScrollbarRef = useRef();
+	const verticalScrollbarRef = useRef();
 
-		/**
-		 * Called to execute additional logic in a themed component to show overscroll effect.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		applyOverscrollEffect: PropTypes.func,
-
-		/**
-		 * A callback function that receives a reference to the `scrollTo` feature.
-		 *
-		 * Once received, the `scrollTo` method can be called as an imperative interface.
-		 *
-		 * The `scrollTo` function accepts the following parameters:
-		 * - {position: {x, y}} - Pixel value for x and/or y position
-		 * - {align} - Where the scroll area should be aligned. Values are:
-		 *   `'left'`, `'right'`, `'top'`, `'bottom'`,
-		 *   `'topleft'`, `'topright'`, `'bottomleft'`, and `'bottomright'`.
-		 * - {index} - Index of specific item. (`0` or positive integer)
-		 *   This option is available for only `VirtualList` kind.
-		 * - {node} - Node to scroll into view
-		 * - {animate} - When `true`, scroll occurs with animation. When `false`, no
-		 *   animation occurs.
-		 * - {focus} - When `true`, attempts to focus item after scroll. Only valid when scrolling
-		 *   by `index` or `node`.
-		 * > Note: Only specify one of: `position`, `align`, `index` or `node`
-		 *
-		 * Example:
-		 * ```
-		 *	// If you set cbScrollTo prop like below;
-		 *	cbScrollTo: (fn) => {this.scrollTo = fn;}
-		 *	// You can simply call like below;
-		 *	this.scrollTo({align: 'top'}); // scroll to the top
-		 * ```
-		 *
-		 * @type {Function}
-		 * @public
-		 */
-		cbScrollTo: PropTypes.func,
-
-		/**
-		 * Called to execute additional logic in a themed component to clear overscroll effect.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		clearOverscrollEffect: PropTypes.func,
-
-		/**
-		 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
-		 *
-		 * @type {Object}
-		 * @property {Number}    clientHeight    The client height of the list.
-		 * @property {Number}    clientWidth    The client width of the list.
-		 * @public
-		 */
-		clientSize: PropTypes.shape({
-			clientHeight: PropTypes.number.isRequired,
-			clientWidth: PropTypes.number.isRequired
-		}),
-
-		/**
-		 * Direction of the list or the scroller.
-		 *
-		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
-		 *
-		 * Valid values are:
-		 * * `'both'`,
-		 * * `'horizontal'`, and
-		 * * `'vertical'`.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
-
-		/**
-		 * Called when resizing window
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		handleResizeWindow: PropTypes.func,
-
-		/**
-		 * Specifies how to show horizontal scrollbar.
-		 *
-		 * Valid values are:
-		 * * `'auto'`,
-		 * * `'visible'`, and
-		 * * `'hidden'`.
-		 *
-		 * @type {String}
-		 * @default 'auto'
-		 * @public
-		 */
-		horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
-
-		/**
-		 * Prevents scroll by dragging or flicking on the list or the scroller.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		noScrollByDrag: PropTypes.bool,
-
-		/**
-		 * Prevents scroll by wheeling on the list or the scroller.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		noScrollByWheel: PropTypes.bool,
-
-		/**
-		 * Called when flicking with a mouse or a touch screen.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onFlick: PropTypes.func,
-
-		/**
-		 * Called when pressing a key.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onKeyDown: PropTypes.func,
-
-		/**
-		 * Called when triggering a mousedown event.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onMouseDown: PropTypes.func,
-
-		/**
-		 * Called when scrolling.
-		 *
-		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
-		 * It is not recommended to set this prop since it can cause performance degradation.
-		 * Use `onScrollStart` or `onScrollStop` instead.
-		 *
-		 * @type {Function}
-		 * @param {Object} event
-		 * @param {Number} event.scrollLeft Scroll left value.
-		 * @param {Number} event.scrollTop Scroll top value.
-		 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
-		 * @public
-		 */
-		onScroll: PropTypes.func,
-
-		/**
-		 * Called when scroll starts.
-		 *
-		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
-		 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
-		 *
-		 * Example:
-		 * ```
-		 * onScrollStart = ({scrollLeft, scrollTop, moreInfo}) => {
-		 *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
-		 *     // do something with firstVisibleIndex and lastVisibleIndex
-		 * }
-		 *
-		 * render = () => (
-		 *     <VirtualList
-		 *         ...
-		 *         onScrollStart={this.onScrollStart}
-		 *         ...
-		 *     />
-		 * )
-		 * ```
-		 *
-		 * @type {Function}
-		 * @param {Object} event
-		 * @param {Number} event.scrollLeft Scroll left value.
-		 * @param {Number} event.scrollTop Scroll top value.
-		 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
-		 * @public
-		 */
-		onScrollStart: PropTypes.func,
-
-		/**
-		 * Called when scroll stops.
-		 *
-		 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
-		 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
-		 *
-		 * Example:
-		 * ```
-		 * onScrollStop = ({scrollLeft, scrollTop, moreInfo}) => {
-		 *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
-		 *     // do something with firstVisibleIndex and lastVisibleIndex
-		 * }
-		 *
-		 * render = () => (
-		 *     <VirtualList
-		 *         ...
-		 *         onScrollStop={this.onScrollStop}
-		 *         ...
-		 *     />
-		 * )
-		 * ```
-		 *
-		 * @type {Function}
-		 * @param {Object} event
-		 * @param {Number} event.scrollLeft Scroll left value.
-		 * @param {Number} event.scrollTop Scroll top value.
-		 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
-		 * @public
-		 */
-		onScrollStop: PropTypes.func,
-
-		/**
-		 * Called when wheeling.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onWheel: PropTypes.func,
-
-		/**
-		 * Specifies overscroll effects shows on which type of inputs.
-		 *
-		 * @type {Object}
-		 * @default {drag: false, pageKey: false, wheel: false}
-		 * @private
-		 */
-		overscrollEffectOn: PropTypes.shape({
-			drag: PropTypes.bool,
-			pageKey: PropTypes.bool,
-			wheel: PropTypes.bool
-		}),
-
-		/**
-		 * Called when removing additional event listeners in a themed component.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		removeEventListeners: PropTypes.func,
-
-		/**
-		 * Indicates the content's text direction is right-to-left.
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		rtl: PropTypes.bool,
-
-		/**
-		 * Called to execute additional logic in a themed component after scrolling.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		scrollStopOnScroll: PropTypes.func,
-
-		/**
-		 * Called to execute additional logic in a themed component when scrollTo is called.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		scrollTo: PropTypes.func,
-
-		/**
-		 * Called to execute additional logic in a themed component when scroll starts.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		start: PropTypes.func,
-
-		/**
-		 * Specifies how to show vertical scrollbar.
-		 *
-		 * Valid values are:
-		 * * `'auto'`,
-		 * * `'visible'`, and
-		 * * `'hidden'`.
-		 *
-		 * @type {String}
-		 * @default 'auto'
-		 * @public
-		 */
-		verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
-	}
-
-	static defaultProps = {
-		cbScrollTo: nop,
-		horizontalScrollbar: 'auto',
-		noScrollByDrag: false,
-		noScrollByWheel: false,
-		onScroll: nop,
-		onScrollStart: nop,
-		onScrollStop: nop,
-		overscrollEffectOn: {drag: false, pageKey: false, wheel: false},
-		verticalScrollbar: 'auto'
-	}
-
-	static contextType = ResizeContext
-
-	constructor (props) {
-		super(props);
-
-		this.state = {
-			remeasure: false,
-			isHorizontalScrollbarVisible: props.horizontalScrollbar === 'visible',
-			isVerticalScrollbarVisible: props.verticalScrollbar === 'visible'
-		};
-
-		this.containerRef = React.createRef();
-		this.horizontalScrollbarRef = React.createRef();
-		this.verticalScrollbarRef = React.createRef();
-
-		this.horizontalScrollbarProps = {
-			ref: this.horizontalScrollbarRef,
+	// Instance variables
+	const variables = useRef({
+		horizontalScrollbarProps: {
+			ref: horizontalScrollbarRef,
 			vertical: false,
 			clientSize: props.clientSize
-		};
-
-		this.verticalScrollbarProps = {
-			ref: this.verticalScrollbarRef,
+		},
+		verticalScrollbarProps: {
+			ref: verticalScrollbarRef,
 			vertical: true,
 			clientSize: props.clientSize
-		};
+		},
 
-		this.overscrollEnabled = !!(props.applyOverscrollEffect);
+		overscrollEnabled: !!(props.applyOverscrollEffect),
 
 		// Enable the early bail out of repeated scrolling to the same position
-		this.animationInfo = null;
+		animationInfo: null,
 
-		this.resizeRegistry = Registry.create(this.handleResize.bind(this));
+		resizeRegistry: null,
 
-		props.cbScrollTo(this.scrollTo);
+
+		// constants
+		pixelPerLine: 39,
+		scrollWheelMultiplierForDeltaPixel: 1.5, // The ratio of wheel 'delta' units to pixels scrolled.
+
+		// status
+		deferScrollTo: true,
+		isScrollAnimationTargetAccumulated: false,
+		isUpdatedScrollThumb: false,
+
+		// overscroll
+		lastInputType: null,
+		overscrollStatus: {
+			horizontal: {
+				before: {type: overscrollTypeNone, ratio: 0},
+				after: {type: overscrollTypeNone, ratio: 0}
+			},
+			vertical: {
+				before: {type: overscrollTypeNone, ratio: 0},
+				after: {type: overscrollTypeNone, ratio: 0}
+			}
+		},
+
+		// bounds info
+		bounds: {
+			clientWidth: 0,
+			clientHeight: 0,
+			scrollWidth: 0,
+			scrollHeight: 0,
+			maxTop: 0,
+			maxLeft: 0
+		},
+
+		// wheel/drag/flick info
+		wheelDirection: 0,
+		isDragging: false,
+		isTouching: false,
+
+		// scroll info
+		scrolling: false,
+		scrollLeft: 0,
+		scrollTop: 0,
+		scrollToInfo: null,
+
+		// component info
+		childRefCurrent: null,
+
+		// scroll animator
+		animator: null,
+
+		// non-declared-variable.
+		accumulatedTargetX: null,
+		accumulatedTargetY: null,
+		flickTarget: null,
+		dragStartX: null,
+		dragStartY: null,
+		scrollStopJob: null
+	});
+
+	if (variables.current.resizeRegistry == null) {
+		variables.current.resizeRegistry = Registry.create(handleResize);
 	}
 
-	componentDidMount () {
-		this.resizeRegistry.parent = this.context;
-		this.addEventListeners();
-		this.updateScrollbars();
+	if (variables.current.animator == null) {
+		variables.current.animator = new ScrollAnimator();
 	}
 
-	componentDidUpdate (prevProps, prevState) {
-		const
-			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
-			{hasDataSizeChanged} = this.childRefCurrent;
+	if (variables.current.scrollStopJob == null) {
+		variables.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
+	}
+
+	props.cbScrollTo(scrollTo);
+
+	// variables for render
+	const
+		{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = props,
+		scrollableClasses = classNames(css.scrollable, className),
+		contentClasses = classNames(css.content, css.contentNative),
+		childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
+		childWrapperProps = {
+			className: contentClasses,
+			...(!noScrollByDrag && {
+				flickConfig,
+				onDrag: onDrag,
+				onDragEnd: onDragEnd,
+				onDragStart: onDragStart,
+				onFlick: onFlick,
+				onTouchStart: onTouchStart
+			})
+		};
+
+	delete rest.addEventListeners;
+	delete rest.applyOverscrollEffect;
+	delete rest.cbScrollTo;
+	delete rest.clearOverscrollEffect;
+	delete rest.handleResizeWindow;
+	delete rest.horizontalScrollbar;
+	delete rest.noScrollByWheel;
+	delete rest.onFlick;
+	delete rest.onKeyDown;
+	delete rest.onMouseDown;
+	delete rest.onScroll;
+	delete rest.onScrollStart;
+	delete rest.onScrollStop;
+	delete rest.onWheel;
+	delete rest.overscrollEffectOn;
+	delete rest.removeEventListeners;
+	delete rest.scrollStopOnScroll;
+	delete rest.scrollTo;
+	delete rest.start;
+	delete rest.verticalScrollbar;
+
+	useEffect(() => {
+		// componentDidMount
+		variables.current.resizeRegistry.parent = context;
+		addEventListeners();
+		updateScrollbars();
+
+		// componentWillUnmount
+		return () => {
+			variables.current.resizeRegistry.parent = null;
+			// Before call cancelAnimationFrame, you must send scrollStop Event.
+			if (variables.current.scrolling) {
+				forwardScrollEvent('onScrollStop', getReachedEdgeInfo());
+			}
+			variables.current.scrollStopJob.stop();
+
+			removeEventListeners();
+		};
+	}, []);
+
+	useEffect(() => {
+		// componentDidUpdate
 
 		// Need to sync calculated client size if it is different from the real size
-		if (this.childRefCurrent.syncClientSize) {
+		if (variables.current.childRefCurrent.syncClientSize) {
 			// If we actually synced, we need to reset scroll position.
-			if (this.childRefCurrent.syncClientSize()) {
-				this.setScrollLeft(0);
-				this.setScrollTop(0);
+			if (variables.current.childRefCurrent.syncClientSize()) {
+				setScrollLeft(0);
+				setScrollTop(0);
 			}
 		}
+		addEventListeners();
+	});
 
-		this.addEventListeners();
+	useEffect(() => {
+		// componentDidUpdate
+		const
+			{hasDataSizeChanged} = variables.current.childRefCurrent;
 		if (
 			hasDataSizeChanged === false &&
-			(isHorizontalScrollbarVisible && !prevState.isHorizontalScrollbarVisible || isVerticalScrollbarVisible && !prevState.isVerticalScrollbarVisible)
+			(isHorizontalScrollbarVisible || isVerticalScrollbarVisible)
 		) {
-			this.deferScrollTo = false;
-			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
+			variables.current.deferScrollTo = false;
+			variables.current.isUpdatedScrollThumb = updateScrollThumbSize();
 		} else {
-			this.updateScrollbars();
+			updateScrollbars();
 		}
 
-		if (this.scrollToInfo !== null) {
-			if (!this.deferScrollTo) {
-				this.scrollTo(this.scrollToInfo);
+		if (variables.current.scrollToInfo !== null) {
+			if (!variables.current.deferScrollTo) {
+				scrollTo(variables.current.scrollToInfo);
 			}
 		}
 
 		// publish container resize changes
-		const horizontal = isHorizontalScrollbarVisible !== prevState.isHorizontalScrollbarVisible;
-		const vertical = isVerticalScrollbarVisible !== prevState.isVerticalScrollbarVisible;
-		if (horizontal || vertical) {
-			this.resizeRegistry.notify({});
-		}
-	}
+		variables.current.resizeRegistry.notify({});
+	}, [isHorizontalScrollbarVisible, isVerticalScrollbarVisible]);
 
-	componentWillUnmount () {
-		this.resizeRegistry.parent = null;
-		// Before call cancelAnimationFrame, you must send scrollStop Event.
-		if (this.scrolling) {
-			this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
-		}
-		this.scrollStopJob.stop();
-
-		this.removeEventListeners();
-	}
-
-	handleResize (ev) {
+	function handleResize (ev) {
 		if (ev.action === 'invalidateBounds') {
-			this.enqueueForceUpdate();
+			enqueueForceUpdate();
 		}
 	}
 
-	handleResizeWindow = () => {
+	function handleResizeWindow () {
 		// `handleSize` in `ui/resolution.ResolutionDecorator` should be executed first.
 		setTimeout(() => {
-			const {handleResizeWindow} = this.props;
-
 			if (handleResizeWindow) {
 				handleResizeWindow();
 			}
-			this.childRefCurrent.containerRef.current.style.scrollBehavior = null;
-			this.childRefCurrent.scrollToPosition(0, 0);
-			this.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
+			variables.current.childRefCurrent.containerRef.current.style.scrollBehavior = null;
+			variables.current.childRefCurrent.scrollToPosition(0, 0);
+			variables.current.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
 
-			this.enqueueForceUpdate();
+			enqueueForceUpdate();
 		});
 	}
 
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
 	// state member.
-	enqueueForceUpdate () {
-		this.childRefCurrent.calculateMetrics(this.childRefCurrent.props);
-		this.forceUpdate();
+	function enqueueForceUpdate () {
+		variables.current.childRefCurrent.calculateMetrics(variables.current.childRefCurrent.props);
+		forceUpdate();
 	}
-
-	// constants
-	pixelPerLine = 39
-	scrollWheelMultiplierForDeltaPixel = 1.5 // The ratio of wheel 'delta' units to pixels scrolled.
-
-	// status
-	deferScrollTo = true
-	isScrollAnimationTargetAccumulated = false
-	isUpdatedScrollThumb = false
-
-	// overscroll
-	lastInputType = null
-	overscrollEnabled = false
-	overscrollStatus = {
-		horizontal: {
-			before: {type: overscrollTypeNone, ratio: 0},
-			after: {type: overscrollTypeNone, ratio: 0}
-		},
-		vertical: {
-			before: {type: overscrollTypeNone, ratio: 0},
-			after: {type: overscrollTypeNone, ratio: 0}
-		}
-	}
-
-	// bounds info
-	bounds = {
-		clientWidth: 0,
-		clientHeight: 0,
-		scrollWidth: 0,
-		scrollHeight: 0,
-		maxTop: 0,
-		maxLeft: 0
-	}
-
-	// wheel/drag/flick info
-	wheelDirection = 0
-	isDragging = false
-	isTouching = false
-
-	// scroll info
-	scrolling = false
-	scrollLeft = 0
-	scrollTop = 0
-	scrollToInfo = null
-
-	// component info
-	childRefCurrent = null
-
-	// scroll animator
-	animator = new ScrollAnimator()
 
 	// event handler for browser native scroll
 
-	getRtlX = (x) => (this.props.rtl ? -x : x)
-
-	onMouseDown = handle(
-		forwardWithPrevent('onMouseDown'),
-		this.stop
-	).bindAs(this, 'onMouseDown')
-
-	onTouchStart = () => {
-		this.isTouching = true;
+	function getRtlX (x) {
+		return (props.rtl ? -x : x);
 	}
 
-	onDragStart = (ev) => {
-		if (!this.isTouching) {
-			this.stop();
-			this.isDragging = true;
+	// TODO : 이거 어떻게 하지? const로 하면 재선언 계속 될텐덴 괜찮나..;;
+	const onMouseDown = handle(
+		forwardWithPrevent('onMouseDown'),
+		stop
+	);
+	// /*.bindAs(this, 'onMouseDown')*/
+
+	function onTouchStart () {
+		variables.current.isTouching = true;
+	}
+
+	function onDragStart (ev) {
+		if (!variables.current.isTouching) {
+			stop();
+			variables.current.isDragging = true;
 		}
 
 		// these values are used also for touch inputs
-		this.dragStartX = this.scrollLeft + this.getRtlX(ev.x);
-		this.dragStartY = this.scrollTop + ev.y;
+		variables.current.dragStartX = variables.current.scrollLeft + getRtlX(ev.x);
+		variables.current.dragStartY = variables.current.scrollTop + ev.y;
 	}
 
-	onDrag = (ev) => {
+	function onDrag (ev) {
 		const
-			{direction, overscrollEffectOn} = this.props,
-			targetX = (direction === 'vertical') ? 0 : this.dragStartX - this.getRtlX(ev.x), // 'horizontal' or 'both'
-			targetY = (direction === 'horizontal') ? 0 : this.dragStartY - ev.y; // 'vertical' or 'both'
+			{direction, overscrollEffectOn} = props,
+			targetX = (direction === 'vertical') ? 0 : variables.current.dragStartX - getRtlX(ev.x), // 'horizontal' or 'both'
+			targetY = (direction === 'horizontal') ? 0 : variables.current.dragStartY - ev.y; // 'vertical' or 'both'
 
-		this.lastInputType = 'drag';
+		variables.current.lastInputType = 'drag';
 
-		if (!this.isTouching) {
-			this.start({targetX, targetY, animate: false, overscrollEffect: overscrollEffectOn.drag});
-		} else if (this.overscrollEnabled && overscrollEffectOn.drag) {
-			this.checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeHold);
+		if (!variables.current.isTouching) {
+			start({targetX, targetY, animate: false, overscrollEffect: overscrollEffectOn.drag});
+		} else if (variables.current.overscrollEnabled && overscrollEffectOn.drag) {
+			checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeHold);
 		}
 	}
 
-	onDragEnd = () => {
-		this.isDragging = false;
+	function onDragEnd () {
+		variables.current.isDragging = false;
 
-		this.lastInputType = 'drag';
+		variables.current.lastInputType = 'drag';
 
-		if (this.flickTarget) {
+		if (variables.current.flickTarget) {
 			const
-				{overscrollEffectOn} = this.props,
-				{targetX, targetY} = this.flickTarget;
+				{overscrollEffectOn} = props,
+				{targetX, targetY} = variables.current.flickTarget;
 
-			if (!this.isTouching) {
-				this.isScrollAnimationTargetAccumulated = false;
-				this.start({targetX, targetY, overscrollEffect: overscrollEffectOn.drag});
-			} else if (this.overscrollEnabled && overscrollEffectOn.drag) {
-				this.checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeOnce);
+			if (!variables.current.isTouching) {
+				variables.current.isScrollAnimationTargetAccumulated = false;
+				start({targetX, targetY, overscrollEffect: overscrollEffectOn.drag});
+			} else if (variables.current.overscrollEnabled && overscrollEffectOn.drag) {
+				checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeOnce);
 			}
-		} else if (!this.isTouching) {
-			this.stop();
+		} else if (!variables.current.isTouching) {
+			stop();
 		}
 
-		if (this.overscrollEnabled) { // not check this.props.overscrollEffectOn.drag for safety
-			this.clearAllOverscrollEffects();
+		if (variables.current.overscrollEnabled) { // not check props.overscrollEffectOn.drag for safety
+			clearAllOverscrollEffects();
 		}
-		this.isTouching = false;
-		this.flickTarget = null;
+		variables.current.isTouching = false;
+		variables.current.flickTarget = null;
 	}
 
-	onFlick = (ev) => {
-		const {direction} = this.props;
+	function onFlick (ev) {
+		const {direction} = props;
 
-		if (!this.isTouching) {
-			this.flickTarget = this.animator.simulate(
-				this.scrollLeft,
-				this.scrollTop,
-				(direction !== 'vertical') ? this.getRtlX(-ev.velocityX) : 0,
+		if (!variables.current.isTouching) {
+			variables.current.flickTarget = variables.current.animator.simulate(
+				variables.current.scrollLeft,
+				variables.current.scrollTop,
+				(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
 				(direction !== 'horizontal') ? -ev.velocityY : 0
 			);
-		} else if (this.overscrollEnabled && this.props.overscrollEffectOn.drag) {
-			this.flickTarget = {
-				targetX: this.scrollLeft + this.getRtlX(-ev.velocityX) * overscrollVelocityFactor, // 'horizontal' or 'both'
-				targetY: this.scrollTop + -ev.velocityY * overscrollVelocityFactor // 'vertical' or 'both'
+		} else if (variables.current.overscrollEnabled && props.overscrollEffectOn.drag) {
+			variables.current.flickTarget = {
+				targetX: variables.current.scrollLeft + getRtlX(-ev.velocityX) * overscrollVelocityFactor, // 'horizontal' or 'both'
+				targetY: variables.current.scrollTop + -ev.velocityY * overscrollVelocityFactor // 'vertical' or 'both'
 			};
 		}
 
-		if (this.props.onFlick) {
-			forward('onFlick', ev, this.props);
+		if (props.onFlick) {
+			forward('onFlick', ev, props);
 		}
 	}
 
-	calculateDistanceByWheel (deltaMode, delta, maxPixel) {
+	function calculateDistanceByWheel (deltaMode, delta, maxPixel) {
 		if (deltaMode === 0) {
-			delta = clamp(-maxPixel, maxPixel, ri.scale(delta * this.scrollWheelMultiplierForDeltaPixel));
+			delta = clamp(-maxPixel, maxPixel, ri.scale(delta * variables.current.scrollWheelMultiplierForDeltaPixel));
 		} else if (deltaMode === 1) { // line; firefox
-			delta = clamp(-maxPixel, maxPixel, ri.scale(delta * this.pixelPerLine * this.scrollWheelMultiplierForDeltaPixel));
+			delta = clamp(-maxPixel, maxPixel, ri.scale(delta * variables.current.pixelPerLine * variables.current.scrollWheelMultiplierForDeltaPixel));
 		} else if (deltaMode === 2) { // page
 			delta = delta < 0 ? -maxPixel : maxPixel;
 		}
@@ -659,74 +392,72 @@ class ScrollableBaseNative extends Component {
 	 * - for horizontal scroll, supports wheel action on any children nodes since web engine cannot support this
 	 * - for vertical scroll, supports wheel action on scrollbars only
 	 */
-	onWheel = (ev) => {
-		if (this.isDragging) {
+	function onWheel (ev) {
+		if (variables.current.isDragging) {
 			ev.preventDefault();
 			ev.stopPropagation();
 		} else {
 			const
-				{overscrollEffectOn} = this.props,
-				overscrollEffectRequired = this.overscrollEnabled && overscrollEffectOn.wheel,
-				bounds = this.getScrollBounds(),
-				canScrollHorizontally = this.canScrollHorizontally(bounds),
-				canScrollVertically = this.canScrollVertically(bounds),
+				{overscrollEffectOn} = props,
+				overscrollEffectRequired = variables.current.overscrollEnabled && overscrollEffectOn.wheel,
+				bounds = getScrollBounds(),
+				bCanScrollHorizontally = canScrollHorizontally(bounds),
+				bCanScrollVertically = canScrollVertically(bounds),
 				eventDeltaMode = ev.deltaMode,
 				eventDelta = (-ev.wheelDeltaY || ev.deltaY);
 			let
 				delta = 0,
 				needToHideThumb = false;
 
-			this.lastInputType = 'wheel';
+			variables.current.lastInputType = 'wheel';
 
-			if (this.props.noScrollByWheel) {
-				if (canScrollVertically) {
+			if (props.noScrollByWheel) {
+				if (bCanScrollVertically) {
 					ev.preventDefault();
 				}
 
 				return;
 			}
 
-			if (this.props.onWheel) {
-				forward('onWheel', ev, this.props);
+			if (props.onWheel) {
+				forward('onWheel', ev, props);
 				return;
 			}
 
-			this.showThumb(bounds);
+			showThumb(bounds);
 
 			// FIXME This routine is a temporary support for horizontal wheel scroll.
 			// FIXME If web engine supports horizontal wheel, this routine should be refined or removed.
-			if (canScrollVertically) { // This routine handles wheel events on scrollbars for vertical scroll.
-				if (eventDelta < 0 && this.scrollTop > 0 || eventDelta > 0 && this.scrollTop < bounds.maxTop) {
-					const {horizontalScrollbarRef, verticalScrollbarRef} = this;
-
+			if (bCanScrollVertically) { // This routine handles wheel events on scrollbars for vertical scroll.
+				if (eventDelta < 0 && variables.current.scrollTop > 0 || eventDelta > 0 && variables.current.scrollTop < bounds.maxTop) {
 					// Not to check if ev.target is a descendant of a wrapped component which may have a lot of nodes in it.
 					if ((horizontalScrollbarRef.current && horizontalScrollbarRef.current.getContainerRef().current.contains(ev.target)) ||
 						(verticalScrollbarRef.current && verticalScrollbarRef.current.getContainerRef().current.contains(ev.target))) {
-						delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+						delta = calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 						needToHideThumb = !delta;
 
 						ev.preventDefault();
 					} else if (overscrollEffectRequired) {
-						this.checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
+						checkAndApplyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce);
 					}
 
 					ev.stopPropagation();
 				} else {
-					if (overscrollEffectRequired && (eventDelta < 0 && this.scrollTop <= 0 || eventDelta > 0 && this.scrollTop >= bounds.maxTop)) {
-						this.applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+					if (overscrollEffectRequired && (eventDelta < 0 && variables.current.scrollTop <= 0 || eventDelta > 0 && variables.current.scrollTop >= bounds.maxTop)) {
+						applyOverscrollEffect('vertical', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 					}
 					needToHideThumb = true;
 				}
-			} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
-				if (eventDelta < 0 && this.scrollLeft > 0 || eventDelta > 0 && this.scrollLeft < bounds.maxLeft) {
-					delta = this.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+			} else if (bCanScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
+				if (eventDelta < 0 && variables.current.scrollLeft > 0 || eventDelta > 0 && variables.current.scrollLeft < bounds.maxLeft) {
+					delta = calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 					needToHideThumb = !delta;
 
 					ev.preventDefault();
 					ev.stopPropagation();
 				} else {
-					if (overscrollEffectRequired && (eventDelta < 0 && this.scrollLeft <= 0 || eventDelta > 0 && this.scrollLeft >= bounds.maxLeft)) {
-						this.applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
+					if (overscrollEffectRequired && (eventDelta < 0 && variables.current.scrollLeft <= 0 || eventDelta > 0 && variables.current.scrollLeft >= bounds.maxLeft)) {
+						applyOverscrollEffect('horizontal', eventDelta > 0 ? 'after' : 'before', overscrollTypeOnce, 1);
 					}
 					needToHideThumb = true;
 				}
@@ -735,71 +466,71 @@ class ScrollableBaseNative extends Component {
 			if (delta !== 0) {
 				const direction = Math.sign(delta);
 				// Not to accumulate scroll position if wheel direction is different from hold direction
-				if (direction !== this.wheelDirection) {
-					this.isScrollAnimationTargetAccumulated = false;
-					this.wheelDirection = direction;
+				if (direction !== variables.current.wheelDirection) {
+					variables.current.isScrollAnimationTargetAccumulated = false;
+					variables.current.wheelDirection = direction;
 				}
-				this.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectOn.wheel);
+				scrollToAccumulatedTarget(delta, bCanScrollVertically, overscrollEffectOn.wheel);
 			}
 
 			if (needToHideThumb) {
-				this.startHidingThumb();
+				startHidingThumb();
 			}
 		}
 	}
 
-	onScroll = (ev) => {
+	function onScroll (ev) {
 		let {scrollLeft, scrollTop} = ev.target;
 
 		const
-			bounds = this.getScrollBounds(),
-			canScrollHorizontally = this.canScrollHorizontally(bounds);
+			bounds = getScrollBounds(),
+			bCanScrollHorizontally = canScrollHorizontally(bounds);
 
-		if (!this.scrolling) {
-			this.scrollStartOnScroll();
+		if (!variables.current.scrolling) {
+			scrollStartOnScroll();
 		}
 
-		if (this.props.rtl && canScrollHorizontally) {
+		if (props.rtl && bCanScrollHorizontally) {
 			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
-		if (scrollLeft !== this.scrollLeft) {
-			this.setScrollLeft(scrollLeft);
+		if (scrollLeft !== variables.current.scrollLeft) {
+			setScrollLeft(scrollLeft);
 		}
-		if (scrollTop !== this.scrollTop) {
-			this.setScrollTop(scrollTop);
+		if (scrollTop !== variables.current.scrollTop) {
+			setScrollTop(scrollTop);
 		}
 
-		if (this.childRefCurrent.didScroll) {
-			this.childRefCurrent.didScroll(this.scrollLeft, this.scrollTop);
+		if (variables.current.childRefCurrent.didScroll) {
+			variables.current.childRefCurrent.didScroll(variables.current.scrollLeft, variables.current.scrollTop);
 		}
-		this.forwardScrollEvent('onScroll');
-		this.scrollStopJob.start();
+		forwardScrollEvent('onScroll');
+		variables.current.scrollStopJob.start();
 	}
 
-	onKeyDown = (ev) => {
-		forward('onKeyDown', ev, this.props);
+	function onKeyDown (ev) {
+		forward('onKeyDown', ev, props);
 	}
 
-	scrollToAccumulatedTarget = (delta, vertical, overscrollEffect) => {
-		if (!this.isScrollAnimationTargetAccumulated) {
-			this.accumulatedTargetX = this.scrollLeft;
-			this.accumulatedTargetY = this.scrollTop;
-			this.isScrollAnimationTargetAccumulated = true;
+	function scrollToAccumulatedTarget (delta, vertical, overscrollEffect) {
+		if (!variables.current.isScrollAnimationTargetAccumulated) {
+			variables.current.accumulatedTargetX = variables.current.scrollLeft;
+			variables.current.accumulatedTargetY = variables.current.scrollTop;
+			variables.current.isScrollAnimationTargetAccumulated = true;
 		}
 
 		if (vertical) {
-			this.accumulatedTargetY += delta;
+			variables.current.accumulatedTargetY += delta;
 		} else {
-			this.accumulatedTargetX += delta;
+			variables.current.accumulatedTargetX += delta;
 		}
 
-		this.start({targetX: this.accumulatedTargetX, targetY: this.accumulatedTargetY, overscrollEffect});
+		start({targetX: variables.current.accumulatedTargetX, targetY: variables.current.accumulatedTargetY, overscrollEffect});
 	}
 
 	// overscroll effect
 
-	getEdgeFromPosition = (position, maxPosition) => {
+	function getEdgeFromPosition (position, maxPosition) {
 		if (position <= 0) {
 			return 'before';
 		/* If a scroll size or a client size is not integer,
@@ -811,17 +542,19 @@ class ScrollableBaseNative extends Component {
 		}
 	}
 
-	setOverscrollStatus = (orientation, edge, type, ratio) => {
-		const status = this.overscrollStatus[orientation][edge];
+	function setOverscrollStatus (orientation, edge, type, ratio) {
+		const status = variables.current.overscrollStatus[orientation][edge];
 		status.type = type;
 		status.ratio = ratio;
 	}
 
-	getOverscrollStatus = (orientation, edge) => (this.overscrollStatus[orientation][edge])
+	function getOverscrollStatus (orientation, edge) {
+		return (variables.current.overscrollStatus[orientation][edge]);
+	}
 
-	calculateOverscrollRatio = (orientation, position) => {
+	function calculateOverscrollRatio (orientation, position) {
 		const
-			bounds = this.getScrollBounds(),
+			bounds = getScrollBounds(),
 			isVertical = (orientation === 'vertical'),
 			baseSize = isVertical ? bounds.clientHeight : bounds.clientWidth,
 			maxPos = bounds[isVertical ? 'maxTop' : 'maxLeft'];
@@ -838,157 +571,154 @@ class ScrollableBaseNative extends Component {
 		return Math.min(1, 2 * overDistance / baseSize);
 	}
 
-	applyOverscrollEffect = (orientation, edge, type, ratio) => {
-		this.props.applyOverscrollEffect(orientation, edge, type, ratio);
-		this.setOverscrollStatus(orientation, edge, type === overscrollTypeOnce ? overscrollTypeDone : type, ratio);
+	function applyOverscrollEffect (orientation, edge, type, ratio) {
+		props.applyOverscrollEffect(orientation, edge, type, ratio);
+		setOverscrollStatus(orientation, edge, type === overscrollTypeOnce ? overscrollTypeDone : type, ratio);
 	}
 
-	checkAndApplyOverscrollEffect = (orientation, edge, type, ratio = 1) => {
+	function checkAndApplyOverscrollEffect (orientation, edge, type, ratio = 1) {
 		const
 			isVertical = (orientation === 'vertical'),
-			curPos = isVertical ? this.scrollTop : this.scrollLeft,
-			maxPos = this.getScrollBounds()[isVertical ? 'maxTop' : 'maxLeft'];
+			curPos = isVertical ? variables.current.scrollTop : variables.current.scrollLeft,
+			maxPos = getScrollBounds()[isVertical ? 'maxTop' : 'maxLeft'];
 
 		/* If a scroll size or a client size is not integer,
 			 browser's max scroll position could be smaller than maxPos by 1 pixel.*/
 		if ((edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos - 1)) { // Already on the edge
-			this.applyOverscrollEffect(orientation, edge, type, ratio);
+			applyOverscrollEffect(orientation, edge, type, ratio);
 		} else {
-			this.setOverscrollStatus(orientation, edge, type, ratio);
+			setOverscrollStatus(orientation, edge, type, ratio);
 		}
 	}
 
-	clearOverscrollEffect = (orientation, edge) => {
-		if (this.getOverscrollStatus(orientation, edge).type !== overscrollTypeNone) {
-			if (this.props.clearOverscrollEffect) {
-				this.props.clearOverscrollEffect(orientation, edge);
+	function clearOverscrollEffect (orientation, edge) {
+		if (getOverscrollStatus(orientation, edge).type !== overscrollTypeNone) {
+			if (props.clearOverscrollEffect) {
+				props.clearOverscrollEffect(orientation, edge);
 			} else {
-				this.applyOverscrollEffect(orientation, edge, overscrollTypeNone, 0);
+				applyOverscrollEffect(orientation, edge, overscrollTypeNone, 0);
 			}
 		}
 	}
 
-	clearAllOverscrollEffects = () => {
+	function clearAllOverscrollEffects () {
 		['horizontal', 'vertical'].forEach((orientation) => {
 			['before', 'after'].forEach((edge) => {
-				this.clearOverscrollEffect(orientation, edge);
+				clearOverscrollEffect(orientation, edge);
 			});
 		});
 	}
 
-	applyOverscrollEffectOnDrag = (orientation, edge, targetPosition, type) => {
+	function applyOverscrollEffectOnDrag (orientation, edge, targetPosition, type) {
 		if (edge) {
 			const
 				oppositeEdge = edge === 'before' ? 'after' : 'before',
-				ratio = this.calculateOverscrollRatio(orientation, targetPosition);
+				ratio = calculateOverscrollRatio(orientation, targetPosition);
 
-			this.applyOverscrollEffect(orientation, edge, type, ratio);
-			this.clearOverscrollEffect(orientation, oppositeEdge);
+			applyOverscrollEffect(orientation, edge, type, ratio);
+			clearOverscrollEffect(orientation, oppositeEdge);
 		} else {
-			this.clearOverscrollEffect(orientation, 'before');
-			this.clearOverscrollEffect(orientation, 'after');
+			clearOverscrollEffect(orientation, 'before');
+			clearOverscrollEffect(orientation, 'after');
 		}
 	}
 
-	checkAndApplyOverscrollEffectOnDrag = (targetX, targetY, type) => {
-		const bounds = this.getScrollBounds();
+	function checkAndApplyOverscrollEffectOnDrag (targetX, targetY, type) {
+		const bounds = getScrollBounds();
 
-		if (this.canScrollHorizontally(bounds)) {
-			this.applyOverscrollEffectOnDrag('horizontal', this.getEdgeFromPosition(targetX, bounds.maxLeft), targetX, type);
+		if (canScrollHorizontally(bounds)) {
+			applyOverscrollEffectOnDrag('horizontal', getEdgeFromPosition(targetX, bounds.maxLeft), targetX, type);
 		}
 
-		if (this.canScrollVertically(bounds)) {
-			this.applyOverscrollEffectOnDrag('vertical', this.getEdgeFromPosition(targetY, bounds.maxTop), targetY, type);
+		if (canScrollVertically(bounds)) {
+			applyOverscrollEffectOnDrag('vertical', getEdgeFromPosition(targetY, bounds.maxTop), targetY, type);
 		}
 	}
 
-	checkAndApplyOverscrollEffectOnScroll = (orientation) => {
+	function checkAndApplyOverscrollEffectOnScroll (orientation) {
 		['before', 'after'].forEach((edge) => {
-			const {ratio, type} = this.getOverscrollStatus(orientation, edge);
+			const {ratio, type} = getOverscrollStatus(orientation, edge);
 
 			if (type === overscrollTypeOnce) {
-				this.checkAndApplyOverscrollEffect(orientation, edge, type, ratio);
+				checkAndApplyOverscrollEffect(orientation, edge, type, ratio);
 			}
 		});
 	}
 
-	checkAndApplyOverscrollEffectOnStart = (orientation, edge, targetPosition) => {
-		if (this.isDragging) {
-			this.applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
+	function checkAndApplyOverscrollEffectOnStart (orientation, edge, targetPosition) {
+		if (variables.current.isDragging) {
+			applyOverscrollEffectOnDrag(orientation, edge, targetPosition, overscrollTypeHold);
 		} else if (edge) {
-			this.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
+			checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 
 	// call scroll callbacks
 
-	forwardScrollEvent (type, reachedEdgeInfo) {
-		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
+	function forwardScrollEvent (type, reachedEdgeInfo) {
+		forward(type, {scrollLeft: variables.current.scrollLeft, scrollTop: variables.current.scrollTop, moreInfo: getMoreInfo(), reachedEdgeInfo}, props);
 	}
 
 	// call scroll callbacks and update scrollbars for native scroll
 
-	scrollStartOnScroll = () => {
-		this.scrolling = true;
-		this.showThumb(this.getScrollBounds());
-		this.forwardScrollEvent('onScrollStart');
+	function scrollStartOnScroll () {
+		variables.current.scrolling = true;
+		showThumb(getScrollBounds());
+		forwardScrollEvent('onScrollStart');
 	}
 
-	scrollStopOnScroll = () => {
-		if (this.props.scrollStopOnScroll) {
-			this.props.scrollStopOnScroll();
+	function scrollStopOnScroll () {
+		if (props.scrollStopOnScroll) {
+			props.scrollStopOnScroll();
 		}
-		if (this.overscrollEnabled && !this.isDragging) { // not check this.props.overscrollEffectOn for safety
-			this.clearAllOverscrollEffects();
+		if (variables.current.overscrollEnabled && !variables.current.isDragging) { // not check props.overscrollEffectOn for safety
+			clearAllOverscrollEffects();
 		}
-		this.lastInputType = null;
-		this.isScrollAnimationTargetAccumulated = false;
-		this.scrolling = false;
-		this.forwardScrollEvent('onScrollStop', this.getReachedEdgeInfo());
-		this.startHidingThumb();
+		variables.current.lastInputType = null;
+		variables.current.isScrollAnimationTargetAccumulated = false;
+		variables.current.scrolling = false;
+		forwardScrollEvent('onScrollStop', getReachedEdgeInfo());
+		startHidingThumb();
 	}
-
-	scrollStopJob = new Job(this.scrollStopOnScroll, scrollStopWaiting);
 
 	// update scroll position
 
-	setScrollLeft (value) {
-		const bounds = this.getScrollBounds();
+	function setScrollLeft (value) {
+		const bounds = getScrollBounds();
 
-		this.scrollLeft = clamp(0, bounds.maxLeft, value);
+		variables.current.scrollLeft = clamp(0, bounds.maxLeft, value);
 
-		if (this.overscrollEnabled && this.props.overscrollEffectOn[this.lastInputType]) {
-			this.checkAndApplyOverscrollEffectOnScroll('horizontal');
+		if (variables.current.overscrollEnabled && props.overscrollEffectOn[variables.current.lastInputType]) {
+			checkAndApplyOverscrollEffectOnScroll('horizontal');
 		}
 
-		if (this.state.isHorizontalScrollbarVisible) {
-			this.updateThumb(this.horizontalScrollbarRef, bounds);
-		}
-	}
-
-	setScrollTop (value) {
-		const bounds = this.getScrollBounds();
-
-		this.scrollTop = clamp(0, bounds.maxTop, value);
-
-		if (this.overscrollEnabled && this.props.overscrollEffectOn[this.lastInputType]) {
-			this.checkAndApplyOverscrollEffectOnScroll('vertical');
-		}
-
-		if (this.state.isVerticalScrollbarVisible) {
-			this.updateThumb(this.verticalScrollbarRef, bounds);
+		if (isHorizontalScrollbarVisible) {
+			updateThumb(horizontalScrollbarRef, bounds);
 		}
 	}
 
-	getReachedEdgeInfo = () => {
+	function setScrollTop (value) {
+		const bounds = getScrollBounds();
+
+		variables.current.scrollTop = clamp(0, bounds.maxTop, value);
+
+		if (variables.current.overscrollEnabled && props.overscrollEffectOn[variables.current.lastInputType]) {
+			checkAndApplyOverscrollEffectOnScroll('vertical');
+		}
+
+		if (isVerticalScrollbarVisible) {
+			updateThumb(verticalScrollbarRef, bounds);
+		}
+	}
+
+	function getReachedEdgeInfo () {
 		const
-			bounds = this.getScrollBounds(),
+			bounds = getScrollBounds(),
 			reachedEdgeInfo = {bottom: false, left: false, right: false, top: false};
 
-		if (this.canScrollHorizontally(bounds)) {
+		if (canScrollHorizontally(bounds)) {
 			const
-				rtl = this.props.rtl,
-				edge = this.getEdgeFromPosition(this.scrollLeft, bounds.maxLeft);
+				edge = getEdgeFromPosition(variables.current.scrollLeft, bounds.maxLeft);
 
 			if (edge) { // if edge is null, no need to check which edge is reached.
 				if ((edge === 'before' && !rtl) || (edge === 'after' && rtl)) {
@@ -999,8 +729,8 @@ class ScrollableBaseNative extends Component {
 			}
 		}
 
-		if (this.canScrollVertically(bounds)) {
-			const edge = this.getEdgeFromPosition(this.scrollTop, bounds.maxTop);
+		if (canScrollVertically(bounds)) {
+			const edge = getEdgeFromPosition(variables.current.scrollTop, bounds.maxTop);
 
 			if (edge === 'before') {
 				reachedEdgeInfo.top = true;
@@ -1014,12 +744,12 @@ class ScrollableBaseNative extends Component {
 
 	// scroll start
 
-	start ({targetX, targetY, animate = true, overscrollEffect = false}) {
+	function start ({targetX, targetY, animate = true, overscrollEffect = false}) {
 		const
-			{scrollLeft, scrollTop} = this,
-			childRefCurrent = this.childRefCurrent,
+			{scrollLeft, scrollTop} = variables.current,
+			childRefCurrent = variables.current.childRefCurrent,
 			childContainerRef = childRefCurrent.containerRef,
-			bounds = this.getScrollBounds(),
+			bounds = getScrollBounds(),
 			{maxLeft, maxTop} = bounds;
 
 		const updatedAnimationInfo = {
@@ -1028,11 +758,11 @@ class ScrollableBaseNative extends Component {
 		};
 
 		// bail early when scrolling to the same position
-		if (this.scrolling && this.animationInfo && this.animationInfo.targetX === targetX && this.animationInfo.targetY === targetY) {
+		if (variables.current.scrolling && variables.current.animationInfo && variables.current.animationInfo.targetX === targetX && variables.current.animationInfo.targetY === targetY) {
 			return;
 		}
 
-		this.animationInfo = updatedAnimationInfo;
+		variables.current.animationInfo = updatedAnimationInfo;
 
 		if (Math.abs(maxLeft - targetX) < epsilon) {
 			targetX = maxLeft;
@@ -1041,12 +771,12 @@ class ScrollableBaseNative extends Component {
 			targetY = maxTop;
 		}
 
-		if (this.overscrollEnabled && overscrollEffect) {
-			if (scrollLeft !== targetX && this.canScrollHorizontally(bounds)) {
-				this.checkAndApplyOverscrollEffectOnStart('horizontal', this.getEdgeFromPosition(targetX, maxLeft), targetX);
+		if (variables.current.overscrollEnabled && overscrollEffect) {
+			if (scrollLeft !== targetX && canScrollHorizontally(bounds)) {
+				checkAndApplyOverscrollEffectOnStart('horizontal', getEdgeFromPosition(targetX, maxLeft), targetX);
 			}
-			if (scrollTop !== targetY && this.canScrollVertically(bounds)) {
-				this.checkAndApplyOverscrollEffectOnStart('vertical', this.getEdgeFromPosition(targetY, maxTop), targetY);
+			if (scrollTop !== targetY && canScrollVertically(bounds)) {
+				checkAndApplyOverscrollEffectOnStart('vertical', getEdgeFromPosition(targetY, maxTop), targetY);
 			}
 		}
 
@@ -1057,30 +787,30 @@ class ScrollableBaseNative extends Component {
 			childRefCurrent.scrollToPosition(targetX, targetY);
 			childContainerRef.current.style.scrollBehavior = 'smooth';
 		}
-		this.scrollStopJob.start();
+		variables.current.scrollStopJob.start();
 
-		if (this.props.start) {
-			this.props.start(animate);
+		if (props.start) {
+			props.start(animate);
 		}
 	}
 
-	stop () {
+	function stop () {
 		const
-			childRefCurrent = this.childRefCurrent,
+			childRefCurrent = variables.current.childRefCurrent,
 			childContainerRef = childRefCurrent.containerRef;
 
 		childContainerRef.current.style.scrollBehavior = null;
-		childRefCurrent.scrollToPosition(this.scrollLeft + 0.1, this.scrollTop + 0.1);
+		childRefCurrent.scrollToPosition(variables.current.scrollLeft + 0.1, variables.current.scrollTop + 0.1);
 		childContainerRef.current.style.scrollBehavior = 'smooth';
 	}
 
 	// scrollTo API
 
-	getPositionForScrollTo = (opt) => {
+	function getPositionForScrollTo (opt) {
 		const
-			bounds = this.getScrollBounds(),
-			canScrollHorizontally = this.canScrollHorizontally(bounds),
-			canScrollVertically = this.canScrollVertically(bounds);
+			bounds = getScrollBounds(),
+			bCanScrollHorizontally = canScrollHorizontally(bounds),
+			bCanScrollVertically = canScrollVertically(bounds);
 		let
 			itemPos,
 			left = null,
@@ -1088,27 +818,27 @@ class ScrollableBaseNative extends Component {
 
 		if (opt instanceof Object) {
 			if (opt.position instanceof Object) {
-				if (canScrollHorizontally) {
+				if (bCanScrollHorizontally) {
 					// We need '!=' to check if opt.position.x is null or undefined
-					left = opt.position.x != null ? opt.position.x : this.scrollLeft;
+					left = opt.position.x != null ? opt.position.x : variables.current.scrollLeft;
 				} else {
 					left = 0;
 				}
-				if (canScrollVertically) {
+				if (bCanScrollVertically) {
 					// We need '!=' to check if opt.position.y is null or undefined
-					top = opt.position.y != null ? opt.position.y : this.scrollTop;
+					top = opt.position.y != null ? opt.position.y : variables.current.scrollTop;
 				} else {
 					top = 0;
 				}
 			} else if (typeof opt.align === 'string') {
-				if (canScrollHorizontally) {
+				if (bCanScrollHorizontally) {
 					if (opt.align.includes('left')) {
 						left = 0;
 					} else if (opt.align.includes('right')) {
 						left = bounds.maxLeft;
 					}
 				}
-				if (canScrollVertically) {
+				if (bCanScrollVertically) {
 					if (opt.align.includes('top')) {
 						top = 0;
 					} else if (opt.align.includes('bottom')) {
@@ -1116,18 +846,18 @@ class ScrollableBaseNative extends Component {
 					}
 				}
 			} else {
-				if (typeof opt.index === 'number' && typeof this.childRefCurrent.getItemPosition === 'function') {
-					itemPos = this.childRefCurrent.getItemPosition(opt.index, opt.stickTo);
+				if (typeof opt.index === 'number' && typeof variables.current.childRefCurrent.getItemPosition === 'function') {
+					itemPos = variables.current.childRefCurrent.getItemPosition(opt.index, opt.stickTo);
 				} else if (opt.node instanceof Object) {
-					if (opt.node.nodeType === 1 && typeof this.childRefCurrent.getNodePosition === 'function') {
-						itemPos = this.childRefCurrent.getNodePosition(opt.node);
+					if (opt.node.nodeType === 1 && typeof variables.current.childRefCurrent.getNodePosition === 'function') {
+						itemPos = variables.current.childRefCurrent.getNodePosition(opt.node);
 					}
 				}
 				if (itemPos) {
-					if (canScrollHorizontally) {
+					if (bCanScrollHorizontally) {
 						left = itemPos.left;
 					}
-					if (canScrollVertically) {
+					if (bCanScrollVertically) {
 						top = itemPos.top;
 					}
 				}
@@ -1137,71 +867,70 @@ class ScrollableBaseNative extends Component {
 		return {left, top};
 	}
 
-	scrollTo = (opt) => {
-		if (!this.deferScrollTo) {
-			const {left, top} = this.getPositionForScrollTo(opt);
+	function scrollTo (opt) {
+		if (!variables.current.deferScrollTo) {
+			const {left, top} = getPositionForScrollTo(opt);
 
-			if (this.props.scrollTo) {
-				this.props.scrollTo(opt);
+			if (props.scrollTo) {
+				props.scrollTo(opt);
 			}
-			this.scrollToInfo = null;
-			this.start({
-				targetX: (left !== null) ? left : this.scrollLeft,
-				targetY: (top !== null) ? top : this.scrollTop,
+			variables.current.scrollToInfo = null;
+			start({
+				targetX: (left !== null) ? left : variables.current.scrollLeft,
+				targetY: (top !== null) ? top : variables.current.scrollTop,
 				animate: opt.animate
 			});
 		} else {
-			this.scrollToInfo = opt;
+			variables.current.scrollToInfo = opt;
 		}
 	}
 
-	canScrollHorizontally = (bounds) => {
-		const {direction} = this.props;
+	function canScrollHorizontally (bounds) {
+		const {direction} = props;
 		return (direction === 'horizontal' || direction === 'both') && (bounds.scrollWidth > bounds.clientWidth) && !isNaN(bounds.scrollWidth);
 	}
 
-	canScrollVertically = (bounds) => {
-		const {direction} = this.props;
+	function canScrollVertically (bounds) {
+		const {direction} = props;
 		return (direction === 'vertical' || direction === 'both') && (bounds.scrollHeight > bounds.clientHeight) && !isNaN(bounds.scrollHeight);
 	}
 
 	// scroll bar
 
-	showThumb (bounds) {
-		if (this.state.isHorizontalScrollbarVisible && this.canScrollHorizontally(bounds) && this.horizontalScrollbarRef.current) {
-			this.horizontalScrollbarRef.current.showThumb();
+	function showThumb (bounds) {
+		if (isHorizontalScrollbarVisible && canScrollHorizontally(bounds) && horizontalScrollbarRef.current) {
+			horizontalScrollbarRef.current.showThumb();
 		}
-		if (this.state.isVerticalScrollbarVisible && this.canScrollVertically(bounds) && this.verticalScrollbarRef.current) {
-			this.verticalScrollbarRef.current.showThumb();
+		if (isVerticalScrollbarVisible && canScrollVertically(bounds) && verticalScrollbarRef.current) {
+			verticalScrollbarRef.current.showThumb();
 		}
 	}
 
-	updateThumb (scrollbarRef, bounds) {
+	function updateThumb (scrollbarRef, bounds) {
 		scrollbarRef.current.update({
 			...bounds,
-			scrollLeft: this.scrollLeft,
-			scrollTop: this.scrollTop
+			scrollLeft: variables.current.scrollLeft,
+			scrollTop: variables.current.scrollTop
 		});
 	}
 
-	startHidingThumb = () => {
-		if (this.state.isHorizontalScrollbarVisible && this.horizontalScrollbarRef.current) {
-			this.horizontalScrollbarRef.current.startHidingThumb();
+	function startHidingThumb () {
+		if (isHorizontalScrollbarVisible && horizontalScrollbarRef.current) {
+			horizontalScrollbarRef.current.startHidingThumb();
 		}
-		if (this.state.isVerticalScrollbarVisible && this.verticalScrollbarRef.current) {
-			this.verticalScrollbarRef.current.startHidingThumb();
+		if (isVerticalScrollbarVisible && verticalScrollbarRef.current) {
+			verticalScrollbarRef.current.startHidingThumb();
 		}
 	}
 
-	updateScrollbars = () => {
+	function updateScrollbars () {
 		const
-			{horizontalScrollbar, verticalScrollbar} = this.props,
-			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
-			bounds = this.getScrollBounds(),
-			canScrollHorizontally = this.canScrollHorizontally(bounds),
-			canScrollVertically = this.canScrollVertically(bounds),
-			curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? canScrollHorizontally : horizontalScrollbar === 'visible',
-			curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? canScrollVertically : verticalScrollbar === 'visible';
+			{horizontalScrollbar, verticalScrollbar} = props,
+			bounds = getScrollBounds(),
+			bCanScrollHorizontally = canScrollHorizontally(bounds),
+			bCanScrollVertically = canScrollVertically(bounds),
+			curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? bCanScrollHorizontally : horizontalScrollbar === 'visible',
+			curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? bCanScrollVertically : verticalScrollbar === 'visible';
 
 		// determine if we should hide or show any scrollbars
 		const
@@ -1212,24 +941,22 @@ class ScrollableBaseNative extends Component {
 
 		if (isVisibilityChanged) {
 			// one or both scrollbars have changed visibility
-			this.setState({
-				isHorizontalScrollbarVisible: curHorizontalScrollbarVisible,
-				isVerticalScrollbarVisible: curVerticalScrollbarVisible
-			});
+			setIsHorizontalScrollbarVisible(curHorizontalScrollbarVisible);
+			setIsVerticalScrollbarVisible(curVerticalScrollbarVisible);
 		} else {
-			this.deferScrollTo = false;
-			this.isUpdatedScrollThumb = this.updateScrollThumbSize();
+			variables.current.deferScrollTo = false;
+			variables.current.isUpdatedScrollThumb = updateScrollThumbSize();
 		}
 	}
 
-	updateScrollThumbSize = () => {
+	function updateScrollThumbSize () {
 		const
-			{horizontalScrollbar, verticalScrollbar} = this.props,
-			bounds = this.getScrollBounds(),
-			canScrollHorizontally = this.canScrollHorizontally(bounds),
-			canScrollVertically = this.canScrollVertically(bounds),
-			curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? canScrollHorizontally : horizontalScrollbar === 'visible',
-			curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? canScrollVertically : verticalScrollbar === 'visible';
+			{horizontalScrollbar, verticalScrollbar} = props,
+			bounds = getScrollBounds(),
+			bCanScrollHorizontally = canScrollHorizontally(bounds),
+			bCanScrollVertically = canScrollVertically(bounds),
+			curHorizontalScrollbarVisible = (horizontalScrollbar === 'auto') ? bCanScrollHorizontally : horizontalScrollbar === 'visible',
+			curVerticalScrollbarVisible = (verticalScrollbar === 'auto') ? bCanScrollVertically : verticalScrollbar === 'visible';
 
 		if (curHorizontalScrollbarVisible || curVerticalScrollbarVisible) {
 			// no visibility change but need to notify whichever scrollbars are visible of the
@@ -1237,15 +964,15 @@ class ScrollableBaseNative extends Component {
 			const
 				updatedBounds = {
 					...bounds,
-					scrollLeft: this.scrollLeft,
-					scrollTop: this.scrollTop
+					scrollLeft: variables.current.scrollLeft,
+					scrollTop: variables.current.scrollTop
 				};
 
-			if (curHorizontalScrollbarVisible && this.horizontalScrollbarRef.current) {
-				this.horizontalScrollbarRef.current.update(updatedBounds);
+			if (curHorizontalScrollbarVisible && horizontalScrollbarRef.current) {
+				horizontalScrollbarRef.current.update(updatedBounds);
 			}
-			if (curVerticalScrollbarVisible && this.verticalScrollbarRef.current) {
-				this.verticalScrollbarRef.current.update(updatedBounds);
+			if (curVerticalScrollbarVisible && verticalScrollbarRef.current) {
+				verticalScrollbarRef.current.update(updatedBounds);
 			}
 			return true;
 		}
@@ -1254,208 +981,490 @@ class ScrollableBaseNative extends Component {
 
 	// ref
 
-	getScrollBounds () {
-		if (this.childRefCurrent && typeof this.childRefCurrent.getScrollBounds === 'function') {
-			return this.childRefCurrent.getScrollBounds();
+	function getScrollBounds () {
+		if (variables.current.childRefCurrent && typeof variables.current.childRefCurrent.getScrollBounds === 'function') {
+			return variables.current.childRefCurrent.getScrollBounds();
 		}
 	}
 
-	getMoreInfo () {
-		if (this.childRefCurrent && typeof this.childRefCurrent.getMoreInfo === 'function') {
-			return this.childRefCurrent.getMoreInfo();
+	function getMoreInfo () {
+		if (variables.current.childRefCurrent && typeof variables.current.childRefCurrent.getMoreInfo === 'function') {
+			return variables.current.childRefCurrent.getMoreInfo();
 		}
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	addEventListeners () {
-		const {childRefCurrent, containerRef} = this;
+	function addEventListeners () {
+		const {childRefCurrent} = variables.current;
 
 		if (containerRef.current && containerRef.current.addEventListener) {
-			containerRef.current.addEventListener('wheel', this.onWheel);
-			containerRef.current.addEventListener('keydown', this.onKeyDown);
-			containerRef.current.addEventListener('mousedown', this.onMouseDown);
+			containerRef.current.addEventListener('wheel', onWheel);
+			containerRef.current.addEventListener('keydown', onKeyDown);
+			containerRef.current.addEventListener('mousedown', onMouseDown);
 		}
 
 		if (childRefCurrent.containerRef.current) {
 			if (childRefCurrent.containerRef.current.addEventListener) {
-				childRefCurrent.containerRef.current.addEventListener('scroll', this.onScroll, {capture: true, passive: true});
+				childRefCurrent.containerRef.current.addEventListener('scroll', onScroll, {capture: true, passive: true});
 			}
-			this.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
+			variables.current.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
 		}
 
-		if (this.props.addEventListeners) {
-			this.props.addEventListeners(childRefCurrent.containerRef);
+		if (props.addEventListeners) {
+			props.addEventListeners(childRefCurrent.containerRef);
 		}
 
 		if (window) {
-			window.addEventListener('resize', this.handleResizeWindow);
+			window.addEventListener('resize', handleResizeWindow);
 		}
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.
-	removeEventListeners () {
-		const {childRefCurrent, containerRef} = this;
+	function removeEventListeners () {
+		const {childRefCurrent} = variables.current;
 
 		if (containerRef.current && containerRef.current.removeEventListener) {
-			containerRef.current.removeEventListener('wheel', this.onWheel);
-			containerRef.current.removeEventListener('keydown', this.onKeyDown);
-			containerRef.current.removeEventListener('mousedown', this.onMouseDown);
+			containerRef.current.removeEventListener('wheel', onWheel);
+			containerRef.current.removeEventListener('keydown', onKeyDown);
+			containerRef.current.removeEventListener('mousedown', onMouseDown);
 		}
 
 		if (childRefCurrent.containerRef.current && childRefCurrent.containerRef.current.removeEventListener) {
-			childRefCurrent.containerRef.current.removeEventListener('scroll', this.onScroll, {capture: true, passive: true});
+			childRefCurrent.containerRef.current.removeEventListener('scroll', onScroll, {capture: true, passive: true});
 		}
 
-		if (this.props.removeEventListeners) {
-			this.props.removeEventListeners(childRefCurrent.containerRef);
+		if (props.removeEventListeners) {
+			props.removeEventListeners(childRefCurrent.containerRef);
 		}
 
 		if (window) {
-			window.removeEventListener('resize', this.handleResizeWindow);
+			window.removeEventListener('resize', handleResizeWindow);
+		}
+	}
+
+	function initChildRef (ref) {
+		if (ref) {
+			variables.current.childRefCurrent = ref.current || ref;
 		}
 	}
 
 	// render
+	variables.current.deferScrollTo = true;
 
-	initChildRef = (ref) => {
-		if (ref) {
-			this.childRefCurrent = ref.current || ref;
-		}
-	}
+	return (
+		<ResizeContext.Provider value={variables.current.resizeRegistry.register}>
+			{containerRenderer({
+				childComponentProps: rest,
+				childWrapper,
+				childWrapperProps,
+				className: scrollableClasses,
+				componentCss: css,
+				containerRef: containerRef,
+				horizontalScrollbarProps: variables.current.horizontalScrollbarProps,
+				initChildRef: initChildRef,
+				isHorizontalScrollbarVisible,
+				isVerticalScrollbarVisible,
+				rtl,
+				scrollTo: scrollTo,
+				style,
+				verticalScrollbarProps: variables.current.verticalScrollbarProps
+			})}
+		</ResizeContext.Provider>
+	);
+};
 
-	render () {
-		const
-			{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = this.props,
-			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
-			scrollableClasses = classNames(css.scrollable, className),
-			contentClasses = classNames(css.content, css.contentNative),
-			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
-			childWrapperProps = {
-				className: contentClasses,
-				...(!noScrollByDrag && {
-					flickConfig,
-					onDrag: this.onDrag,
-					onDragEnd: this.onDragEnd,
-					onDragStart: this.onDragStart,
-					onFlick: this.onFlick,
-					onTouchStart: this.onTouchStart
-				})
-			};
+ScrollableBaseNative.displayName = 'ui:ScrollableBaseNative';
 
-		delete rest.addEventListeners;
-		delete rest.applyOverscrollEffect;
-		delete rest.cbScrollTo;
-		delete rest.clearOverscrollEffect;
-		delete rest.handleResizeWindow;
-		delete rest.horizontalScrollbar;
-		delete rest.noScrollByWheel;
-		delete rest.onFlick;
-		delete rest.onKeyDown;
-		delete rest.onMouseDown;
-		delete rest.onScroll;
-		delete rest.onScrollStart;
-		delete rest.onScrollStop;
-		delete rest.onWheel;
-		delete rest.overscrollEffectOn;
-		delete rest.removeEventListeners;
-		delete rest.scrollStopOnScroll;
-		delete rest.scrollTo;
-		delete rest.start;
-		delete rest.verticalScrollbar;
+ScrollableBaseNative.propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
+	/**
+	 * Render function.
+	 *
+	 * @type {Function}
+	 * @required
+	 * @private
+	 */
+	containerRenderer: PropTypes.func.isRequired,
 
-		this.deferScrollTo = true;
+	/**
+	 * Called when adding additional event listeners in a themed component.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	addEventListeners: PropTypes.func,
 
-		return (
-			<ResizeContext.Provider value={this.resizeRegistry.register}>
-				{containerRenderer({
-					childComponentProps: rest,
-					childWrapper,
-					childWrapperProps,
-					className: scrollableClasses,
-					componentCss: css,
-					containerRef: this.containerRef,
-					horizontalScrollbarProps: this.horizontalScrollbarProps,
-					initChildRef: this.initChildRef,
-					isHorizontalScrollbarVisible,
-					isVerticalScrollbarVisible,
-					rtl,
-					scrollTo: this.scrollTo,
-					style,
-					verticalScrollbarProps: this.verticalScrollbarProps
-				})}
-			</ResizeContext.Provider>
-		);
-	}
-}
+	/**
+	 * Called to execute additional logic in a themed component to show overscroll effect.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	applyOverscrollEffect: PropTypes.func,
+
+	/**
+	 * A callback function that receives a reference to the `scrollTo` feature.
+	 *
+	 * Once received, the `scrollTo` method can be called as an imperative interface.
+	 *
+	 * The `scrollTo` function accepts the following parameters:
+	 * - {position: {x, y}} - Pixel value for x and/or y position
+	 * - {align} - Where the scroll area should be aligned. Values are:
+	 *   `'left'`, `'right'`, `'top'`, `'bottom'`,
+	 *   `'topleft'`, `'topright'`, `'bottomleft'`, and `'bottomright'`.
+	 * - {index} - Index of specific item. (`0` or positive integer)
+	 *   This option is available for only `VirtualList` kind.
+	 * - {node} - Node to scroll into view
+	 * - {animate} - When `true`, scroll occurs with animation. When `false`, no
+	 *   animation occurs.
+	 * - {focus} - When `true`, attempts to focus item after scroll. Only valid when scrolling
+	 *   by `index` or `node`.
+	 * > Note: Only specify one of: `position`, `align`, `index` or `node`
+	 *
+	 * Example:
+	 * ```
+	 *	// If you set cbScrollTo prop like below;
+	 *	cbScrollTo: (fn) => {scrollTo = fn;}
+	 *	// You can simply call like below;
+	 *	scrollTo({align: 'top'}); // scroll to the top
+	 * ```
+	 *
+	 * @type {Function}
+	 * @public
+	 */
+	cbScrollTo: PropTypes.func,
+
+	/**
+	 * Called to execute additional logic in a themed component to clear overscroll effect.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	clearOverscrollEffect: PropTypes.func,
+
+	/**
+	 * Client size of the container; valid values are an object that has `clientWidth` and `clientHeight`.
+	 *
+	 * @type {Object}
+	 * @property {Number}    clientHeight    The client height of the list.
+	 * @property {Number}    clientWidth    The client width of the list.
+	 * @public
+	 */
+	clientSize: PropTypes.shape({
+		clientHeight: PropTypes.number.isRequired,
+		clientWidth: PropTypes.number.isRequired
+	}),
+
+	/**
+	 * Direction of the list or the scroller.
+	 *
+	 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
+	 *
+	 * Valid values are:
+	 * * `'both'`,
+	 * * `'horizontal'`, and
+	 * * `'vertical'`.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
+
+	/**
+	 * Called when resizing window
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	handleResizeWindow: PropTypes.func,
+
+	/**
+	 * Specifies how to show horizontal scrollbar.
+	 *
+	 * Valid values are:
+	 * * `'auto'`,
+	 * * `'visible'`, and
+	 * * `'hidden'`.
+	 *
+	 * @type {String}
+	 * @default 'auto'
+	 * @public
+	 */
+	horizontalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
+
+	/**
+	 * Prevents scroll by dragging or flicking on the list or the scroller.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @private
+	 */
+	noScrollByDrag: PropTypes.bool,
+
+	/**
+	 * Prevents scroll by wheeling on the list or the scroller.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	noScrollByWheel: PropTypes.bool,
+
+	/**
+	 * Called when flicking with a mouse or a touch screen.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	onFlick: PropTypes.func,
+
+	/**
+	 * Called when pressing a key.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	onKeyDown: PropTypes.func,
+
+	/**
+	 * Called when triggering a mousedown event.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	onMouseDown: PropTypes.func,
+
+	/**
+	 * Called when scrolling.
+	 *
+	 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+	 * It is not recommended to set this prop since it can cause performance degradation.
+	 * Use `onScrollStart` or `onScrollStop` instead.
+	 *
+	 * @type {Function}
+	 * @param {Object} event
+	 * @param {Number} event.scrollLeft Scroll left value.
+	 * @param {Number} event.scrollTop Scroll top value.
+	 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+	 * @public
+	 */
+	onScroll: PropTypes.func,
+
+	/**
+	 * Called when scroll starts.
+	 *
+	 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+	 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
+	 *
+	 * Example:
+	 * ```
+	 * onScrollStart = ({scrollLeft, scrollTop, moreInfo}) => {
+	 *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
+	 *     // do something with firstVisibleIndex and lastVisibleIndex
+	 * }
+	 *
+	 * render = () => (
+	 *     <VirtualList
+	 *         ...
+	 *         onScrollStart={onScrollStart}
+	 *         ...
+	 *     />
+	 * )
+	 * ```
+	 *
+	 * @type {Function}
+	 * @param {Object} event
+	 * @param {Number} event.scrollLeft Scroll left value.
+	 * @param {Number} event.scrollTop Scroll top value.
+	 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+	 * @public
+	 */
+	onScrollStart: PropTypes.func,
+
+	/**
+	 * Called when scroll stops.
+	 *
+	 * Passes `scrollLeft`, `scrollTop`, and `moreInfo`.
+	 * You can get firstVisibleIndex and lastVisibleIndex from VirtualList with `moreInfo`.
+	 *
+	 * Example:
+	 * ```
+	 * onScrollStop = ({scrollLeft, scrollTop, moreInfo}) => {
+	 *     const {firstVisibleIndex, lastVisibleIndex} = moreInfo;
+	 *     // do something with firstVisibleIndex and lastVisibleIndex
+	 * }
+	 *
+	 * render = () => (
+	 *     <VirtualList
+	 *         ...
+	 *         onScrollStop={onScrollStop}
+	 *         ...
+	 *     />
+	 * )
+	 * ```
+	 *
+	 * @type {Function}
+	 * @param {Object} event
+	 * @param {Number} event.scrollLeft Scroll left value.
+	 * @param {Number} event.scrollTop Scroll top value.
+	 * @param {Object} event.moreInfo The object including `firstVisibleIndex` and `lastVisibleIndex` properties.
+	 * @public
+	 */
+	onScrollStop: PropTypes.func,
+
+	/**
+	 * Called when wheeling.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	onWheel: PropTypes.func,
+
+	/**
+	 * Specifies overscroll effects shows on which type of inputs.
+	 *
+	 * @type {Object}
+	 * @default {drag: false, pageKey: false, wheel: false}
+	 * @private
+	 */
+	overscrollEffectOn: PropTypes.shape({
+		drag: PropTypes.bool,
+		pageKey: PropTypes.bool,
+		wheel: PropTypes.bool
+	}),
+
+	/**
+	 * Called when removing additional event listeners in a themed component.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	removeEventListeners: PropTypes.func,
+
+	/**
+	 * Indicates the content's text direction is right-to-left.
+	 *
+	 * @type {Boolean}
+	 * @private
+	 */
+	rtl: PropTypes.bool,
+
+	/**
+	 * Called to execute additional logic in a themed component after scrolling.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	scrollStopOnScroll: PropTypes.func,
+
+	/**
+	 * Called to execute additional logic in a themed component when scrollTo is called.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	scrollTo: PropTypes.func,
+
+	/**
+	 * Called to execute additional logic in a themed component when scroll starts.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	start: PropTypes.func,
+
+	/**
+	 * Specifies how to show vertical scrollbar.
+	 *
+	 * Valid values are:
+	 * * `'auto'`,
+	 * * `'visible'`, and
+	 * * `'hidden'`.
+	 *
+	 * @type {String}
+	 * @default 'auto'
+	 * @public
+	 */
+	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
+};
+
+ScrollableBaseNative.defaultProps = {
+	cbScrollTo: nop,
+	horizontalScrollbar: 'auto',
+	noScrollByDrag: false,
+	noScrollByWheel: false,
+	onScroll: nop,
+	onScrollStart: nop,
+	onScrollStop: nop,
+	overscrollEffectOn: {drag: false, pageKey: false, wheel: false},
+	verticalScrollbar: 'auto'
+};
 
 /**
  * An unstyled native component that provides horizontal and vertical scrollbars and makes a render prop element scrollable.
  *
- * @class ScrollableNative
+ * @function ScrollableNative
  * @memberof ui/ScrollableNative
  * @extends ui/Scrollable.ScrollableBaseNative
  * @ui
  * @private
  */
-class ScrollableNative extends Component {
-	static displayName = 'ui:ScrollableNative'
+const ScrollableNative = (props) => {
+	const {childRenderer, ...rest} = props;
 
-	static propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
-		/**
-		 * Render function.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		childRenderer: PropTypes.func
-	}
-
-	render () {
-		const {childRenderer, ...rest} = this.props;
-
-		return (
-			<ScrollableBaseNative
-				{...rest}
-				containerRenderer={({ // eslint-disable-line react/jsx-no-bind
-					childComponentProps,
-					childWrapper: ChildWrapper,
-					childWrapperProps,
-					className,
-					componentCss,
-					containerRef,
-					horizontalScrollbarProps,
-					initChildRef,
-					isHorizontalScrollbarVisible,
-					isVerticalScrollbarVisible,
-					rtl,
-					scrollTo,
-					style,
-					verticalScrollbarProps
-				}) => (
-					<div
-						className={className}
-						ref={containerRef}
-						style={style}
-					>
-						<div className={componentCss.container}>
-							<ChildWrapper {...childWrapperProps}>
-								{childRenderer({
-									...childComponentProps,
-									cbScrollTo: scrollTo,
-									className: componentCss.scrollableFill,
-									initChildRef,
-									rtl
-								})}
-							</ChildWrapper>
-							{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}
-						</div>
-						{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} corner={isVerticalScrollbarVisible} disabled={!isHorizontalScrollbarVisible} /> : null}
+	return (
+		<ScrollableBaseNative
+			{...rest}
+			containerRenderer={({ // eslint-disable-line react/jsx-no-bind
+				childComponentProps,
+				childWrapper: ChildWrapper,
+				childWrapperProps,
+				className,
+				componentCss,
+				containerRef,
+				horizontalScrollbarProps,
+				initChildRef,
+				isHorizontalScrollbarVisible,
+				isVerticalScrollbarVisible,
+				rtl,
+				scrollTo,
+				style,
+				verticalScrollbarProps
+			}) => (
+				<div
+					className={className}
+					ref={containerRef}
+					style={style}
+				>
+					<div className={componentCss.container}>
+						<ChildWrapper {...childWrapperProps}>
+							{childRenderer({
+								...childComponentProps,
+								cbScrollTo: scrollTo,
+								className: componentCss.scrollableFill,
+								initChildRef,
+								rtl
+							})}
+						</ChildWrapper>
+						{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} disabled={!isVerticalScrollbarVisible} /> : null}
 					</div>
-				)}
-			/>
-		);
-	}
-}
+					{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} corner={isVerticalScrollbarVisible} disabled={!isHorizontalScrollbarVisible} /> : null}
+				</div>
+			)}
+		/>
+	);
+};
+
+ScrollableNative.displayName = 'ui:ScrollableNative';
+
+ScrollableNative.propTypes = /** @lends ui/ScrollableNative.ScrollableNative.prototype */ {
+	/**
+	 * Render function.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	childRenderer: PropTypes.func
+};
 
 export default ScrollableNative;
 export {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -27,18 +27,14 @@ import css from './Scroller.module.less';
  * @ui
  * @public
  */
-let ScrollerBase = (props, reference) => {
+const ScrollerBase = forwardRef((props, reference) => {
 	// constructor (props) {
 	const containerRef = useRef();
 	const [, forceUpdate] = useReducer(x => x + 1, 0);
 
 	useEffect(() => {
-		// componentDidMount
-		calculateMetrics();
-	}, []);
-
-	useEffect(() => {
 		// componentDidUpdate
+		// TODO: Check this code is still needed.  This code introduced from #1618. (ahn)
 		forceUpdate();
 	}, [props.isVerticalScrollbarVisible]);
 
@@ -46,7 +42,6 @@ let ScrollerBase = (props, reference) => {
 		// componentDidUpdate
 		calculateMetrics();
 	});
-	// }
 
 	// Instance variables
 	const variables = useRef({
@@ -167,9 +162,7 @@ let ScrollerBase = (props, reference) => {
 			style={mergedStyle}
 		/>
 	);
-};
-
-ScrollerBase = forwardRef(ScrollerBase);
+});
 
 ScrollerBase.displayName = 'ui:ScrollerBase';
 

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -10,7 +10,7 @@
 import classNames from 'classnames';
 import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
-import React, {useEffect, useReducer, useRef} from 'react';
+import React, {forwardRef, useEffect, useImperativeHandle, useReducer, useRef} from 'react';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -27,7 +27,7 @@ import css from './Scroller.module.less';
  * @ui
  * @public
  */
-const ScrollerBase = (props) => {
+let ScrollerBase = (props, reference) => {
 	// constructor (props) {
 	const containerRef = useRef();
 	const [, forceUpdate] = useReducer(x => x + 1, 0);
@@ -35,7 +35,7 @@ const ScrollerBase = (props) => {
 	useEffect(() => {
 		// componentDidMount
 		calculateMetrics();
-	});
+	}, []);
 
 	useEffect(() => {
 		// componentDidUpdate
@@ -64,6 +64,14 @@ const ScrollerBase = (props) => {
 		}
 	});
 
+	useImperativeHandle(reference, () => ({
+		didScroll,
+		getNodePosition,
+		getScrollBounds,
+		scrollToPosition,
+		setScrollPosition,
+		containerRef
+	}));
 
 	function getScrollBounds () {
 		return variables.current.scrollBounds;
@@ -160,6 +168,8 @@ const ScrollerBase = (props) => {
 		/>
 	);
 };
+
+ScrollerBase = forwardRef(ScrollerBase);
 
 ScrollerBase.displayName = 'ui:ScrollerBase';
 

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -2,8 +2,7 @@ import classNames from 'classnames';
 import {forward} from '@enact/core/handle';
 import {platform} from '@enact/core/platform';
 import PropTypes from 'prop-types';
-import equals from 'ramda/src/equals';
-import React, {Component} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 
 import Scrollable from '../Scrollable';
 import ScrollableNative from '../Scrollable/ScrollableNative';
@@ -48,328 +47,187 @@ const itemSizesShape = PropTypes.shape({
 /**
  * The base version of the virtual list component.
  *
- * @class VirtualListCore
+ * @function VirtualListCore
  * @memberof ui/VirtualList
  * @ui
  * @private
  */
 const VirtualListBaseFactory = (type) => {
-	return class VirtualListCore extends Component {
+	const VirtualListCore = (props) => {
 		/* No displayName here. We set displayName to returned components of this factory function. */
 
-		static propTypes = /** @lends ui/VirtualList.VirtualListBase.prototype */ {
-			/**
-			 * The rendering function called for each item in the list.
-			 *
-			 * > **Note**: The list does **not** always render a component whenever its render function is called
-			 * due to performance optimization.
-			 *
-			 * Example:
-			 * ```
-			 * renderItem = ({index, ...rest}) => {
-			 * 	delete rest.data;
-			 *
-			 * 	return (
-			 * 		<MyComponent index={index} {...rest} />
-			 * 	);
-			 * }
-			 * ```
-			 *
-			 * @type {Function}
-			 * @param {Object}     event
-			 * @param {Number}     event.data-index    It is required for `Spotlight` 5-way navigation. Pass to the root element in the component.
-			 * @param {Number}     event.index    The index number of the component to render
-			 * @param {Number}     event.key    It MUST be passed as a prop to the root element in the component for DOM recycling.
-			 *
-			 * @required
-			 * @public
-			 */
-			itemRenderer: PropTypes.func.isRequired,
+		let nextState = null;
 
-			/**
-			 * The size of an item for the list; valid values are either a number for `VirtualList`
-			 * or an object that has `minWidth` and `minHeight` for `VirtualGridList`.
-			 *
-			 * @type {Number|ui/VirtualList.gridListItemSizeShape}
-			 * @required
-			 * @private
-			 */
-			itemSize: PropTypes.oneOfType([
-				PropTypes.number,
-				gridListItemSizeShape
-			]).isRequired,
+		const containerRef = useRef();
+		const contentRef = useRef();
+		const itemContainerRef = useRef();
 
-			/**
-			 * The render function for the items.
-			 *
-			 * @type {Function}
-			 * @required
-			 * @private
-			 */
-			itemsRenderer: PropTypes.func.isRequired,
-
-			/**
-			 * Callback method of scrollTo.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
-			 *
-			 * @type {Function}
-			 * @private
-			 */
-			cbScrollTo: PropTypes.func,
-
-			/**
-			 * Additional props included in the object passed to the `itemsRenderer` callback.
-			 *
-			 * @type {Object}
-			 * @public
-			 */
-			childProps: PropTypes.object,
-
-			/**
-			 * Client size of the list; valid values are an object that has `clientWidth` and `clientHeight`.
-			 *
-			 * @type {Object}
-			 * @property {Number}    clientHeight    The client height of the list.
-			 * @property {Number}    clientWidth    The client width of the list.
-			 * @public
-			 */
-			clientSize: PropTypes.shape({
-				clientHeight: PropTypes.number.isRequired,
-				clientWidth: PropTypes.number.isRequired
-			}),
-
-			/**
-			 * Disable voice control feature of component.
-			 *
-			 * @type {Boolean}
-			 * @public
-			 */
-			'data-webos-voice-disabled': PropTypes.bool,
-
-			/**
-			 * Activates the component for voice control.
-			 *
-			 * @type {Boolean}
-			 * @public
-			 */
-			'data-webos-voice-focused': PropTypes.bool,
-
-			/**
-			 * The voice control group label.
-			 *
-			 * @type {String}
-			 * @public
-			 */
-			'data-webos-voice-group-label': PropTypes.string,
-
-			/**
-			 * The number of items of data the list contains.
-			 *
-			 * @type {Number}
-			 * @default 0
-			 * @public
-			 */
-			dataSize: PropTypes.number,
-
-			/**
-			 * The layout direction of the list.
-			 *
-			 * Valid values are:
-			 * * `'horizontal'`, and
-			 * * `'vertical'`.
-			 *
-			 * @type {String}
-			 * @default 'vertical'
-			 * @public
-			 */
-			direction: PropTypes.oneOf(['horizontal', 'vertical']),
-
-			/**
-			 * Called to get the props for list items.
-			 *
-			 * @type {Function}
-			 * @private
-			 */
-			getComponentProps: PropTypes.func,
-
-			/**
-			 * The array for individually sized items.
-			 *
-			 * @type {Number[]}
-			 * @private
-			 */
-			itemSizes: PropTypes.arrayOf(PropTypes.number),
-
-			/**
-			 * Called when the range of items has updated.
-			 *
-			 * Event payload includes the `firstIndex` and `lastIndex` of the list.
-			 *
-			 * @type {Function}
-			 * @private
-			 */
-			onUpdateItems: PropTypes.func,
-
-			/**
-			 * Number of spare DOM node.
-			 * `3` is good for the default value experimentally and
-			 * this value is highly recommended not to be changed by developers.
-			 *
-			 * @type {Number}
-			 * @default 3
-			 * @private
-			 */
-			overhang: PropTypes.number,
-
-			/**
-			 * When `true`, the list will scroll by page.  Otherwise the list will scroll by item.
-			 *
-			 * @type {Boolean}
-			 * @default false
-			 * @private
-			 */
-			pageScroll: PropTypes.bool,
-
-			/**
-			 * `true` if RTL, `false` if LTR.
-			 *
-			 * @type {Boolean}
-			 * @private
-			 */
-			rtl: PropTypes.bool,
-
-			/**
-			 * The spacing between items.
-			 *
-			 * @type {Number}
-			 * @default 0
-			 * @public
-			 */
-			spacing: PropTypes.number,
-
-			/**
-			 * Called to execute additional logic in a themed component when updating states and bounds.
-			 *
-			 * @type {Function}
-			 * @private
-			 */
-			updateStatesAndBounds: PropTypes.func
+		if (props.clientSize) {
+			calculateMetrics(props);
+			nextState = getStatesAndUpdateBounds();
 		}
 
-		static defaultProps = {
-			cbScrollTo: nop,
-			dataSize: 0,
-			direction: 'vertical',
-			overhang: 3,
-			pageScroll: false,
-			spacing: 0
-		}
+		const [prevChildProps, setPrevChildProps] = useState(null);
+		const [prevFirstIndex, setPrevFirstIndex] = useState(0);
+		const [updateFrom, setUpdateFrom] = useState(0);
+		const [updateTo, setUpdateTo] = useState(0);
+		const [firstIndex, setFirstIndex] = useState(nextState.firstIndex);
+		const [numOfItems, setNumOfItems] = useState(nextState.numOfItems);
 
-		constructor (props) {
-			let nextState = null;
-
-			super(props);
-
-			this.containerRef = React.createRef();
-			this.contentRef = React.createRef();
-			this.itemContainerRef = React.createRef();
-
-			if (props.clientSize) {
-				this.calculateMetrics(props);
-				nextState = this.getStatesAndUpdateBounds(props);
-			}
-
-			this.state = {
-				firstIndex: 0,
-				numOfItems: 0,
-				prevChildProps: null,
-				prevFirstIndex: 0,
-				updateFrom: 0,
-				updateTo: 0,
-				...nextState
-			};
-		}
-
-		static getDerivedStateFromProps (props, state) {
+		// getDerivedStateFromProps
+		{
 			const
 				shouldInvalidate = (
-					state.prevFirstIndex === state.firstIndex ||
-					state.prevChildProps !== props.childProps
+					prevFirstIndex === firstIndex ||
+					prevChildProps !== props.childProps
 				),
-				diff = state.firstIndex - state.prevFirstIndex,
-				updateTo = (-state.numOfItems >= diff || diff > 0 || shouldInvalidate) ? state.firstIndex + state.numOfItems : state.prevFirstIndex,
-				updateFrom = (0 >= diff || diff >= state.numOfItems || shouldInvalidate) ? state.firstIndex : state.prevFirstIndex + state.numOfItems,
-				nextUpdateFromAndTo = (state.updateFrom !== updateFrom || state.updateTo !== updateTo) ? {updateFrom, updateTo} : null;
+				diff = firstIndex - prevFirstIndex,
+				newUpdateTo = (-numOfItems >= diff || diff > 0 || shouldInvalidate) ? firstIndex + numOfItems : prevFirstIndex,
+				newUpdateFrom = (0 >= diff || diff >= numOfItems || shouldInvalidate) ? firstIndex : prevFirstIndex + numOfItems;
 
-			return {
-				...nextUpdateFromAndTo,
-				prevChildProps: props.childProps,
-				prevFirstIndex: state.firstIndex
-			};
+			if (updateFrom !== newUpdateFrom || updateTo !== newUpdateTo) {
+				setUpdateFrom(newUpdateFrom);
+				setUpdateTo(newUpdateTo);
+			}
+			setPrevChildProps(props.childProps);
+			setPrevFirstIndex(firstIndex);
+		}
+
+		// Instance variables
+		const variables = useRef({
+			scrollBounds: {
+				clientWidth: 0,
+				clientHeight: 0,
+				scrollWidth: 0,
+				scrollHeight: 0,
+				maxLeft: 0,
+				maxTop: 0
+			},
+
+			moreInfo: {
+				firstVisibleIndex: null,
+				lastVisibleIndex: null
+			},
+
+			primary: null,
+			secondary: null,
+
+			isPrimaryDirectionVertical: true,
+			isItemSized: false,
+
+			shouldUpdateBounds: false,
+
+			dimensionToExtent: 0,
+			threshold: 0,
+			maxFirstIndex: 0,
+			curDataSize: 0,
+			hasDataSizeChanged: false,
+			cc: [],
+			scrollPosition: 0,
+			scrollPositionTarget: 0,
+
+			// For individually sized item
+			itemPositions: [],
+			indexToScrollIntoView: -1,
+
+			deferScrollTo : false
+		});
+
+		// render
+		const
+			{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-disabled': voiceDisabled, itemsRenderer, style, ...rest} = props,
+			{cc, primary} = variables.current,
+			containerClasses = getContainerClasses(),
+			contentClasses = getContentClasses();
+
+		delete rest.cbScrollTo;
+		delete rest.childProps;
+		delete rest.clientSize;
+		delete rest.dataSize;
+		delete rest.direction;
+		delete rest.getComponentProps;
+		delete rest.isHorizontalScrollbarVisible;
+		delete rest.isVerticalScrollbarVisible;
+		delete rest.itemRenderer;
+		delete rest.itemSize;
+		delete rest.onUpdate;
+		delete rest.onUpdateItems;
+		delete rest.overhang;
+		delete rest.pageScroll;
+		delete rest.rtl;
+		delete rest.spacing;
+		delete rest.updateStatesAndBounds;
+		delete rest.itemSizes;
+
+		if (primary) {
+			positionItems();
 		}
 
 		// Calculate metrics for VirtualList after the 1st render to know client W/H.
-		componentDidMount () {
-			if (!this.props.clientSize) {
-				this.calculateMetrics(this.props);
+		useEffect(() => {
+			// componentDidMount
+			if (!props.clientSize) {
+				calculateMetrics(props);
 				// eslint-disable-next-line react/no-did-mount-set-state
-				this.setState(this.getStatesAndUpdateBounds(this.props));
+				const statesAndUpdateBounds = getStatesAndUpdateBounds();
+				setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+				setNumOfItems(statesAndUpdateBounds.numOfItems);
+
 			} else {
-				this.emitUpdateItems();
+				emitUpdateItems();
 			}
 
-			if (this.props.itemSizes) {
-				this.adjustItemPositionWithItemSize();
+			if (props.itemSizes) {
+				adjustItemPositionWithItemSize();
 			} else {
-				this.setContainerSize();
+				setContainerSize();
 			}
-		}
+		}, []);
 
-		componentDidUpdate (prevProps, prevState) {
-			let deferScrollTo = false;
-			const {firstIndex, numOfItems} = this.state;
+		useEffect(() => {
+			// componentDidUpdate
+			// if (prevState.firstIndex !== firstIndex || prevState.numOfItems !== numOfItems) {
+			emitUpdateItems();
+		}, [firstIndex, numOfItems]);
 
-			this.shouldUpdateBounds = false;
+		useEffect(() => {
+			// componentDidUpdate
+			variables.current.deferScrollTo = false;
 
-			// TODO: remove `this.hasDataSizeChanged` and fix ui/Scrollable*
-			this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
-
-			if (prevState.firstIndex !== firstIndex || prevState.numOfItems !== numOfItems) {
-				this.emitUpdateItems();
-			}
+			variables.current.shouldUpdateBounds = false;
 
 			// When an item expands or shrinks,
 			// we need to calculate the item position again and
 			// the item needs to scroll into view if the item does not show fully.
-			if (this.props.itemSizes) {
-				if (this.itemPositions.length > this.props.itemSizes.length) {
-					// The item with `this.props.itemSizes.length` index is not rendered yet.
+			if (props.itemSizes) {
+				if (variables.current.itemPositions.length > props.itemSizes.length) {
+					// The item with `props.itemSizes.length` index is not rendered yet.
 					// So the item could scroll into view after it rendered.
-					// To do it, `this.props.itemSizes.length` value is cached in `this.indexToScrollIntoView`.
-					this.indexToScrollIntoView = this.props.itemSizes.length;
+					// To do it, `props.itemSizes.length` value is cached in `indexToScrollIntoView`.
+					variables.current.indexToScrollIntoView = props.itemSizes.length;
 
-					this.itemPositions = [...this.itemPositions.slice(0, this.props.itemSizes.length)];
-					this.adjustItemPositionWithItemSize();
+					variables.current.itemPositions = [...variables.current.itemPositions.slice(0, props.itemSizes.length)];
+					adjustItemPositionWithItemSize();
 				} else {
-					const {indexToScrollIntoView} = this;
+					const {indexToScrollIntoView} = variables.current;
 
-					this.adjustItemPositionWithItemSize();
+					adjustItemPositionWithItemSize();
 
 					if (indexToScrollIntoView !== -1) {
 						// Currently we support expandable items in only vertical VirtualList.
 						// So the top and bottom of the boundaries are checked.
 						const
-							scrollBounds = {top: this.scrollPosition, bottom: this.scrollPosition + this.scrollBounds.clientHeight},
-							itemBounds = {top: this.getGridPosition(indexToScrollIntoView).primaryPosition, bottom: this.getItemBottomPosition(indexToScrollIntoView)};
+							scrollBounds = {top: variables.current.scrollPosition, bottom: variables.current.scrollPosition + variables.current.scrollBounds.clientHeight},
+							itemBounds = {top: getGridPosition(indexToScrollIntoView).primaryPosition, bottom: getItemBottomPosition(indexToScrollIntoView)};
 
 						if (itemBounds.top < scrollBounds.top) {
-							this.props.cbScrollTo({
+							props.cbScrollTo({
 								index: indexToScrollIntoView,
 								stickTo: 'start',
 								animate: true
 							});
 						} else if (itemBounds.bottom > scrollBounds.bottom) {
-							this.props.cbScrollTo({
+							props.cbScrollTo({
 								index: indexToScrollIntoView,
 								stickTo: 'end',
 								animate: true
@@ -377,106 +235,101 @@ const VirtualListBaseFactory = (type) => {
 						}
 					}
 
-					this.indexToScrollIntoView = -1;
+					variables.current.indexToScrollIntoView = -1;
 				}
 			}
+		});
 
-			if (
-				prevProps.direction !== this.props.direction ||
-				prevProps.overhang !== this.props.overhang ||
-				prevProps.spacing !== this.props.spacing ||
-				!equals(prevProps.itemSize, this.props.itemSize)
-			) {
-				const {x, y} = this.getXY(this.scrollPosition, 0);
+		useEffect(() => {
+			// if (
+			// 	prevProps.direction !== this.props.direction ||
+			// 	prevProps.overhang !== this.props.overhang ||
+			// 	prevProps.spacing !== this.props.spacing ||
+			// 	!equals(prevProps.itemSize, this.props.itemSize)
+			// )
+			const {x, y} = getXY(variables.current.scrollPosition, 0);
 
-				this.calculateMetrics(this.props);
+			calculateMetrics(props);
+			// eslint-disable-next-line react/no-did-update-set-state
+			const statesAndUpdateBounds = getStatesAndUpdateBounds();
+			setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+			setNumOfItems(statesAndUpdateBounds.numOfItems);
+
+			setContainerSize();
+
+			const {clientHeight, clientWidth, scrollHeight, scrollWidth} = variables.current.scrollBounds;
+			const xMax = scrollWidth - clientWidth;
+			const yMax = scrollHeight - clientHeight;
+
+			updateScrollPosition({
+				x: xMax > x ? x : xMax,
+				y: yMax > y ? y : yMax
+			});
+
+			variables.current.deferScrollTo = true;
+
+		}, [props.direction, props.overhang, props.spacing, props.itemSize]);
+
+
+		useEffect(() => {
+			// TODO: remove `hasDataSizeChanged` and fix ui/Scrollable*
+			// this.hasDataSizeChanged = (prevProps.dataSize !== this.props.dataSize);
+			variables.current.hasDataSizeChanged = true;
+			if (!variables.current.deferScrollTo && variables.current.hasDataSizeChanged) {
+				const newState = getStatesAndUpdateBounds();
 				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(this.getStatesAndUpdateBounds(this.props));
-				this.setContainerSize();
+				setFirstIndex(newState.newFirstIndex);
+				setNumOfItems(newState.numOfItems);
 
-				const {clientHeight, clientWidth, scrollHeight, scrollWidth} = this.scrollBounds;
-				const xMax = scrollWidth - clientWidth;
-				const yMax = scrollHeight - clientHeight;
+				setContainerSize();
 
-				this.updateScrollPosition({
-					x: xMax > x ? x : xMax,
-					y: yMax > y ? y : yMax
-				});
-
-				deferScrollTo = true;
-			} else if (this.hasDataSizeChanged) {
-				const newState = this.getStatesAndUpdateBounds(this.props, this.state.firstIndex);
-				// eslint-disable-next-line react/no-did-update-set-state
-				this.setState(newState);
-				this.setContainerSize();
-
-				deferScrollTo = true;
-			} else if (prevProps.rtl !== this.props.rtl) {
-				this.updateScrollPosition(this.getXY(this.scrollPosition, 0));
+				variables.current.deferScrollTo = true;
 			}
+		}, [props.dataSize]);
 
-			const maxPos = this.isPrimaryDirectionVertical ? this.scrollBounds.maxTop : this.scrollBounds.maxLeft;
-
-			if (!deferScrollTo && this.scrollPosition > maxPos) {
-				this.props.cbScrollTo({position: (this.isPrimaryDirectionVertical) ? {y: maxPos} : {x: maxPos}, animate: false});
+		useEffect(() => {
+			// else if (prevProps.rtl !== this.props.rtl)
+			if (!variables.current.deferScrollTo) {
+				updateScrollPosition(getXY(variables.current.scrollPosition, 0));
 			}
-		}
+		}, [props.rtl]);
 
-		scrollBounds = {
-			clientWidth: 0,
-			clientHeight: 0,
-			scrollWidth: 0,
-			scrollHeight: 0,
-			maxLeft: 0,
-			maxTop: 0
-		}
+		useEffect(() => {
+			const maxPos = variables.current.isPrimaryDirectionVertical ? variables.current.scrollBounds.maxTop : variables.current.scrollBounds.maxLeft;
 
-		moreInfo = {
-			firstVisibleIndex: null,
-			lastVisibleIndex: null
-		}
+			if (!variables.current.deferScroll && variables.current.scrollPosition > maxPos) {
+				props.cbScrollTo({position: (variables.current.isPrimaryDirectionVertical) ? {y: maxPos} : {x: maxPos}, animate: false});
+			}
+		});
 
-		primary = null
-		secondary = null
-
-		isPrimaryDirectionVertical = true
-		isItemSized = false
-
-		shouldUpdateBounds = false
-
-		dimensionToExtent = 0
-		threshold = 0
-		maxFirstIndex = 0
-		curDataSize = 0
-		hasDataSizeChanged = false
-		cc = []
-		scrollPosition = 0
-		scrollPositionTarget = 0
-
-		// For individually sized item
-		itemPositions = []
-		indexToScrollIntoView = -1
-
-		updateScrollPosition = ({x, y}, rtl = this.props.rtl) => {
+		function updateScrollPosition ({x, y}, rtl = props.rtl) {
 			if (type === Native) {
-				this.scrollToPosition(x, y, rtl);
+				scrollToPosition(x, y, rtl);
 			} else {
-				this.setScrollPosition(x, y, rtl, x, y);
+				setScrollPosition(x, y, rtl, x, y);
 			}
 		}
 
-		isVertical = () => this.isPrimaryDirectionVertical
+		function isVertical () {
+			return variables.current.isPrimaryDirectionVertical;
+		}
 
-		isHorizontal = () => !this.isPrimaryDirectionVertical
+		function isHorizontal () {
+			return !variables.current.isPrimaryDirectionVertical;
+		}
 
-		getScrollBounds = () => this.scrollBounds
+		function getScrollBounds () {
+			return variables.current.scrollBounds;
+		}
 
-		getMoreInfo = () => this.moreInfo
+		function getMoreInfo () {
+			return variables.current.moreInfo;
+		}
 
-		getGridPosition (index) {
+		function getGridPosition (index) {
 			const
-				{dataSize, itemSizes} = this.props,
-				{dimensionToExtent, itemPositions, primary, secondary} = this,
+				{dataSize, itemSizes} = props,
+				{dimensionToExtent, itemPositions, secondary} = variables.current,
 				secondaryPosition = (index % dimensionToExtent) * secondary.gridSize,
 				extent = Math.floor(index / dimensionToExtent);
 			let primaryPosition;
@@ -487,7 +340,7 @@ const VirtualListBaseFactory = (type) => {
 				if (!itemPositions[firstIndexInExtent]) {
 					// Cache individually sized item positions
 					for (let i = itemPositions.length; i <= index; i++) {
-						this.calculateAndCacheItemPosition(i);
+						calculateAndCacheItemPosition(i);
 					}
 				}
 
@@ -504,73 +357,76 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		// For individually sized item
-		getItemBottomPosition = (index) => {
+		function getItemBottomPosition (index) {
 			const
-				itemPosition = this.itemPositions[index],
-				itemSize = this.props.itemSizes[index];
+				itemPosition = variables.current.itemPositions[index],
+				itemSize = props.itemSizes[index];
 
 			if (itemPosition && (itemSize || itemSize === 0)) {
 				return itemPosition.position + itemSize;
 			} else {
-				return index * this.primary.gridSize - this.props.spacing;
+				return index * variables.current.primary.gridSize - props.spacing;
 			}
 		}
 
 		// For individually sized item
-		getItemTopPositionFromPreviousItemBottomPosition = (index, spacing) => {
-			return index === 0 ? 0 : this.getItemBottomPosition(index - 1) + spacing;
+		function getItemTopPositionFromPreviousItemBottomPosition (index, spacing) {
+			return index === 0 ? 0 : getItemBottomPosition(index - 1) + spacing;
 		}
 
-		getItemPosition = (index, stickTo = 'start') => {
+		function getItemPosition (index, stickTo = 'start') {
 			const
-				{primary} = this,
-				position = this.getGridPosition(index);
+				position = getGridPosition(index);
 			let  offset = 0;
 
 			if (stickTo === 'start') {
 				offset = 0;
-			} else if (this.props.itemSizes) {
-				offset = primary.clientSize - this.props.itemSizes[index];
+			} else if (props.itemSizes) {
+				offset = primary.clientSize - props.itemSizes[index];
 			} else {
 				offset = primary.clientSize - primary.itemSize;
 			}
 
 			position.primaryPosition -= offset;
 
-			return this.gridPositionToItemPosition(position);
+			return gridPositionToItemPosition(position);
 		}
 
-		gridPositionToItemPosition = ({primaryPosition, secondaryPosition}) =>
-			(this.isPrimaryDirectionVertical ? {left: secondaryPosition, top: primaryPosition} : {left: primaryPosition, top: secondaryPosition})
+		function gridPositionToItemPosition ({primaryPosition, secondaryPosition}) {
+			return (variables.current.isPrimaryDirectionVertical ? {left: secondaryPosition, top: primaryPosition} : {left: primaryPosition, top: secondaryPosition});
+		}
 
-		getXY = (primaryPosition, secondaryPosition) => (this.isPrimaryDirectionVertical ? {x: secondaryPosition, y: primaryPosition} : {x: primaryPosition, y: secondaryPosition})
+		function getXY (primaryPosition, secondaryPosition) {
+			return (variables.current.isPrimaryDirectionVertical ? {x: secondaryPosition, y: primaryPosition} : {x: primaryPosition, y: secondaryPosition});
+		}
 
-		getClientSize = (node) => ({
-			clientWidth: node.clientWidth,
-			clientHeight: node.clientHeight
-		})
+		function getClientSize (node) {
+			return {
+				clientWidth: node.clientWidth,
+				clientHeight: node.clientHeight
+			};
+		}
 
-		emitUpdateItems () {
-			const {dataSize} = this.props;
-			const {firstIndex, numOfItems} = this.state;
+		function emitUpdateItems () {
+			const {dataSize} = props;
 
 			forward('onUpdateItems', {
 				firstIndex: firstIndex,
 				lastIndex: Math.min(firstIndex + numOfItems, dataSize)
-			}, this.props);
+			}, props);
 		}
 
-		calculateMetrics (props) {
+		function calculateMetrics () {
 			const
 				{clientSize, direction, itemSize, overhang, spacing} = props,
-				node = this.containerRef.current;
+				node = containerRef.current;
 
 			if (!clientSize && !node) {
 				return;
 			}
 
 			const
-				{clientWidth, clientHeight} = (clientSize || this.getClientSize(node)),
+				{clientWidth, clientHeight} = (clientSize || getClientSize(node)),
 				heightInfo = {
 					clientSize: clientHeight,
 					minItemSize: itemSize.minHeight || null,
@@ -581,22 +437,22 @@ const VirtualListBaseFactory = (type) => {
 					minItemSize: itemSize.minWidth || null,
 					itemSize: itemSize
 				};
-			let primary, secondary, dimensionToExtent, thresholdBase;
+			let primaryInfo, secondary, dimensionToExtent, thresholdBase;
 
-			this.isPrimaryDirectionVertical = (direction === 'vertical');
+			variables.current.isPrimaryDirectionVertical = (direction === 'vertical');
 
-			if (this.isPrimaryDirectionVertical) {
-				primary = heightInfo;
+			if (variables.current.isPrimaryDirectionVertical) {
+				primaryInfo = heightInfo;
 				secondary = widthInfo;
 			} else {
-				primary = widthInfo;
+				primaryInfo = widthInfo;
 				secondary = heightInfo;
 			}
 			dimensionToExtent = 1;
 
-			this.isItemSized = (primary.minItemSize && secondary.minItemSize);
+			variables.current.isItemSized = (primaryInfo.minItemSize && secondary.minItemSize);
 
-			if (this.isItemSized) {
+			if (variables.current.isItemSized) {
 				// the number of columns is the ratio of the available width plus the spacing
 				// by the minimum item width plus the spacing
 				dimensionToExtent = Math.max(Math.floor((secondary.clientSize + spacing) / (secondary.minItemSize + spacing)), 1);
@@ -604,69 +460,69 @@ const VirtualListBaseFactory = (type) => {
 				// and spacing are accounted for and the number of columns that we know we should have
 				secondary.itemSize = Math.floor((secondary.clientSize - (spacing * (dimensionToExtent - 1))) / dimensionToExtent);
 				// the actual item height is related to the item width
-				primary.itemSize = Math.floor(primary.minItemSize * (secondary.itemSize / secondary.minItemSize));
+				primaryInfo.itemSize = Math.floor(primaryInfo.minItemSize * (secondary.itemSize / secondary.minItemSize));
 			}
 
-			primary.gridSize = primary.itemSize + spacing;
+			primaryInfo.gridSize = primaryInfo.itemSize + spacing;
 			secondary.gridSize = secondary.itemSize + spacing;
-			thresholdBase = primary.gridSize * Math.ceil(overhang / 2);
+			thresholdBase = primaryInfo.gridSize * Math.ceil(overhang / 2);
 
-			this.threshold = {min: -Infinity, max: thresholdBase, base: thresholdBase};
-			this.dimensionToExtent = dimensionToExtent;
+			variables.current.threshold = {min: -Infinity, max: thresholdBase, base: thresholdBase};
+			variables.current.dimensionToExtent = dimensionToExtent;
 
-			this.primary = primary;
-			this.secondary = secondary;
+			variables.current.primary = primaryInfo;
+			variables.current.secondary = secondary;
 
 			// reset
-			this.scrollPosition = 0;
-			if (type === JS && this.contentRef.current) {
-				this.contentRef.current.style.transform = null;
+			variables.current.scrollPosition = 0;
+			if (type === JS && contentRef.current) {
+				contentRef.current.style.transform = null;
 			}
 		}
 
-		getStatesAndUpdateBounds = (props, firstIndex = 0) => {
+		function getStatesAndUpdateBounds () {
 			const
 				{dataSize, overhang, updateStatesAndBounds} = props,
-				{dimensionToExtent, primary, moreInfo, scrollPosition} = this,
-				numOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
-				wasFirstIndexMax = ((this.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === this.maxFirstIndex)),
-				dataSizeDiff = dataSize - this.curDataSize;
+				{dimensionToExtent, moreInfo, scrollPosition} = variables.current,
+				newNumOfItems = Math.min(dataSize, dimensionToExtent * (Math.ceil(primary.clientSize / primary.gridSize) + overhang)),
+				wasFirstIndexMax = ((variables.current.maxFirstIndex < moreInfo.firstVisibleIndex - dimensionToExtent) && (firstIndex === variables.current.maxFirstIndex)),
+				dataSizeDiff = dataSize - variables.current.curDataSize;
 			let newFirstIndex = firstIndex;
 
 			// When calling setState() except in didScroll(), `shouldUpdateBounds` should be `true`
 			// so that setState() in didScroll() could be called to override state.
 			// Before calling setState() except in didScroll(), getStatesAndUpdateBounds() is always called.
 			// So `shouldUpdateBounds` is true here.
-			this.shouldUpdateBounds = true;
+			variables.current.shouldUpdateBounds = true;
 
-			this.maxFirstIndex = Math.ceil((dataSize - numOfItems) / dimensionToExtent) * dimensionToExtent;
-			this.curDataSize = dataSize;
+			variables.current.maxFirstIndex = Math.ceil((dataSize - newNumOfItems) / dimensionToExtent) * dimensionToExtent;
+			variables.current.curDataSize = dataSize;
 
 			// reset children
-			this.cc = [];
-			this.itemPositions = []; // For individually sized item
-			this.calculateScrollBounds(props);
-			this.updateMoreInfo(dataSize, scrollPosition);
+			variables.current.cc = [];
+			variables.current.itemPositions = []; // For individually sized item
+			calculateScrollBounds();
+			updateMoreInfo(dataSize, scrollPosition);
 
 			if (!(updateStatesAndBounds && updateStatesAndBounds({
 				cbScrollTo: props.cbScrollTo,
-				numOfItems,
+				newNumOfItems,
 				dataSize,
 				moreInfo
 			}))) {
-				newFirstIndex = this.calculateFirstIndex(props, wasFirstIndexMax, dataSizeDiff, firstIndex);
+				newFirstIndex = calculateFirstIndex(wasFirstIndexMax, dataSizeDiff);
 			}
 
 			return {
 				firstIndex: newFirstIndex,
-				numOfItems: numOfItems
+				numOfItems: newNumOfItems
 			};
 		}
 
-		calculateFirstIndex (props, wasFirstIndexMax, dataSizeDiff, firstIndex) {
+		function calculateFirstIndex (wasFirstIndexMax, dataSizeDiff) {
 			const
 				{overhang} = props,
-				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, primary, scrollBounds, scrollPosition, threshold} = this,
+				{dimensionToExtent, isPrimaryDirectionVertical, maxFirstIndex, scrollBounds, scrollPosition, threshold} = variables.current,
 				{gridSize} = primary;
 			let newFirstIndex = firstIndex;
 
@@ -698,64 +554,63 @@ const VirtualListBaseFactory = (type) => {
 			return newFirstIndex;
 		}
 
-		calculateScrollBounds (props) {
+		function calculateScrollBounds () {
 			const
 				{clientSize} = props,
-				node = this.containerRef.current;
+				node = containerRef.current;
 
 			if (!clientSize && !node) {
 				return;
 			}
 
 			const
-				{scrollBounds, isPrimaryDirectionVertical} = this,
-				{clientWidth, clientHeight} = clientSize || this.getClientSize(node);
+				{scrollBounds, isPrimaryDirectionVertical} = variables.current,
+				{clientWidth, clientHeight} = clientSize || getClientSize(node);
 			let maxPos;
 
 			scrollBounds.clientWidth = clientWidth;
 			scrollBounds.clientHeight = clientHeight;
-			scrollBounds.scrollWidth = this.getScrollWidth();
-			scrollBounds.scrollHeight = this.getScrollHeight();
+			scrollBounds.scrollWidth = getScrollWidth();
+			scrollBounds.scrollHeight = getScrollHeight();
 			scrollBounds.maxLeft = Math.max(0, scrollBounds.scrollWidth - clientWidth);
 			scrollBounds.maxTop = Math.max(0, scrollBounds.scrollHeight - clientHeight);
 
 			// correct position
 			maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft;
 
-			this.syncThreshold(maxPos);
+			syncThreshold(maxPos);
 		}
 
-		setContainerSize = () => {
-			if (this.contentRef.current) {
-				this.contentRef.current.style.width = this.scrollBounds.scrollWidth + (this.isPrimaryDirectionVertical ? -1 : 0) + 'px';
-				this.contentRef.current.style.height = this.scrollBounds.scrollHeight + (this.isPrimaryDirectionVertical ? 0 : -1) + 'px';
+		function setContainerSize () {
+			if (contentRef.current) {
+				contentRef.current.style.width = variables.current.scrollBounds.scrollWidth + (variables.current.isPrimaryDirectionVertical ? -1 : 0) + 'px';
+				contentRef.current.style.height = variables.current.scrollBounds.scrollHeight + (variables.current.isPrimaryDirectionVertical ? 0 : -1) + 'px';
 			}
 		}
 
-		updateMoreInfo (dataSize, primaryPosition) {
+		function updateMoreInfo (dataSize, primaryPosition) {
 			const
-				{dimensionToExtent, moreInfo} = this,
-				{itemSize, gridSize, clientSize} = this.primary;
+				{dimensionToExtent: dimensionToExtent, moreInfo: moreInfo} = variables.current,
+				{itemSize, gridSize, clientSize} = variables.current.primary;
 
 			if (dataSize <= 0) {
 				moreInfo.firstVisibleIndex = null;
 				moreInfo.lastVisibleIndex = null;
-			} else if (this.props.itemSizes) {
-				const {firstIndex, numOfItems} = this.state;
-				const {isPrimaryDirectionVertical, scrollBounds: {clientWidth, clientHeight}, scrollPosition} = this;
+			} else if (props.itemSizes) {
+				const {isPrimaryDirectionVertical, scrollBounds: {clientWidth, clientHeight}, scrollPosition} = variables.current;
 				const size = isPrimaryDirectionVertical ? clientHeight : clientWidth;
 
 				let firstVisibleIndex = null, lastVisibleIndex = null;
 
 				for (let i = firstIndex; i < firstIndex +  numOfItems; i++) {
-					if (scrollPosition <= this.getItemBottomPosition(i)) {
+					if (scrollPosition <= getItemBottomPosition(i)) {
 						firstVisibleIndex = i;
 						break;
 					}
 				}
 
 				for (let i = firstIndex + numOfItems - 1; i >= firstIndex; i--) {
-					if (scrollPosition + size >= this.getItemBottomPosition(i) - this.props.itemSizes[i]) {
+					if (scrollPosition + size >= getItemBottomPosition(i) - props.itemSizes[i]) {
 						lastVisibleIndex = i;
 						break;
 					}
@@ -774,8 +629,8 @@ const VirtualListBaseFactory = (type) => {
 			}
 		}
 
-		syncThreshold (maxPos) {
-			const {threshold} = this;
+		function syncThreshold (maxPos) {
+			const {threshold} = variables.current;
 
 			if (threshold.max > maxPos) {
 				if (maxPos < threshold.base) {
@@ -789,46 +644,45 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		// Native only
-		scrollToPosition (x, y, rtl = this.props.rtl) {
-			if (this.containerRef.current) {
-				if (this.isPrimaryDirectionVertical) {
-					this.scrollPositionTarget = y;
+		function scrollToPosition (x, y, rtl = props.rtl) {
+			if (containerRef.current) {
+				if (variables.current.isPrimaryDirectionVertical) {
+					variables.current.scrollPositionTarget = y;
 				} else {
-					this.scrollPositionTarget = x;
+					variables.current.scrollPositionTarget = x;
 				}
 
 				if (rtl) {
-					x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+					x = (platform.ios || platform.safari) ? -x : variables.current.scrollBounds.maxLeft - x;
 				}
 
-				this.containerRef.current.scrollTo(x, y);
+				containerRef.current.scrollTo(x, y);
 			}
 		}
 
 		// JS only
-		setScrollPosition (x, y, rtl = this.props.rtl, targetX = 0, targetY = 0) {
-			if (this.contentRef.current) {
-				this.contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
+		function setScrollPosition (x, y, rtl = props.rtl, targetX = 0, targetY = 0) {
+			if (contentRef.current) {
+				contentRef.current.style.transform = `translate3d(${rtl ? x : -x}px, -${y}px, 0)`;
 
 				// The `x`, `y` as parameters in scrollToPosition() are the position when stopping scrolling.
 				// But the `x`, `y` as parameters in setScrollPosition() are the position between current position and the position stopping scrolling.
 				// To know the position when stopping scrolling here, `targetX` and `targetY` are passed and cached in `this.scrollPositionTarget`.
-				if (this.isPrimaryDirectionVertical) {
-					this.scrollPositionTarget = targetY;
+				if (variables.current.isPrimaryDirectionVertical) {
+					variables.current.scrollPositionTarget = targetY;
 				} else {
-					this.scrollPositionTarget = targetX;
+					variables.current.scrollPositionTarget = targetX;
 				}
 
-				this.didScroll(x, y);
+				didScroll(x, y);
 			}
 		}
 
-		didScroll (x, y) {
+		function didScroll (x, y) {
 			const
-				{dataSize, spacing, itemSizes} = this.props,
-				{firstIndex} = this.state,
-				{isPrimaryDirectionVertical, threshold, dimensionToExtent, maxFirstIndex, scrollBounds, itemPositions} = this,
-				{clientSize, gridSize} = this.primary,
+				{dataSize, spacing, itemSizes} = props,
+				{isPrimaryDirectionVertical, threshold, dimensionToExtent, maxFirstIndex, scrollBounds, itemPositions} = variables.current,
+				{clientSize, gridSize} = variables.current.primary,
 				maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft;
 			let newFirstIndex = firstIndex, index, pos, size, itemPosition;
 
@@ -841,8 +695,8 @@ const VirtualListBaseFactory = (type) => {
 			if (pos > threshold.max || pos < threshold.min) {
 				let newThresholdMin = -Infinity, newThresholdMax = Infinity;
 
-				if (this.props.itemSizes) {
-					const overhangBefore = Math.floor(this.props.overhang / 2);
+				if (props.itemSizes) {
+					const overhangBefore = Math.floor(props.overhang / 2);
 					let firstRenderedIndex = -1;
 
 					// find an item which is known as placed the first rendered item's position
@@ -884,7 +738,7 @@ const VirtualListBaseFactory = (type) => {
 					newFirstIndex = Math.max(0, Math.min(maxFirstIndex, newFirstIndex));
 				} else {
 					const
-						overhangBefore = Math.floor(this.props.overhang / 2),
+						overhangBefore = Math.floor(props.overhang / 2),
 						firstExtent = Math.max(
 							0,
 							Math.min(
@@ -902,35 +756,34 @@ const VirtualListBaseFactory = (type) => {
 				threshold.max = newFirstIndex === maxFirstIndex ? Infinity : newThresholdMax;
 			}
 
-			this.syncThreshold(maxPos);
-			this.scrollPosition = pos;
-			this.updateMoreInfo(dataSize, pos);
+			syncThreshold(maxPos);
+			variables.current.scrollPosition = pos;
+			updateMoreInfo(dataSize, pos);
 
-			if (this.shouldUpdateBounds || firstIndex !== newFirstIndex) {
-				this.setState({firstIndex: newFirstIndex});
+			if (variables.current.shouldUpdateBounds || firstIndex !== newFirstIndex) {
+				setFirstIndex(newFirstIndex);
 			}
 		}
 
 		// For individually sized item
-		calculateAndCacheItemPosition (index) {
-			const {itemSizes} = this.props;
+		function calculateAndCacheItemPosition (index) {
+			const {itemSizes} = props;
 
-			if (!this.itemPositions[index] && itemSizes[index]) {
+			if (!variables.current.itemPositions[index] && itemSizes[index]) {
 				const
-					{spacing} = this.props,
-					position = this.getItemTopPositionFromPreviousItemBottomPosition(index, spacing);
+					{spacing} = props,
+					position = getItemTopPositionFromPreviousItemBottomPosition(index, spacing);
 
-				this.itemPositions[index] = {position};
+				variables.current.itemPositions[index] = {position};
 			}
 		}
 
 		// For individually sized item
-		applyItemPositionToDOMElement (index) {
+		function applyItemPositionToDOMElement (index) {
 			const
-				{direction, rtl} = this.props,
-				{numOfItems} = this.state,
-				{itemPositions} = this,
-				childNode = this.itemContainerRef.current.children[index % numOfItems];
+				{direction, rtl} = props,
+				{itemPositions} = variables.current,
+				childNode = itemContainerRef.current.children[index % numOfItems];
 
 			if (childNode && itemPositions[index]) {
 				const position = itemPositions[index].position;
@@ -943,35 +796,33 @@ const VirtualListBaseFactory = (type) => {
 		}
 
 		// For individually sized item
-		updateThresholdWithItemPosition () {
+		function updateThresholdWithItemPosition () {
 			const
-				{overhang} = this.props,
-				{firstIndex} = this.state,
-				{maxFirstIndex} = this,
+				{overhang} = props,
+				{maxFirstIndex} = variables.current,
 				numOfUpperLine = Math.floor(overhang / 2);
 
-			this.threshold.min = firstIndex === 0 ? -Infinity : this.getItemBottomPosition(firstIndex + numOfUpperLine);
-			this.threshold.max = firstIndex === maxFirstIndex ? Infinity : this.getItemBottomPosition(firstIndex + (numOfUpperLine + 1));
+			variables.current.threshold.min = firstIndex === 0 ? -Infinity : getItemBottomPosition(firstIndex + numOfUpperLine);
+			variables.current.threshold.max = firstIndex === maxFirstIndex ? Infinity : getItemBottomPosition(firstIndex + (numOfUpperLine + 1));
 		}
 
 		// For individually sized item
-		updateScrollBoundsWithItemPositions () {
+		function updateScrollBoundsWithItemPositions () {
 			const
-				{dataSize, itemSizes, spacing} = this.props,
-				{firstIndex, numOfItems} = this.state,
-				{isPrimaryDirectionVertical, itemPositions} = this,
+				{dataSize, itemSizes, spacing} = props,
+				{isPrimaryDirectionVertical, itemPositions} = variables.current,
 				scrollBoundsDimension = isPrimaryDirectionVertical ? 'scrollHeight' : 'scrollWidth';
 
 			if (itemPositions.length === dataSize) { // all item sizes are known
-				this.scrollBounds[scrollBoundsDimension] =
+				variables.current.scrollBounds[scrollBoundsDimension] =
 					itemSizes.reduce((acc, cur) => acc + cur, 0) + (dataSize - 1) * spacing;
 			} else {
 				for (let index = firstIndex + numOfItems - 1; index < dataSize; index++) {
 					const nextInfo = itemPositions[index + 1];
 					if (!nextInfo) {
-						const endPosition = this.getItemBottomPosition(index);
-						if (endPosition > this.scrollBounds[scrollBoundsDimension]) {
-							this.scrollBounds[scrollBoundsDimension] = endPosition;
+						const endPosition = getItemBottomPosition(index);
+						if (endPosition > variables.current.scrollBounds[scrollBoundsDimension]) {
+							variables.current.scrollBounds[scrollBoundsDimension] = endPosition;
 						}
 
 						break;
@@ -979,120 +830,118 @@ const VirtualListBaseFactory = (type) => {
 				}
 			}
 
-			this.scrollBounds.maxTop = Math.max(0, this.scrollBounds.scrollHeight - this.scrollBounds.clientHeight);
+			variables.current.scrollBounds.maxTop = Math.max(0, variables.current.scrollBounds.scrollHeight - variables.current.scrollBounds.clientHeight);
 		}
 
 		// For individually sized item
-		adjustItemPositionWithItemSize () {
-			if (this.itemContainerRef.current) {
+		function adjustItemPositionWithItemSize () {
+			if (itemContainerRef.current) {
 				const
-					{dataSize} = this.props,
-					{firstIndex, numOfItems} = this.state,
+					{dataSize} = props,
 					lastIndex = firstIndex + numOfItems - 1;
 
 				// Cache individually sized item positions
 				// and adjust item DOM element positions
 				for (let index = firstIndex; index <= lastIndex; index++) {
-					this.calculateAndCacheItemPosition(index);
-					this.applyItemPositionToDOMElement(index);
+					calculateAndCacheItemPosition(index);
+					applyItemPositionToDOMElement(index);
 				}
 
-				// Update threshold based on this.itemPositions
-				this.updateThresholdWithItemPosition();
+				// Update threshold based on itemPositions
+				updateThresholdWithItemPosition();
 
-				// Update scroll bounds based on this.itemPositions
-				this.updateScrollBoundsWithItemPositions();
+				// Update scroll bounds based on itemPositions
+				updateScrollBoundsWithItemPositions();
 
-				// Set container size based on this.scrollbounds
-				this.setContainerSize();
+				// Set container size based on scrollbounds
+				setContainerSize();
 
-				// Update moreInfo based on this.itemPositions
-				this.updateMoreInfo(dataSize, this.scrollPosition);
+				// Update moreInfo based on itemPositions
+				updateMoreInfo(dataSize, variables.current.scrollPosition);
 			}
 		}
 
-		getItemNode = (index) => {
-			const ref = this.itemContainerRef.current;
+		function getItemNode (index) {
+			const ref = itemContainerRef.current;
 
-			return ref ? ref.children[index % this.state.numOfItems] : null;
+			return ref ? ref.children[index % numOfItems] : null;
 		}
 
-		composeStyle (width, height, primaryPosition, secondaryPosition) {
+		function composeStyle (width, height, primaryPosition, secondaryPosition) {
 			const
-				{x, y} = this.getXY(primaryPosition, secondaryPosition),
-				style = {
+				{x, y} = getXY(primaryPosition, secondaryPosition),
+				composedStyle = {
 					position: 'absolute',
 					/* FIXME: RTL / this calculation only works for Chrome */
-					transform: `translate3d(${this.props.rtl ? -x : x}px, ${y}px, 0)`
+					transform: `translate3d(${props.rtl ? -x : x}px, ${y}px, 0)`
 				};
 
-			if (this.isItemSized) {
-				style.width = width;
-				style.height = height;
+			if (variables.current.isItemSized) {
+				composedStyle.width = width;
+				composedStyle.height = height;
 			}
 
-			return style;
+			return composedStyle;
 		}
 
-		applyStyleToNewNode = (index, ...rest) => {
+		function applyStyleToNewNode (index, ...restParam) {
 			const
-				{itemRenderer, getComponentProps} = this.props,
-				key = index % this.state.numOfItems,
+				{itemRenderer, getComponentProps} = props,
+				key = index % numOfItems,
 				itemElement = itemRenderer({
-					...this.props.childProps,
+					...props.childProps,
 					key,
 					index
 				}),
 				componentProps = getComponentProps && getComponentProps(index) || {};
 
-			this.cc[key] = React.cloneElement(itemElement, {
+			variables.current.cc[key] = React.cloneElement(itemElement, {
 				...componentProps,
 				className: classNames(css.listItem, itemElement.props.className),
-				style: {...itemElement.props.style, ...(this.composeStyle(...rest))}
+				style: {...itemElement.props.style, ...(composeStyle(...restParam))}
 			});
 		}
 
-		applyStyleToHideNode = (index) => {
-			const key = index % this.state.numOfItems;
-			this.cc[key] = <div key={key} style={{display: 'none'}} />;
+		function applyStyleToHideNode (index) {
+			const key = index % numOfItems;
+			variables.current.cc[key] = <div key={key} style={{display: 'none'}} />;
 		}
 
-		positionItems () {
+		function positionItems () {
 			const
-				{dataSize, itemSizes} = this.props,
-				{firstIndex, numOfItems} = this.state,
-				{cc, isPrimaryDirectionVertical, dimensionToExtent, primary, secondary, itemPositions} = this;
-			let
-				hideTo = 0,
-				updateFrom = cc.length ? this.state.updateFrom : firstIndex,
-				updateTo = cc.length ? this.state.updateTo : firstIndex + numOfItems;
+				{dataSize, itemSizes} = props,
+				{isPrimaryDirectionVertical, dimensionToExtent, secondary, itemPositions} = variables.current;
+			let hideTo = 0,
+				// TODO : check whether the belows variables(newUpdateFrom, newUpdateTo) are needed or not.
+				newUpdateFrom = cc.length ? updateFrom : firstIndex,
+				newUpdateTo = cc.length ? updateTo : firstIndex + numOfItems;
 
-			if (updateFrom >= updateTo) {
+			if (newUpdateFrom >= newUpdateTo) {
 				return;
-			} else if (updateTo > dataSize) {
-				hideTo = updateTo;
-				updateTo = dataSize;
+			} else if (newUpdateTo > dataSize) {
+				hideTo = newUpdateTo;
+				newUpdateTo = dataSize;
 			}
 
 			let
 				width, height,
-				{primaryPosition, secondaryPosition} = this.getGridPosition(updateFrom);
+				{primaryPosition, secondaryPosition} = getGridPosition(newUpdateFrom);
 
 			width = (isPrimaryDirectionVertical ? secondary.itemSize : primary.itemSize) + 'px';
 			height = (isPrimaryDirectionVertical ? primary.itemSize : secondary.itemSize) + 'px';
 
 			// positioning items
-			for (let i = updateFrom, j = updateFrom % dimensionToExtent; i < updateTo; i++) {
-				this.applyStyleToNewNode(i, width, height, primaryPosition, secondaryPosition);
+			for (let i = newUpdateFrom, j = newUpdateFrom % dimensionToExtent; i < newUpdateTo; i++) {
+				applyStyleToNewNode(i, width, height, primaryPosition, secondaryPosition);
 
 				if (++j === dimensionToExtent) {
 					secondaryPosition = 0;
 
-					if (this.props.itemSizes) {
+					if (props.itemSizes) {
 						if (itemPositions[i + 1] || itemPositions[i + 1] === 0) {
 							primaryPosition = itemPositions[i + 1].position;
 						} else if (itemSizes[i]) {
-							primaryPosition += itemSizes[i] + this.props.spacing;
+							primaryPosition += itemSizes[i] + props.spacing;
 						} else {
 							primaryPosition += primary.gridSize;
 						}
@@ -1106,44 +955,50 @@ const VirtualListBaseFactory = (type) => {
 				}
 			}
 
-			for (let i = updateTo; i < hideTo; i++) {
-				this.applyStyleToHideNode(i);
+			for (let i = newUpdateTo; i < hideTo; i++) {
+				applyStyleToHideNode(i);
 			}
 		}
 
-		getScrollHeight = () => (this.isPrimaryDirectionVertical ? this.getVirtualScrollDimension() : this.scrollBounds.clientHeight)
+		function getScrollHeight () {
+			return (variables.current.isPrimaryDirectionVertical ? getVirtualScrollDimension() : variables.current.scrollBounds.clientHeight);
+		}
 
-		getScrollWidth = () => (this.isPrimaryDirectionVertical ? this.scrollBounds.clientWidth : this.getVirtualScrollDimension())
+		function getScrollWidth () {
+			return (variables.current.isPrimaryDirectionVertical ? variables.current.scrollBounds.clientWidth : getVirtualScrollDimension());
+		}
 
-		getVirtualScrollDimension = () => {
-			if (this.props.itemSizes) {
-				return this.props.itemSizes.reduce((total, size, index) => (total + size + (index > 0 ? this.props.spacing : 0)), 0);
+		function getVirtualScrollDimension () {
+			if (props.itemSizes) {
+				return props.itemSizes.reduce((total, size, index) => (total + size + (index > 0 ? props.spacing : 0)), 0);
 			} else {
 				const
-					{dimensionToExtent, primary, curDataSize} = this,
-					{spacing} = this.props;
+					{dimensionToExtent, curDataSize} = variables.current,
+					{spacing} = props;
 
 				return (Math.ceil(curDataSize / dimensionToExtent) * primary.gridSize) - spacing;
 			}
 		}
 
-		syncClientSize = () => {
-			const
-				{props} = this,
-				node = this.containerRef.current;
+		function syncClientSize () {
+			const node = containerRef.current;
 
 			if (!props.clientSize && !node) {
 				return false;
 			}
 
 			const
-				{clientWidth, clientHeight} = props.clientSize || this.getClientSize(node),
-				{scrollBounds} = this;
+				{clientWidth, clientHeight} = props.clientSize || getClientSize(node),
+				{scrollBounds} = variables.current;
 
 			if (clientWidth !== scrollBounds.clientWidth || clientHeight !== scrollBounds.clientHeight) {
-				this.calculateMetrics(props);
-				this.setState(this.getStatesAndUpdateBounds(props));
-				this.setContainerSize();
+				calculateMetrics(props);
+
+				const statesAndUpdateBounds = getStatesAndUpdateBounds();
+				setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+				setNumOfItems(statesAndUpdateBounds.numOfItems);
+
+				setContainerSize();
 				return true;
 			}
 
@@ -1152,59 +1007,238 @@ const VirtualListBaseFactory = (type) => {
 
 		// render
 
-		getContainerClasses (className) {
+		function getContainerClasses () {
 			let containerClass = null;
 
 			if (type === Native) {
-				containerClass = this.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
+				containerClass = variables.current.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
 			}
 
 			return classNames(css.virtualList, containerClass, className);
 		}
 
-		getContentClasses () {
+		function getContentClasses () {
 			return type === Native ? null : css.content;
 		}
 
-		render () {
-			const
-				{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-disabled': voiceDisabled, itemsRenderer, style, ...rest} = this.props,
-				{cc, itemContainerRef, primary} = this,
-				containerClasses = this.getContainerClasses(className),
-				contentClasses = this.getContentClasses();
-
-			delete rest.cbScrollTo;
-			delete rest.childProps;
-			delete rest.clientSize;
-			delete rest.dataSize;
-			delete rest.direction;
-			delete rest.getComponentProps;
-			delete rest.isHorizontalScrollbarVisible;
-			delete rest.isVerticalScrollbarVisible;
-			delete rest.itemRenderer;
-			delete rest.itemSize;
-			delete rest.onUpdate;
-			delete rest.onUpdateItems;
-			delete rest.overhang;
-			delete rest.pageScroll;
-			delete rest.rtl;
-			delete rest.spacing;
-			delete rest.updateStatesAndBounds;
-			delete rest.itemSizes;
-
-			if (primary) {
-				this.positionItems();
-			}
-
-			return (
-				<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} data-webos-voice-disabled={voiceDisabled} ref={this.containerRef} style={style}>
-					<div {...rest} className={contentClasses} ref={this.contentRef}>
-						{itemsRenderer({cc, itemContainerRef, primary})}
-					</div>
+		return (
+			<div className={containerClasses} data-webos-voice-focused={voiceFocused} data-webos-voice-group-label={voiceGroupLabel} data-webos-voice-disabled={voiceDisabled} ref={containerRef} style={style}>
+				<div {...rest} className={contentClasses} ref={contentRef}>
+					{itemsRenderer({cc, itemContainerRef, primary})}
 				</div>
-			);
-		}
+			</div>
+		);
 	};
+
+	VirtualListCore.propTypes = /** @lends ui/VirtualList.VirtualListBase.prototype */ {
+		/**
+		 * The rendering function called for each item in the list.
+		 *
+		 * > **Note**: The list does **not** always render a component whenever its render function is called
+		 * due to performance optimization.
+		 *
+		 * Example:
+		 * ```
+		 * renderItem = ({index, ...rest}) => {
+		 * 	delete rest.data;
+		 *
+		 * 	return (
+		 * 		<MyComponent index={index} {...rest} />
+		 * 	);
+		 * }
+		 * ```
+		 *
+		 * @type {Function}
+		 * @param {Object}     event
+		 * @param {Number}     event.data-index    It is required for `Spotlight` 5-way navigation. Pass to the root element in the component.
+		 * @param {Number}     event.index    The index number of the component to render
+		 * @param {Number}     event.key    It MUST be passed as a prop to the root element in the component for DOM recycling.
+		 *
+		 * @required
+		 * @public
+		 */
+		itemRenderer: PropTypes.func.isRequired,
+
+		/**
+		 * The size of an item for the list; valid values are either a number for `VirtualList`
+		 * or an object that has `minWidth` and `minHeight` for `VirtualGridList`.
+		 *
+		 * @type {Number|ui/VirtualList.gridListItemSizeShape}
+		 * @required
+		 * @private
+		 */
+		itemSize: PropTypes.oneOfType([
+			PropTypes.number,
+			gridListItemSizeShape
+		]).isRequired,
+
+		/**
+		 * The render function for the items.
+		 *
+		 * @type {Function}
+		 * @required
+		 * @private
+		 */
+		itemsRenderer: PropTypes.func.isRequired,
+
+		/**
+		 * Callback method of scrollTo.
+		 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		cbScrollTo: PropTypes.func,
+
+		/**
+		 * Additional props included in the object passed to the `itemsRenderer` callback.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		childProps: PropTypes.object,
+
+		/**
+		 * Client size of the list; valid values are an object that has `clientWidth` and `clientHeight`.
+		 *
+		 * @type {Object}
+		 * @property {Number}    clientHeight    The client height of the list.
+		 * @property {Number}    clientWidth    The client width of the list.
+		 * @public
+		 */
+		clientSize: PropTypes.shape({
+			clientHeight: PropTypes.number.isRequired,
+			clientWidth: PropTypes.number.isRequired
+		}),
+
+		/**
+		 * Disable voice control feature of component.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		'data-webos-voice-disabled': PropTypes.bool,
+
+		/**
+		 * Activates the component for voice control.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		'data-webos-voice-focused': PropTypes.bool,
+
+		/**
+		 * The voice control group label.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		'data-webos-voice-group-label': PropTypes.string,
+
+		/**
+		 * The number of items of data the list contains.
+		 *
+		 * @type {Number}
+		 * @default 0
+		 * @public
+		 */
+		dataSize: PropTypes.number,
+
+		/**
+		 * The layout direction of the list.
+		 *
+		 * Valid values are:
+		 * * `'horizontal'`, and
+		 * * `'vertical'`.
+		 *
+		 * @type {String}
+		 * @default 'vertical'
+		 * @public
+		 */
+		direction: PropTypes.oneOf(['horizontal', 'vertical']),
+
+		/**
+		 * Called to get the props for list items.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		getComponentProps: PropTypes.func,
+
+		/**
+		 * The array for individually sized items.
+		 *
+		 * @type {Number[]}
+		 * @private
+		 */
+		itemSizes: PropTypes.arrayOf(PropTypes.number),
+
+		/**
+		 * Called when the range of items has updated.
+		 *
+		 * Event payload includes the `firstIndex` and `lastIndex` of the list.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onUpdateItems: PropTypes.func,
+
+		/**
+		 * Number of spare DOM node.
+		 * `3` is good for the default value experimentally and
+		 * this value is highly recommended not to be changed by developers.
+		 *
+		 * @type {Number}
+		 * @default 3
+		 * @private
+		 */
+		overhang: PropTypes.number,
+
+		/**
+		 * When `true`, the list will scroll by page.  Otherwise the list will scroll by item.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		pageScroll: PropTypes.bool,
+
+		/**
+		 * `true` if RTL, `false` if LTR.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		rtl: PropTypes.bool,
+
+		/**
+		 * The spacing between items.
+		 *
+		 * @type {Number}
+		 * @default 0
+		 * @public
+		 */
+		spacing: PropTypes.number,
+
+		/**
+		 * Called to execute additional logic in a themed component when updating states and bounds.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		updateStatesAndBounds: PropTypes.func
+	};
+
+	VirtualListCore.defaultProps = {
+		cbScrollTo: nop,
+		dataSize: 0,
+		direction: 'vertical',
+		overhang: 3,
+		pageScroll: false,
+		spacing: 0
+	};
+
+	return VirtualListCore;
 };
 
 /**

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -190,7 +190,7 @@ const VirtualListBaseFactory = (type) => {
 				calculateMetrics(props);
 				// eslint-disable-next-line react/no-did-mount-set-state
 				const statesAndUpdateBounds = getStatesAndUpdateBounds();
-				setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+				setFirstIndex(statesAndUpdateBounds.firstIndex);
 				setNumOfItems(statesAndUpdateBounds.numOfItems);
 
 			} else {
@@ -272,7 +272,7 @@ const VirtualListBaseFactory = (type) => {
 			calculateMetrics(props);
 			// eslint-disable-next-line react/no-did-update-set-state
 			const statesAndUpdateBounds = getStatesAndUpdateBounds();
-			setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+			setFirstIndex(statesAndUpdateBounds.firstIndex);
 			setNumOfItems(statesAndUpdateBounds.numOfItems);
 
 			setContainerSize();
@@ -299,7 +299,7 @@ const VirtualListBaseFactory = (type) => {
 			if (!variables.current.deferScrollTo && variables.current.hasDataSizeChanged) {
 				const newState = getStatesAndUpdateBounds();
 				// eslint-disable-next-line react/no-did-update-set-state
-				setFirstIndex(newState.newFirstIndex);
+				setFirstIndex(newState.firstIndex);
 				setNumOfItems(newState.numOfItems);
 
 				setContainerSize();
@@ -1009,7 +1009,7 @@ const VirtualListBaseFactory = (type) => {
 				calculateMetrics(props);
 
 				const statesAndUpdateBounds = getStatesAndUpdateBounds();
-				setFirstIndex(statesAndUpdateBounds.newFirstIndex);
+				setFirstIndex(statesAndUpdateBounds.firstIndex);
 				setNumOfItems(statesAndUpdateBounds.numOfItems);
 
 				setContainerSize();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We want to migrate HoC and render props to hooks for all VirtualList and Scroller.
As the first step, I converted 4 UI scroller components defined by class to functional component.
And then, resolved a problem about component method accessing using ref.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

4 UI scroller components have been converted to functional component.
* Target component
UI/VirtualListBase
UI/Scrollable
UI/ScollableNative
UI/Scroller

1) Change `class NameOfComponent extends Component` to `const NameOfComponent => (props){`
2) Change `defaultProp`, `propTypes` to `NameOfComponent.defaultProp`,  `NameOfComponent.propTypes`. 
3) Remove the constructor
4) Remove the render() method, keep the return
5) Convert all methods to `function` for hoisting.
6) Use `useRef` for all instance variables. 
7) Replace all lifecycle functnion to `useEffect`. 
8) Use `useRef` or `useContext` As needed.
9) Remove all references to ‘this’ throughout the component
10) Set initial state with `useState()`. ie…
11) Declare some undeclared member variables. (this.variable)
12) Adjust duplicated variable names.
13) Resolve dependency problem between UI Scroller React components ( `useImperativeHandle`)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
* When I use useEffect,  I got lint warning from exhaustive-deps ESLint rule
(https://github.com/facebook/react/issues/14920).
I checked the operation, but lint-warning is occurring.
More discussion is needed to solve this problem.


### Links
[//]: # (Related issues, references)
PLAT-98506
PLAT-98204
