### PR TITLE
ENYO-6470: Fix items are not rendered properly in case of various item sizes

### DIFF
--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -303,6 +303,7 @@ class VirtualListBasic extends Component {
 		super(props);
 
 		this.contentRef = React.createRef();
+		this.itemContainerRefs = [];
 
 		if (props.clientSize) {
 			this.calculateMetrics(props);
@@ -954,10 +955,10 @@ class VirtualListBasic extends Component {
 	// For individually sized item
 	applyItemPositionToDOMElement (index) {
 		const
-			{direction, itemRefs, rtl} = this.props,
+			{direction, rtl} = this.props,
 			{numOfItems} = this.state,
 			{itemPositions} = this,
-			childNode = itemRefs.current[index % numOfItems];
+			childNode = this.itemContainerRefs[index % numOfItems];
 
 		if (childNode && itemPositions[index]) {
 			const position = itemPositions[index].position;
@@ -1068,6 +1069,11 @@ class VirtualListBasic extends Component {
 					itemRefs.current[key] = (parseInt(itemNode.dataset.index) === index) ?
 						itemNode :
 						ref.querySelector(`[data-index="${index}"]`);
+
+					if (itemRefs.current[key]) {
+						this.itemContainerRefs[key] = (this.contentRef.current === itemRefs.current[key].parentElement) ?
+							itemRefs.current[key] : itemRefs.current[key].parentElement;
+					}
 				}
 			};
 

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -952,24 +952,6 @@ class VirtualListBasic extends Component {
 	}
 
 	// For individually sized item
-	applyItemPositionToDOMElement (index) {
-		const
-			{direction, itemRefs, rtl} = this.props,
-			{numOfItems} = this.state,
-			{itemPositions} = this,
-			childNode = itemRefs.current[index % numOfItems];
-
-		if (childNode && itemPositions[index]) {
-			const position = itemPositions[index].position;
-			if (direction === 'vertical') {
-				childNode.style.transform = `translate3d(0, ${position}px, 0)`;
-			} else {
-				childNode.style.transform = `translate3d(${position * (rtl ? -1 : 1)}px, 0, 0)`;
-			}
-		}
-	}
-
-	// For individually sized item
 	updateThresholdWithItemPosition () {
 		const
 			{overhang} = this.props,
@@ -1021,7 +1003,6 @@ class VirtualListBasic extends Component {
 			// and adjust item DOM element positions
 			for (let index = firstIndex; index <= lastIndex; index++) {
 				this.calculateAndCacheItemPosition(index);
-				this.applyItemPositionToDOMElement(index);
 			}
 
 			// Update threshold based on this.itemPositions

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -952,6 +952,24 @@ class VirtualListBasic extends Component {
 	}
 
 	// For individually sized item
+	applyItemPositionToDOMElement (index) {
+		const
+			{direction, itemRefs, rtl} = this.props,
+			{numOfItems} = this.state,
+			{itemPositions} = this,
+			childNode = itemRefs.current[index % numOfItems];
+
+		if (childNode && itemPositions[index]) {
+			const position = itemPositions[index].position;
+			if (direction === 'vertical') {
+				childNode.style.transform = `translate3d(0, ${position}px, 0)`;
+			} else {
+				childNode.style.transform = `translate3d(${position * (rtl ? -1 : 1)}px, 0, 0)`;
+			}
+		}
+	}
+
+	// For individually sized item
 	updateThresholdWithItemPosition () {
 		const
 			{overhang} = this.props,
@@ -1003,6 +1021,7 @@ class VirtualListBasic extends Component {
 			// and adjust item DOM element positions
 			for (let index = firstIndex; index <= lastIndex; index++) {
 				this.calculateAndCacheItemPosition(index);
+				this.applyItemPositionToDOMElement(index);
 			}
 
 			// Update threshold based on this.itemPositions

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -1070,10 +1070,7 @@ class VirtualListBasic extends Component {
 						itemNode :
 						ref.querySelector(`[data-index="${index}"]`);
 
-					if (itemRefs.current[key]) {
-						this.itemContainerRefs[key] = (this.contentRef.current === itemRefs.current[key].parentElement) ?
-							itemRefs.current[key] : itemRefs.current[key].parentElement;
-					}
+					this.itemContainerRefs[key] = ref;
 				}
 			};
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The items disappear in VL with different item sizes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Cause 
The item is wrapped in another div (itemContaineRef) and the position value is already assigned by composeStyle(). applyItemPositionToDOMElement did not consider this case, and assign "translate3d" style to internal item elements. 

* Resolution
The node to which "translate3d" style is applied should be a direct descendant of VL.
Store the VL's direct descendant in the itemContainerRefs and apply "translate3d" style to it.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
ENYO-6470

### Comments
