### PR TITLE
PLAT-107660: Add forwardCustom handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/handle.forwardCustom` handler to simplify forwarding custom events from components
+
 ## [3.3.0-alpha.9] - 2020-05-11
 
 No significant changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Added
-
-- `core/handle.forwardCustom` handler to simplify forwarding custom events from components
 ## [3.3.0-alpha.10] - 2020-05-26
 
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/handle.forwardCustom` handler to simplify forwarding custom events from components
+
 ## [3.3.0-alpha.10] - 2020-05-26
 
 No significant changes.

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -725,7 +725,6 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
  *                                     (suitable for passing to handle or used directly within
  *                                     `handlers` in [kind]{@link core/kind}) that will forward the
  *                                     custom event.
- * @curried
  * @memberof core/handle
  * @public
  */

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -696,7 +696,7 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
 });
 
 /**
- * Forwards the event to a function at `name` on `props`.
+ * Creates a handler that will forward the event to a function at `name` on `props`.
  *
  * If `adapter` is not specified, a new event payload will be generated with a `type` member with
  * the `name` of the custom event. If `adapter` is specified, the `type` member is added to the

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -696,6 +696,54 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
 });
 
 /**
+ * Adapts an event with `adapter` before calling `handler`.
+ *
+ * The `adapter` function receives the same arguments as any handler. The value returned from
+ * `adapter` is passed as the first argument to `handler` with the remaining arguments kept the
+ * same. This is often useful to generate a custom event payload before forwarding on to a callback.
+ *
+ * Example:
+ * ```
+ * import {adaptEvent, forward} from '@enact/core/handle';
+ *
+ * // calls the onChange callback with an event payload containing a type and value member
+ * const incrementAndChange = adaptEvent(
+ * 	(ev, props) => ({
+ * 	  type: 'onChange',
+ * 	  value: props.value + 1
+ * 	}),
+ * 	forward('onChange')
+ * )
+ * ```
+ *
+ * @method   forwardCustom
+ * @param    {EventAdapter}     adapter  Function to adapt the event payload
+ * @param    {HandlerFunction}  handler  Handler to call with the handler function
+ *
+ * @returns  {HandlerFunction}           Returns an [event handler]{@link core/handle.HandlerFunction} (suitable for passing to handle) that returns the result of `handler`
+ * @curried
+ * @memberof core/handle
+ * @public
+ */
+const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
+	adaptEvent(
+		(...args) => {
+			let ev = adapter ? adapter(...args) : null;
+
+			// Handle either no adapter or a non-object return from the adapter
+			if (!ev || typeof ev !== 'object') {
+				ev = {};
+			}
+
+			ev.type = name;
+
+			return ev;
+		},
+		forward(name)
+	)
+).named('forwardCustom');
+
+/**
  * Accepts a handler and returns the logical complement of the value returned from the handler.
  *
  * Example:
@@ -728,6 +776,7 @@ export {
 	call,
 	callOnEvent,
 	forward,
+	forwardCustom,
 	forwardWithPrevent,
 	forEventProp,
 	forKey,

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -696,7 +696,11 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
 });
 
 /**
- * Adapts an event with `adapter` before calling `handler`.
+ * Forwards the event to a function at `name` on `props`.
+ *
+ * If `adapter` is not specified, a new event payload will be generated with a `type` member with
+ * the `name` of the custom event. If `adapter` is specified, the `type` member is added to the
+ * value returned by `adapter`.
  *
  * The `adapter` function receives the same arguments as any handler. The value returned from
  * `adapter` is passed as the first argument to `handler` with the remaining arguments kept the
@@ -704,23 +708,23 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
  *
  * Example:
  * ```
- * import {adaptEvent, forward} from '@enact/core/handle';
+ * import {forwardCustom} from '@enact/core/handle';
  *
- * // calls the onChange callback with an event payload containing a type and value member
- * const incrementAndChange = adaptEvent(
- * 	(ev, props) => ({
- * 	  type: 'onChange',
- * 	  value: props.value + 1
- * 	}),
- * 	forward('onChange')
- * )
+ * // calls the onChange callback with the event: {type: 'onChange'}
+ * const forwardChange = forwardCustom('onChange');
+ *
+ * // calls the onChange callback with the event: {type: 'onChange', index}
+ * const forwardChangeWithIndex = forwardCustom('onChange', (ev, {index}) => ({index}));
  * ```
  *
  * @method   forwardCustom
- * @param    {EventAdapter}     adapter  Function to adapt the event payload
- * @param    {HandlerFunction}  handler  Handler to call with the handler function
+ * @param    {String}        name      Name of method on the `props`
+ * @param    {EventAdapter}  [adapter] Function to adapt the event payload
  *
- * @returns  {HandlerFunction}           Returns an [event handler]{@link core/handle.HandlerFunction} (suitable for passing to handle) that returns the result of `handler`
+ * @returns  {HandlerFunction}         Returns an [event handler]{@link core/handle.EventHandler}
+ *                                     (suitable for passing to handle or used directly within
+ *                                     `handlers` in [kind]{@link core/kind}) that will forward the
+ *                                     custom event.
  * @curried
  * @memberof core/handle
  * @public

--- a/packages/core/handle/tests/handle-specs.js
+++ b/packages/core/handle/tests/handle-specs.js
@@ -7,6 +7,7 @@ import {
 	forKeyCode,
 	forProp,
 	forward,
+	forwardCustom,
 	forwardWithPrevent,
 	oneOf,
 	preventDefault,
@@ -536,6 +537,63 @@ describe('handle', () => {
 
 			const expected = [1, 2, 3];
 			const actual = obj.handler.mock.calls[0];
+
+			expect(actual).toEqual(expected);
+		});
+	});
+
+	describe('#forwardCustom', () => {
+		test('should pass an object with `type` when no adapter is provided', () => {
+			const handler = jest.fn();
+
+			forwardCustom('onCustomEvent')(null, {onCustomEvent: handler});
+
+			const expected = {
+				type: 'onCustomEvent'
+			};
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expected);
+		});
+
+		test('should add `type` to object returned by adapter', () => {
+			const handler = jest.fn();
+			const adapter = () => ({index: 0});
+			forwardCustom('onCustomEvent', adapter)(null, {onCustomEvent: handler});
+
+			const expected = {
+				type: 'onCustomEvent',
+				index: 0
+			};
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expected);
+		});
+
+		test('should create an event payload if the adapter returns nothing', () => {
+			const handler = jest.fn();
+			const adapter = () => null;
+			forwardCustom('onCustomEvent', adapter)(null, {onCustomEvent: handler});
+
+			const expected = {
+				type: 'onCustomEvent'
+			};
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expected);
+		});
+
+		test('should pass event, props, and context args to adapter', () => {
+			const adapter = jest.fn();
+			const args = [
+				1, // ev,
+				2, // props,
+				3  // context
+			];
+			forwardCustom('onCustomEvent', adapter)(...args);
+
+			const expected = args;
+			const actual = adapter.mock.calls[0];
 
 			expect(actual).toEqual(expected);
 		});


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have often created one-off handlers to emit custom events.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `forwardCustom` to standardize emitting custom events to always include a `type` member along with the value returned from `adapter`.
