### PR TITLE
PLAT-100212: Export objectify in Skinnable

### DIFF
--- a/packages/ui/Skinnable/Skinnable.js
+++ b/packages/ui/Skinnable/Skinnable.js
@@ -209,6 +209,7 @@ const Skinnable = hoc(defaultConfig, (config, Wrapped) => {
 
 export default Skinnable;
 export {
+	objectify,
 	Skinnable,
 	useSkins
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added /Resolution
[//]: # (Describe the issue resolved or feature added by this pull request)

If passing the `skinVariants` prop to the sandstone `AccessibilityDecorator`,
the `AccessibilityDecorator` should merge its own `skinVariants` object into the `AccessibilityDecorator`'s `skinVariants` prop. But the `AccessibilityDecorator`'s `skinVariants` prop could be a string, an array, or an object. There is the `objectify` to support merging an object into those type objects. So I hope I could use it by exporting it from `Skinnable` instead of creating a new one.

So I used the `objectify` in https://github.com/enyojs/sandstone/pull/418/files#diff-1a21eb0b9c3bc7df485048524c544490R112 and added some unit tests related with that case in https://github.com/enyojs/sandstone/pull/418/files#diff-2f55a7ca463aa02732246d17fcf0aa0fR137.

### Links
[//]: # (Related issues, references)

PLAT-100212

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)