### PR TITLE
PLAT-102033: Revert renaming `childProps` to `itemProps` in VirtualList

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` prop `itemProps` to `childProps` for legacy.
+
 ## [3.3.0-alpha.1] - 2020-02-26
 
 ### Added

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -110,6 +110,14 @@ class VirtualListBasic extends Component {
 		cbScrollTo: PropTypes.func,
 
 		/**
+		 * Additional props included in the object passed to the `itemRenderer` callback.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		childProps: PropTypes.object,
+
+		/**
 		 * Client size of the list; valid values are an object that has `clientWidth` and `clientHeight`.
 		 *
 		 * @type {Object}
@@ -175,14 +183,6 @@ class VirtualListBasic extends Component {
 		 * @private
 		 */
 		getComponentProps: PropTypes.func,
-
-		/**
-		 * Additional props included in the object passed to the `itemRenderer` callback.
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		itemProps: PropTypes.object,
 
 		/**
 		 * The array for individually sized items.
@@ -289,8 +289,8 @@ class VirtualListBasic extends Component {
 		this.state = {
 			firstIndex: 0,
 			numOfItems: 0,
+			prevChildProps: null,
 			prevFirstIndex: 0,
-			prevItemProps: null,
 			updateFrom: 0,
 			updateTo: 0,
 			...nextState
@@ -303,7 +303,7 @@ class VirtualListBasic extends Component {
 		const
 			shouldInvalidate = (
 				state.prevFirstIndex === state.firstIndex ||
-				state.prevItemProps !== props.itemProps
+				state.prevChildProps !== props.childProps
 			),
 			diff = state.firstIndex - state.prevFirstIndex,
 			updateTo = (-state.numOfItems >= diff || diff > 0 || shouldInvalidate) ? state.firstIndex + state.numOfItems : state.prevFirstIndex,
@@ -312,8 +312,8 @@ class VirtualListBasic extends Component {
 
 		return {
 			...nextUpdateFromAndTo,
-			prevFirstIndex: state.firstIndex,
-			prevItemProps: props.itemProps
+			prevChildProps: props.childProps,
+			prevFirstIndex: state.firstIndex
 		};
 	}
 
@@ -1044,13 +1044,13 @@ class VirtualListBasic extends Component {
 
 	applyStyleToNewNode = (index, ...rest) => {
 		const
-			{itemProps, itemRenderer, getComponentProps} = this.props,
+			{childProps, itemRenderer, getComponentProps} = this.props,
 			key = index % this.state.numOfItems,
 			componentProps = getComponentProps && getComponentProps(index) || {};
 
 		this.cc[key] = (
 			<div className={css.listItem} key={key} style={this.composeStyle(...rest)}>
-				{itemRenderer({...itemProps, ...componentProps, index})}
+				{itemRenderer({...childProps, ...componentProps, index})}
 			</div>
 		);
 	}
@@ -1163,13 +1163,13 @@ class VirtualListBasic extends Component {
 			contentClasses = scrollMode === 'native' ? null : css.content;
 
 		delete rest.cbScrollTo;
+		delete rest.childProps;
 		delete rest.clientSize;
 		delete rest.dataSize;
 		delete rest.direction;
 		delete rest.getComponentProps;
 		delete rest.isHorizontalScrollbarVisible;
 		delete rest.isVerticalScrollbarVisible;
-		delete rest.itemProps;
 		delete rest.itemRenderer;
 		delete rest.itemSize;
 		delete rest.itemSizes;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I've renamed `childProps` to `itemProps` from https://github.com/enactjs/enact/pull/2685.
I didn't realize there was a discussion on the prop name before in https://github.com/enactjs/enact/pull/2004#discussion_r230107198.
So I want to revert the change.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revert renaming `childProps` to `itemProps` in VirtualList

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-102033

### Comments
