### PR TITLE
PLAT-101792: Fix not to scroll abnormally while pressing 5-way keys after wheeling

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` not to scroll while pressing 5-way keys after wheeling.
+
 ## [3.3.0-alpha.1] - 2020-02-26
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` not to scroll while pressing 5-way keys after wheeling.
+- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` not to suddenly jump when pressing directional keys after wheeling.
 
 ## [3.3.0-alpha.1] - 2020-02-26
 

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -832,6 +832,14 @@ class VirtualListBasic extends Component {
 		}
 	}
 
+	updateScrollPositionTarget (x, y) {
+		if (this.isPrimaryDirectionVertical) {
+			this.scrollPositionTarget = x;
+		} else {
+			this.scrollPositionTarget = y;
+		}
+	}
+
 	didScroll (x, y) {
 		const
 			{dataSize, spacing, itemSizes} = this.props,

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -833,11 +833,7 @@ class VirtualListBasic extends Component {
 	}
 
 	updateScrollPositionTarget (x, y) {
-		if (this.isPrimaryDirectionVertical) {
-			this.scrollPositionTarget = x;
-		} else {
-			this.scrollPositionTarget = y;
-		}
+		this.scrollPositionTarget = this.isPrimaryDirectionVertical ? y : x;
 	}
 
 	didScroll (x, y) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -729,7 +729,7 @@ const useScrollBase = (props) => {
 		}
 
 		if (scrollMode === 'native') {
-			scrollContentHandle.current.updateScrollPositionTarget(mutableRef.current.scrollTop, mutableRef.current.scrollLeft);
+			scrollContentHandle.current.updateScrollPositionTarget(mutableRef.current.scrollLeft, mutableRef.current.scrollTop);
 		}
 
 		if (scrollContentHandle.current.didScroll) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -728,6 +728,10 @@ const useScrollBase = (props) => {
 			setScrollTop(scrollTop);
 		}
 
+		if (scrollMode === 'native') {
+			scrollContentHandle.current.updateScrollPositionTarget(mutableRef.current.scrollTop, mutableRef.current.scrollLeft);
+		}
+
 		if (scrollContentHandle.current.didScroll) {
 			scrollContentHandle.current.didScroll(mutableRef.current.scrollLeft, mutableRef.current.scrollTop);
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

1. After wheeling in native VirtualList,
2. if pressing 5-way keys,
3. then the list suddenly scrolls.
4. So the spotted item is stick to the viewport.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

While wheeling, the scroll position was not cached properly. So if pressing 5-way keys, then the wrong scroll position was referenced. Therefore that scroll position is now cached properly while wheeling.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-101792

### Comments
