### PR TITLE
ENYO-6436: Only use iLib loader when necessary.

### DIFF
--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -1,4 +1,4 @@
-/* global ILIB_DISABLE */
+/* global ILIB_NO_ASSETS */
 /*
  * glue.js - glue code to fit ilib into enyo
  *
@@ -25,9 +25,10 @@ import './dates';
 import Loader from './Loader';
 import {updateLocale} from '../locale';
 
-// if iLib data is pre-provided, or ILIB_DISABLE is set, skip iLib loader usage
+// if iLib data is pre-provided, or ILIB_NO_ASSETS is set, skip iLib loader usage
 // otherwise use our local Loader.js file
-if (!global.ilibData && !(typeof ILIB_DISABLE !== 'undefined' && ILIB_DISABLE === true)) {
+if (!global.ilibData &&
+		!(typeof ILIB_NO_ASSETS !== 'undefined' && ILIB_NO_ASSETS === true)) {
 	ilib.setLoaderCallback(new Loader());
 }
 

--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -1,3 +1,4 @@
+/* global ILIB_DISABLE */
 /*
  * glue.js - glue code to fit ilib into enyo
  *
@@ -24,7 +25,12 @@ import './dates';
 import Loader from './Loader';
 import {updateLocale} from '../locale';
 
-ilib.setLoaderCallback(new Loader());
+// if iLib data is pre-provided, or ILIB_DISABLE is set, skip iLib loader usage
+// otherwise use our local Loader.js file
+if (!global.ilibData && !(typeof ILIB_DISABLE !== 'undefined' && ILIB_DISABLE === true)) {
+	ilib.setLoaderCallback(new Loader());
+}
+
 
 if (typeof window === 'object' && typeof window.UILocale !== 'undefined') {
 	// this is a hack until GF-1581 is fixed


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* The are a select few scenarios where we don't always want to load the iLib loader. Particularly in instances where XHR is forbidden or there are no assets to load.

### Resolution
* When global pre-populated iLib data is available (`global.ilibData` like with EnactBrowser), don't attach out Enact XHR Loader routine.
* When iLibPlugin has set the `ILIB_NO_ASSETS` constant, indicating this project does not include/use iLib assets, don't attach out Enact XHR Loader routine.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>