### PR TITLE
PLAT-99658: Fixed to cover scrollbars also with scrim when container is muted

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -98,7 +98,7 @@ const useScrollBase = (props) => {
 			noScrollByDrag,
 			noScrollByWheel,
 			overhang,
-			overscrollEffectOn = {drag: false, pageKey: false, wheel: false},
+			overscrollEffectOn,
 			pageScroll,
 			rtl,
 			scrollContainerRef,
@@ -480,7 +480,7 @@ const useScrollBase = (props) => {
 				targetX: (direction === 'vertical') ? 0 : mutableRef.current.dragStartX - getRtlX(ev.x), // 'horizontal' or 'both'
 				targetY: (direction === 'horizontal') ? 0 : mutableRef.current.dragStartY - ev.y, // 'vertical' or 'both'
 				animate: false,
-				overscrollEffect: overscrollEffectOn.drag
+				overscrollEffect: overscrollEffectOn && overscrollEffectOn.drag
 			});
 		} else {
 			const
@@ -490,8 +490,8 @@ const useScrollBase = (props) => {
 			mutableRef.current.lastInputType = 'drag';
 
 			if (!mutableRef.current.isTouching) {
-				start({targetX, targetY, animate: false, overscrollEffect: overscrollEffectOn.drag});
-			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn.drag) {
+				start({targetX, targetY, animate: false, overscrollEffect: overscrollEffectOn && overscrollEffectOn.drag});
+			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) {
 				checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeHold);
 			}
 		}
@@ -512,12 +512,12 @@ const useScrollBase = (props) => {
 				mutableRef.current.lastInputType = 'drag';
 
 				mutableRef.current.isScrollAnimationTargetAccumulated = false;
-				start({targetX, targetY, duration, overscrollEffect: overscrollEffectOn.drag});
+				start({targetX, targetY, duration, overscrollEffect: overscrollEffectOn && overscrollEffectOn.drag});
 			} else {
 				stop();
 			}
 
-			if (mutableRef.current.overscrollEnabled) { // not check overscrollEffectOn.drag for safety
+			if (mutableRef.current.overscrollEnabled) { // not check overscrollEffectOn && overscrollEffectOn.drag for safety
 				clearAllOverscrollEffects();
 			}
 
@@ -532,15 +532,15 @@ const useScrollBase = (props) => {
 
 				if (!mutableRef.current.isTouching) {
 					mutableRef.current.isScrollAnimationTargetAccumulated = false;
-					start({targetX, targetY, overscrollEffect: overscrollEffectOn.drag});
-				} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn.drag) {
+					start({targetX, targetY, overscrollEffect: overscrollEffectOn && overscrollEffectOn.drag});
+				} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) {
 					checkAndApplyOverscrollEffectOnDrag(targetX, targetY, overscrollTypeOnce);
 				}
 			} else if (!mutableRef.current.isTouching) {
 				stop();
 			}
 
-			if (mutableRef.current.overscrollEnabled) { // not check overscrollEffectOn.drag for safety
+			if (mutableRef.current.overscrollEnabled) { // not check overscrollEffectOn && overscrollEffectOn.drag for safety
 				clearAllOverscrollEffects();
 			}
 
@@ -565,7 +565,7 @@ const useScrollBase = (props) => {
 					(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
 					(direction !== 'horizontal') ? -ev.velocityY : 0
 				);
-			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn.drag) {
+			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) {
 				mutableRef.current.flickTarget = {
 					targetX: mutableRef.current.scrollLeft + getRtlX(-ev.velocityX) * overscrollVelocityFactor, // 'horizontal' or 'both'
 					targetY: mutableRef.current.scrollTop + -ev.velocityY * overscrollVelocityFactor // 'vertical' or 'both'
@@ -636,12 +636,12 @@ const useScrollBase = (props) => {
 				forward('onWheel', {delta, horizontalScrollbarRef, verticalScrollbarRef}, props);
 
 				if (delta !== 0) {
-					scrollToAccumulatedTarget(delta, canScrollV, overscrollEffectOn.wheel);
+					scrollToAccumulatedTarget(delta, canScrollV, overscrollEffectOn && overscrollEffectOn.wheel);
 					ev.preventDefault();
 					ev.stopPropagation();
 				}
 			} else { // scrollMode 'native'
-				const overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn.wheel;
+				const overscrollEffectRequired = mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.wheel;
 				let needToHideThumb = false;
 
 				if (props.onWheel) {
@@ -701,7 +701,7 @@ const useScrollBase = (props) => {
 						mutableRef.current.wheelDirection = dir;
 					}
 
-					scrollToAccumulatedTarget(delta, canScrollV, overscrollEffectOn.wheel);
+					scrollToAccumulatedTarget(delta, canScrollV, overscrollEffectOn && overscrollEffectOn.wheel);
 				}
 
 				if (needToHideThumb) {
@@ -720,7 +720,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.lastInputType = 'pageKey';
 
-		scrollToAccumulatedTarget(pageDistance, canScrollV, overscrollEffectOn.pageKey);
+		scrollToAccumulatedTarget(pageDistance, canScrollV, overscrollEffectOn && overscrollEffectOn.pageKey);
 	}
 	// scrollMode 'translate' ]]
 
@@ -933,7 +933,7 @@ const useScrollBase = (props) => {
 		if (props.scrollStopOnScroll) {
 			props.scrollStopOnScroll();
 		}
-		if (mutableRef.current.overscrollEnabled && !mutableRef.current.isDragging) { // not check overscrollEffectOn for safety
+		if (mutableRef.current.overscrollEnabled && !mutableRef.current.isDragging) { // not check overscrollEffectOn && overscrollEffectOn for safety
 			clearAllOverscrollEffects();
 		}
 		mutableRef.current.lastInputType = null;
@@ -951,7 +951,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.scrollLeft = clamp(0, bounds.maxLeft, value);
 
-		if (mutableRef.current.overscrollEnabled && overscrollEffectOn[mutableRef.current.lastInputType]) {
+		if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn[mutableRef.current.lastInputType]) {
 			checkAndApplyOverscrollEffectOnScroll('horizontal');
 		}
 
@@ -965,7 +965,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.scrollTop = clamp(0, bounds.maxTop, value);
 
-		if (mutableRef.current.overscrollEnabled && overscrollEffectOn[mutableRef.current.lastInputType]) {
+		if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn[mutableRef.current.lastInputType]) {
 			checkAndApplyOverscrollEffectOnScroll('vertical');
 		}
 
@@ -1167,7 +1167,7 @@ const useScrollBase = (props) => {
 		mutableRef.current.isScrollAnimationTargetAccumulated = false;
 		startHidingThumb();
 
-		if (mutableRef.current.overscrollEnabled && !mutableRef.current.isDragging) { // not check overscrollEffectOn for safety
+		if (mutableRef.current.overscrollEnabled && !mutableRef.current.isDragging) { // not check overscrollEffectOn && overscrollEffectOn for safety
 			clearAllOverscrollEffects();
 		}
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -16,7 +16,7 @@ import {platform} from '@enact/core/platform'; // scrollMode 'native'
 import Registry from '@enact/core/internal/Registry';
 import {Job} from '@enact/core/util';
 import clamp from 'ramda/src/clamp';
-import {useCallback, useContext, useEffect, useLayoutEffect, useReducer, useRef, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useLayoutEffect, useReducer, useRef, useState} from 'react';
 import warning from 'warning';
 
 import ForwardRef from '../ForwardRef';
@@ -63,7 +63,9 @@ const
 		scrollWheelPageMultiplierForMaxPixel
 	} = constants;
 
-const TouchableDiv = ForwardRef({prop: 'ref'}, Touchable('div'));
+const TouchableDiv = ForwardRef({prop: 'componentRef'}, Touchable(
+	({componentRef, ...rest}) => (<div {...rest} ref={componentRef} />)
+));
 
 const useForceUpdate = () => (useReducer(x => x + 1, 0));
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -98,7 +98,7 @@ const useScrollBase = (props) => {
 			noScrollByDrag,
 			noScrollByWheel,
 			overhang,
-			overscrollEffectOn,
+			overscrollEffectOn = {drag: false, pageKey: false, wheel: false},
 			pageScroll,
 			rtl,
 			scrollContainerRef,

--- a/packages/ui/useScroll/useScroll.module.less
+++ b/packages/ui/useScroll/useScroll.module.less
@@ -14,21 +14,22 @@
 	box-sizing: border-box;
 	flex-direction: column;
 
+	&[data-container-muted="true"]::before {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		content: '';
+		z-index: 10;
+	}
+
 	.scrollInnerContainer {
 		display: flex;
 		width: 100%;
 		height: 100%;
 		min-height: 0;
 		flex: auto;
-		[data-container-muted="true"]::before {
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			content: '';
-			z-index: 10;
-		}
 	}
 
 	.scrollContentWrapper {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A scrim for a muted container of a scroller or a list does not cover scrollbars properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Moved related CSS to the top node of scrollable components.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This change is also required to support a muted container in other theme libs.

### Links
[//]: # (Related issues, references)
PLAT-99658

### Comments
