### PR TITLE
Add unit test for data-webos-voice-disabled prop

### DIFF
--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -320,5 +320,26 @@ describe('VirtualList', () => {
 				expect(actual).toBe(expected);
 			}
 		);
+
+		test(
+			'should render "data-webos-voice-disabled" to outermost node of VirtualList',
+			() => {
+				const subject = mount(
+					<VirtualList
+						cbScrollTo={getScrollTo}
+						clientSize={clientSize}
+						dataSize={dataSize}
+						itemRenderer={renderItem}
+						itemSize={30}
+						data-webos-voice-disabled
+					/>
+				);
+
+				const expected = true;
+				const actual = subject.find(`.${css.virtualList}`).prop('data-webos-voice-disabled');
+
+				expect(actual).toBe(expected);
+			}
+		);
 	});
 });


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some voice control related features are added in PLAT-97909
This PR is unit test of newly added props.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
N/A

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
ENYO-6421

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee changgi.lee@lge.com