### PR TITLE
ENYO-6462: Fix spinner to align center

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Spinner` to set left position to 0 by default to align center
+
 ## [3.3.0-alpha.6] - 2020-04-14
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Spinner` to set left position to 0 by default to align center
+- `ui/Spinner` to set `left` instead of `maring-left` for center alignment
 
 ## [3.3.0-alpha.6] - 2020-04-14
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -13,7 +13,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/ViewManager` to only fire `onTransition` once per transition
-- `ui/Spinner` to set `left` instead of `maring-left` for center alignment
+- `ui/Spinner` center alignment
 
 ## [3.3.0-alpha.6] - 2020-04-14
 

--- a/packages/ui/Spinner/Spinner.module.less
+++ b/packages/ui/Spinner/Spinner.module.less
@@ -8,12 +8,9 @@
 
 	// centered
 	&.centered {
-		left: 0;
-		margin: 0;
-		margin-left: 50%;
+		left: 50%;
 		position: absolute;
 		top: 50%;
-		-webkit-transform: translateX(-50%) translateY(-50%);
 		transform: translateX(-50%) translateY(-50%);
 	}
 
@@ -25,10 +22,7 @@
 		// centered
 		&.centered {
 			left: initial;
-			right: 0;
-			margin: 0;
-			margin-right: 50%;
-			-webkit-transform: translateX(50%) translateY(-50%);
+			right: 50%;
 			transform: translateX(50%) translateY(-50%);
 		}
 	}

--- a/packages/ui/Spinner/Spinner.module.less
+++ b/packages/ui/Spinner/Spinner.module.less
@@ -8,6 +8,7 @@
 
 	// centered
 	&.centered {
+		left: 0;
 		margin: 0;
 		margin-left: 50%;
 		position: absolute;
@@ -23,6 +24,8 @@
 	:global(.enact-locale-right-to-left) & {
 		// centered
 		&.centered {
+			left: initial;
+			right: 0;
 			margin: 0;
 			margin-right: 50%;
 			-webkit-transform: translateX(50%) translateY(-50%);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
If the containing block of  `Spinner`has `padding-left` , the `Spinner` moves to the right by the size of the `padding-left`.
Because `left` is set to `padding-left` value. (for now, `left` is set to default value. not specified)
In moonstone, there is no issue because the `section` of `Panel` has no `padding-left`.

### Resolution
`left` is set to 0. (if rtl, right is set to 0)

[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6462


### Comments
