### PR TITLE
ENYO-6428: Fixed the outer scroller's abnormal thumb moving on scroll inside the inner scroller

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` to update scroll thumb position properly in nested cases
+
 ## [3.3.0-alpha.2] - 2020-03-09
 
 ### Changed

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1544,12 +1544,15 @@ const assignPropertiesOf = (instance) => (name, properties) => {
 	if (typeof properties === 'object') {
 		for (const property in properties) {
 			if (property === 'className') {
+
 				warning(
 					Array.isArray(properties.className),
 					'Unsupported other types for `className` prop except Array'
 				);
 
-				instance[name].className = classNames(instance[name].className, properties.className);
+				instance[name].className = instance[name].className ?
+					instance[name].className + ' ' + properties.className.join(' ') :
+					properties.className.join(' ');
 			} else {
 				warning(
 					!instance[name][property],

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1397,12 +1397,7 @@ const useScrollBase = (props) => {
 
 		// scrollMode 'native' [[
 		if (scrollMode === 'native' && scrollContentRef.current) {
-			utilEvent('scroll').addEventListener(
-				scrollContentRef,
-				onScroll,
-				{capture: true, passive: true}
-			);
-
+			utilEvent('scroll').addEventListener(scrollContentRef, onScroll, {passive: true});
 			scrollContentRef.current.style.scrollBehavior = 'smooth';
 		}
 		// scrollMode 'native' ]]
@@ -1423,7 +1418,7 @@ const useScrollBase = (props) => {
 		utilEvent('mousedown').removeEventListener(scrollContainerRef, onMouseDown);
 
 		// scrollMode 'native' [[
-		utilEvent('scroll').removeEventListener(scrollContentRef, onScroll, {capture: true, passive: true});
+		utilEvent('scroll').removeEventListener(scrollContentRef, onScroll, {passive: true});
 		// scrollMode 'native' ]]
 
 		if (props.removeEventListeners) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1544,15 +1544,12 @@ const assignPropertiesOf = (instance) => (name, properties) => {
 	if (typeof properties === 'object') {
 		for (const property in properties) {
 			if (property === 'className') {
-
 				warning(
 					Array.isArray(properties.className),
 					'Unsupported other types for `className` prop except Array'
 				);
 
-				instance[name].className = instance[name].className ?
-					instance[name].className + ' ' + properties.className.join(' ') :
-					properties.className.join(' ');
+				instance[name].className = classNames(instance[name].className, properties.className);
 			} else {
 				warning(
 					!instance[name][property],


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a scroller has another scroller inside, the outer scroller's thumb moves to the wrong place without scrolling of the outer scroller if the inner scroller scrolls.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed `scroll` event to be caught from the inner scroller first by changing the event handler option from `capture` phase to `bubble` phase.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6428

### Comments
