### PR TITLE
PLAT-102259: Convert Slottable to use hooks

### DIFF
--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -45,23 +45,28 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 	const slots = config.slots;
 
 	// eslint-disable-next-line no-shadow
-	return function Slottable ({children, ...rest}) {
+	return function Slottable (props) {
+		// extract the slots into a new object but populating the default value to be null to allow
+		// the current "harmful" behavior below.
+		const slotProps = {children: props.children};
+		slots.forEach(k => (slotProps[k] = null));
+
 		// Slottable allows there to be other values in the destination slot and merges them.
 		// However, consumers can't avoid key warnings when merging the two lists so we should
 		// "consider this harmful" and not continue to support this with the hook and instead
 		// encourage using the slot as the default with the prop as a fallback as implemented by the
 		// hook.
-		const distributed = useSlots({slots, props: {children}});
+		const distributed = useSlots(slotProps);
 		slots.forEach(slot => {
 			const dist = distributed[slot];
-			const prop = rest[slot];
+			const prop = props[slot];
 			if (prop && dist) {
 				distributed[slot] = [].concat(prop, dist);
 			}
 		});
 
 		return (
-			<Wrapped {...rest} {...distributed} />
+			<Wrapped {...props} {...distributed} />
 		);
 	};
 });

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -46,13 +46,12 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 
 	// eslint-disable-next-line no-shadow
 	return function Slottable ({children, ...rest}) {
-		const distributed = useSlots({slots, children});
-
 		// Slottable allows there to be other values in the destination slot and merges them.
 		// However, consumers can't avoid key warnings when merging the two lists so we should
 		// "consider this harmful" and not continue to support this with the hook and instead
-		// encourage "either/or". We should continue to support it here so this block ensures
-		// backwards compatibility.
+		// encourage using the slot as the default with the prop as a fallback as implemented by the
+		// hook.
+		const distributed = useSlots({slots, props: {children}});
 		slots.forEach(slot => {
 			const dist = distributed[slot];
 			const prop = rest[slot];

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -62,6 +62,8 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 			const prop = props[slot];
 			if (prop && dist) {
 				distributed[slot] = [].concat(prop, dist);
+			} else if (prop) {
+				distributed[slot] = prop;
 			}
 		});
 

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -60,7 +60,7 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 		slots.forEach(slot => {
 			const dist = distributed[slot];
 			const prop = props[slot];
-			if (prop && dist) {
+			if (prop != null && dist != null) {
 				distributed[slot] = [].concat(prop, dist);
 			} else if (prop) {
 				distributed[slot] = prop;

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -54,4 +54,7 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 });
 
 export default Slottable;
-export {Slottable};
+export {
+	Slottable,
+	useSlots
+};

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -8,84 +8,24 @@
  */
 
 import hoc from '@enact/core/hoc';
-import kind from '@enact/core/kind';
 import React from 'react';
-import warning from 'warning';
 
-// ** WARNING ** This is an intentional but likely dangerous hack necessary to clone a child while
-// omitting the `slot` property. It relies on the black box structure of a React element which could
-// change breaking this code. Without it, the slot property will cascade to a DOM node causing a
-// React warning.
-const cloneElement = (child) => {
-	const newProps = Object.assign({}, child.props);
-	delete newProps.slot;
+import useSlots from './useSlots';
 
-	return React.createElement(child.type, newProps);
-};
-
-const distributeChild = (child, index, slots, props) => {
-	let c, slot;
-	const hasSlot = (name) => slots.indexOf(name) !== -1;
-
-	if (!React.isValidElement(child)) {
-		return false;
-	} else if (child.props.slot) {
-		const hasUserSlot = hasSlot(slot = child.props.slot);
-		warning(hasUserSlot, 'The slot "%s" specified on %s does not exist', child.props.slot,
-			typeof child.type === 'string' ? child.type : (child.type.name || child.type.displayName || 'component')
-		);
-
-		if (hasUserSlot) {
-			c = cloneElement(child);
-		}
-	} else if (hasSlot(slot = child.type.defaultSlot)) {
-		c = child;
-	} else if (hasSlot(slot = child.type)) {
-		const propNames = Object.keys(child.props);
-		if (propNames.length === 1 && propNames[0] === 'children') {
-			c = child.props.children;
-		} else {
-			c = child;
-		}
-	}
-
-	if (c) {
-		let prop = props[slot];
-		if (prop) {
-			if (Array.isArray(prop)) {
-				prop.push(c);
-			} else {
-				prop = [prop, c];
-			}
-		} else {
-			prop = c;
-		}
-		props[slot] = prop;
-
-		return true;
-	}
-
-	return false;
-};
-
-const distribute = function (slots, props) {
-	if (slots) {
-		const children = [];
-		const adjusted = {...props};
-		React.Children.forEach(props.children, (child, index) => {
-			if (!distributeChild(child, index, slots, adjusted)) {
-				children.push(child);
-			}
-		});
-
-		adjusted.children = children.length > 0 ? children : null;
-		return adjusted;
-	}
-
-	return props;
-};
-
+/**
+ * Default config for `Slottable`.
+ *
+ * @memberof ui/Slottable.Slottable
+ * @hocconfig
+ * @public
+ */
 const defaultConfig = {
+	/**
+	 * Array of slot names which will be extracted from `children` and distributed to props.
+	 *
+	 * @type {String[]}
+	 * @memberof ui/Slottable.Slottable.defaultConfig
+	 */
 	slots: null
 };
 
@@ -103,15 +43,14 @@ const defaultConfig = {
  */
 const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 	const slots = config.slots;
-	return kind({
-		name: 'Slottable',
-		render: (props) => {
-			const adjusted = distribute(slots, props);
-			return (
-				<Wrapped {...adjusted} />
-			);
-		}
-	});
+
+	// eslint-disable-next-line no-shadow
+	return function Slottable (props) {
+		const distributed = useSlots({slots, children: props.children});
+		return (
+			<Wrapped {...props} {...distributed} />
+		);
+	};
 });
 
 export default Slottable;

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -45,10 +45,10 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 	const slots = config.slots;
 
 	// eslint-disable-next-line no-shadow
-	return function Slottable (props) {
-		const distributed = useSlots({slots, children: props.children});
+	return function Slottable ({children, ...rest}) {
+		const distributed = useSlots({slots, children});
 		return (
-			<Wrapped {...props} {...distributed} />
+			<Wrapped {...rest} {...distributed} />
 		);
 	};
 });

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -57,7 +57,7 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 			const dist = distributed[slot];
 			const prop = rest[slot];
 			if (prop && dist) {
-				distributed[slot] = Array.isArray(dist) ? [prop, ...dist] : [prop, dist];
+				distributed[slot] = [].concat(prop, dist);
 			}
 		});
 

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -62,7 +62,7 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 			const prop = props[slot];
 			if (prop != null && dist != null) {
 				distributed[slot] = [].concat(prop, dist);
-			} else if (prop) {
+			} else if (prop != null) {
 				distributed[slot] = prop;
 			}
 		});

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -47,6 +47,20 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 	// eslint-disable-next-line no-shadow
 	return function Slottable ({children, ...rest}) {
 		const distributed = useSlots({slots, children});
+
+		// Slottable allows there to be other values in the destination slot and merges them.
+		// However, consumers can't avoid key warnings when merging the two lists so we should
+		// "consider this harmful" and not continue to support this with the hook and instead
+		// encourage "either/or". We should continue to support it here so this block ensures
+		// backwards compatibility.
+		slots.forEach(slot => {
+			const dist = distributed[slot];
+			const prop = rest[slot];
+			if (prop && dist) {
+				distributed[slot] = Array.isArray(dist) ? [prop, ...dist] : [prop, dist];
+			}
+		});
+
 		return (
 			<Wrapped {...rest} {...distributed} />
 		);

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -231,7 +231,7 @@ describe('Slottable Specs', () => {
 	test(
 		'should distribute multiple children with the same slot into the same slot',
 		() => {
-
+			// eslint-disable-next-line enact/prop-types
 			function ComponentBase ({a}) {
 				return (
 					<div className="root-div">

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -187,4 +187,26 @@ describe('Slottable Specs', () => {
 			expect(actualTitle).toBe(expectedTitle);
 		}
 	);
+
+	test('should preserve values in \'slot\' property', () => {
+		// This suppresses the unique key warning that this implementation creates. Also, we can't
+		// restore this because it breaks our global warning listener.
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		const Component = Slottable({slots: ['a']}, ({a}) => (
+			<div>
+				{a}
+			</div>
+		));
+		const subject = mount(
+			<Component a={[<div key="X">X</div>]}>
+				<div slot="a" key="A">A</div>
+			</Component>
+		);
+
+		const expected = 'XA';
+		const actual = subject.text();
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -2,7 +2,7 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import kind from '@enact/core/kind';
 import Slottable from '../Slottable';
 
@@ -209,4 +209,51 @@ describe('Slottable Specs', () => {
 
 		expect(actual).toBe(expected);
 	});
+
+	test('should add values to existing array in \'slot\' property', () => {
+		const Component = Slottable({slots: ['a']}, ({a}) => (
+			<div>
+				{a}
+			</div>
+		));
+		const subject = shallow(
+			<Component a={['a', 'b']}>
+				<a>c</a>
+			</Component>
+		);
+
+		const expected = ['a', 'b', 'c'];
+		const actual = subject.prop('a');
+
+		expect(actual).toEqual(expected);
+	});
+
+	test(
+		'should distribute multiple children with the same slot into the same slot',
+		() => {
+
+			function ComponentBase ({a}) {
+				return (
+					<div className="root-div">
+						{a}
+					</div>
+				);
+			}
+
+			const Component = Slottable({slots: ['a']}, ComponentBase);
+
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="a">A</div>
+					<div slot="a">A</div>
+				</Component>
+			);
+
+			const expected = 'AAA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
 });

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -199,7 +199,7 @@ describe('Slottable Specs', () => {
 			</div>
 		));
 		const subject = mount(
-			<Component a={[<div key="X">X</div>]}>
+			<Component a={<div key="X">X</div>}>
 				<div slot="a" key="A">A</div>
 			</Component>
 		);

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -36,6 +36,32 @@ describe('useSlots', () => {
 		expect(actual).toBe(expected);
 	});
 
+	test('should have no children when all have been distributed', () => {
+		// eslint-disable-next-line enact/prop-types
+		function Component ({a, b, c, children}) {
+			const slots = useSlots({a, b, c, children});
+
+			return (
+				<div>
+					{slots.children}
+				</div>
+			);
+		}
+
+		const subject = mount(
+			<Component>
+				<div slot="a">A</div>
+				<div slot="b">B</div>
+				<div slot="c">C</div>
+			</Component>
+		);
+
+		const expected = '';
+		const actual = subject.text();
+
+		expect(actual).toBe(expected);
+	});
+
 	test(
 		'should distribute children with a \'type\' that matches a slot',
 		() => {

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -9,8 +9,8 @@ import useSlots from '../useSlots';
 describe('useSlots', () => {
 
 	test('should distribute children with a \'slot\' property', () => {
-		function Component ({children}) {
-			const {a, b, c} = useSlots({slots: ['a', 'b', 'c'], children});
+		function Component (props) {
+			const {a, b, c} = useSlots({slots: ['a', 'b', 'c'], props});
 
 			return (
 				<div>
@@ -38,8 +38,8 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with a \'type\' that matches a slot',
 		() => {
-			function Component ({children}) {
-				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], children});
+			function Component (props) {
+				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], props});
 
 				return (
 					<div>
@@ -69,13 +69,13 @@ describe('useSlots', () => {
 	test(
 		'should distribute children whose \'type\' has a \'defaultSlot\' property that matches a slot',
 		() => {
-			function Custom ({children}) {
-				return <div>{children}</div>;
+			function Custom (props) {
+				return <div>{props.children}</div>;
 			}
 			Custom.defaultSlot = 'c';
 
-			function Component ({children}) {
-				const {a, b, c} = useSlots({slots: ['a', 'b',  'c'], children});
+			function Component (props) {
+				const {a, b, c} = useSlots({slots: ['a', 'b',  'c'], props});
 
 				return (
 					<div>
@@ -105,7 +105,7 @@ describe('useSlots', () => {
 		'should distribute children with no \'slot\' property to Slottable\'s \'children\'',
 		() => {
 			function Component (props) {
-				const {a, b, children} = useSlots({slots: ['a', 'b'], children: props.children});
+				const {a, b, children} = useSlots({slots: ['a', 'b'], props});
 
 				return (
 					<div>
@@ -137,8 +137,8 @@ describe('useSlots', () => {
 			// an empty mock implementation
 			console.error.mockImplementation();
 
-			function Component ({children}) {
-				const {a, b, c} = useSlots({slots: ['a', 'b'], children});
+			function Component (props) {
+				const {a, b, c} = useSlots({slots: ['a', 'b'], props});
 
 				return (
 					<div>
@@ -178,8 +178,8 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with props other than simply \'children\', in entirety, to the matching destination slot',
 		() => {
-			function Component ({children}) {
-				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], children});
+			function Component (props) {
+				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], props});
 				return (
 					<div className="root-div">
 						{c}
@@ -212,8 +212,8 @@ describe('useSlots', () => {
 	test(
 		'should distribute multiple children with the same slot into the same slot',
 		() => {
-			function Component ({children}) {
-				const {a} = useSlots({slots: ['a'], children});
+			function Component (props) {
+				const {a} = useSlots({slots: ['a'], props});
 				return (
 					<div className="root-div">
 						{a}
@@ -229,6 +229,52 @@ describe('useSlots', () => {
 			);
 
 			const expected = 'AAA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should override prop with slot value',
+		() => {
+			function Component (props) {
+				const {a} = useSlots({slots: ['a'], props});
+				return (
+					<div className="root-div">
+						{a}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component a="B">
+					<div slot="a">A</div>
+				</Component>
+			);
+
+			const expected = 'A';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should fallback to prop when slot is omitted',
+		() => {
+			function Component (props) {
+				const {a} = useSlots({slots: ['a'], props});
+				return (
+					<div className="root-div">
+						{a}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component a="B" />
+			);
+
+			const expected = 'B';
 			const actual = subject.text();
 
 			expect(actual).toBe(expected);

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -76,6 +76,7 @@ describe('useSlots', () => {
 			}
 			Custom.defaultSlot = 'c';
 
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, b, c, children}) {
 				const slots = useSlots({a, b, c, children});
 
@@ -106,6 +107,7 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with no \'slot\' property to Slottable\'s \'children\'',
 		() => {
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, b, children}) {
 				const slots = useSlots({a, b, children});
 
@@ -139,6 +141,7 @@ describe('useSlots', () => {
 			// an empty mock implementation
 			console.error.mockImplementation();
 
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, b, children}) {
 				const slots = useSlots({a, b, children});
 
@@ -180,6 +183,7 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with props other than simply \'children\', in entirety, to the matching destination slot',
 		() => {
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, b, c, children, custom}) {
 				const slots = useSlots({a, b, c, children, custom});
 
@@ -215,6 +219,7 @@ describe('useSlots', () => {
 	test(
 		'should distribute multiple children with the same slot into the same slot',
 		() => {
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, children}) {
 				const slots = useSlots({a, children});
 				return (
@@ -241,6 +246,7 @@ describe('useSlots', () => {
 	test(
 		'should override prop with slot value',
 		() => {
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, children}) {
 				const slots = useSlots({a, children});
 				return (
@@ -265,6 +271,7 @@ describe('useSlots', () => {
 	test(
 		'should fallback to prop when slot is omitted',
 		() => {
+			// eslint-disable-next-line enact/prop-types
 			function Component ({a, children}) {
 				const slots = useSlots({a, children});
 				return (

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -1,0 +1,212 @@
+/* globals console */
+/* eslint no-console: ["error", { allow: ["warn", "error"] }] */
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import useSlots from '../useSlots';
+
+describe('useSlots', () => {
+
+	test('should distribute children with a \'slot\' property', () => {
+		function Component ({children}) {
+			const {a, b, c} = useSlots({slots: ['a', 'b', 'c'], children});
+
+			return (
+				<div>
+					{c}
+					{b}
+					{a}
+				</div>
+			);
+		}
+
+		const subject = mount(
+			<Component>
+				<div slot="a">A</div>
+				<div slot="b">B</div>
+				<div slot="c">C</div>
+			</Component>
+		);
+
+		const expected = 'CBA';
+		const actual = subject.text();
+
+		expect(actual).toBe(expected);
+	});
+
+	test(
+		'should distribute children with a \'type\' that matches a slot',
+		() => {
+			function Component ({children}) {
+				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], children});
+
+				return (
+					<div>
+						{c}
+						{b}
+						{a}
+						{custom}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="b">B</div>
+					<custom>D</custom>
+					<div slot="c">C</div>
+				</Component>
+			);
+
+			const expected = 'CBAD';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should distribute children whose \'type\' has a \'defaultSlot\' property that matches a slot',
+		() => {
+			function Custom ({children}) {
+				return <div>{children}</div>;
+			}
+			Custom.defaultSlot = 'c';
+
+			function Component ({children}) {
+				const {a, b, c} = useSlots({slots: ['a', 'b',  'c'], children});
+
+				return (
+					<div>
+						{c}
+						{b}
+						{a}
+					</div>
+				);
+			}
+
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="b">B</div>
+					<Custom>C</Custom>
+				</Component>
+			);
+
+			const expected = 'CBA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should distribute children with no \'slot\' property to Slottable\'s \'children\'',
+		() => {
+			function Component (props) {
+				const {a, b, children} = useSlots({slots: ['a', 'b'], children: props.children});
+
+				return (
+					<div>
+						{children}
+						{b}
+						{a}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="b">B</div>
+					<div>C</div>
+				</Component>
+			);
+
+			const expected = 'CBA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should not distribute children with an invalid \'slot\' property',
+		() => {
+			// Modify the console spy to silence error output with
+			// an empty mock implementation
+			console.error.mockImplementation();
+
+			function Component ({children}) {
+				const {a, b, c} = useSlots({slots: ['a', 'b'], children});
+
+				return (
+					<div>
+						{c}
+						{b}
+						{a}
+					</div>
+				);
+			}
+
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="b">B</div>
+					<div slot="c">C</div>
+				</Component>
+			);
+
+			const expected = 'BA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+
+			// Check to make sure that we only get the one expected error
+			const actualErrorsLength = console.error.mock.calls.length;
+			const expectedErrorLength = 1;
+
+			expect(actualErrorsLength).toBe(expectedErrorLength);
+
+			const actualError = console.error.mock.calls[0][0];
+			const expectedError = 'Warning: The slot "c" specified on div does not exist';
+
+			expect(actualError).toBe(expectedError);
+		}
+	);
+
+	test(
+		'should distribute children with props other than simply \'children\', in entirety, to the matching destination slot',
+		() => {
+
+			function Component ({children}) {
+				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], children});
+				return (
+					<div className="root-div">
+						{c}
+						{b}
+						{a}
+						{custom}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component>
+					<div slot="a" title="Div A" />
+					<div slot="b">B</div>
+					<custom>D</custom>
+					<div slot="c">C</div>
+				</Component>
+			);
+
+			const expected = 'CBD';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+
+			const expectedTitle = 'Div A';
+			const actualTitle = subject.find('.root-div').childAt(2).prop('title');
+			expect(actualTitle).toBe(expectedTitle);
+		}
+	);
+});

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -9,14 +9,15 @@ import useSlots from '../useSlots';
 describe('useSlots', () => {
 
 	test('should distribute children with a \'slot\' property', () => {
-		function Component (props) {
-			const {a, b, c} = useSlots({slots: ['a', 'b', 'c'], props});
+		// eslint-disable-next-line enact/prop-types
+		function Component ({a, b, c, children}) {
+			const slots = useSlots({a, b, c, children});
 
 			return (
 				<div>
-					{c}
-					{b}
-					{a}
+					{slots.c}
+					{slots.b}
+					{slots.a}
 				</div>
 			);
 		}
@@ -38,15 +39,16 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with a \'type\' that matches a slot',
 		() => {
-			function Component (props) {
-				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], props});
+			// eslint-disable-next-line enact/prop-types
+			function Component ({a, b, c, children, custom}) {
+				const slots = useSlots({a, b, c, children, custom});
 
 				return (
 					<div>
-						{c}
-						{b}
-						{a}
-						{custom}
+						{slots.c}
+						{slots.b}
+						{slots.a}
+						{slots.custom}
 					</div>
 				);
 			}
@@ -74,14 +76,14 @@ describe('useSlots', () => {
 			}
 			Custom.defaultSlot = 'c';
 
-			function Component (props) {
-				const {a, b, c} = useSlots({slots: ['a', 'b',  'c'], props});
+			function Component ({a, b, c, children}) {
+				const slots = useSlots({a, b, c, children});
 
 				return (
 					<div>
-						{c}
-						{b}
-						{a}
+						{slots.c}
+						{slots.b}
+						{slots.a}
 					</div>
 				);
 			}
@@ -104,14 +106,14 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with no \'slot\' property to Slottable\'s \'children\'',
 		() => {
-			function Component (props) {
-				const {a, b, children} = useSlots({slots: ['a', 'b'], props});
+			function Component ({a, b, children}) {
+				const slots = useSlots({a, b, children});
 
 				return (
 					<div>
-						{children}
-						{b}
-						{a}
+						{slots.children}
+						{slots.b}
+						{slots.a}
 					</div>
 				);
 			}
@@ -137,14 +139,14 @@ describe('useSlots', () => {
 			// an empty mock implementation
 			console.error.mockImplementation();
 
-			function Component (props) {
-				const {a, b, c} = useSlots({slots: ['a', 'b'], props});
+			function Component ({a, b, children}) {
+				const slots = useSlots({a, b, children});
 
 				return (
 					<div>
-						{c}
-						{b}
-						{a}
+						{slots.c}
+						{slots.b}
+						{slots.a}
 					</div>
 				);
 			}
@@ -178,14 +180,15 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with props other than simply \'children\', in entirety, to the matching destination slot',
 		() => {
-			function Component (props) {
-				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], props});
+			function Component ({a, b, c, children, custom}) {
+				const slots = useSlots({a, b, c, children, custom});
+
 				return (
 					<div className="root-div">
-						{c}
-						{b}
-						{a}
-						{custom}
+						{slots.c}
+						{slots.b}
+						{slots.a}
+						{slots.custom}
 					</div>
 				);
 			}
@@ -212,11 +215,11 @@ describe('useSlots', () => {
 	test(
 		'should distribute multiple children with the same slot into the same slot',
 		() => {
-			function Component (props) {
-				const {a} = useSlots({slots: ['a'], props});
+			function Component ({a, children}) {
+				const slots = useSlots({a, children});
 				return (
-					<div className="root-div">
-						{a}
+					<div>
+						{slots.a}
 					</div>
 				);
 			}
@@ -238,11 +241,11 @@ describe('useSlots', () => {
 	test(
 		'should override prop with slot value',
 		() => {
-			function Component (props) {
-				const {a} = useSlots({slots: ['a'], props});
+			function Component ({a, children}) {
+				const slots = useSlots({a, children});
 				return (
-					<div className="root-div">
-						{a}
+					<div>
+						{slots.a}
 					</div>
 				);
 			}
@@ -262,11 +265,11 @@ describe('useSlots', () => {
 	test(
 		'should fallback to prop when slot is omitted',
 		() => {
-			function Component (props) {
-				const {a} = useSlots({slots: ['a'], props});
+			function Component ({a, children}) {
+				const slots = useSlots({a, children});
 				return (
-					<div className="root-div">
-						{a}
+					<div>
+						{slots.a}
 					</div>
 				);
 			}

--- a/packages/ui/Slottable/tests/useSlots-specs.js
+++ b/packages/ui/Slottable/tests/useSlots-specs.js
@@ -178,7 +178,6 @@ describe('useSlots', () => {
 	test(
 		'should distribute children with props other than simply \'children\', in entirety, to the matching destination slot',
 		() => {
-
 			function Component ({children}) {
 				const {a, b, c, custom} = useSlots({slots: ['a', 'b', 'c', 'custom'], children});
 				return (
@@ -207,6 +206,32 @@ describe('useSlots', () => {
 			const expectedTitle = 'Div A';
 			const actualTitle = subject.find('.root-div').childAt(2).prop('title');
 			expect(actualTitle).toBe(expectedTitle);
+		}
+	);
+
+	test(
+		'should distribute multiple children with the same slot into the same slot',
+		() => {
+			function Component ({children}) {
+				const {a} = useSlots({slots: ['a'], children});
+				return (
+					<div className="root-div">
+						{a}
+					</div>
+				);
+			}
+			const subject = mount(
+				<Component>
+					<div slot="a">A</div>
+					<div slot="a">A</div>
+					<div slot="a">A</div>
+				</Component>
+			);
+
+			const expected = 'AAA';
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
 		}
 	);
 });

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -58,15 +58,16 @@ function distributeChild (child, index, slots, props) {
 	return false;
 }
 
-function distribute (slots, {children, ...fallback}) {
+function distribute ({children, ...slots}) {
+	const slotNames = Object.keys(slots);
 	const props = {
 		children
 	};
 
-	if (slots) {
+	if (slotNames.length > 0) {
 		const remaining = [];
 		React.Children.forEach(children, (child, index) => {
-			if (!distributeChild(child, index, slots, props)) {
+			if (!distributeChild(child, index, slotNames, props)) {
 				remaining.push(child);
 			}
 		});
@@ -82,7 +83,7 @@ function distribute (slots, {children, ...fallback}) {
 	// will append to existing props and we want the distributed value to override the fallback
 	// value.
 	return {
-		...fallback,
+		...slots,
 		...props
 	};
 }
@@ -92,8 +93,8 @@ function distribute (slots, {children, ...fallback}) {
  *
  * @typedef {Object} useSlotsConfig
  * @memberof ui/Slottable
- * @property {String[]} [slots] List of slot names
- * @property {Object}   [props] Props object
+ * @property {Object} [slots] An object mapping slot names to default values. It must contain a
+ *                            `children` key with an array of elements to be distributed into slots.
  * @private
  */
 
@@ -119,14 +120,14 @@ function distribute (slots, {children, ...fallback}) {
  *   the prop value.
  *
  * ```
- * function Component (props) {
- *   const {before, after, children} = useSlots({slots: ['before', 'after', 'label'], props});
+ * function Component ({after, before, children, label, ...rest}) {
+ *   const slots = useSlots({after, before, children, label});
  *
  *   return (
  *     <div {...rest} aria-label={label}>
- *       <span class="before">{before}</span>
- *       {children}
- *       <span class="after">{after}</span>
+ *       <span class="before">{slots.before}</span>
+ *       {slots.children}
+ *       <span class="after">{slots.after}</span>
  *     </div>
  *   );
  * }
@@ -145,10 +146,8 @@ function distribute (slots, {children, ...fallback}) {
  * @memberof ui/Slottable
  * @private
  */
-function useSlots (config = {}) {
-	const {slots, props} = config;
-
-	return distribute(slots, props);
+function useSlots (slots) {
+	return distribute(slots);
 }
 
 export default useSlots;

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -1,0 +1,113 @@
+/**
+ * Provides a higher-order component that render child components into pre-designated slots.
+ *
+ * See [SlotItem]{@link ui/SlotItem.SlotItemDecorator} for the use of `Slottable`.
+ *
+ * @module ui/Slottable
+ * @exports Slottable
+ */
+
+import React from 'react';
+import warning from 'warning';
+
+// ** WARNING ** This is an intentional but likely dangerous hack necessary to clone a child while
+// omitting the `slot` property. It relies on the black box structure of a React element which could
+// change breaking this code. Without it, the slot property will cascade to a DOM node causing a
+// React warning.
+function cloneElement (child) {
+	const newProps = Object.assign({}, child.props);
+	delete newProps.slot;
+
+	return React.createElement(child.type, newProps);
+}
+
+function distributeChild (child, index, slots, props) {
+	let c, slot;
+	const hasSlot = (name) => slots.indexOf(name) !== -1;
+
+	if (!React.isValidElement(child)) {
+		return false;
+	} else if (child.props.slot) {
+		const hasUserSlot = hasSlot(slot = child.props.slot);
+		warning(hasUserSlot, 'The slot "%s" specified on %s does not exist', child.props.slot,
+			typeof child.type === 'string' ? child.type : (child.type.name || child.type.displayName || 'component')
+		);
+
+		if (hasUserSlot) {
+			c = cloneElement(child);
+		}
+	} else if (hasSlot(slot = child.type.defaultSlot)) {
+		c = child;
+	} else if (hasSlot(slot = child.type)) {
+		const propNames = Object.keys(child.props);
+		if (propNames.length === 1 && propNames[0] === 'children') {
+			c = child.props.children;
+		} else {
+			c = child;
+		}
+	}
+
+	if (c) {
+		let prop = props[slot];
+		if (prop) {
+			if (Array.isArray(prop)) {
+				prop.push(c);
+			} else {
+				prop = [prop, c];
+			}
+		} else {
+			prop = c;
+		}
+		props[slot] = prop;
+
+		return true;
+	}
+
+	return false;
+}
+
+function distribute (slots, children) {
+	const props = {
+		children
+	};
+
+	if (slots) {
+		const remaining = [];
+		React.Children.forEach(children, (child, index) => {
+			if (!distributeChild(child, index, slots, props)) {
+				remaining.push(child);
+			}
+		});
+
+		if (remaining.length > 0) {
+			props.children = remaining;
+		} else {
+			delete props.children;
+		}
+	}
+
+	return props;
+}
+
+/**
+ * A higher-order component that allows wrapped components to separate children into pre-designated 'slots'.
+ *
+ * To use `Slottable`, you must configure it by passing in a config object with the `slots` member set to an
+ * array of slot names.  Any children whose `slot` or `defaultSlot` property matches a named slot or whose
+ * type matches a named slot will be placed into a property of the same name on the wrapped component.
+ *
+ * @class Slottable
+ * @memberof ui/Slottable
+ * @hoc
+ * @public
+ */
+function useSlots (config = {}) {
+	const {slots, children} = config;
+
+	return distribute(slots, children);
+}
+
+export default useSlots;
+export {
+	useSlots
+};

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -1,12 +1,3 @@
-/**
- * Provides a higher-order component that render child components into pre-designated slots.
- *
- * See [SlotItem]{@link ui/SlotItem.SlotItemDecorator} for the use of `Slottable`.
- *
- * @module ui/Slottable
- * @exports Slottable
- */
-
 import React from 'react';
 import warning from 'warning';
 
@@ -90,16 +81,44 @@ function distribute (slots, children) {
 }
 
 /**
- * A higher-order component that allows wrapped components to separate children into pre-designated 'slots'.
+ * Configuration for `useSlots`
  *
- * To use `Slottable`, you must configure it by passing in a config object with the `slots` member set to an
- * array of slot names.  Any children whose `slot` or `defaultSlot` property matches a named slot or whose
- * type matches a named slot will be placed into a property of the same name on the wrapped component.
- *
- * @class Slottable
+ * @typedef {Object} useSlotsConfig
  * @memberof ui/Slottable
- * @hoc
- * @public
+ * @property {String[]} [slots]    List of slot names
+ * @property {Node}     [children] Nodes to distribute into the slots
+ * @private
+ */
+
+/**
+ * Distributes `children` into the configured `slots`.
+ *
+ * ```
+ * function Component ({children: original, ...rest}) {
+ *   const {before, after, children} = useSlots({slots: ['before', 'after'], original});
+ *
+ *   return (
+ *     <div {...rest}>
+ *       <span class="before">{before}</span>
+ *       {children}
+ *       <span class="after">{after}</span>
+ *     </div>
+ *   );
+ * }
+ *
+ * <Component>
+ *   <Icon slot="before">star</Icon>
+ *   Some other content
+ *   <Icon slot="after">flag</Icon>
+ * </Component>
+ * ```
+ *
+ * @param {useSlotsConfig} config Configuration options
+ * @returns {Object} A object whose keys are the slot names and values are the nodes from
+ *                   `children`. If any nodes were not assigned to a slot, they will be returned in
+ *                   the `children` prop. If no nodes remain, the `children` prop will be omitted.
+ * @memberof ui/Slottable
+ * @private
  */
 function useSlots (config = {}) {
 	const {slots, children} = config;

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -72,6 +72,8 @@ function distribute ({children, ...slots}) {
 			}
 		});
 
+		// we need to retain the children prop so that it can overwrite the value from props if the
+		// author spreads the return of useSlots over props
 		props.children = remaining.length === 0 ? null : remaining;
 	}
 

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -5,9 +5,10 @@ import warning from 'warning';
 // omitting the `slot` property. It relies on the black box structure of a React element which could
 // change breaking this code. Without it, the slot property will cascade to a DOM node causing a
 // React warning.
-function cloneElement (child) {
+function cloneElement (child, index) {
 	const newProps = Object.assign({}, child.props);
 	delete newProps.slot;
+	newProps.key = `slot-${index}`;
 
 	return React.createElement(child.type, newProps);
 }
@@ -25,7 +26,7 @@ function distributeChild (child, index, slots, props) {
 		);
 
 		if (hasUserSlot) {
-			c = cloneElement(child);
+			c = cloneElement(child, index);
 		}
 	} else if (hasSlot(slot = child.type.defaultSlot)) {
 		c = child;

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -77,6 +77,12 @@ function distribute ({children, ...slots}) {
 		props.children = remaining.length === 0 ? null : remaining;
 	}
 
+	slotNames.forEach(slot => {
+		if (slots[slot] === undefined) { // eslint-disable-line no-undefined
+			delete slots[slot];
+		}
+	});
+
 	// We handle fallback here (rather than at the props initialization) because distributeChild
 	// will append to existing props and we want the distributed value to override the fallback
 	// value.

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -105,7 +105,7 @@ function distribute (slots, {children, ...fallback}) {
  *
  * * If the child has a `slot` property matching a valid slot, or
  * * If the component for the child has the `defaultSlot` static member matching a valid slot, or
- * * If the child component is a string matching a valid slot.
+ * * If the child component's type is a string matching a valid slot.
  *
  * When a child matches one of the above rules, it is removed from children and inserted into a prop
  * matching the name of the slot.

--- a/packages/ui/Slottable/useSlots.js
+++ b/packages/ui/Slottable/useSlots.js
@@ -72,11 +72,7 @@ function distribute ({children, ...slots}) {
 			}
 		});
 
-		if (remaining.length > 0) {
-			props.children = remaining;
-		} else {
-			delete props.children;
-		}
+		props.children = remaining.length === 0 ? null : remaining;
 	}
 
 	// We handle fallback here (rather than at the props initialization) because distributeChild


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Convert `ui/Slottable` to use hooks. Not much else to say about it. :)