### PR TITLE
PLAT-100498 Fix thumb does not hide after scrolling in VL, Scroller native

### DIFF
--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -715,11 +715,19 @@ const useScrollBase = (props) => {
 		mutableRef.current.resizeRegistry = Registry.create(handleResize);
 	}
 
-	if (type === 'JS') {
-		mutableRef.current.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
-	} else {
-		mutableRef.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
-	}
+	useEffect(() => {
+		const ref = mutableRef.current;
+
+		if (type === 'JS') {
+			ref.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
+		} else {
+			ref.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
+		}
+
+		return () => {
+			ref.scrollStopJob.stop();
+		};
+	}); // esline-disable-next-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		const

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -715,12 +715,10 @@ const useScrollBase = (props) => {
 		mutableRef.current.resizeRegistry = Registry.create(handleResize);
 	}
 
-	if (mutableRef.current.scrollStopJob == null) {
-		if (type === 'JS') {
-			mutableRef.current.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
-		} else {
-			mutableRef.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
-		}
+	if (type === 'JS') {
+		mutableRef.current.scrollStopJob = new Job(doScrollStop, scrollStopWaiting);
+	} else {
+		mutableRef.current.scrollStopJob = new Job(scrollStopOnScroll, scrollStopWaiting);
 	}
 
 	useEffect(() => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The thumb does not hide after scrolling in VirtualList and scroller native type.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
While migration with hooks, we made to create `scrollStopJob` once, while `scrollStopOnScroll` which is the actual "job" for `scrollStopJob` can be created multiple times.
So when `scrollStopJob` started, it started with "old" `scrollStopJob` that holds faulty `isVerticalScrollbarVisible` state.
To `scrollStopOnScroll` have the right state, I made to create `scrollStopJob` multiple times just like `scrollStopOnScroll` did.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-100498

### Comments
