### PR TITLE
PLAT-102261: Migrate ui/A11yDecorator to use hooks

### DIFF
--- a/packages/ui/A11yDecorator/A11yDecorator.js
+++ b/packages/ui/A11yDecorator/A11yDecorator.js
@@ -6,9 +6,10 @@
  */
 
 import hoc from '@enact/core/hoc';
-import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+import useA11y from './useA11y';
 
 /**
  * Default config for {@link ui/A11yDecorator.A11yDecorator}.
@@ -60,66 +61,52 @@ const defaultConfig = {
 const A11yDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {prop} = config;
 
-	return kind({
-		name: 'A11yDecorator',
+	// eslint-disable-next-line no-shadow
+	function A11yDecorator ({'aria-label': ariaLabel, accessibilityHint, accessibilityPreHint, [prop]: content, ...rest}) {
+		const a11y = useA11y({
+			accessibilityHint,
+			accessibilityPreHint,
+			'aria-label': ariaLabel,
+			content
+		});
 
-		propTypes: /** @lends ui/A11yDecorator.A11yDecorator.prototype */ {
-			/**
-			 * Sets the hint text to be read after the content.
-			 *
-			 * @type {String}
-			 * @public
-			 */
-			accessibilityHint: PropTypes.string,
+		return (
+			<Wrapped {...rest} {...a11y} />
+		);
+	};
 
-			/**
-			 * Sets the hint text to be read before the content.
-			 *
-			 * @type {String}
-			 * @public
-			 */
-			accessibilityPreHint: PropTypes.string,
+	A11yDecorator.propTypes = /** @lends ui/A11yDecorator.A11yDecorator.prototype */ {
+		/**
+		 * Sets the hint text to be read after the content.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		accessibilityHint: PropTypes.string,
 
-			/**
-			 * Sets the value of the `aria-label` attribute for the wrapped component.
-			 *
-			 * @memberof ui/A11yDecorator.A11yDecorator.prototype
-			 * @type {String}
-			 * @public
-			 */
-			'aria-label': PropTypes.string
-		},
+		/**
+		 * Sets the hint text to be read before the content.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		accessibilityPreHint: PropTypes.string,
 
-		computed: {
-			'aria-label': ({'aria-label': aria, accessibilityPreHint: prehint, accessibilityHint: hint, [prop]: content}) => {
-				if (!aria) {
-					const
-						prefix = content || null,
-						label = prehint && prefix && hint && (prehint + ' ' + prefix + ' ' + hint) ||
-							prehint && prefix && (prehint + ' ' + prefix) ||
-							prehint && hint && (prehint + ' ' + hint) ||
-							hint && prefix && (prefix + ' ' + hint) ||
-							prehint ||
-							hint ||
-							null;
-					return label;
-				}
-				return aria;
-			}
-		},
+		/**
+		 * Sets the value of the `aria-label` attribute for the wrapped component.
+		 *
+		 * @memberof ui/A11yDecorator.A11yDecorator.prototype
+		 * @type {String}
+		 * @public
+		 */
+		'aria-label': PropTypes.string
+	};
 
-		render: (props) => {
-			delete props.accessibilityPreHint;
-			delete props.accessibilityHint;
-
-			return (
-				<Wrapped {...props} />
-			);
-		}
-	});
+	return A11yDecorator;
 });
 
 export default A11yDecorator;
 export {
-	A11yDecorator
+	A11yDecorator,
+	useA11y
 };

--- a/packages/ui/A11yDecorator/useA11y.js
+++ b/packages/ui/A11yDecorator/useA11y.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+function computeAriaLabel ({aria, hint, prehint, content}) {
+	if (!aria) {
+		const
+			prefix = content || null,
+			label = prehint && prefix && hint && (prehint + ' ' + prefix + ' ' + hint) ||
+				prehint && prefix && (prehint + ' ' + prefix) ||
+				prehint && hint && (prehint + ' ' + hint) ||
+				hint && prefix && (prefix + ' ' + hint) ||
+				prehint ||
+				hint ||
+                null;
+
+		return label;
+    }
+
+	return aria;
+}
+
+/**
+ * Configuration for `useA11y`
+ *
+ * @typedef {Object} useA11yConfig
+ * @memberof ui/A11yDecorator
+ * @property {String}  [accessibilityPreHint] Sets the hint text to be read after the content.
+ * @property {String}  [accessibilityHint]    Sets the hint text to be read before the content.
+ * @property {String}  [aria-label]           Sets the value of the `aria-label` attribute for the wrapped component.
+ * @property {String}  [content]              The accessibility content.
+ * @private
+ */
+
+/**
+ * Object returned by `useA11y`
+ *
+ * @typedef {Object} useA11yInterface
+ * @memberof ui/A11yDecorator
+ * @property {String}  [aria-label]           The value of the `aria-label` attribute for the wrapped component.
+ * @private
+ */
+
+/**
+ * Manages a accessibility label.
+ * The accessibility label is decorated with `accessibilityPreHint`, `accessibilityHint`, and `content`.
+ *
+ * @param {useA11yConfig} config Configuration options
+ * @returns {useA11yInterface}
+ * @private
+ */
+const useA11y = ({accessibilityPreHint: prehint, accessibilityHint: hint, 'aria-label': aria, content}) => {
+	return {
+		'aria-label': React.useMemo(() => computeAriaLabel({aria, hint, prehint, content}), [aria, hint, prehint, content])
+	};
+};
+
+export default useA11y;
+export {
+    useA11y
+};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Migrate ui/A11yDecorator to use hooks

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Add useA11y hook.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

N/A

### Links
[//]: # (Related issues, references)

PLAT-102261

### Comments

The `useA11y` returns `a11y` object with the `aria-label` property so that the object could be spreaded into the JSX directly.