### PR TITLE
ENYO-6429: Hide the scrollbar after n seconds.

### DIFF
--- a/packages/ui/useScroll/Scrollbar.js
+++ b/packages/ui/useScroll/Scrollbar.js
@@ -64,6 +64,9 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 	}
 
 	useEffect(() => {
+		addClass(thumbRef.current, css.thumbShown);
+		hideThumbJob.current.start();
+
 		return () => {
 			hideThumbJob.current.stop();
 		};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- `scrollbar` of `ui scroller` is not showing when initial time.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?) 
- Show `scrollbar` of `ui scroller` when initial time.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
ENYO-6429

### Comments