### PR TITLE
PLAT-101081: Fix sync ilib loader on chromium > 79

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n` loader to catch errors on failed synchronous requests
+
 ## [3.2.5] - 2019-11-14
 
 No significant changes.

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -33,7 +33,13 @@ const getImpl = (url, callback, sync) => {
 	}
 };
 
-const getSync = (url, callback) => getImpl(url, callback, true);
+const getSync = (url, callback) => {
+	try {
+		getImpl(url, callback, true);
+	} catch (e) {
+		callback(null, e);
+	}
+};
 
 const get = memoize((url) => new Promise((resolve, reject) => {
 	getImpl(url, (json, error) => {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Chromium > 79 throws errors on failed synchronous XHR

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Catch errors and invoke callback