### PR TITLE
PLAT-105257: Enact repo package.json cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@
 
 Enact uses lerna to manage the individual modules within this repo.
 
-## Usage
+## Getting Started
 
 Developers should use the individual npm modules hosted under the `@enact` namespace.
 
-For framework developers, execute the bootstrap command to build and link modules:
+For local framework development, this mono-repo can be setup using the bootstrap command
 
 ```
 npm run bootstrap
 ```
+
+Alternatively, if you wish to install and setup package dependencies for global usage on a system, the bootstrap-link command can be used:
+```
+npm run bootstrap-link
+```
+That command will `npm link` the packages into global NPM userspace, for usage in other projects via `npm link <package` or `enact link`.
 
 ## Copyright and License Information
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alternatively, if you wish to install and setup package dependencies for global 
 ```
 npm run bootstrap-link
 ```
-That command will `npm link` the packages into global NPM userspace, for usage in other projects via `npm link <package` or `enact link`.
+That command will `npm link` the packages into global NPM userspace, for usage in other projects via `npm link <package>` or `enact link`.
 
 ## Copyright and License Information
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Enact uses lerna to manage the individual modules within this repo.
 
 Developers should use the individual npm modules hosted under the `@enact` namespace.
 
-For local framework development, this mono-repo can be setup using the bootstrap command
+For local framework development, this mono-repo can be setup using the `bootstrap` command:
 
 ```
 npm run bootstrap
 ```
 
-Alternatively, if you wish to install and setup package dependencies for global usage on a system, the bootstrap-link command can be used:
+Alternatively, if you wish to install and setup package dependencies for global usage on a system, the `bootstrap-link` command can be used:
 ```
 npm run bootstrap-link
 ```
-That command will `npm link` the packages into global NPM userspace, for usage in other projects via `npm link <package>` or `enact link`.
+That command will `npm link` the packages into global NPM userspace, for use in other projects via `npm link <package>` or `enact link`.
 
 ## Copyright and License Information
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap --concurrency 1",
+    "bootstrap-link": "npm run link-all && npm run interlink",
+    "interlink": "lerna link --loglevel error",
+    "link-all": "lerna --concurrency 1 exec -- npm --loglevel error --no-package-lock link",
+    "unlink-all": "lerna --concurrency 1 exec -- npm --loglevel error --no-package-lock unlink",
     "publish": "lerna publish --skip-npm --skip-git",
-    "link-all": "lerna --concurrency 1 --ignore enact-sampler exec -- npm --loglevel error link",
-    "unlink-all": "lerna --concurrency 1 --ignore enact-sampler exec -- npm --loglevel error unlink",
     "test": "lerna --concurrency 1 run test",
     "clean": "lerna clean"
   },


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* If people `npm link` a library or `npm link-all`, then a bootstrap is required to fix the repo interlinking. This proves costly in time when done repeatedly/regularly.

### Resolution
* Adds 2 new `npm run <script>` entries:
    * `npm run bootstrap-link` - Includes the functionality of bootstrap with npm global linking built-in.  Should be used whenever linking to global NPM userspace is desired.
    * `npm run interlink` - Reconnects monorepo libraries together without the need to re-install/re-bootstrap.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>