### PR TITLE
PLAT-102264: Convert AnnounceDecorator to use hooks

### DIFF
--- a/packages/ui/AnnounceDecorator/AnnounceDecorator.js
+++ b/packages/ui/AnnounceDecorator/AnnounceDecorator.js
@@ -101,5 +101,6 @@ const AnnounceDecorator = hoc(defaultConfig, ({prop}, Wrapped) => {
 export default AnnounceDecorator;
 export {
 	Announce,
-	AnnounceDecorator
+	AnnounceDecorator,
+	useAnnounce
 };

--- a/packages/ui/AnnounceDecorator/AnnounceDecorator.js
+++ b/packages/ui/AnnounceDecorator/AnnounceDecorator.js
@@ -6,10 +6,12 @@
  * @exports AnnounceDecorator
  */
 
-import Announce from './Announce';
 import hoc from '@enact/core/hoc';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
+import Announce from './Announce';
+import useAnnounce from './useAnnounce';
 
 /**
  * Default config for {@link ui/AnnounceDecorator.AnnounceDecorator}.
@@ -67,44 +69,33 @@ const defaultConfig = {
  * @public
  */
 const AnnounceDecorator = hoc(defaultConfig, ({prop}, Wrapped) => {
-	return class extends React.Component {
-		static displayName = 'AnnounceDecorator'
+	// eslint-disable-next-line no-shadow
+	function AnnounceDecorator ({children, ...rest}) {
+		const announce = useAnnounce();
 
-		static propTypes = /** @lends ui/AnnounceDecorator.AnnounceDecorator.prototype */ {
-			/**
-			 * The wrapped component's children.
-			 *
-			 * An instance of {@link ui/AnnounceDecorator.Announce} will be appended to `children`.
-			 *
-			 * @type {Node}
-			 * @public
-			 */
-			children: PropTypes.node
-		}
+		if (prop) rest[prop] = announce.announce;
 
-		announce = (message) => {
-			if (this.announceRef) {
-				this.announceRef.announce(message);
-			}
-		}
+		return (
+			<Wrapped {...rest}>
+				{children}
+				{announce.children}
+			</Wrapped>
+		);
+	}
 
-		setAnnounceRef = (node) => {
-			this.announceRef = node;
-		}
-
-		render () {
-			const {children, ...rest} = this.props;
-
-			rest[prop] = this.announce;
-
-			return (
-				<Wrapped {...rest}>
-					{children}
-					<Announce ref={this.setAnnounceRef} />
-				</Wrapped>
-			);
-		}
+	AnnounceDecorator.propTypes = /** @lends ui/AnnounceDecorator.AnnounceDecorator.prototype */ {
+		/**
+		 * The wrapped component's children.
+		 *
+		 * An instance of {@link ui/AnnounceDecorator.Announce} will be appended to `children`.
+		 *
+		 * @type {Node}
+		 * @public
+		 */
+		children: PropTypes.node
 	};
+
+	return AnnounceDecorator;
 });
 
 export default AnnounceDecorator;

--- a/packages/ui/AnnounceDecorator/tests/useAnnounce-specs.js
+++ b/packages/ui/AnnounceDecorator/tests/useAnnounce-specs.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+
+import useAnnounce from '../useAnnounce';
+
+describe('useAnnounce', () => {
+	function Base ({children}) {
+		return <div>{children}</div>;
+	}
+
+	function Component () {
+		const {announce, children} = useAnnounce();
+
+		return (
+			<Base announce={announce}>
+				{children}
+			</Base>
+		);
+	}
+
+	test('should return an announce function', () => {
+		const subject = shallow(
+			<Component />
+		);
+
+		const expected = 'function';
+		const actual = typeof subject.prop('announce');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should return a single element in children', () => {
+		const subject = shallow(
+			<Component />
+		);
+
+		const expected = true;
+		const actual = React.isValidElement(subject.prop('children'));
+
+		expect(actual).toBe(expected);
+	});
+
+	// this might be too specialized to the implmentation but we lack a better way to unit test this
+	// capability right now
+	test('should set the value passed to announce into the ARIA role="alert" node', () => {
+		const text = '__NOTIFY__';
+		const subject = mount(
+			<Component />
+		);
+
+		subject.find(Base).invoke('announce')(text);
+		subject.update();
+
+		const expected = text;
+		// Have to get the actual DOM node here since Announce updates the DOM directly so the
+		// change isn't represented in either the Reach or Enzyme views
+		const actual = subject.find({role: 'alert'}).instance().getAttribute('aria-label');
+
+		expect(actual).toBe(expected);
+
+	});
+
+});

--- a/packages/ui/AnnounceDecorator/tests/useAnnounce-specs.js
+++ b/packages/ui/AnnounceDecorator/tests/useAnnounce-specs.js
@@ -53,7 +53,7 @@ describe('useAnnounce', () => {
 
 		const expected = text;
 		// Have to get the actual DOM node here since Announce updates the DOM directly so the
-		// change isn't represented in either the Reach or Enzyme views
+		// change isn't represented in either the React or Enzyme views
 		const actual = subject.find({role: 'alert'}).instance().getAttribute('aria-label');
 
 		expect(actual).toBe(expected);

--- a/packages/ui/AnnounceDecorator/useAnnounce.js
+++ b/packages/ui/AnnounceDecorator/useAnnounce.js
@@ -2,6 +2,34 @@ import React from 'react';
 
 import Announce from './Announce';
 
+/**
+ * Object returned by `useAnnounce`
+ *
+ * @typedef {Object} useAnnounceInterface
+ * @property {Function} announce Called to alert the user of behavior for accessibility
+ * @property {Node}     children An additional element which must be added to the component tree to
+ *                               support notifying the user
+ * @private
+ */
+
+/**
+ * Provides a method to alert the user of behavior for accessibility.
+ *
+ * ```
+ * 	function Component () {
+ *		const {announce, children} = useAnnounce();
+ *
+ *		return (
+ *			<Base onClick={() => announce('Unusually important notification for accessibility')}>
+ *				{children}
+ *			</Base>
+ *		);
+ *	}
+ * ```
+ *
+ * @returns {useAnnounceInterface}
+ * @private
+ */
 function useAnnouce () {
 	const ref = React.useRef(null);
 	const announce = React.useCallback(message => {

--- a/packages/ui/AnnounceDecorator/useAnnounce.js
+++ b/packages/ui/AnnounceDecorator/useAnnounce.js
@@ -1,0 +1,31 @@
+import useClass from '@enact/core/useClass';
+import React from 'react';
+
+import AnnounceComp from './Announce';
+
+class Announce {
+	constructor (ref) {
+		this.ref = ref;
+	}
+
+	announce = (message) => {
+		if (this.ref && this.ref.current) {
+			this.ref.current.announce(message);
+		}
+	}
+}
+
+function useAnnouce () {
+	const ref = React.useRef(null);
+	const inst = useClass(Announce, ref);
+
+	return {
+		announce: inst.announce,
+		children: <AnnounceComp ref={ref} />
+	};
+};
+
+export default useAnnouce;
+export {
+	useAnnouce
+};

--- a/packages/ui/AnnounceDecorator/useAnnounce.js
+++ b/packages/ui/AnnounceDecorator/useAnnounce.js
@@ -1,29 +1,20 @@
-import useClass from '@enact/core/useClass';
 import React from 'react';
 
-import AnnounceComp from './Announce';
-
-class Announce {
-	constructor (ref) {
-		this.ref = ref;
-	}
-
-	announce = (message) => {
-		if (this.ref && this.ref.current) {
-			this.ref.current.announce(message);
-		}
-	}
-}
+import Announce from './Announce';
 
 function useAnnouce () {
 	const ref = React.useRef(null);
-	const inst = useClass(Announce, ref);
+	const announce = React.useCallback(message => {
+		if (ref && ref.current) {
+			ref.current.announce(message);
+		}
+	}, [ref]);
 
 	return {
-		announce: inst.announce,
-		children: <AnnounceComp ref={ref} />
+		announce,
+		children: <Announce ref={ref} />
 	};
-};
+}
 
 export default useAnnouce;
 export {

--- a/packages/ui/AnnounceDecorator/useAnnounce.js
+++ b/packages/ui/AnnounceDecorator/useAnnounce.js
@@ -33,7 +33,7 @@ import Announce from './Announce';
 function useAnnouce () {
 	const ref = React.useRef(null);
 	const announce = React.useCallback(message => {
-		if (ref && ref.current) {
+		if (ref.current) {
 			ref.current.announce(message);
 		}
 	}, [ref]);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Adopt hooks for `ui/AnnounceDecorator`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Chose to use `useCallback` rather than `useClass` in this case because it seemed like unnecessary complexity without any handlers and only one method. Thanks to @sugardave for reminding me of that earlier in the day. :)