### PR TITLE
PLAT-106519: ui/Group should allow specifying the key that contains the selected item's value when it is selected

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that it gives the `onSelect` event
+
 ## [3.3.0-alpha.9] - 2020-05-11
 
 No significant changes.
@@ -16,7 +22,6 @@ No significant changes.
 
 ### Added
 
-- `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that it gives the `onSelect` event
 - `ui/ProgressBar` support for `orientation` type of `'radial'`
 - `ui/ProgressBar` public class name `radial`
 - `ui/ViewManager` events `onTransition` and `onWillTransition` payload members `index` and `previousIndex`

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
-- `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that is gives the `onSelect` event
+- `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that it gives the `onSelect` event
 - `ui/ProgressBar` support for `orientation` type of `'radial'`
 - `ui/ProgressBar` public class name `radial`
 - `ui/ViewManager` events `onTransition` and `onWillTransition` payload members `index` and `previousIndex`

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
+- `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that is gives the `onSelect` event
 - `ui/ProgressBar` support for `orientation` type of `'radial'`
 - `ui/ProgressBar` public class name `radial`
 - `ui/ViewManager` events `onTransition` and `onWillTransition` payload members `index` and `previousIndex`

--- a/packages/ui/Group/Group.js
+++ b/packages/ui/Group/Group.js
@@ -130,6 +130,15 @@ const GroupBase = kind({
 		selected: PropTypes.oneOfType([PropTypes.number, PropTypes.array]),
 
 		/**
+		 * The key that will hold the value in the event passed to `onSelect`.
+		 *
+		 * @type {String}
+		 * @default 'data'
+		 * @public
+		 */
+		selectedEventProp: PropTypes.string,
+
+		/**
 		 * The name of the DOM property that represents the selected state.
 		 *
 		 * @type {String}
@@ -144,6 +153,7 @@ const GroupBase = kind({
 		childSelect: 'onClick',
 		indexProp: 'data-index',
 		select: 'single',
+		selectedEventProp: 'data',
 		selectedProp: 'data-selected'
 	},
 
@@ -161,6 +171,7 @@ const GroupBase = kind({
 		delete props.childSelect;
 		delete props.select;
 		delete props.selected;
+		delete props.selectedEventProp;
 		delete props.selectedProp;
 
 		return <Repeater role="group" {...props} childComponent={GroupItem} />;

--- a/packages/ui/Group/GroupItem.js
+++ b/packages/ui/Group/GroupItem.js
@@ -28,6 +28,7 @@ const pickGroupItemProps = (props) => ({
 		onSelect: props.onSelect,
 		select: props.select,
 		selected: props.selected,
+		selectedEventProp: props.selectedEventProp,
 		selectedProp: props.selectedProp
 	}
 });
@@ -58,16 +59,16 @@ const GroupItemBase = kind({
 					indexProp,
 					onSelect,
 					select,
-					selected
+					selected,
+					selectedEventProp
 				}
 			} = props;
 
 			if (onSelect) {
 				const index = props[indexProp];
-				const data = props[childProp];
 
 				onSelect({
-					data,
+					[selectedEventProp]: props[childProp],
 					selected: selectItem(select, index, selected)
 				});
 			}

--- a/packages/ui/Group/tests/Group-specs.js
+++ b/packages/ui/Group/tests/Group-specs.js
@@ -39,6 +39,23 @@ describe('Group', () => {
 		expect(actual).toBe(expected);
 	});
 
+	test('should call handler with data on select stored in the key specified by `selectedEventProp`', () => {
+		const handleClick = jest.fn();
+		const subject = mount(
+			<GroupBase childComponent="div" onSelect={handleClick} selectedEventProp="value">
+				{stringItems}
+			</GroupBase>
+		);
+
+		const selected = 1;
+		subject.find('div').at(selected).simulate('click', {});
+
+		const expected = stringItems[selected];
+		const actual = handleClick.mock.calls[0][0].value;
+
+		expect(actual).toBe(expected);
+	});
+
 	test(
 		'should call handler on move when childSelect="onMouseMove"',
 		() => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When working with a default `Changeable` component that uses `value` as the changing prop and has a `Group` of choices that it can be updated to (i.e. the group items have a `value` prop), you have to go through an interim step to adapt the `onSelect` event payload because it will have the selected item's value in the `data` key (`{data: theValue}` -> `{value: theValue}`).

See the inspiration here: enactjs/agate/pull/249

This change adds a `selectedEventProp` prop to `ui/Group` so that `onSelect` can use that key instead.  For example, `selectedEventProp: 'value'` would allow the event to be forwarded unchanged to the `onChange` handler of a `Changeable` component managing a `value` prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This should be low-impact.  Existing use of `Group` components will continue to operate with no change because the new `selectedEventProp` defaults to `'data'`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The change can be tested by using an event handler that logs the event object and specifying it as the `onSelect` prop for two `Group`s where one has the `selectedEventProp` defined as some string, and the other does not and comparing the outputs of the different event objects.

### Links
[//]: # (Related issues, references)
PLAT-106519
