### PR TITLE
PLAT-109178: Strings are not translated in prerendered HTML

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/I18nDecorator` locale selection during prerendering
+
 ## [3.3.0-alpha.10] - 2020-05-26
 
 No significant changes.

--- a/packages/i18n/I18nDecorator/useI18n.js
+++ b/packages/i18n/I18nDecorator/useI18n.js
@@ -1,6 +1,8 @@
 import useClass from '@enact/core/useClass';
 import React from 'react';
 
+import ilib from '../src/index.js';
+
 import I18n from './I18n';
 
 /**
@@ -37,6 +39,9 @@ import I18n from './I18n';
  * @private
  */
 function useI18n ({locale, ...config} = {}) {
+	const ilibLocale = ilib.getLocale();
+	locale = locale && locale !== ilibLocale ? locale : ilibLocale;
+
 	const [state, setState] = React.useState({
 		locale,
 		loaded: Boolean(config.sync)


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Strings were not being correctly localized during localized prerendering.

### Resolution
* Restores locale value validation/logic from before https://github.com/enactjs/enact/pull/2727 in the old I18nDecorator so any established iLib locale value is used when needed. This restores the ability for Enact CLI to change locales for each localized render, without it getting overridden.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>