### PR TITLE
PLAT-100713: Fix item layout and an item being scrolled into view properly

### DIFF
--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -12,8 +12,12 @@
 .vertical {
 	&.native {
 		overflow-y: scroll;
+
+		.listItem {
+			width: calc(100% - 2 * var(--scroll-fadeout-size));
+		}
 	}
-	.listItem {
+	&:not(.native) .listItem {
 		width: 100%;
 	}
 }
@@ -21,8 +25,12 @@
 .horizontal {
 	&.native {
 		overflow-x: scroll;
+
+		.listItem {
+			height: calc(100% - 2 * var(--scroll-fadeout-size));
+		}
 	}
-	.listItem {
+	&:not(.native) .listItem {
 		height: 100%;
 	}
 }

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -748,11 +748,8 @@ class VirtualListBasic extends Component {
 
 	setContainerSize = () => {
 		if (this.contentRef.current) {
-			if (this.isPrimaryDirectionVertical) {
-				this.contentRef.current.style.height = this.scrollBounds.scrollHeight + 'px';
-			} else {
-				this.contentRef.current.style.width = this.scrollBounds.scrollWidth + 'px';
-			}
+			this.contentRef.current.style.width = this.scrollBounds.scrollWidth + (this.isPrimaryDirectionVertical ? -1 : 0) + 'px';
+			this.contentRef.current.style.height = this.scrollBounds.scrollHeight + (this.isPrimaryDirectionVertical ? 0 : -1) + 'px';
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Items' layout is broken after structural changes of `VirtualList` so items on right bottom edges are not rendered fit into a content area of a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated internal calculation logic to handle items' position and size correctly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-100713

### Comments
