### PR TITLE
Add `pointer-events` property for ui/Button less

### DIFF
--- a/packages/ui/Button/Button.module.less
+++ b/packages/ui/Button/Button.module.less
@@ -33,6 +33,7 @@
 		box-sizing: border-box;
 		height: 100%;
 		position: relative;
+		pointer-events: none;
 	}
 
 	.icon,

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,8 +6,9 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee` to not error when passed `null` `children` during an animation.
+- `ui/Marquee` to not error when passed `null` `children` during an animation
 - `ui/Button` to have more robust support for a customized `iconComponent` prop
+- `ui/Button` to not readout when operating accessibility by touch
 
 ## [3.2.5] - 2019-11-14
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Marquee` to not error when passed `null` `children` during an animation
 - `ui/Button` to have more robust support for a customized `iconComponent` prop
-- `ui/Button` to not readout when operating accessibility by touch
+- `ui/Button` to not readout when touching non-focusable element on accessibility mode
 
 ## [3.2.5] - 2019-11-14
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- Touching the content area of the button ignores the button role and only reads the content.
- Clicking the button (double tap for GMRSI VVO) reads the button's contents.

### Resolution
- Use `pointer-event: none` to prevent events from reaching the contents area.


### Additional Considerations