### PR TITLE
PLAT-101531: Update VirtualList and Scroller styles in default samplers

### DIFF
--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -67,7 +67,7 @@ storiesOf('UI', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualGridListConfig)}
 				itemRenderer={uiRenderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 180)),
+					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 100)),
 					minHeight: ri.scale(number('minHeight', VirtualGridListConfig, 270))
 				}}
 				noScrollByWheel={boolean('noScrollByWheel', VirtualGridListConfig)}

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -27,6 +27,7 @@ const
 				{...rest}
 				caption={text}
 				source={source}
+				style={{width: '100%'}}
 				subCaption={subText}
 			/>
 		);
@@ -67,7 +68,7 @@ storiesOf('UI', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualGridListConfig)}
 				itemRenderer={uiRenderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 100)),
+					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 180)),
 					minHeight: ri.scale(number('minHeight', VirtualGridListConfig, 270))
 				}}
 				noScrollByWheel={boolean('noScrollByWheel', VirtualGridListConfig)}

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -8,13 +8,21 @@ import {storiesOf} from '@storybook/react';
 import {VirtualList, VirtualListBasic} from '@enact/ui/VirtualList';
 
 const
-	prop = {scrollbarOption: ['auto', 'hidden', 'visible']},
+	prop = {
+		scrollbarOption: ['auto', 'hidden', 'visible']
+	},
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	uiRenderItem = (size) => ({index, ...rest}) => {
+		const itemStyle = {
+			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
+			boxSizing: 'border-box',
+			height: size + 'px'
+		};
+
 		return (
-			<UiItem {...rest} style={{height: size + 'px'}}>
+			<UiItem {...rest} style={itemStyle}>
 				{items[index]}
 			</UiItem>
 		);
@@ -46,8 +54,8 @@ storiesOf('UI', module)
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualListConfig)}
-					itemRenderer={uiRenderItem(ri.scale(number('itemSize', VirtualListConfig, 156)))}
-					itemSize={ri.scale(number('itemSize', VirtualListConfig, 156))}
+					itemRenderer={uiRenderItem(ri.scale(number('itemSize', VirtualListConfig, 72)))}
+					itemSize={ri.scale(number('itemSize', VirtualListConfig, 72))}
 					noScrollByWheel={boolean('noScrollByWheel', VirtualListConfig)}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -8,9 +8,7 @@ import {storiesOf} from '@storybook/react';
 import {VirtualList, VirtualListBasic} from '@enact/ui/VirtualList';
 
 const
-	prop = {
-		scrollbarOption: ['auto', 'hidden', 'visible']
-	},
+	prop = {scrollbarOption: ['auto', 'hidden', 'visible']},
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -8,21 +8,13 @@ import {storiesOf} from '@storybook/react';
 import {VirtualList, VirtualListBasic} from '@enact/ui/VirtualList';
 
 const
-	prop = {
-		scrollbarOption: ['auto', 'hidden', 'visible']
-	},
+	prop = {scrollbarOption: ['auto', 'hidden', 'visible']},
 	items = [],
 	defaultDataSize = 1000,
 	// eslint-disable-next-line enact/prop-types, enact/display-name
 	uiRenderItem = (size) => ({index, ...rest}) => {
-		const itemStyle = {
-			borderBottom: ri.unit(3, 'rem') + ' solid #202328',
-			boxSizing: 'border-box',
-			height: size + 'px'
-		};
-
 		return (
-			<UiItem {...rest} style={itemStyle}>
+			<UiItem {...rest} style={{height: size + 'px'}}>
 				{items[index]}
 			</UiItem>
 		);
@@ -54,8 +46,8 @@ storiesOf('UI', module)
 				<VirtualList
 					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualListConfig)}
-					itemRenderer={uiRenderItem(ri.scale(number('itemSize', VirtualListConfig, 72)))}
-					itemSize={ri.scale(number('itemSize', VirtualListConfig, 72))}
+					itemRenderer={uiRenderItem(ri.scale(number('itemSize', VirtualListConfig, 156)))}
+					itemSize={ri.scale(number('itemSize', VirtualListConfig, 156))}
 					noScrollByWheel={boolean('noScrollByWheel', VirtualListConfig)}
 					onScrollStart={action('onScrollStart')}
 					onScrollStop={action('onScrollStop')}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added / Resolution
[//]: # (Describe the issue resolved or feature added by this pull request)

According to the theme libraries, the styles of the VirtualList and the Scroller updates.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

If we don't need to align with the theme sampler's UX/GUI, this PR could be discarded.

### Links
[//]: # (Related issues, references)

PLAT-101531

### Comments
