### PR TITLE
ENYO-6473: Enhance ImageItem rendering performance

### DIFF
--- a/packages/ui/CacheReactElementDecorator/CacheReactElementDecorator.js
+++ b/packages/ui/CacheReactElementDecorator/CacheReactElementDecorator.js
@@ -1,0 +1,212 @@
+/**
+ * caches React elements, but allows context values to re-render.
+ *
+ * @module ui/CacheReactElementContext
+ * @exports CacheReactElementContext
+ */
+
+import hoc from '@enact/core/hoc';
+import PropTypes from 'prop-types';
+import omit from 'ramda/src/omit';
+import pick from 'ramda/src/pick';
+import React from 'react';
+
+const CacheReactElementContext = React.createContext();
+
+const CacheReactElementWithChildrenContextDecorator = (property) => {
+	// eslint-disable-next-line no-shadow
+	function CacheReactElementWithChildrenContextDecorator ({children}) {
+		const context = React.useContext(CacheReactElementContext);
+
+		return context && context[property] || children;
+	}
+
+	return CacheReactElementWithChildrenContextDecorator;
+};
+
+/**
+ * A higher-order component that pass context as render props
+ *
+ * Example:
+ * ```
+ * return (
+ * 	<CacheReactElementWithPropContext {...rest}>
+ * 		{(props) => (<UiImageItem {...props})}
+ * 	</CacheReactElementWithPropContext>
+ * );
+ * ```
+ *
+ * @class CacheReactElementWithPropContext
+ * @memberof ui/CacheReactElementDecorator
+ * @hoc
+ * @private
+ */
+const CacheReactElementWithPropContext = ({filterProps}) => {
+	// eslint-disable-next-line no-shadow
+	function CacheReactElementWithPropContext ({cached, children}) {
+		if (cached) {
+			return (
+				<CacheReactElementContext.Consumer>
+					{(props) => {
+						const cachedProps = pick(filterProps, props);
+						return children ? children(cachedProps) : null;
+					}}
+				</CacheReactElementContext.Consumer>
+			);
+		} else {
+			return children && typeof children === 'function' ? children({}) : null;
+		}
+	}
+
+	CacheReactElementWithPropContext.propTypes = /** @lends sandstone/ImageItem.CacheReactElementWithPropContext.prototype */ {
+		/**
+		 * Cache React elements.
+		 *
+		 * @type {Boolean}
+		 * @default true
+		 * @public
+		 */
+		cached: PropTypes.bool
+	};
+
+	CacheReactElementWithPropContext.defaultProps = {
+		cached: true
+	};
+
+	return CacheReactElementWithPropContext;
+};
+
+const defaultWithPropConfig = {
+	filterProps: []
+};
+
+const CacheReactElementWithPropContextDecorator = hoc(defaultWithPropConfig, (config, Wrapped) => {
+	const {filterProps} = config;
+
+	// eslint-disable-next-line no-shadow
+	function CacheReactElementWithPropContextDecorator ({cached, ...rest}) {
+		const cachedContext = React.useContext(CacheReactElementContext);
+		if (cached) {
+			const cachedProps = pick(filterProps, cachedContext);
+			return <Wrapped {...rest} {...cachedProps} />;
+		} else {
+			return <Wrapped {...rest} />;
+		}
+	}
+
+	CacheReactElementWithPropContextDecorator.propTypes = /** @lends sandstone/ImageItem.CacheReactElementWithPropContextDecorator.prototype */ {
+		/**
+		 * Cache React elements.
+		 *
+		 * @type {Boolean}
+		 * @default true
+		 * @public
+		 */
+		cached: PropTypes.bool
+	};
+
+	CacheReactElementWithPropContextDecorator.defaultProps = {
+		cached: true
+	};
+
+	return CacheReactElementWithPropContextDecorator;
+});
+
+/**
+ * Default config for `CacheReactElementDecorator`.
+ *
+ * @memberof ui/ImageItem.CacheReactElementDecorator
+ * @hocconfig
+ * @private
+ */
+const defaultConfig = {
+	/**
+	 * The array includes the key strings of the context object
+	 * which will be used as children prop.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	filterChildren: []
+};
+
+/**
+ * A higher-order component that caches React elements, but allows context values to re-render.
+ *
+ * Example:
+ * ```
+ * const ImageItemDecorator = compose(
+ * 	CacheReactElementDecorator({filterChildren: ['children', 'label']}),
+ * 	MarqueeController({marqueeOnFocus: true}),
+ * 	Spottable,
+ * 	Skinnable
+ * );
+ * ```
+ *
+ * @class CacheReactElementDecorator
+ * @memberof ui/ImageItem
+ * @hoc
+ * @private
+ */
+const CacheReactElementDecorator = hoc(defaultConfig, (config, Wrapped) => {
+	const {filterChildren} = config;
+
+	// eslint-disable-next-line no-shadow
+	function CacheReactElementDecorator ({cached, ...rest}) {
+		const element = React.useRef(null);
+
+		if (!cached) {
+			return <Wrapped {...rest} />;
+		}
+
+		const cachedProps = {};
+		const pickProps = pick(filterChildren, rest);
+		const updatedProps = omit(filterChildren, rest);
+
+		for (const key in pickProps) {
+			const CachedContextProp = CacheReactElementWithChildrenContextDecorator(key);
+			cachedProps[key] = <CachedContextProp>{rest[key]}</CachedContextProp>;
+		}
+
+		element.current = element.current || (
+			<Wrapped
+				{...cachedProps}
+				{...updatedProps}
+				cached={cached}
+			/>
+		);
+
+		return (
+			<CacheReactElementContext.Provider value={rest}>
+				{element.current}
+			</CacheReactElementContext.Provider>
+		);
+	}
+
+	CacheReactElementDecorator.propTypes = /** @lends sandstone/ImageItem.CacheReactElementDecorator.prototype */ {
+		/**
+		 * Cache React elements.
+		 *
+		 * @type {Boolean}
+		 * @default true
+		 * @public
+		 */
+		cached: PropTypes.bool
+	};
+
+	CacheReactElementDecorator.defaultProps = {
+		cached: true
+	};
+
+	return CacheReactElementDecorator;
+});
+
+export default CacheReactElementDecorator;
+export {
+	CacheReactElementContext,
+	CacheReactElementDecorator,
+	CacheReactElementWithChildrenContextDecorator,
+	CacheReactElementWithPropContext,
+	CacheReactElementWithPropContextDecorator
+};

--- a/packages/ui/CacheReactElementDecorator/CacheReactElementDecorator.js
+++ b/packages/ui/CacheReactElementDecorator/CacheReactElementDecorator.js
@@ -26,7 +26,7 @@ const CacheReactElementContext = React.createContext();
  * );
  * ```
  *
- * @class CacheReactElementAndUpdatePropsContext
+ * @class CacheReactElementAndUpdateChildrenContextDecorator
  * @memberof ui/CacheReactElementDecorator
  * @hoc
  * @private

--- a/packages/ui/CacheReactElementDecorator/package.json
+++ b/packages/ui/CacheReactElementDecorator/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "CacheReactElementDecorator.js"
+}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -10,7 +10,7 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {CacheReactElementWithPropContextDecorator} from '../CacheReactElementDecorator';
+import {CacheReactElementAndUpdateDOMAttributesContextDecorator} from '../CacheReactElementDecorator';
 import ComponentOverride from '../ComponentOverride';
 import Image from '../Image';
 import {Cell, Column, Row} from '../Layout';
@@ -41,7 +41,7 @@ const ImageItemBase = kind({
 		 * Cache React elements.
 		 *
 		 * @type {Boolean}
-		 * @default true
+		 * @default false
 		 * @public
 		 */
 		cached: PropTypes.bool,
@@ -117,7 +117,7 @@ const ImageItemBase = kind({
 	},
 
 	defaultProps: {
-		cached: true,
+		cached: false,
 		imageComponent: Image,
 		orientation: 'vertical',
 		selected: false
@@ -142,13 +142,14 @@ const ImageItemBase = kind({
 
 		const isHorizontal = orientation === 'horizontal';
 		const Component = isHorizontal ? Row : Column;
-		const ContextComponent = cached ? CacheReactElementWithPropContextDecorator({filterProps: ['data-index', 'src']})(Component) : Component;
-		const ContextCell = cached ? CacheReactElementWithPropContextDecorator({filterProps: ['src']})(Cell) : Cell;
+		const ContextComponent = cached ? CacheReactElementAndUpdateDOMAttributesContextDecorator({filterProps: ['data-index', 'src']})(Component) : Component;
+		const ContextCell = cached ? CacheReactElementAndUpdateDOMAttributesContextDecorator({filterProps: ['src']})(Cell) : Cell;
+		const cachedProp = cached ? {cached} : null;
 
 		return (
-			<ContextComponent {...rest} cached={cached} >
+			<ContextComponent {...rest} {...cachedProp} >
 				<ContextCell
-					cached={cached}
+					{...cachedProp}
 					className={css.image}
 					component={ImageOverride}
 					imageComponent={imageComponent}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -10,6 +10,7 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {CacheReactElementWithPropContextDecorator} from '../CacheReactElementDecorator';
 import ComponentOverride from '../ComponentOverride';
 import Image from '../Image';
 import {Cell, Column, Row} from '../Layout';
@@ -36,6 +37,15 @@ const ImageItemBase = kind({
 	name: 'ui:ImageItem',
 
 	propTypes: /** @lends ui/ImageItem.ImageItem.prototype */ {
+		/**
+		 * Cache React elements.
+		 *
+		 * @type {Boolean}
+		 * @default true
+		 * @public
+		 */
+		cached: PropTypes.bool,
+
 		/**
 		 * The caption displayed with the image.
 		 *
@@ -107,6 +117,7 @@ const ImageItemBase = kind({
 	},
 
 	defaultProps: {
+		cached: true,
 		imageComponent: Image,
 		orientation: 'vertical',
 		selected: false
@@ -126,15 +137,18 @@ const ImageItemBase = kind({
 		})
 	},
 
-	render: ({children, css, imageComponent, orientation, placeholder, src, ...rest}) => {
+	render: ({cached, children, css, imageComponent, orientation, placeholder, src, ...rest}) => {
 		delete rest.selected;
 
 		const isHorizontal = orientation === 'horizontal';
 		const Component = isHorizontal ? Row : Column;
+		const ContextComponent = cached ? CacheReactElementWithPropContextDecorator({filterProps: ['data-index', 'src']})(Component) : Component;
+		const ContextCell = cached ? CacheReactElementWithPropContextDecorator({filterProps: ['src']})(Cell) : Cell;
 
 		return (
-			<Component {...rest}>
-				<Cell
+			<ContextComponent {...rest} cached={cached} >
+				<ContextCell
+					cached={cached}
 					className={css.image}
 					component={ImageOverride}
 					imageComponent={imageComponent}
@@ -152,7 +166,7 @@ const ImageItemBase = kind({
 						{children}
 					</Cell>
 				) : null}
-			</Component>
+			</ContextComponent>
 		);
 	}
 });

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -142,7 +142,7 @@ const ImageItemBase = kind({
 
 		const isHorizontal = orientation === 'horizontal';
 		const Component = isHorizontal ? Row : Column;
-		const ContextComponent = cached ? CacheReactElementAndUpdateDOMAttributesContextDecorator({filterProps: ['data-index', 'src']})(Component) : Component;
+		const ContextComponent = cached ? CacheReactElementAndUpdateDOMAttributesContextDecorator({filterProps: ['data-index']})(Component) : Component;
 		const ContextCell = cached ? CacheReactElementAndUpdateDOMAttributesContextDecorator({filterProps: ['src']})(Cell) : Cell;
 		const cachedProp = cached ? {cached} : null;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

ImageItem rendering time is higher when scrolling in VirtualList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The main root cause is one rendering so many React Elements again. So I tried to cache the React Elements and re-rendered only children prop or some props with a `CacheReactElementContext`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

The `CacheReactElementWithPropContext` in the `CacheReactElementContext` is provided because it could be used as a Component. For now there is no place to use it.

### Links
[//]: # (Related issues, references)

ENYO-6473

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)