### PR TITLE
ENYO-6427: Scroller: calculate the content size properly with padding

### DIFF
--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -43,6 +43,14 @@ class ScrollerBasic extends Component {
 		direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
 
 		/**
+		 * Called to get size of a content area
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		getContentSize: PropTypes.func,
+
+		/**
 		 * Prop to check context value if Scrollbar exists or not.
 		 *
 		 * @type {Boolean}

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -149,10 +149,18 @@ class ScrollerBasic extends Component {
 		return (this.props.direction !== 'vertical');
 	}
 
+	getContentSize = () => {
+		const contentSize = this.props.scrollContentRef.current;
+
+		return contentSize && this.props.getContentSize ? this.props.getContentSize(contentSize) : contentSize;
+	}
+
 	calculateMetrics () {
 		const
 			{scrollBounds} = this,
-			{scrollWidth, scrollHeight, clientWidth, clientHeight} = this.props.scrollContentRef.current;
+			{clientWidth, clientHeight} = this.getContentSize(),
+			{scrollWidth, scrollHeight} = this.props.scrollContentRef.current;
+
 		scrollBounds.scrollWidth = scrollWidth;
 		scrollBounds.scrollHeight = scrollHeight;
 		scrollBounds.clientWidth = clientWidth;

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -178,6 +178,7 @@ class ScrollerBasic extends Component {
 			});
 
 		delete rest.cbScrollTo;
+		delete rest.getContentSize;
 		delete rest.direction;
 		delete rest.isHorizontalScrollbarVisible;
 		delete rest.isVerticalScrollbarVisible;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If there is paddings in the scroll area, the content couldn't be scrolled into a view properly. To fix it, it is needed to calculate the content size first.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The `getContentSize ` is provided to calculate the content size.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I'll add a change log after the first review.

### Links
[//]: # (Related issues, references)

ENYO-6427

### Comments
