### PR TITLE
ENYO-6435: Use classNames rather than joining

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1549,15 +1549,12 @@ const assignPropertiesOf = (instance) => (name, properties) => {
 	if (typeof properties === 'object') {
 		for (const property in properties) {
 			if (property === 'className') {
-
 				warning(
 					Array.isArray(properties.className),
 					'Unsupported other types for `className` prop except Array'
 				);
 
-				instance[name].className = instance[name].className ?
-					instance[name].className + ' ' + properties.className.join(' ') :
-					properties.className.join(' ');
+				instance[name].className = classNames(instance[name].className, properties.className);
 			} else {
 				warning(
 					!instance[name][property],


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We joined classNames for scrollers and lists, so we had to take care of falsy values when we deal with class names. For better and safe management, replaced related logic with `classNames` module.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6435

### Comments
