### PR TITLE
PLAT-98240: Support to specify the item size of VirtualList

### DIFF
--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -4,23 +4,32 @@
 	width: 100%;
 	overflow: hidden;
 
-	&.vertical {
-		overflow-y: scroll;
-	}
-
-	&.horizontal {
-		overflow-x: scroll;
-	}
-
 	.content {
 		will-change: transform;
+	}
+}
+
+.vertical {
+	&.native {
+		overflow-y: scroll;
+	}
+	.listItem {
+		width: 100%;
+	}
+}
+
+.horizontal {
+	&.native {
+		overflow-x: scroll;
+	}
+	.listItem {
+		height: 100%;
 	}
 }
 
 .listItem {
 	position: absolute;
 	overflow: hidden;
-	width: 100%;
 
 	will-change: transform;
 }

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1155,26 +1155,12 @@ class VirtualListBase extends Component {
 
 	// render
 
-	getContainerClasses (className) {
-		let containerClass = null;
-
-		if (this.props.type === 'Native') {
-			containerClass = this.isPrimaryDirectionVertical ? css.vertical : css.horizontal;
-		}
-
-		return classNames(css.virtualList, containerClass, className);
-	}
-
-	getContentClasses () {
-		return this.props.type === 'Native' ? null : css.content;
-	}
-
 	render () {
 		const
-			{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-disabled': voiceDisabled, itemsRenderer, style, ...rest} = this.props,
-			{cc, itemContainerRef, primary} = this,
-			containerClasses = this.getContainerClasses(className),
-			contentClasses = this.getContentClasses();
+			{className, 'data-webos-voice-focused': voiceFocused, 'data-webos-voice-group-label': voiceGroupLabel, 'data-webos-voice-disabled': voiceDisabled, itemsRenderer, style, type, ...rest} = this.props,
+			{cc, isPrimaryDirectionVertical, itemContainerRef, primary} = this,
+			containerClasses = classNames(css.virtualList, isPrimaryDirectionVertical ? css.vertical : css.horizontal, type === 'Native' ? css.native : null, className),
+			contentClasses = type === 'Native' ? null : css.content;
 
 		delete rest.cbScrollTo;
 		delete rest.clientSize;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There were no default item size for horizontal VirtualList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To support default item sizes for each direction, added `vertical` and `horizontal` classes to both JS and native list.
To specify css attributes only for native list, added `native` class.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Moved out `vertical` and `horizontal` classes of `virtualList`.

### Links
[//]: # (Related issues, references)
PLAT-98240

### Comments
