### PR TITLE
PLAT-101903: Add proxy support into mergeClassNames

### DIFF
--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -188,6 +188,15 @@ const mergeClassNameMaps = (baseMap, additiveMap, allowedClassNames) => {
 				css[key] = baseMap[key] + ' ' + additiveMap[key];
 			}
 		});
+
+		if (process.env.NODE_ENV === 'test') {
+			return new Proxy({}, {
+				get (target, key) {
+					// use the merged value if it exists and the key otherwise
+					return css[key] || key;
+				}
+			});
+		}
 	}
 
 	return css;


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using CSS overrides with CSS modules in unit tests, the reflection proxy plugin is subverted by merging that object into a new one.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a test-only proxy that emulates the same behavior with support for merged class names.