### PR TITLE
Add text-index for Marquee

### DIFF
--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -27,6 +27,7 @@
 		transition-property: left, right;
 		transition-timing-function: linear;
 		position: relative;
+		text-indent: 0.05em;  // Fix for characters like `j` being left-truncated because of being too close to the edge
 
 		&.willAnimate {
 			will-change: left, right;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fix for characters like `j` being left-truncated because of being too close to the edge


### Resolution
Adjust indentation of the marquee text 


### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)