### PR TITLE
Fix Toggleable when props update

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Group` prop `selectedEventProp` to configure the key that `ui/GroupItem` uses to hold the value that it gives the `onSelect` event
 
+### Fixed
+
+- `Toggleable` to recognize changes in `disabled` and `onToggle`
+
 ## [3.3.0-alpha.9] - 2020-05-11
 
 No significant changes.

--- a/packages/ui/Toggleable/Toggle.js
+++ b/packages/ui/Toggleable/Toggle.js
@@ -12,7 +12,8 @@ class Toggle {
 		this.context = {};
 	}
 
-	setContext (value, onToggle) {
+	setContext (props, value, onToggle) {
+		this.props = {...this.props, ...props};
 		this.context.value = value;
 		this.context.onToggle = onToggle;
 	}

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -255,7 +255,7 @@ describe('Toggleable', () => {
 				<Component onToggle={handleToggle} disabled />
 			);
 
-			subject.setProps({disabled: false})
+			subject.setProps({disabled: false});
 
 			subject.simulate('toggle');
 
@@ -275,7 +275,7 @@ describe('Toggleable', () => {
 				<Component />
 			);
 
-			subject.setProps({onToggle: handleToggle})
+			subject.setProps({onToggle: handleToggle});
 
 			subject.simulate('toggle');
 

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -247,6 +247,46 @@ describe('Toggleable', () => {
 	);
 
 	test(
+		'should invoke passed \'onToggle\' handler when disabled at creation and becoming enabled',
+		() => {
+			const handleToggle = jest.fn();
+			const Component = Toggleable(DivComponent);
+			const subject = shallow(
+				<Component onToggle={handleToggle} disabled />
+			);
+
+			subject.setProps({disabled: false})
+
+			subject.simulate('toggle');
+
+			const expected = 1;
+			const actual = handleToggle.mock.calls.length;
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
+		'should invoke changed \'onToggle\' handler',
+		() => {
+			const handleToggle = jest.fn();
+			const Component = Toggleable(DivComponent);
+			const subject = shallow(
+				<Component />
+			);
+
+			subject.setProps({onToggle: handleToggle})
+
+			subject.simulate('toggle');
+
+			const expected = 1;
+			const actual = handleToggle.mock.calls.length;
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
 		'should not invoke passed \'onActivate\' handler when disabled',
 		() => {
 			const handleActivate = jest.fn();

--- a/packages/ui/Toggleable/useToggle.js
+++ b/packages/ui/Toggleable/useToggle.js
@@ -48,7 +48,8 @@ function useToggle ({defaultSelected, selected, ...config} = {}) {
 		typeof selected !== 'undefined'
 	);
 
-	toggle.setContext(...state);
+	const props = {disabled: config.disabled, onToggle: config.onToggle};
+	toggle.setContext(props, ...state);
 
 	return {
 		activate: toggle.handleActivate,


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`useToggle` did not update some required props (`disabled`, `onToggle`) after creation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update props when they change

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We should watch for other to-be-implemented hooks that use `useClass()`.  The current uses seem to be OK.

### Links
[//]: # (Related issues, references)
PLAT-105588

### Comments
