### PR TITLE
PLAT-109159: Allow iconProps prop in Button to pass it to the Icon

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -107,6 +107,17 @@ const ButtonBase = kind({
 		iconComponent: EnactPropTypes.componentOverride,
 
 		/**
+		 * The icon component prop passed to the {@link ui/Button.Button.iconComponent} component as props.
+		 *
+		 * If [icon]{@link ui/Button.ButtonBase.icon} is not assigned or is false, the icon
+		 * will not be rendered.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		iconProps: PropTypes.object,
+
+		/**
 		 * Enforces a minimum width for the component.
 		 *
 		 * Applies the `minWidth` CSS class which can be customized by
@@ -175,12 +186,13 @@ const ButtonBase = kind({
 			pressed,
 			selected
 		}, size),
-		icon: ({css, icon, iconComponent, size}) => {
+		icon: ({css, icon, iconComponent, iconProps, size}) => {
 			if (icon == null || icon === false) return;
 
 			// Establish the base collection of props for the moost basic `iconComponent` type, an
 			// HTML element string.
 			const props = {
+				...iconProps,
 				className: css.icon,
 				component: iconComponent
 			};
@@ -201,6 +213,7 @@ const ButtonBase = kind({
 
 	render: ({children, css, decoration, disabled, icon, ...rest}) => {
 		delete rest.iconComponent;
+		delete rest.iconProps;
 		delete rest.minWidth;
 		delete rest.pressed;
 		delete rest.selected;


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Need the way to pass Icon's prop though Button.

To flip an icon In RTL, we want to pass {flip: 'horizontal'} prop from Button to Icon.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Support the `iconProp` in Button and pass it to the Icon.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-109159
Related PR: https://github.com/enyojs/sandstone/pull/438

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)