### PR TITLE
PLAT-98771: Switched Marquee from position right/left to transform

### DIFF
--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -24,12 +24,12 @@
 		overflow: hidden;
 		width: 100%;
 		white-space: pre !important;
-		transition-property: left, right;
+		transition-property: transform;
 		transition-timing-function: linear;
 		position: relative;
 
 		&.willAnimate {
-			will-change: left, right;
+			will-change: transform;
 			overflow: visible;
 		}
 

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -210,7 +210,7 @@ const MarqueeBase = kind({
 			// If the components content directionality doesn't match the context, we need to set it
 			// inline
 			const direction = rtl ? 'rtl' : 'ltr';
-			const sideProperty = rtl ? 'left' : 'right';
+			const rtlDirectionMultiplier = rtl ? 1 : -1;
 			const style = {
 				'--ui-marquee-spacing': spacing,
 				direction,
@@ -221,10 +221,10 @@ const MarqueeBase = kind({
 			if (animating) {
 				const duration = distance / speed;
 
-				style[sideProperty] = `${distance}px`;
+				style.transform = `translateX(${distance * rtlDirectionMultiplier}px)`;
 				style.transitionDuration = `${duration}s`;
 			} else {
-				style[sideProperty] = 0;
+				style.transform = 'translateX(0)';
 			}
 
 			return style;

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -268,22 +268,22 @@ describe('MarqueeBase', () => {
 		}
 	);
 
-	test('should transition from the right with LTR text', () => {
+	test('should transition from the right with LTR text (a negative translate value)', () => {
 		const subject = shallow(
 			<MarqueeBase animating distance={100} />
 		);
 
-		const actual = subject.childAt(0).prop('style');
-		expect(actual).toHaveProperty('right');
+		const actual = subject.childAt(0).prop('style').transform;
+		expect(actual).toContain('-');
 	});
 
-	test('should transition from the left with RTL text', () => {
+	test('should transition from the left with RTL text (a positive translate value)', () => {
 		const subject = shallow(
 			<MarqueeBase animating distance={100} rtl />
 		);
 
-		const actual = subject.childAt(0).prop('style');
-		expect(actual).toHaveProperty('left');
+		const actual = subject.childAt(0).prop('style').transform;
+		expect(actual).not.toContain('-');
 	});
 
 	test('should duplicate from content when promoted and a non-zero distance', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Each Marquee fires as many style recalculations and relayouts as it can while animating. This adds up quickly and overburdens the CPU. This amounts to ~50-60 recalculations every second, for each marquee.

### Resolution
It turns out that `right` and `left` CSS properties are not as optimized for recalculation as they likely should be in this case. By using `transform` instead, we get the same functionality at essentially zero CPU cost because we're not kicking-off hundreds of layout recalculations.