### PR TITLE
PLAT-104180: Save scrollPositionTarget both for translate and native scrollMode

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1074,11 +1074,12 @@ const useScrollBase = (props) => {
 			}
 		}
 
+		if (scrollContentHandle.current && scrollContentHandle.current.setScrollPositionTarget) {
+			scrollContentHandle.current.setScrollPositionTarget(targetX, targetY);
+		}
+
 		if (scrollMode === 'translate') {
 			showScrollbarTrack(bounds);
-			if (scrollContentHandle.current && scrollContentHandle.current.setScrollPositionTarget) {
-				scrollContentHandle.current.setScrollPositionTarget(targetX, targetY);
-			}
 
 			if (animate) {
 				mutableRef.current.animator.animate(scrollAnimation(mutableRef.current.animationInfo));


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To fix the jumping focus issue from VirtualList when a user pressed a directional key right after page up/down key, we need to save the `scrollPositionTarget` both for translate and native scrollMode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Save the `scrollPositionTarget` both for translate and native scrollMode

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-104180

### Comments
