### PR TITLE
ENYO-6438: Fix to store client size and content size properly

### DIFF
--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -158,21 +158,33 @@ class ScrollerBasic extends Component {
 	}
 
 	getContentSize = () => {
-		const contentSize = this.props.scrollContentRef.current;
+		const scrollContentNode = this.props.scrollContentRef.current;
 
-		return contentSize && this.props.getContentSize ? this.props.getContentSize(contentSize) : contentSize;
+		if (scrollContentNode) {
+			if (this.props.getContentSize) {
+				return this.props.getContentSize(scrollContentNode);
+			} else {
+				const {clientWidth: contentWidth, clientHeight: contentHeight} = scrollContentNode;
+				return {contentWidth, contentHeight};
+			}
+		} else {
+			return {contentWidth: 0, contentHeight: 0};
+		}
 	}
 
 	calculateMetrics () {
 		const
 			{scrollBounds} = this,
-			{clientWidth, clientHeight} = this.getContentSize(),
-			{scrollWidth, scrollHeight} = this.props.scrollContentRef.current;
+			{contentWidth, contentHeight} = this.getContentSize(),
+			{clientWidth, clientHeight, scrollWidth, scrollHeight} = this.props.scrollContentRef.current;
 
 		scrollBounds.scrollWidth = scrollWidth;
 		scrollBounds.scrollHeight = scrollHeight;
 		scrollBounds.clientWidth = clientWidth;
 		scrollBounds.clientHeight = clientHeight;
+		scrollBounds.contentWidth = contentWidth;
+		scrollBounds.contentHeight = contentHeight;
+
 		scrollBounds.maxLeft = Math.max(0, scrollWidth - clientWidth);
 		scrollBounds.maxTop = Math.max(0, scrollHeight - clientHeight);
 	}


### PR DESCRIPTION
#2707 # Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

The Scroller doesn't scroll to the end.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The content height was used instead of the client height to check if scrolling to the end because the content height was stored in the `clientHeight` variable and the `clientHeight` was used incorrectly.
So the `clientHeight` and the `contentHeight` are stored separately in different variables now.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

ENYO-6438

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)