### PR TITLE
PLAT-101893: Add ComponentOverride support + structural updates

### DIFF
--- a/packages/ui/ComponentOverride/ComponentOverride.js
+++ b/packages/ui/ComponentOverride/ComponentOverride.js
@@ -55,10 +55,9 @@ import React from 'react';
  * @ui
  * @public
  */
-const ComponentOverride = ({component: Component, overrideComponent, ...props}) => {
-	if (overrideComponent) {
-		Component = overrideComponent;
-		delete props.overrideComponent;
+const ComponentOverride = ({component: Component, ...props}) => {
+	if (!Component && props.$component) {
+		Component = props.$component;
 	}
 
 	return Component && (

--- a/packages/ui/ComponentOverride/ComponentOverride.js
+++ b/packages/ui/ComponentOverride/ComponentOverride.js
@@ -55,7 +55,12 @@ import React from 'react';
  * @ui
  * @public
  */
-const ComponentOverride = ({component: Component, ...props}) => {
+const ComponentOverride = ({component: Component, overrideComponent, ...props}) => {
+	if (overrideComponent) {
+		Component = overrideComponent;
+		delete props.overrideComponent;
+	}
+
 	return Component && (
 		(typeof Component === 'function' || typeof Component === 'string') && (
 			<Component {...props} />

--- a/packages/ui/ComponentOverride/ComponentOverride.js
+++ b/packages/ui/ComponentOverride/ComponentOverride.js
@@ -56,10 +56,6 @@ import React from 'react';
  * @public
  */
 const ComponentOverride = ({component: Component, ...props}) => {
-	if (!Component && props.$component) {
-		Component = props.$component;
-	}
-
 	return Component && (
 		(typeof Component === 'function' || typeof Component === 'string') && (
 			<Component {...props} />

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -14,6 +14,7 @@ import Image from '../Image';
 import {Cell, Column, Row} from '../Layout';
 
 import componentCss from './ImageItem.module.less';
+import EnactPropTypes from '@enact/core/internal/prop-types/prop-types';
 
 // Adapts ComponentOverride to work within Cell since both use the component prop
 function ImageOverride ({imageComponent, ...rest}) {
@@ -61,10 +62,10 @@ const ImageItem = kind({
 		/**
 		 * The component used to render the image component.
 		 *
-		 * @type {Node}
+		 * @type {Component|Element}
 		 * @public
 		 */
-		imageComponent: PropTypes.node,
+		imageComponent: EnactPropTypes.componentOverride,
 
 		/**
 		 * The layout orientation of the component.
@@ -135,7 +136,7 @@ const ImageItem = kind({
 		const Component = isHorizontal ? Row : Column;
 
 		return (
-			<Component {...rest} inline={!isHorizontal}>
+			<Component {...rest}>
 				<Cell
 					className={css.image}
 					component={ImageOverride}
@@ -144,14 +145,16 @@ const ImageItem = kind({
 					shrink={isHorizontal}
 					src={src}
 				/>
-				<Cell
-					className={css.caption}
-					shrink={!isHorizontal}
-					// eslint-disable-next-line no-undefined
-					align={isHorizontal ? 'center' : undefined}
-				>
-					{caption}
-				</Cell>
+				{caption ? (
+					<Cell
+						className={css.caption}
+						shrink={!isHorizontal}
+						// eslint-disable-next-line no-undefined
+						align={isHorizontal ? 'center' : undefined}
+					>
+						{caption}
+					</Cell>
+				) : null}
 			</Component>
 		);
 	}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -9,8 +9,9 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Column, Cell, Row} from '../Layout';
+import ComponentOverride from '../ComponentOverride';
 import Image from '../Image';
+import {Cell, Column, Row} from '../Layout';
 
 import componentCss from './ImageItem.module.less';
 
@@ -100,6 +101,7 @@ const ImageItem = kind({
 	},
 
 	defaultProps: {
+		imageComponent: Image,
 		orientation: 'vertical',
 		selected: false
 	},
@@ -111,31 +113,33 @@ const ImageItem = kind({
 	},
 
 	computed: {
-		className: ({orientation, selected, styler}) => styler.append(
-			{selected, horizontal: orientation === 'horizontal', vertical: orientation === 'vertical'}
-		),
-		caption: ({caption, css, orientation}) => {
-			const captionComponent = typeof caption === 'string' ? <Cell className={css.caption} shrink>{caption}</Cell> : caption;
-
-			return (
-				orientation === 'horizontal' ? <Cell align="center">
-					{captionComponent}
-				</Cell> : captionComponent
-			);
-		}
+		className: ({orientation, selected, styler}) => styler.append({
+			selected,
+			horizontal: orientation === 'horizontal',
+			vertical: orientation === 'vertical'
+		})
 	},
 
 	render: ({caption, css, imageComponent, orientation, placeholder, src, ...rest}) => {
 		delete rest.selected;
 
-		const
-			isHorizontal = orientation === 'horizontal',
-			Component = isHorizontal ? Row : Column;
+		const isHorizontal = orientation === 'horizontal';
+		const Component = isHorizontal ? Row : Column;
 
 		return (
 			<Component {...rest} inline>
-				{imageComponent ? imageComponent : <Cell className={css.image} component={Image} placeholder={placeholder} shrink={isHorizontal} src={src} />}
-				{caption}
+				<Cell
+					className={css.image}
+					component={ComponentOverride}
+					overrideComponent={imageComponent}
+					placeholder={placeholder}
+					shrink={isHorizontal}
+					src={src}
+				/>
+				{/* eslint-disable-next-line no-undefined */}
+				<Cell className={css.caption} shrink align={isHorizontal ? 'center' : undefined}>
+					{caption}
+				</Cell>
 			</Component>
 		);
 	}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -15,6 +15,14 @@ import {Cell, Column, Row} from '../Layout';
 
 import componentCss from './ImageItem.module.less';
 
+// Adapts ComponentOverride to work within Cell since both use the component prop
+function ImageOverride ({imageComponent, ...rest}) {
+	return ComponentOverride({
+		component: imageComponent,
+		...rest
+	});
+}
+
 /**
  * A basic image item without any behavior.
  *
@@ -130,14 +138,18 @@ const ImageItem = kind({
 			<Component {...rest} inline>
 				<Cell
 					className={css.image}
-					component={ComponentOverride}
-					$component={imageComponent}
+					component={ImageOverride}
+					imageComponent={imageComponent}
 					placeholder={placeholder}
 					shrink={isHorizontal}
 					src={src}
 				/>
-				{/* eslint-disable-next-line no-undefined */}
-				<Cell className={css.caption} shrink align={isHorizontal ? 'center' : undefined}>
+				<Cell
+					className={css.caption}
+					shrink={!isHorizontal}
+					// eslint-disable-next-line no-undefined
+					align={isHorizontal ? 'center' : undefined}
+				>
 					{caption}
 				</Cell>
 			</Component>

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -135,7 +135,7 @@ const ImageItem = kind({
 		const Component = isHorizontal ? Row : Column;
 
 		return (
-			<Component {...rest} inline>
+			<Component {...rest} inline={!isHorizontal}>
 				<Cell
 					className={css.image}
 					component={ImageOverride}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -131,7 +131,7 @@ const ImageItem = kind({
 				<Cell
 					className={css.image}
 					component={ComponentOverride}
-					overrideComponent={imageComponent}
+					$component={imageComponent}
 					placeholder={placeholder}
 					shrink={isHorizontal}
 					src={src}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -6,6 +6,7 @@
  */
 
 import kind from '@enact/core/kind';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -14,7 +15,6 @@ import Image from '../Image';
 import {Cell, Column, Row} from '../Layout';
 
 import componentCss from './ImageItem.module.less';
-import EnactPropTypes from '@enact/core/internal/prop-types/prop-types';
 
 // Adapts ComponentOverride to work within Cell since both use the component prop
 function ImageOverride ({imageComponent, ...rest}) {


### PR DESCRIPTION
* Adds `ComponentOverride` support for `imageComponent` so authors can provide either a built element (`<Image>`) or a component (`Image`) which will both receive the `placeholder`, `className`, and `src` props. Due to both `Cell` and `ComponentOverride` using the `component` prop, I've added a new `ImageComponent` component to redirect the `imageComponent` prop but have avoided the extra component layer by calling `ComponentOverride` directly (which it is designed to support).
* Some structural simplification of the caption block