### PR TITLE
PLAT-100708: Fix JSDoc parse errors

### DIFF
--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -2,8 +2,8 @@
  * A higher-order component for customizing the visual appearance throughout an application.
  *
  * This is the base-level implementation of this component. It will typically never be accessed
- * directly, and only be instantiated with a configuration once inside a visual library like
- * {@link moonstone/Skinnable}. Interface libraries will supply a set of supported skins which will
+ * directly, and only be instantiated with a configuration once inside a visual library.
+ * Interface libraries will supply a set of supported skins which will
  * be accessible to their components.
  *
  * @module ui/Skinnable

--- a/packages/ui/VirtualList/VirtualListBase.js
+++ b/packages/ui/VirtualList/VirtualListBase.js
@@ -1208,7 +1208,8 @@ class VirtualListBase extends Component {
  * @memberof ui/VirtualList
  * @ui
  * @public
- //
+ */
+VirtualListBase.displayName = 'ui:VirtualListBase';
 
 /**
  * A callback function that receives a reference to the `scrollTo` feature.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There are the following JSDoc parse errors.
```
Invalid reference: ui/VirtualList.VirtualListBase:
    type: extends - VirtualList in packages/ui/VirtualList/VirtualList.js:29
    type: extends - VirtualGridList in packages/ui/VirtualList/VirtualList.js:137
Invalid link: moonstone/Skinnable:
    Used in: ui/Skinnable
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Assign VirtualListBase displayName properly
- Remove moonstone theme component link.

### Links
[//]: # (Related issues, references)

PLAT-100708

### Comments
