### PR TITLE
PLAT-102625: Support lists in the position mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Added
 
+- `ui/styles/mixins.less` `.position()` support for list-style arguments, in addition to the existing separated arguments
 - `ui/GridListItemItem` prop `subComponents`
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/styles/mixins.less` `.position()` support for list-style arguments, in addition to the existing separated arguments
+
 ## [3.3.0-alpha.2] - 2020-03-09
 
 ### Changed

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -154,22 +154,34 @@
 	left: @l;
 }
 .position (@t, @rl, @b) {
-	top: @t;
-	right: @rl;
-	bottom: @b;
-	left: @rl;
+	.position(@t, @rl, @b, @rl);
 }
 .position (@tb, @rl) {
-	top: @tb;
-	right: @rl;
-	bottom: @tb;
-	left: @rl;
+	.position(@tb, @rl, @tb, @rl);
 }
-.position (@trbl) {
-	top: @trbl;
-	right: @trbl;
-	bottom: @trbl;
-	left: @trbl;
+.position (@trbl) when (length(@trbl) = 4) {
+	.position(
+		extract(@trbl, 1),
+		extract(@trbl, 2),
+		extract(@trbl, 3),
+		extract(@trbl, 4)
+	);
+}
+.position (@trbl) when (length(@trbl) = 3) {
+	.position(
+		extract(@trbl, 1),
+		extract(@trbl, 2),
+		extract(@trbl, 3)
+	);
+}
+.position (@trbl) when (length(@trbl) = 2) {
+	.position(
+		extract(@trbl, 1),
+		extract(@trbl, 2)
+	);
+}
+.position (@trbl) when (length(@trbl) = 1) {
+	.position(@trbl, @trbl, @trbl, @trbl);
 }
 
 .border-box() {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Currently, the .position() LESS mixin only supports separated arguments.

This prevents the use of a single shorthand variable being used positioning. This leads to unnecessary variables being created, deleted, and altered any time a position design changes.


### Resolution
A new approach that supports the existing 1-4 arguments to the mixin, as well as a single argument list, deliverable as a single variable.


#### Current API:
```less
.position(10px);
.position(10px, 20px);
.position(10px, 20px, 30px);
.position(10px, 20px, 30px, 40px);
```

#### Updated API:
```less
.position(10px);
.position(10px, 20px);
.position(10px, 20px, 30px);
.position(10px, 20px, 30px, 40px);
// Note no comma, like traditional shorthand
.position(10px 20px);
.position(10px 20px 30px);
.position(10px 20px 30px 40px);
```

### Example code to test with
1. Create 7 `<div>` elements
2. Add the following LESS code to style them with this mixin:
```less
div:nth-child(1) {
	.position(6px);
}
div:nth-child(2) {
	.position(6px, 12px);
}
div:nth-child(3) {
	.position(6px, 12px, 18px);
}
div:nth-child(4) {
	.position(6px, 12px, 18px, 24px);
}
div:nth-child(5) {
	@example-list-position: 6px 12px;
	.position(@example-list-position);
}
div:nth-child(6) {
	@example-list-position: 6px 12px 18px;
	.position(@example-list-position);
}
div:nth-child(7) {
	@example-list-position: 6px 12px 18px 24px;
	.position(@example-list-position);
}
```
3. Inspect each and verify that the correct `top; right; buttom; left;` rules have been applied according to the common 1-4 argument shorthand syntax:
    * 1 argument, spread to all properties
    * 2 arguments, first spread to top and bottom, second to right and left
    * 3 arguments, first to top, second spread to right and left, third to bottom
    * 4 arguments, first to top, second to right, third to bottom, fourth to left