### PR TITLE
Check undefined reference in Scrollable.utilEvent

### DIFF
--- a/packages/ui/Scrollable/utilEvent.js
+++ b/packages/ui/Scrollable/utilEvent.js
@@ -3,7 +3,9 @@
 const utilEvent = (eventName) => {
 	return {
 		addEventListener (ref, fn, param) {
-			if (typeof window !== 'undefined' && (ref === window || ref === document)) {
+			if (!ref) {
+				return;
+			} else if (typeof window !== 'undefined' && (ref === window || ref === document)) {
 				ref.addEventListener(eventName, fn, param);
 			} else if (ref.current) {
 				ref.current.addEventListener(eventName, fn, param);
@@ -13,7 +15,9 @@ const utilEvent = (eventName) => {
 		},
 
 		removeEventListener (ref, fn, param) {
-			if (typeof window !== 'undefined' && (ref === window || ref === document)) {
+			if (!ref) {
+				return;
+			} else if (typeof window !== 'undefined' && (ref === window || ref === document)) {
 				ref.removeEventListener(eventName, fn, param);
 			} else if (ref.current) {
 				ref.current.removeEventListener(eventName, fn, param);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There is the error when the `ref` parameter in `Scrollable.utilEvent.addEventListener()` or `removeEventListener()` is undefined.

```
const utilEvent = (eventName) => {
	return {
		addEventListener (ref, fn, param) {
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If `ref` is undefined, just execute `return`.

### Links
[//]: # (Related issues, references)

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)