### PR TITLE
PLAT-105314: Fix ViewManager to only fire onTransition once per transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/ViewManager` to only fire `onTransition` once per transition
+
 ## [3.3.0-alpha.6] - 2020-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `ui/ViewManager` to only fire `onTransition` once per transition
-
 ## [3.3.0-alpha.6] - 2020-04-14
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/ViewManager` events `onTransition` and `onWillTransition` payload members `index` and `previousIndex`
+
+### Fixed
+
+- `ui/ViewManager` to only fire `onTransition` once per transition
+
 ## [3.3.0-alpha.6] - 2020-04-14
 
 ### Fixed

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -293,10 +293,12 @@ class TransitionGroup extends React.Component {
 	}
 
 	completeTransition (key) {
-		delete this.currentlyTransitioningKeys[key];
+		if (key in this.currentlyTransitioningKeys) {
+			delete this.currentlyTransitioningKeys[key];
 
-		if (Object.keys(this.currentlyTransitioningKeys).length === 0) {
-			forwardOnTransition(null, this.props);
+			if (Object.keys(this.currentlyTransitioningKeys).length === 0) {
+				forwardOnTransition(null, this.props);
+			}
 		}
 	}
 

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -13,6 +13,7 @@
  * @exports ViewManagerDecorator
  */
 
+import handle, {adaptEvent, call, forward} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -224,6 +225,24 @@ const ViewManagerBase = class extends React.Component {
 		return null;
 	}
 
+	makeTransitionEvent () {
+		return {index: this.props.index, previousIndex: this.state.prevIndex};
+	}
+
+	handleTransition = handle(
+		adaptEvent(
+			call('makeTransitionEvent'),
+			forward('onTransition')
+		)
+	).bindAs(this, 'handleTransition')
+
+	handleWillTransition = handle(
+		adaptEvent(
+			call('makeTransitionEvent'),
+			forward('onWillTransition')
+		)
+	).bindAs(this, 'handleWillTransition')
+
 	render () {
 		const {arranger, childProps, children, duration, index, noAnimation, enteringDelay, enteringProp, ...rest} = this.props;
 		let {end = index, start = index} = this.props;
@@ -254,7 +273,14 @@ const ViewManagerBase = class extends React.Component {
 		delete rest.start;
 
 		return (
-			<TransitionGroup {...rest} childFactory={childFactory} size={size} currentIndex={index}>
+			<TransitionGroup
+				{...rest}
+				childFactory={childFactory}
+				currentIndex={index}
+				onTransition={this.handleTransition}
+				onWillTransition={this.handleWillTransition}
+				size={size}
+			>
 				{views}
 			</TransitionGroup>
 		);

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -350,4 +350,34 @@ describe('ViewManager', () => {
 
 		expect(subject.find('View')).toHaveLength(3);
 	});
+
+	test('should fire onTransition once per transition', () => {
+		const spy = jest.fn();
+		const subject = mount(
+			<ViewManager index={0} onTransition={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		spy.mockClear();
+
+		subject.setProps({index: 1});
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test('should fire onWillTransition once per transition', () => {
+		const spy = jest.fn();
+		const subject = mount(
+			<ViewManager index={0} onWillTransition={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		subject.setProps({index: 1});
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -367,6 +367,26 @@ describe('ViewManager', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
+	test('should include the current index and previous index in onTransition event payload', () => {
+		const spy = jest.fn();
+		const subject = mount(
+			<ViewManager index={0} onTransition={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		spy.mockClear();
+
+		subject.setProps({index: 1});
+
+		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0});
+
+		subject.setProps({index: 0});
+
+		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1});
+	});
+
 	test('should fire onWillTransition once per transition', () => {
 		const spy = jest.fn();
 		const subject = mount(
@@ -379,5 +399,23 @@ describe('ViewManager', () => {
 		subject.setProps({index: 1});
 
 		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test('should include the current index and previous index in onWillTransition event payload', () => {
+		const spy = jest.fn();
+		const subject = mount(
+			<ViewManager index={0} onWillTransition={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		subject.setProps({index: 1});
+
+		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0});
+
+		subject.setProps({index: 0});
+
+		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1});
 	});
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ViewManager fired two `onTransition` events for every transition

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Prevent firing `onTransition` for views that weren't transitioning
* Add some useful data to the event payload.
