### PR TITLE
PLAT-102257: Migrate Skinnable to hooks

### DIFF
--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -11,13 +11,13 @@
  * @public
  */
 
-import kind from '@enact/core/kind';
-import hoc from '@enact/core/hoc';
-import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import hoc from '@enact/core/hoc';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-import {objectify, preferDefined} from './util';
+import useSkins from './useSkins';
+import {objectify} from './util';
 
 /**
  * Default config for `Skinnable`.
@@ -93,28 +93,6 @@ const defaultConfig = {
 };
 
 /**
- * Allows a component to respond to skin changes via the Context API
- *
- * Example:
- * ```
- * <App skin="dark">
- * 	<Section>
- * 		<Button>Gray Button</Button>
- * 	<Section>
- * 	<Popup skin="light">
- * 		<Button>White Button</Button>
- * 	</Popup>
- * </App>
- * ```
- *
- * @class SkinContext
- * @memberof ui/Skinnable
- * @hoc
- * @public
- */
-const SkinContext = React.createContext(null);
-
-/**
  * A higher-order component that assigns skinning classes for the purposes of styling children components.
  *
  * Use the config options to specify the skins your theme has. Set this up in your theme's decorator
@@ -145,137 +123,83 @@ const SkinContext = React.createContext(null);
  * @public
  */
 const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
-	const {prop, skins, defaultSkin, allowedVariants, variantsProp} = config;
+	const {prop, skins, defaultSkin, allowedVariants: variants, variantsProp} = config;
 	const defaultVariants = objectify(config.defaultVariants);
 
-	function determineSkin (authorSkin, parentSkin) {
-		return authorSkin || defaultSkin || parentSkin;
-	}
+	const hookConfig = {defaultSkin, defaultVariants, skins, variants};
 
-	function determineVariants (authorVariants, parentVariants) {
-		if (!allowedVariants || !(allowedVariants instanceof Array)) {
-			// There are no allowed variants, so just return an empty object, indicating that there are no viable determined variants.
-			return {};
+	// eslint-disable-next-line no-shadow
+	function Skinnable ({className, skin, skinVariants, ...rest}) {
+		const hook = useSkins(hookConfig, skin, skinVariants);
+
+		const allClassNames = classnames(hook.className, className);
+		if (allClassNames) {
+			rest.className = allClassNames;
 		}
 
-		authorVariants = objectify(authorVariants);
-		parentVariants = objectify(parentVariants);
+		if (prop) {
+			rest[prop] = hook.skin;
+		}
 
-		// Merge all of the variants objects, preferring values in objects from left to right.
-		const mergedObj = [defaultVariants, parentVariants, authorVariants].reduce(
-			(obj, a) => {
-				Object.keys(a).forEach(key => {
-					obj[key] = preferDefined(a[key], obj[key]);
-				});
+		if (variantsProp) {
+			rest[variantsProp] = hook.variants;
+		}
 
-				return obj;
-			},
-			{}
+		return hook.provideSkins(
+			<Wrapped {...rest} />
 		);
-
-		// Clean up the merged object
-		for (const key in mergedObj) {
-			// Delete keys that are null or undefined and delete keys that aren't allowed
-			if (mergedObj[key] == null || !allowedVariants.includes(key)) {
-				delete mergedObj[key];
-			}
-		}
-
-
-		return mergedObj;
 	}
 
-	function getClassName (effectiveSkin, className, variants) {
-		const skin = skins && skins[effectiveSkin];
+	Skinnable.propTypes = /** @lends ui/Skinnable.Skinnable.prototype */ {
+		/**
+		 * The name of the skin a component should use to render itself. Available skins are
+		 * defined in the "defaultConfig" for this HOC.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		skin: PropTypes.string,
 
-		// only apply the skin class if it's set and different from the "current" skin as
-		// defined by the value in context
-		if (skin || variants) {
-			className = classnames(skin, variants, className);
-		}
+		/**
+		 * The variant(s) on a skin that a component should use when rendering. These will
+		 * typically alter the appearance of a skin's existing definition in a way that does not
+		 * override that skin's general styling.
+		 *
+		 * Multiple data types are supported by this prop, which afford different conveniences
+		 * and abilities. String and Array are effectively the same, supporting just additions
+		 * to the variants being applied to a component, and are much more convenient. Objects
+		 * may also be used, and have the ability to disable variants being passed by their
+		 * ancestors. Objects take the format of a basic hash, with variants as key names and
+		 * true/false Booleans as values, depicting their state. If a variant is excluded from
+		 * any version of data type used to set this prop, that variant will ignored, falling
+		 * back to the defaultVariant or parent variant, in that order.
+		 *
+		 * skinVariants examples:
+		 * ```
+		 *  // String
+		 *  skinVariants="highContrast"
+		 *
+		 *  // Array
+		 *  skinVariants={['highContrast']}
+		 *
+		 *  // Object
+		 *  skinVariants={{
+		 *  	highContrast: true,
+		 *  	grayscale: false
+		 *  }}
+		 * ```
+		 *
+		 * @type {String|String[]|Object}
+		 * @public
+		 */
+		skinVariants: PropTypes.oneOfType([
+			PropTypes.string,
+			PropTypes.array,
+			PropTypes.object
+		])
+	};
 
-		if (className) return className;
-	}
-
-	return kind({
-		name: 'Skinnable',
-		propTypes: /** @lends ui/Skinnable.Skinnable.prototype */{
-			/**
-			 * The name of the skin a component should use to render itself. Available skins are
-			 * defined in the "defaultConfig" for this HOC.
-			 *
-			 * @type {String}
-			 * @public
-			 */
-			skin: PropTypes.string,
-
-			/**
-			 * The variant(s) on a skin that a component should use when rendering. These will
-			 * typically alter the appearance of a skin's existing definition in a way that does not
-			 * override that skin's general styling.
-			 *
-			 * Multiple data types are supported by this prop, which afford different conveniences
-			 * and abilities. String and Array are effectively the same, supporting just additions
-			 * to the variants being applied to a component, and are much more convenient. Objects
-			 * may also be used, and have the ability to disable variants being passed by their
-			 * ancestors. Objects take the format of a basic hash, with variants as key names and
-			 * true/false Booleans as values, depicting their state. If a variant is excluded from
-			 * any version of data type used to set this prop, that variant will ignored, falling
-			 * back to the defaultVariant or parent variant, in that order.
-			 *
-			 * skinVariants examples:
-			 * ```
-			 *  // String
-			 *  skinVariants="highContrast"
-			 *
-			 *  // Array
-			 *  skinVariants={['highContrast']}
-			 *
-			 *  // Object
-			 *  skinVariants={{
-			 *  	highContrast: true,
-			 *  	grayscale: false
-			 *  }}
-			 * ```
-			 *
-			 * @type {String|String[]|Object}
-			 * @public
-			 */
-			skinVariants: PropTypes.oneOfType([
-				PropTypes.string,
-				PropTypes.array,
-				PropTypes.object
-			])
-		},
-		render: ({className, skin, skinVariants, ...rest}) => (
-			<SkinContext.Consumer>
-				{(value) => {
-					const {parentSkin, parentVariants} = value || {};
-					const effectiveSkin = determineSkin(skin, parentSkin);
-					const variants = determineVariants(skinVariants, parentVariants);
-					const allClassNames = getClassName(effectiveSkin, className, variants);
-
-					if (allClassNames) {
-						rest.className = allClassNames;
-					}
-
-					if (prop) {
-						rest[prop] = effectiveSkin;
-					}
-
-					if (variantsProp) {
-						rest[variantsProp] = variants;
-					}
-
-					return (
-						<SkinContext.Provider value={{parentSkin: effectiveSkin, parentVariants: variants}}>
-							<Wrapped {...rest} />
-						</SkinContext.Provider>
-					);
-				}}
-			</SkinContext.Consumer>
-		)
-	});
+	return Skinnable;
 });
 
 export default Skinnable;

--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -126,11 +126,16 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 	const {prop, skins, defaultSkin, allowedVariants: variants, variantsProp} = config;
 	const defaultVariants = objectify(config.defaultVariants);
 
-	const hookConfig = {defaultSkin, defaultVariants, skins, variants};
-
 	// eslint-disable-next-line no-shadow
 	function Skinnable ({className, skin, skinVariants, ...rest}) {
-		const hook = useSkins(hookConfig, skin, skinVariants);
+		const hook = useSkins({
+			defaultSkin,
+			defaultVariants,
+			skin,
+			skins,
+			skinVariants,
+			variants
+		});
 
 		const allClassNames = classnames(hook.className, className);
 		if (allClassNames) {
@@ -204,5 +209,6 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 export default Skinnable;
 export {
-	Skinnable
+	Skinnable,
+	useSkins
 };

--- a/packages/ui/Skinnable/tests/Skinnable-specs.js
+++ b/packages/ui/Skinnable/tests/Skinnable-specs.js
@@ -343,7 +343,7 @@ describe('Skinnable Specs', () => {
 		expect(actual).toEqual(expected);
 	});
 
-	test.only('should inherit an overridden default variant', () => {
+	test('should inherit an overridden default variant', () => {
 		const config = {
 			defaultSkin: 'dark',
 			defaultVariants: 'normal',

--- a/packages/ui/Skinnable/tests/Skinnable-specs.js
+++ b/packages/ui/Skinnable/tests/Skinnable-specs.js
@@ -307,8 +307,8 @@ describe('Skinnable Specs', () => {
 			</SkinnableParent>
 		);
 
-		const expected = 'darkSkin normal unicase smallCaps';
-		const actual = subject.find('div').last().prop('className');
+		const expected = 'darkSkin normal unicase smallCaps'.split(' ').sort();
+		const actual = subject.find('div').last().prop('className').split(' ').sort();
 
 		expect(actual).toEqual(expected);
 	});
@@ -343,7 +343,7 @@ describe('Skinnable Specs', () => {
 		expect(actual).toEqual(expected);
 	});
 
-	test('should inherit an overridden default variant', () => {
+	test.only('should inherit an overridden default variant', () => {
 		const config = {
 			defaultSkin: 'dark',
 			defaultVariants: 'normal',

--- a/packages/ui/Skinnable/tests/Skinnable-specs.js
+++ b/packages/ui/Skinnable/tests/Skinnable-specs.js
@@ -307,8 +307,8 @@ describe('Skinnable Specs', () => {
 			</SkinnableParent>
 		);
 
-		const expected = 'darkSkin normal unicase smallCaps'.split(' ').sort();
-		const actual = subject.find('div').last().prop('className').split(' ').sort();
+		const expected = 'darkSkin normal unicase smallCaps';
+		const actual = subject.find('div').last().prop('className');
 
 		expect(actual).toEqual(expected);
 	});

--- a/packages/ui/Skinnable/tests/useSkins-specs.js
+++ b/packages/ui/Skinnable/tests/useSkins-specs.js
@@ -1,0 +1,281 @@
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+
+import useSkins from '../useSkins';
+
+describe('Skinnable Specs', () => {
+
+	function Base () {
+		return null;
+	}
+	function Component ({config}) { // eslint-disable-line enact/prop-types
+		const skins = useSkins(config);
+		return (
+			<Base {...skins} />
+		);
+	}
+
+	function Parent ({config, children}) {
+		const skins = useSkins(config);
+
+		return skins.provideSkins(children);
+	}
+
+	test('should add a default skin class when no skin prop is specified', () => {
+		const config = {
+			defaultSkin: 'dark',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			}
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should add the preferred skin class when the skin prop is specified', () => {
+		const config = {
+			defaultSkin: 'dark',
+			skin: 'light',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			}
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'lightSkin';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should ignore the preferred skin prop if it\'s not one of the available skins', () => {
+		const config = {
+			defaultSkin: 'dark',
+			skin: 'potato',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			}
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = '';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should ignore the skinVariants prop if there are no defined allowedVariants', () => {
+		const config = {
+			defaultSkin: 'dark',
+			skinVariants: 'potato',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			}
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should only apply allowed variants assigned by the skinVariants prop', () => {
+		const config = {
+			defaultSkin: 'dark',
+			skinVariants: 'normal potato unicase',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin normal unicase';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should apply default variants even if the skinVariants prop is explicitly empty', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skinVariants: '',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin normal';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should apply default variants and the skinVariants if both are defined', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skinVariants: 'unicase',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin normal unicase';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should apply variants supplied via an array or a string in the same way', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subjectA = shallow(<Component config={{...config, skinVariants: 'normal unicase'}} />);
+		const subjectB = shallow(<Component config={{...config, skinVariants: ['normal', 'unicase']}} />);
+
+		expect(subjectA.find(Base).prop('className')).toBe(subjectB.find(Base).prop('className'));
+	});
+
+	test('should allow opting out of the default variants if an object is supplied to skinVariants with false as variant-key values', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skinVariants: {normal: false, unicase: true},
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin unicase';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should ignore variants, sent by an object, equaling null, undefined, or empty string', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skinVariants: {normal: null, smallCaps: void 0, unicase: ''},
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = shallow(<Component config={config} />);
+
+		const expected = 'darkSkin normal';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should apply parent variants', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = mount(
+			<Parent config={{...config, skinVariants: 'unicase'}}>
+				<Component config={{...config, skinVariants: 'smallCaps'}} />
+			</Parent>
+		);
+
+		const expected = 'darkSkin normal unicase smallCaps';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should be able to override a parent\'s variants by assigning a false skinVariant', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = mount(
+			<Parent config={{...config, skinVariants: 'smallCaps unicase'}}>
+				<Component config={{...config, skinVariants: {unicase: false}}} />
+			</Parent>
+		);
+
+		const expected = 'darkSkin normal smallCaps';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should inherit an overridden default variant', () => {
+		const config = {
+			defaultSkin: 'dark',
+			defaultVariants: 'normal',
+			skins: {
+				dark: 'darkSkin',
+				light: 'lightSkin'
+			},
+			variants: ['normal', 'smallCaps', 'unicase']
+		};
+
+		const subject = mount(
+			<Parent config={config}>
+				<Parent config={{...config, skinVariants: {normal: false}}}>
+					<Component config={config} />
+				</Parent>
+			</Parent>
+		);
+
+		const expected = 'darkSkin';
+		const actual = subject.find(Base).prop('className');
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/packages/ui/Skinnable/useSkins.js
+++ b/packages/ui/Skinnable/useSkins.js
@@ -56,7 +56,7 @@ const SkinContext = React.createContext(null);
  */
 
 /**
- * Deteremines the effective skin and skin variants for a component and provides a method to provide
+ * Determines the effective skin and skin variants for a component and provides a method to provide
  * those values to other contained components in this subtree.
  *
  * ```

--- a/packages/ui/Skinnable/useSkins.js
+++ b/packages/ui/Skinnable/useSkins.js
@@ -19,7 +19,6 @@ import {determineSkin, determineVariants, getClassName} from './util';
  *
  * @class SkinContext
  * @memberof ui/Skinnable
- * @hoc
  * @private
  */
 const SkinContext = React.createContext(null);
@@ -29,12 +28,12 @@ const SkinContext = React.createContext(null);
  *
  * @typedef {Object} useSkinsConfig
  * @memberof ui/Skinnable
- * @property {String}   defaultSkin     Default skin name when none has been specified or inherited.
- * @property {String[]} defaultVariants Default variants when none have been specified or inherited.
- * @property {String}   [skin]          Specific skin to apply to this instance which will take precedence over the default or the inherited value.
- * @property {String[]} skins           List of allowed skins
- * @property {String[]} [skinVariants]  Specific variants to apply to this instance which will take precedence over the default or the inherited value.
- * @property {String[]} variants        List of allowed variants
+ * @property {String}   defaultSkin       Default skin name when none has been specified or inherited.
+ * @property {String[]} [defaultVariants] Default variants when none have been specified or inherited.
+ * @property {String}   [skin]            Specific skin to apply to this instance which will take precedence over the default or the inherited value.
+ * @property {String[]} skins             List of allowed skins
+ * @property {String[]} [skinVariants]    Specific variants to apply to this instance which will take precedence over the default or the inherited value.
+ * @property {String[]} [variants]        List of allowed variants
  * @private
  */
 

--- a/packages/ui/Skinnable/useSkins.js
+++ b/packages/ui/Skinnable/useSkins.js
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import {determineSkin, determineVariants, getClassName} from './util';
+
+/**
+ * Allows a component to respond to skin changes via the Context API
+ *
+ * Example:
+ * ```
+ * <App skin="dark">
+ * 	<Section>
+ * 		<Button>Gray Button</Button>
+ * 	<Section>
+ * 	<Popup skin="light">
+ * 		<Button>White Button</Button>
+ * 	</Popup>
+ * </App>
+ * ```
+ *
+ * @class SkinContext
+ * @memberof ui/Skinnable
+ * @hoc
+ * @private
+ */
+const SkinContext = React.createContext(null);
+
+/**
+ * A higher-order component that assigns skinning classes for the purposes of styling children components.
+ *
+ * Use the config options to specify the skins your theme has. Set this up in your theme's decorator
+ * component to establish your supported skins.
+ *
+ * Note: This HoC passes `className` to the wrapped component. It must be passed to the main DOM
+ * node. Additionally, it can be configured to pass the skin and skin variant as props.
+ *
+ * Example:
+ * ```
+ * const MyApp = ({skinName, ...rest) => (<div {...props}>{skinName}</div>);
+ * ...
+ * App = Skinnable({
+ * 	prop: 'skinName',
+ * 	skins: {
+ * 		dark: 'moonstone',
+ * 		light: 'moonstone-light'
+ * 	},
+ * 	defaultTheme: 'dark'
+ * 	defaultVariants: ['highContrast'],
+ * 	allowedVariants: ['highContrast', 'largeText', 'grayscale']
+ * }, MyApp);
+ * ```
+ *
+ * @class Skinnable
+ * @memberof ui/Skinnable
+ * @hoc
+ * @public
+ */
+function useSkins (config, skin, skinVariants) {
+	const {defaultSkin, defaultVariants, skins, variants} = config;
+
+	const {parentSkin, parentVariants} = React.useContext(SkinContext) || {};
+
+	const effectiveSkin = determineSkin(defaultSkin, skin, parentSkin);
+	const effectiveVariants = determineVariants(defaultVariants, variants, skinVariants, parentVariants);
+	const className = getClassName(skins, effectiveSkin, effectiveVariants);
+
+	const provideSkins = React.useCallback((children) => {
+		const value = {parentSkin: effectiveSkin, parentVariants: effectiveVariants};
+		return (
+			<SkinContext.Provider value={value}>
+				{children}
+			</SkinContext.Provider>
+		);
+	}, [effectiveSkin, effectiveVariants]);
+
+	return {
+		className,
+		skin: effectiveSkin,
+		variants: effectiveVariants,
+		provideSkins
+	};
+}
+
+export default useSkins;
+export {
+	useSkins
+};

--- a/packages/ui/Skinnable/useSkins.js
+++ b/packages/ui/Skinnable/useSkins.js
@@ -25,34 +25,60 @@ import {determineSkin, determineVariants, getClassName} from './util';
 const SkinContext = React.createContext(null);
 
 /**
- * A higher-order component that assigns skinning classes for the purposes of styling children components.
+ * Configuration for `useSkins`
  *
- * Use the config options to specify the skins your theme has. Set this up in your theme's decorator
- * component to establish your supported skins.
- *
- * Note: This HoC passes `className` to the wrapped component. It must be passed to the main DOM
- * node. Additionally, it can be configured to pass the skin and skin variant as props.
- *
- * Example:
- * ```
- * const MyApp = ({skinName, ...rest) => (<div {...props}>{skinName}</div>);
- * ...
- * App = Skinnable({
- * 	prop: 'skinName',
- * 	skins: {
- * 		dark: 'moonstone',
- * 		light: 'moonstone-light'
- * 	},
- * 	defaultTheme: 'dark'
- * 	defaultVariants: ['highContrast'],
- * 	allowedVariants: ['highContrast', 'largeText', 'grayscale']
- * }, MyApp);
- * ```
- *
- * @class Skinnable
+ * @typedef {Object} useSkinsConfig
  * @memberof ui/Skinnable
- * @hoc
- * @public
+ * @property {String}   defaultSkin     Default skin name when none has been specified or inherited.
+ * @property {String[]} defaultVariants Default variants when none have been specified or inherited.
+ * @property {String}   [skin]          Specific skin to apply to this instance which will take precedence over the default or the inherited value.
+ * @property {String[]} skins           List of allowed skins
+ * @property {String[]} [skinVariants]  Specific variants to apply to this instance which will take precedence over the default or the inherited value.
+ * @property {String[]} variants        List of allowed variants
+ * @private
+ */
+
+/**
+ * Object returned by `useSkins`
+ *
+ * @typedef {Object} useSkinsInterface
+ * @memberof ui/Skinnable
+ * @property {String}   className    CSS classes for the effective skin and variants.
+ * @property {String}   skin         Effective skin based on the allowed skins, the configured.
+ *                                   `skin`, the default skin, and the inherited `skin` from up the
+ *                                   component tree.
+ * @property {String[]} variants     Effective skins variant based on the allowed variants, the
+ *                                   configured variants, the default variants, and the inherited
+ *                                   variants from up the component tree.
+ * @property {Function} provideSkins Wraps a component tree with a skin provider to allow that tree
+ *                                   to inherit the effective skin configured at this level.
+ * @private
+ */
+
+/**
+ * Deteremines the effective skin and skin variants for a component and provides a method to provide
+ * those values to other contained components in this subtree.
+ *
+ * ```
+ * function ComponentDecorator (props) {
+ *   const skins = useSkins({
+ *     defaultSkin: 'neutral',
+ *     defaultVariants: [],
+ *     skins: ['neutral', 'bold'],
+ *     variants: ['highContrast'],
+ *     skin: props.skin,
+ *     skinVariants: props.skinVariants
+ *   });
+ *
+ *   return skins.provideSkins(
+ *     <Component className={classnames(props.className, skins.className)} />
+ *   );
+ * }
+ * ```
+ *
+ * @param {useSkinsConfig} config Configuration options
+ * @returns {useSkinsInterface}
+ * @private
  */
 function useSkins (config) {
 	const {defaultSkin, defaultVariants, skin, skins, skinVariants, variants} = config;

--- a/packages/ui/Skinnable/useSkins.js
+++ b/packages/ui/Skinnable/useSkins.js
@@ -54,8 +54,8 @@ const SkinContext = React.createContext(null);
  * @hoc
  * @public
  */
-function useSkins (config, skin, skinVariants) {
-	const {defaultSkin, defaultVariants, skins, variants} = config;
+function useSkins (config) {
+	const {defaultSkin, defaultVariants, skin, skins, skinVariants, variants} = config;
 
 	const {parentSkin, parentVariants} = React.useContext(SkinContext) || {};
 

--- a/packages/ui/Skinnable/util.js
+++ b/packages/ui/Skinnable/util.js
@@ -37,15 +37,18 @@ function determineVariants (defaultVariants, allowedVariants, authorVariants, pa
 		return {};
 	}
 
+	defaultVariants = objectify(defaultVariants);
 	authorVariants = objectify(authorVariants);
 	parentVariants = objectify(parentVariants);
 
 	// Merge all of the variants objects, preferring values in objects from left to right.
 	const mergedObj = [defaultVariants, parentVariants, authorVariants].reduce(
 		(obj, a) => {
-			Object.keys(a).forEach(key => {
-				obj[key] = preferDefined(a[key], obj[key]);
-			});
+			if (a) {
+				Object.keys(a).forEach(key => {
+					obj[key] = preferDefined(a[key], obj[key]);
+				});
+			}
 
 			return obj;
 		},
@@ -60,20 +63,15 @@ function determineVariants (defaultVariants, allowedVariants, authorVariants, pa
 		}
 	}
 
-
 	return mergedObj;
 }
 
-function getClassName (skins, effectiveSkin, className, variants) {
+function getClassName (skins, effectiveSkin, variants) {
 	const skin = skins && skins[effectiveSkin];
 
 	// only apply the skin class if it's set and different from the "current" skin as
 	// defined by the value in context
-	if (skin || variants) {
-		className = classnames(skin, variants, className);
-	}
-
-	if (className) return className;
+	return classnames(skin, variants);
 }
 
 

--- a/packages/ui/Skinnable/util.js
+++ b/packages/ui/Skinnable/util.js
@@ -46,6 +46,7 @@ function determineSkin (defaultSkin, authorSkin, parentSkin) {
  * @param {String|String[]} allowedVariants The allowed variants for this instance
  * @param {String|String[]} authorVariants  The author-provided variants
  * @param {String|String[]} parentVariants  The inherited variants from an upstream useSkins
+ * @private
  */
 function determineVariants (defaultVariants, allowedVariants, authorVariants, parentVariants) {
 	if (!allowedVariants || !(allowedVariants instanceof Array)) {

--- a/packages/ui/Skinnable/util.js
+++ b/packages/ui/Skinnable/util.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 
 const objectify = (arg) => {
 	// undefined, null, empty string case
@@ -26,7 +27,60 @@ const objectify = (arg) => {
 
 const preferDefined = (a, b) => ((a != null) ? a : b);
 
+function determineSkin (defaultSkin, authorSkin, parentSkin) {
+	return authorSkin || defaultSkin || parentSkin;
+}
+
+function determineVariants (defaultVariants, allowedVariants, authorVariants, parentVariants) {
+	if (!allowedVariants || !(allowedVariants instanceof Array)) {
+		// There are no allowed variants, so just return an empty object, indicating that there are no viable determined variants.
+		return {};
+	}
+
+	authorVariants = objectify(authorVariants);
+	parentVariants = objectify(parentVariants);
+
+	// Merge all of the variants objects, preferring values in objects from left to right.
+	const mergedObj = [defaultVariants, parentVariants, authorVariants].reduce(
+		(obj, a) => {
+			Object.keys(a).forEach(key => {
+				obj[key] = preferDefined(a[key], obj[key]);
+			});
+
+			return obj;
+		},
+		{}
+	);
+
+	// Clean up the merged object
+	for (const key in mergedObj) {
+		// Delete keys that are null or undefined and delete keys that aren't allowed
+		if (mergedObj[key] == null || !allowedVariants.includes(key)) {
+			delete mergedObj[key];
+		}
+	}
+
+
+	return mergedObj;
+}
+
+function getClassName (skins, effectiveSkin, className, variants) {
+	const skin = skins && skins[effectiveSkin];
+
+	// only apply the skin class if it's set and different from the "current" skin as
+	// defined by the value in context
+	if (skin || variants) {
+		className = classnames(skin, variants, className);
+	}
+
+	if (className) return className;
+}
+
+
 export {
+	determineSkin,
+	determineVariants,
+	getClassName,
 	objectify,
 	preferDefined
 };

--- a/packages/ui/Skinnable/util.js
+++ b/packages/ui/Skinnable/util.js
@@ -27,10 +27,26 @@ const objectify = (arg) => {
 
 const preferDefined = (a, b) => ((a != null) ? a : b);
 
+/**
+ * Determines the effective skin
+ *
+ * @param {String} defaultSkin The local default for this instance of useSkins
+ * @param {String} authorSkin  The author-provided skin value
+ * @param {String} parentSkin  The inherited skin value from an upstream useSkins
+ * @private
+ */
 function determineSkin (defaultSkin, authorSkin, parentSkin) {
 	return authorSkin || defaultSkin || parentSkin;
 }
 
+/**
+ * Determines the effective skin variant
+ *
+ * @param {String|String[]} defaultVariants The local default variants for this instance
+ * @param {String|String[]} allowedVariants The allowed variants for this instance
+ * @param {String|String[]} authorVariants  The author-provided variants
+ * @param {String|String[]} parentVariants  The inherited variants from an upstream useSkins
+ */
 function determineVariants (defaultVariants, allowedVariants, authorVariants, parentVariants) {
 	if (!allowedVariants || !(allowedVariants instanceof Array)) {
 		// There are no allowed variants, so just return an empty object, indicating that there are no viable determined variants.


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrates Skinnable to use hooks

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This is the first hook (I believe) to expose a context provider. I've gone with `provideSkins` as a member of the returned object from the hook. I like that this avoids exporting the context and doesn't require the user to assemble the provider but it's still a little awkward looking

```jsx
const skins = useSkins(config);
return skins.provideSkins(
    <Component {...props} />
);
```

This model works okay with stacking multiple providers too
```
skins.provideSkins(
    other.provideOther(
        <Comp />
    )
)
```

I've also adjusted the config parameter names a bit for consistency. We had `skins` and `allowedVariants` but both referred to the allowed values. I chose to use `skins` and `variants` rather than `allowedSkins` and `allowedVariants`. I'm not :100: on this, however, since the config also accepts the current values in `skin` and `skinVariants` so we have `skins`/`skin` and `variants`/`skinVariants`.