### PR TITLE
PLAT-102257: Migrate ui/Skinnable to use hooks

### DIFF
--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -20,6 +20,48 @@ import classnames from 'classnames';
 import {objectify, preferDefined} from './util';
 
 /**
+ * Allows a component to respond to skin changes via the Context API
+ *
+ * Example:
+ * ```
+ * <App skin="dark">
+ * 	<Section>
+ * 		<Button>Gray Button</Button>
+ * 	<Section>
+ * 	<Popup skin="light">
+ * 		<Button>White Button</Button>
+ * 	</Popup>
+ * </App>
+ * ```
+ *
+ * @class SkinContext
+ * @memberof ui/Skinnable
+ * @hoc
+ * @public
+ */
+const SkinContext = React.createContext(null);
+
+/**
+ * Object returned by `useSkinContext`
+ *
+ * @typedef {Object} useSkinContextInterface
+ * @memberof ui/Skinnable
+ * @property {String}   parentSkin     The applied parent skin
+ * @property {Array}    parentVariants The collection of applied parent variants
+ * @private
+ */
+
+/**
+ * Retrieves the parent skin and variants
+ *
+ * @returns {useSkinContextInterface}
+ * @private
+ */
+function useSkinContext () {
+	return React.useContext(SkinContext);
+}
+
+/**
  * Default config for `Skinnable`.
  *
  * @memberof ui/Skinnable.Skinnable
@@ -91,48 +133,6 @@ const defaultConfig = {
 	 */
 	allowedVariants: null
 };
-
-/**
- * Allows a component to respond to skin changes via the Context API
- *
- * Example:
- * ```
- * <App skin="dark">
- * 	<Section>
- * 		<Button>Gray Button</Button>
- * 	<Section>
- * 	<Popup skin="light">
- * 		<Button>White Button</Button>
- * 	</Popup>
- * </App>
- * ```
- *
- * @class SkinContext
- * @memberof ui/Skinnable
- * @hoc
- * @public
- */
-const SkinContext = React.createContext(null);
-
-/**
- * Object returned by `useSkinContext`
- *
- * @typedef {Object} useSkinContextInterface
- * @memberof ui/Skinnable
- * @property {String}   parentSkin     The applied parent skin
- * @property {Array}    parentVariants The collection of applied parent variants
- * @private
- */
-
-/**
- * Retrieves the parent skin and variants
- *
- * @returns {useSkinContextInterface}
- * @private
- */
-function useSkinContext () {
-	return React.useContext(SkinContext);
-}
 
 /**
  * A higher-order component that assigns skinning classes for the purposes of styling children components.

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -114,6 +114,10 @@ const defaultConfig = {
  */
 const SkinContext = React.createContext(null);
 
+function useSkinContext () {
+	return React.useContext(SkinContext);
+}
+
 /**
  * A higher-order component that assigns skinning classes for the purposes of styling children components.
  *
@@ -247,34 +251,31 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 				PropTypes.object
 			])
 		},
-		render: ({className, skin, skinVariants, ...rest}) => (
-			<SkinContext.Consumer>
-				{(value) => {
-					const {parentSkin, parentVariants} = value || {};
-					const effectiveSkin = determineSkin(skin, parentSkin);
-					const variants = determineVariants(skinVariants, parentVariants);
-					const allClassNames = getClassName(effectiveSkin, className, variants);
+		render: ({className, skin, skinVariants, ...rest}) => {
+			const skinContext = useSkinContext();
+			const {parentSkin, parentVariants} = skinContext || {};
+			const effectiveSkin = determineSkin(skin, parentSkin);
+			const variants = determineVariants(skinVariants, parentVariants);
+			const allClassNames = getClassName(effectiveSkin, className, variants);
 
-					if (allClassNames) {
-						rest.className = allClassNames;
-					}
+			if (allClassNames) {
+				rest.className = allClassNames;
+			}
 
-					if (prop) {
-						rest[prop] = effectiveSkin;
-					}
+			if (prop) {
+				rest[prop] = effectiveSkin;
+			}
 
-					if (variantsProp) {
-						rest[variantsProp] = variants;
-					}
+			if (variantsProp) {
+				rest[variantsProp] = variants;
+			}
 
-					return (
-						<SkinContext.Provider value={{parentSkin: effectiveSkin, parentVariants: variants}}>
-							<Wrapped {...rest} />
-						</SkinContext.Provider>
-					);
-				}}
-			</SkinContext.Consumer>
-		)
+			return (
+				<SkinContext.Provider value={{parentSkin: effectiveSkin, parentVariants: variants}}>
+					<Wrapped {...rest} />
+				</SkinContext.Provider>
+			);
+		}
 	});
 });
 

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -114,6 +114,22 @@ const defaultConfig = {
  */
 const SkinContext = React.createContext(null);
 
+/**
+ * Object returned by `useSkinContext`
+ *
+ * @typedef {Object} useSkinContextInterface
+ * @memberof ui/Skinnable
+ * @property {String}   parentSkin     The applied parent skin
+ * @property {Array}    parentVariants The collection of applied parent variants
+ * @private
+ */
+
+/**
+ * Retrieves the parent skin and variants
+ *
+ * @returns {useSkinContextInterface}
+ * @private
+ */
 function useSkinContext () {
 	return React.useContext(SkinContext);
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Migrate ui/Skinnable to use hooks

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Add `useSkinContext` hook like the way that we did in `useI18nContext`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- The `kind` will be a functional component in the https://github.com/enactjs/enact/pull/2745. So I don't think that we need to migrate from the `kind` to a functional component any more for the `Skinnable` kind.

- Switch the `SkinContext` and the `defaultConfig` to stick the `defaultConfig` to the `Skinnable` because the the `defaultConfig` is only used in the `Skinnable` and the `SkinContext` is used both in the `Skinnable` and `useSkinContext`.

### Links
[//]: # (Related issues, references)

PLAT-102257

### Comments

** CAUTION **

- The PR - https://github.com/enactjs/enact/pull/2745 should be merged first before this PR is merged.
- The CHANGELOG.md will be udpated.