### PR TITLE
PLAT-100369: Fix event listeners to be added once

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -631,11 +631,16 @@ const useScrollBase = (props) => {
 				animator.stop();
 			}
 			// JS ]
-
-			removeEventListeners();
 		};
 
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect(() => {
+		addEventListeners();
+		return () => {
+			removeEventListeners();
+		};
+	});
 
 	const
 		{className, noScrollByDrag, rtl, style, ...rest} = props,
@@ -733,8 +738,6 @@ const useScrollBase = (props) => {
 		}
 
 		clampScrollPosition(); // JS
-
-		addEventListeners();
 
 		if (
 			hasDataSizeChanged === false &&


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Event listeners for `Scroller` and `VirtualList` are added repeatedly on render cycles.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed remove previous handlers when new handlers need to be added again.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-100369

### Comments
