### PR TITLE
PLAT-101914: Remove some moonstone references in inline docs

### DIFF
--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -102,13 +102,13 @@
  * @example
  * <Layout className="debug layout">
  * 	<Cell shrink>
- * 		<Button>First</Button>
+ * 		<button>First</button>
  * 	</Cell>
  * 	<Cell>
- * 		<Item>An Item with some long text in it</Item>
+ * 		<div>A div with some long text in it</div>
  * 	</Cell>
  * 	<Cell shrink>
- * 		<Button>Last</Button>
+ * 		<button>Last</button>
  * 	</Cell>
  * </Layout>
  *


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
UI in-line doc sample references Moonstone components

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace with generic HTML elements

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-101914

### Comments
