### PR TITLE
PLAT-99533: fix itemProps to childProps

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -79,6 +79,7 @@ const useForceUpdate = () => (useReducer(x => x + 1, 0));
 const useScrollBase = (props) => {
 	const
 		{
+			childProps,
 			children,
 			className,
 			clientSize,
@@ -90,7 +91,6 @@ const useScrollBase = (props) => {
 			direction,
 			horizontalScrollbar,
 			horizontalScrollbarRef,
-			itemProps,
 			itemRenderer,
 			itemSize,
 			itemSizes,
@@ -1475,12 +1475,12 @@ const useScrollBase = (props) => {
 
 	const scrollContentProps = props.itemRenderer ? // If the child component is a VirtualList
 		{
+			childProps,
 			clientSize,
 			'data-webos-voice-disabled': voiceDisabled,
 			'data-webos-voice-focused': voiceFocused,
 			'data-webos-voice-group-label': voiceGroupLabel,
 			dataSize,
-			itemProps,
 			itemRenderer,
 			itemSize,
 			itemSizes,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was a change renaming `itemProps` to `childProps`, but not in https://github.com/enactjs/enact/pull/2711.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed wrong name

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-99533

### Comments
