### PR TITLE
PLAT-106662: Fix Slottable to work with downstream defaultProps

### DIFF
--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -46,10 +46,11 @@ const Slottable = hoc(defaultConfig, (config, Wrapped) => {
 
 	// eslint-disable-next-line no-shadow
 	return function Slottable (props) {
-		// extract the slots into a new object but populating the default value to be null to allow
-		// the current "harmful" behavior below.
+		// extract the slots into a new object but populating the default value to be undefined so
+		// the key exists in order to allow the current "harmful" behavior below. Must be undefined
+		// in order to trigger defaultProps on downstream components.
 		const slotProps = {children: props.children};
-		slots.forEach(k => (slotProps[k] = null));
+		slots.forEach(k => (slotProps[k] = undefined)); // eslint-disable-line no-undefined
 
 		// Slottable allows there to be other values in the destination slot and merges them.
 		// However, consumers can't avoid key warnings when merging the two lists so we should

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -256,4 +256,33 @@ describe('Slottable Specs', () => {
 			expect(actual).toBe(expected);
 		}
 	);
+
+	test(
+		'should allow downstream component to have default value for unset slot',
+		() => {
+			// eslint-disable-next-line enact/prop-types
+			function ComponentBase ({a}) {
+				return (
+					<div>
+						{a}
+					</div>
+				);
+			}
+
+			ComponentBase.defaultProps = {
+				a: 'Default A'
+			};
+
+			const Component = Slottable({slots: ['a']}, ComponentBase);
+
+			const subject = mount(
+				<Component />
+			);
+
+			const expected = ComponentBase.defaultProps.a;
+			const actual = subject.text();
+
+			expect(actual).toBe(expected);
+		}
+	);
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The Slottable hook migration broke components that used slots along with default props. If the slot is unset and the downstream component has a defaultProps entry for that prop, the prop will be set to null and not receive the default value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Use `undefined` instead of `null` for placeholder value
* Adds tests for this scenario
