### PR TITLE
ENYO-6444: Fix console warning of scrollAndFocusScrollbarButton prop

### DIFF
--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -175,6 +175,7 @@ class ScrollerBasic extends Component {
 		delete rest.isHorizontalScrollbarVisible;
 		delete rest.isVerticalScrollbarVisible;
 		delete rest.rtl;
+		delete rest.scrollAndFocusScrollbarButton;
 		delete rest.scrollContainerContainsDangerously;
 		delete rest.scrollContentRef;
 		delete rest.scrollMode;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Agate sampler shows console warning of React does not recognize the `scrollAndFocusScrollbarButton` prop on a DOM element

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delete prop on ScrollerBasic render

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6444

### Comments
