### PR TITLE
PLAT-100231: Fix not to receive `onScroll` event if type is equal to `JS` in Scroller

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -31,7 +31,10 @@ import utilEvent from './utilEvent';
 
 import css from './Scrollable.module.less';
 
-const nop = () => {};
+const
+	nop = () => {},
+	JS = 'JS',
+	Native = 'Native';
 
 const
 	constants = {
@@ -439,7 +442,7 @@ class ScrollableBase extends Component {
 		onScrollStart: nop,
 		onScrollStop: nop,
 		overscrollEffectOn: {drag: false, pageKey: false, wheel: false},
-		type: 'JS',
+		type: JS,
 		verticalScrollbar: 'auto'
 	}
 }
@@ -687,7 +690,7 @@ const useScrollBase = (props) => {
 			if (propsHandleResizeWindow) {
 				propsHandleResizeWindow();
 			}
-			if (type === 'JS') {
+			if (type === JS) {
 				scrollTo({position: {x: 0, y: 0}, animate: false});
 			} else {
 				uiChildContainerRef.current.style.scrollBehavior = null;
@@ -711,7 +714,7 @@ const useScrollBase = (props) => {
 	}
 
 	if (mutableRef.current.scrollStopJob == null) {
-		if (type === 'JS') {
+		if (type === JS) {
 			mutableRef.current.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
 		} else {
 			mutableRef.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
@@ -794,7 +797,7 @@ const useScrollBase = (props) => {
 	// Native ]]
 
 	function onDragStart (ev) {
-		if (type === 'JS' ) {
+		if (type === JS ) {
 			if (ev.type === 'dragstart') return;
 
 			forward('onDragStart', ev, props);
@@ -815,7 +818,7 @@ const useScrollBase = (props) => {
 	}
 
 	function onDrag (ev) {
-		if (type === 'JS') {
+		if (type === JS) {
 			if (ev.type === 'drag') {
 				return;
 			}
@@ -848,7 +851,7 @@ const useScrollBase = (props) => {
 	}
 
 	function onDragEnd (ev) {
-		if (type === 'JS') {
+		if (type === JS) {
 			if (ev.type === 'dragend') {
 				return;
 			}
@@ -904,14 +907,14 @@ const useScrollBase = (props) => {
 	function onFlick (ev) {
 		const {direction} = props;
 
-		if (type === 'JS') {
+		if (type === JS) {
 			mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 				mutableRef.current.scrollLeft,
 				mutableRef.current.scrollTop,
 				(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
 				(direction !== 'horizontal') ? -ev.velocityY : 0
 			);
-		} else if (type === 'Native') {
+		} else if (type === Native) {
 			if (!mutableRef.current.isTouching) {
 				mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 					mutableRef.current.scrollLeft,
@@ -956,38 +959,31 @@ const useScrollBase = (props) => {
 			ev.stopPropagation();
 		} else {
 			const
-				// Native [[
-				{overscrollEffectOn} = props,
-				overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn.wheel,
-				// Native ]]
 				bounds = getScrollBounds(),
 				canScrollH = canScrollHorizontally(bounds),
 				canScrollV = canScrollVertically(bounds),
 				eventDeltaMode = ev.deltaMode,
 				eventDelta = (-ev.wheelDeltaY || ev.deltaY);
-			let
-				delta = 0,
-				direction, // JS
-				needToHideThumb = false; // Native
+			let delta = 0;
 
 			mutableRef.current.lastInputType = 'wheel';
 
 			if (props.noScrollByWheel) {
-				if (type === 'Native' && canScrollV) {
+				if (type === Native && canScrollV) {
 					ev.preventDefault();
 				}
 
 				return;
 			}
 
-			if (type === 'JS') {
+			if (type === JS) {
 				if (canScrollV) {
 					delta = calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 				} else if (canScrollH) {
 					delta = calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
 				}
 
-				direction = Math.sign(delta);
+				const direction = Math.sign(delta);
 
 				if (direction !== mutableRef.current.wheelDirection) {
 					mutableRef.current.isScrollAnimationTargetAccumulated = false;
@@ -1002,6 +998,11 @@ const useScrollBase = (props) => {
 					ev.stopPropagation();
 				}
 			} else { // Native
+				const
+					{overscrollEffectOn} = props,
+					overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn.wheel,
+					needToHideThumb = false;;
+
 				if (props.onWheel) {
 					forward('onWheel', ev, props);
 					return;
@@ -1051,7 +1052,7 @@ const useScrollBase = (props) => {
 				}
 
 				if (delta !== 0) {
-					direction = Math.sign(delta);
+					const direction = Math.sign(delta);
 					// Not to accumulate scroll position if wheel direction is different from hold direction
 					if (direction !== mutableRef.current.wheelDirection) {
 						mutableRef.current.isScrollAnimationTargetAccumulated = false;
@@ -1115,7 +1116,7 @@ const useScrollBase = (props) => {
 	// Native ]]
 
 	function onKeyDown (ev) {
-		if (type === 'JS') {
+		if (type === JS) {
 			if (props.onKeyDown) {
 				forward('onKeyDown', ev, props);
 			} else if ((isPageUp(ev.keyCode) || isPageDown(ev.keyCode))) {
@@ -1149,7 +1150,7 @@ const useScrollBase = (props) => {
 			return 'before';
 		/* If a scroll size or a client size is not integer,
 			browser's max scroll position could be smaller than maxPos by 1 pixel.*/
-		} else if (type === 'JS' && position >= maxPosition || type === 'Native' && position >= maxPosition - 1) {
+		} else if (type === JS && position >= maxPosition || type === Native && position >= maxPosition - 1) {
 			return 'after';
 		} else {
 			return null;
@@ -1197,8 +1198,8 @@ const useScrollBase = (props) => {
 			maxPos = getScrollBounds()[isVertical ? 'maxTop' : 'maxLeft'];
 
 		if (
-			type === 'JS' && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos) ||
-			type === 'Native' && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos - 1)
+			type === JS && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos) ||
+			type === Native && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos - 1)
 		) { // Already on the edge
 			applyOverscrollEffect(orientation, edge, overscrollEffectType, ratio);
 		} else {
@@ -1377,7 +1378,7 @@ const useScrollBase = (props) => {
 			bounds = getScrollBounds(),
 			{maxLeft, maxTop} = bounds;
 
-		const updatedAnimationInfo = type === 'JS' ?
+		const updatedAnimationInfo = type === JS ?
 			{
 				sourceX: scrollLeft,
 				sourceY: scrollTop,
@@ -1392,7 +1393,7 @@ const useScrollBase = (props) => {
 
 		// bail early when scrolling to the same position
 		if (
-			(type === 'JS' && mutableRef.current.animator.isAnimating() || type === 'Native' && mutableRef.current.scrolling) &&
+			(type === JS && mutableRef.current.animator.isAnimating() || type === Native && mutableRef.current.scrolling) &&
 			mutableRef.current.animationInfo &&
 			mutableRef.current.animationInfo.targetX === targetX &&
 			mutableRef.current.animationInfo.targetY === targetY
@@ -1402,7 +1403,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.animationInfo = updatedAnimationInfo;
 
-		if (type === 'JS') {
+		if (type === JS) {
 			mutableRef.current.animator.stop();
 
 			if (!mutableRef.current.scrolling) {
@@ -1430,7 +1431,7 @@ const useScrollBase = (props) => {
 			}
 		}
 
-		if (type === 'JS') {
+		if (type === JS) {
 			showThumb(bounds);
 
 			if (animate) {
@@ -1542,7 +1543,7 @@ const useScrollBase = (props) => {
 
 	// esline-disable-next-line react-hooks/exhaustive-deps
 	function stop () {
-		if (type === 'JS') {
+		if (type === JS) {
 			stopForJS();
 		} else {
 			stopForNative();
@@ -1756,7 +1757,7 @@ const useScrollBase = (props) => {
 		utilEvent('mousedown').addEventListener(uiScrollContainerRef, onMouseDown);
 
 		// Native [[
-		if (type === 'Native' && uiChildContainerRef.current) {
+		if (type === Native && uiChildContainerRef.current) {
 			utilEvent('scroll').addEventListener(
 				uiChildContainerRef,
 				onScroll,
@@ -1822,14 +1823,14 @@ const useScrollBase = (props) => {
 	});
 
 	decorateChildProps('childWrapperProps', {
-		className: type === 'JS' ? [css.content] : [css.content, css.contentNative], // Native;,
+		className: type === JS ? [css.content] : [css.content, css.contentNative], // Native;,
 		...(!noScrollByDrag && {
 			flickConfig,
 			onDrag: onDrag,
 			onDragEnd: onDragEnd,
 			onDragStart: onDragStart,
 			onFlick: onFlick,
-			onTouchStart: onTouchStart // Native
+			onTouchStart: type === Native ? onTouchStart : null// Native
 		})
 	});
 
@@ -1844,7 +1845,7 @@ const useScrollBase = (props) => {
 		get isVerticalScrollbarVisible () {
 			return isVerticalScrollbarVisible;
 		},
-		onScroll: type === 'JS' ? handleScroll : null,
+		onScroll: type === JS ? handleScroll : null,
 		rtl,
 		setUiChildAdapter,
 		type
@@ -1974,7 +1975,7 @@ const useScroll = (props) => {
 			wheel: true
 		},
 		setUiChildAdapter,
-		type: props.type || 'JS', // FIXME
+		type: props.type || JS, // FIXME
 		uiChildAdapter,
 		uiChildContainerRef,
 		uiScrollContainerRef,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1756,7 +1756,7 @@ const useScrollBase = (props) => {
 		utilEvent('mousedown').addEventListener(uiScrollContainerRef, onMouseDown);
 
 		// Native [[
-		if (uiChildContainerRef.current) {
+		if (type === 'Native' && uiChildContainerRef.current) {
 			utilEvent('scroll').addEventListener(
 				uiChildContainerRef,
 				onScroll,

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1000,8 +1000,8 @@ const useScrollBase = (props) => {
 			} else { // Native
 				const
 					{overscrollEffectOn} = props,
-					overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn.wheel,
-					needToHideThumb = false;;
+					overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn.wheel;
+				let needToHideThumb = false;
 
 				if (props.onWheel) {
 					forward('onWheel', ev, props);

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -31,10 +31,7 @@ import utilEvent from './utilEvent';
 
 import css from './Scrollable.module.less';
 
-const
-	nop = () => {},
-	JS = 'JS',
-	Native = 'Native';
+const nop = () => {};
 
 const
 	constants = {
@@ -442,7 +439,7 @@ class ScrollableBase extends Component {
 		onScrollStart: nop,
 		onScrollStop: nop,
 		overscrollEffectOn: {drag: false, pageKey: false, wheel: false},
-		type: JS,
+		type: 'JS',
 		verticalScrollbar: 'auto'
 	}
 }
@@ -690,7 +687,7 @@ const useScrollBase = (props) => {
 			if (propsHandleResizeWindow) {
 				propsHandleResizeWindow();
 			}
-			if (type === JS) {
+			if (type === 'JS') {
 				scrollTo({position: {x: 0, y: 0}, animate: false});
 			} else {
 				uiChildContainerRef.current.style.scrollBehavior = null;
@@ -714,7 +711,7 @@ const useScrollBase = (props) => {
 	}
 
 	if (mutableRef.current.scrollStopJob == null) {
-		if (type === JS) {
+		if (type === 'JS') {
 			mutableRef.current.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
 		} else {
 			mutableRef.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
@@ -797,7 +794,7 @@ const useScrollBase = (props) => {
 	// Native ]]
 
 	function onDragStart (ev) {
-		if (type === JS ) {
+		if (type === 'JS' ) {
 			if (ev.type === 'dragstart') return;
 
 			forward('onDragStart', ev, props);
@@ -818,7 +815,7 @@ const useScrollBase = (props) => {
 	}
 
 	function onDrag (ev) {
-		if (type === JS) {
+		if (type === 'JS') {
 			if (ev.type === 'drag') {
 				return;
 			}
@@ -851,7 +848,7 @@ const useScrollBase = (props) => {
 	}
 
 	function onDragEnd (ev) {
-		if (type === JS) {
+		if (type === 'JS') {
 			if (ev.type === 'dragend') {
 				return;
 			}
@@ -907,14 +904,14 @@ const useScrollBase = (props) => {
 	function onFlick (ev) {
 		const {direction} = props;
 
-		if (type === JS) {
+		if (type === 'JS') {
 			mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 				mutableRef.current.scrollLeft,
 				mutableRef.current.scrollTop,
 				(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
 				(direction !== 'horizontal') ? -ev.velocityY : 0
 			);
-		} else if (type === Native) {
+		} else if (type === 'Native') {
 			if (!mutableRef.current.isTouching) {
 				mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 					mutableRef.current.scrollLeft,
@@ -969,14 +966,14 @@ const useScrollBase = (props) => {
 			mutableRef.current.lastInputType = 'wheel';
 
 			if (props.noScrollByWheel) {
-				if (type === Native && canScrollV) {
+				if (type === 'Native' && canScrollV) {
 					ev.preventDefault();
 				}
 
 				return;
 			}
 
-			if (type === JS) {
+			if (type === 'JS') {
 				if (canScrollV) {
 					delta = calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
 				} else if (canScrollH) {
@@ -1116,7 +1113,7 @@ const useScrollBase = (props) => {
 	// Native ]]
 
 	function onKeyDown (ev) {
-		if (type === JS) {
+		if (type === 'JS') {
 			if (props.onKeyDown) {
 				forward('onKeyDown', ev, props);
 			} else if ((isPageUp(ev.keyCode) || isPageDown(ev.keyCode))) {
@@ -1150,7 +1147,7 @@ const useScrollBase = (props) => {
 			return 'before';
 		/* If a scroll size or a client size is not integer,
 			browser's max scroll position could be smaller than maxPos by 1 pixel.*/
-		} else if (type === JS && position >= maxPosition || type === Native && position >= maxPosition - 1) {
+		} else if (type === 'JS' && position >= maxPosition || type === 'Native' && position >= maxPosition - 1) {
 			return 'after';
 		} else {
 			return null;
@@ -1198,8 +1195,8 @@ const useScrollBase = (props) => {
 			maxPos = getScrollBounds()[isVertical ? 'maxTop' : 'maxLeft'];
 
 		if (
-			type === JS && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos) ||
-			type === Native && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos - 1)
+			type === 'JS' && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos) ||
+			type === 'Native' && (edge === 'before' && curPos <= 0) || (edge === 'after' && curPos >= maxPos - 1)
 		) { // Already on the edge
 			applyOverscrollEffect(orientation, edge, overscrollEffectType, ratio);
 		} else {
@@ -1378,7 +1375,7 @@ const useScrollBase = (props) => {
 			bounds = getScrollBounds(),
 			{maxLeft, maxTop} = bounds;
 
-		const updatedAnimationInfo = type === JS ?
+		const updatedAnimationInfo = type === 'JS' ?
 			{
 				sourceX: scrollLeft,
 				sourceY: scrollTop,
@@ -1393,7 +1390,7 @@ const useScrollBase = (props) => {
 
 		// bail early when scrolling to the same position
 		if (
-			(type === JS && mutableRef.current.animator.isAnimating() || type === Native && mutableRef.current.scrolling) &&
+			(type === 'JS' && mutableRef.current.animator.isAnimating() || type === 'Native' && mutableRef.current.scrolling) &&
 			mutableRef.current.animationInfo &&
 			mutableRef.current.animationInfo.targetX === targetX &&
 			mutableRef.current.animationInfo.targetY === targetY
@@ -1403,7 +1400,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.animationInfo = updatedAnimationInfo;
 
-		if (type === JS) {
+		if (type === 'JS') {
 			mutableRef.current.animator.stop();
 
 			if (!mutableRef.current.scrolling) {
@@ -1431,7 +1428,7 @@ const useScrollBase = (props) => {
 			}
 		}
 
-		if (type === JS) {
+		if (type === 'JS') {
 			showThumb(bounds);
 
 			if (animate) {
@@ -1543,7 +1540,7 @@ const useScrollBase = (props) => {
 
 	// esline-disable-next-line react-hooks/exhaustive-deps
 	function stop () {
-		if (type === JS) {
+		if (type === 'JS') {
 			stopForJS();
 		} else {
 			stopForNative();
@@ -1757,7 +1754,7 @@ const useScrollBase = (props) => {
 		utilEvent('mousedown').addEventListener(uiScrollContainerRef, onMouseDown);
 
 		// Native [[
-		if (type === Native && uiChildContainerRef.current) {
+		if (type === 'Native' && uiChildContainerRef.current) {
 			utilEvent('scroll').addEventListener(
 				uiChildContainerRef,
 				onScroll,
@@ -1823,14 +1820,14 @@ const useScrollBase = (props) => {
 	});
 
 	decorateChildProps('childWrapperProps', {
-		className: type === JS ? [css.content] : [css.content, css.contentNative], // Native;,
+		className: type === 'JS' ? [css.content] : [css.content, css.contentNative], // Native;,
 		...(!noScrollByDrag && {
 			flickConfig,
 			onDrag: onDrag,
 			onDragEnd: onDragEnd,
 			onDragStart: onDragStart,
 			onFlick: onFlick,
-			onTouchStart: type === Native ? onTouchStart : null// Native
+			onTouchStart: type === 'Native' ? onTouchStart : null// Native
 		})
 	});
 
@@ -1845,7 +1842,7 @@ const useScrollBase = (props) => {
 		get isVerticalScrollbarVisible () {
 			return isVerticalScrollbarVisible;
 		},
-		onScroll: type === JS ? handleScroll : null,
+		onScroll: type === 'JS' ? handleScroll : null,
 		rtl,
 		setUiChildAdapter,
 		type
@@ -1975,7 +1972,7 @@ const useScroll = (props) => {
 			wheel: true
 		},
 		setUiChildAdapter,
-		type: props.type || JS, // FIXME
+		type: props.type || 'JS', // FIXME
 		uiChildAdapter,
 		uiChildContainerRef,
 		uiScrollContainerRef,

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -274,7 +274,7 @@ class VirtualListBase extends Component {
 		overhang: 3,
 		pageScroll: false,
 		spacing: 0,
-		type: 'JS'
+		type: JS
 	}
 
 	constructor (props) {

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -7,10 +7,7 @@ import React, {Component} from 'react';
 
 import css from './VirtualList.module.less';
 
-const
-	nop = () => {},
-	JS = 'JS',
-	Native = 'Native';
+const nop = () => {};
 
 /**
  * The shape for the grid list item size
@@ -274,7 +271,7 @@ class VirtualListBase extends Component {
 		overhang: 3,
 		pageScroll: false,
 		spacing: 0,
-		type: JS
+		type: 'JS'
 	}
 
 	constructor (props) {
@@ -471,7 +468,7 @@ class VirtualListBase extends Component {
 	indexToScrollIntoView = -1
 
 	updateScrollPosition = ({x, y}, rtl = this.props.rtl) => {
-		if (this.props.type === Native) {
+		if (this.props.type === 'Native') {
 			this.scrollToPosition(x, y, rtl);
 		} else {
 			this.setScrollPosition(x, y, rtl, x, y);
@@ -632,7 +629,7 @@ class VirtualListBase extends Component {
 
 		// reset
 		this.scrollPosition = 0;
-		if (this.props.type === JS && this.contentRef.current) {
+		if (this.props.type === 'JS' && this.contentRef.current) {
 			this.contentRef.current.style.transform = null;
 		}
 	}
@@ -1168,7 +1165,7 @@ class VirtualListBase extends Component {
 	getContainerClasses (className) {
 		let containerClass = null;
 
-		if (this.props.type === Native) {
+		if (this.props.type === 'Native') {
 			containerClass = this.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
 		}
 
@@ -1176,7 +1173,7 @@ class VirtualListBase extends Component {
 	}
 
 	getContentClasses () {
-		return this.props.type === Native ? null : css.content;
+		return this.props.type === 'Native' ? null : css.content;
 	}
 
 	render () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When scrolling to the boundaries of the Scroller, the Scroller vibrates and it seems that the Scroller keeps scrolling.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Even though the type of the Scroller was 'JS', the Scroller received the 'onScroll' event and tried to scroll again like having the 'Native' type. So the Scroller is fixed not to receive the 'onScroll' event like before.

It's the side effect while unifying ui/Scrollable.js and ui/ScrollableNative.js into one custom hook.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Clean up some code related with the JS and Native type in Scroller

### Links
[//]: # (Related issues, references)

PLAT-100231