### PR TITLE
Revert "ENYO-6436: Only use iLib loader when necessary."

### DIFF
--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -1,4 +1,3 @@
-/* global ILIB_NO_ASSETS */
 /*
  * glue.js - glue code to fit ilib into enyo
  *
@@ -25,13 +24,7 @@ import './dates';
 import Loader from './Loader';
 import {updateLocale} from '../locale';
 
-// if iLib data is pre-provided, or ILIB_NO_ASSETS is set, skip iLib loader usage
-// otherwise use our local Loader.js file
-if (!global.ilibData &&
-		!(typeof ILIB_NO_ASSETS !== 'undefined' && ILIB_NO_ASSETS === true)) {
-	ilib.setLoaderCallback(new Loader());
-}
-
+ilib.setLoaderCallback(new Loader());
 
 if (typeof window === 'object' && typeof window.UILocale !== 'undefined') {
 	// this is a hack until GF-1581 is fixed


### PR DESCRIPTION
Reverts enactjs/enact#2768

This change has an unexpected side effect of causing some iLib routines to fail that otherwise work OK so long as the requests don't succeed.