### PR TITLE
PLAT-109159: Add Button prop iconFlip

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -94,7 +94,7 @@ const ButtonBase = kind({
 		/**
 		 * Flips the icon.
 		 *
-		 * @see {@link ui/Icon.IconDecorator#flip}
+		 * @see {@link ui/Icon.Icon#flip}
 		 * @type {String}
 		 * @public
 		 */
@@ -108,7 +108,7 @@ const ButtonBase = kind({
 		 * will not be rendered.
 		 *
 		 * If this is a component rather than an HTML element string, this component will also
-		 * receive the `size` property and should be configured to handle it.
+		 * receive the `size` and `flip` properties and should be configured to handle it.
 		 *
 		 * @type {Component|Node}
 		 * @public
@@ -187,7 +187,7 @@ const ButtonBase = kind({
 		icon: ({css, icon, iconComponent, iconFlip, size}) => {
 			if (icon == null || icon === false) return;
 
-			// Establish the base collection of props for the moost basic `iconComponent` type, an
+			// Establish the base collection of props for the most basic `iconComponent` type, an
 			// HTML element string.
 			const props = {
 				className: css.icon,

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -99,7 +99,8 @@ const ButtonBase = kind({
 		 * will not be rendered.
 		 *
 		 * If this is a component rather than an HTML element string, this component will also
-		 * receive the `size` and `flip` properties and should be configured to handle it.
+		 * receive the `size` and `iconFlip` (as `flip`) properties and should be configured to
+		 * handle it.
 		 *
 		 * @type {Component|Node}
 		 * @public

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -92,15 +92,13 @@ const ButtonBase = kind({
 		icon: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
 
 		/**
-		 * Flips the icon
+		 * Flips the icon.
 		 *
-		 * When `'auto'`, the icon is flipped horizontally for locales that use right-to-left text
-		 * direction.
-		 *
-		 * @type {('auto'|'both'|'horizontal'|'vertical')}
+		 * @see {@link ui/Icon.IconDecorator#flip}
+		 * @type {String}
 		 * @public
 		 */
-		iconFlip: PropTypes.oneOf(['auto', 'both', 'horizontal', 'vertical']),
+		iconFlip: PropTypes.string,
 
 		/**
 		 * The component used to render the [icon]{@link ui/Button.ButtonBase.icon}.

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -92,15 +92,6 @@ const ButtonBase = kind({
 		icon: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
 
 		/**
-		 * Flips the icon.
-		 *
-		 * @see {@link ui/Icon.Icon#flip}
-		 * @type {String}
-		 * @public
-		 */
-		iconFlip: PropTypes.string,
-
-		/**
 		 * The component used to render the [icon]{@link ui/Button.ButtonBase.icon}.
 		 *
 		 * This component will receive the `icon` class to customize its styling.
@@ -114,6 +105,15 @@ const ButtonBase = kind({
 		 * @public
 		 */
 		iconComponent: EnactPropTypes.componentOverride,
+
+		/**
+		 * Flips the icon.
+		 *
+		 * @see {@link ui/Icon.Icon#flip}
+		 * @type {String}
+		 * @public
+		 */
+		iconFlip: PropTypes.string,
 
 		/**
 		 * Enforces a minimum width for the component.
@@ -198,6 +198,8 @@ const ButtonBase = kind({
 			// configured to handle.
 			if (typeof iconComponent !== 'string') {
 				props.size = size;
+				// the following inadvertently triggers a linting rule
+				// eslint-disable-next-line enact/prop-types
 				props.flip = iconFlip;
 			}
 

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -92,6 +92,17 @@ const ButtonBase = kind({
 		icon: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
 
 		/**
+		 * Flips the icon
+		 *
+		 * When `'auto'`, the icon is flipped horizontally for locales that use right-to-left text
+		 * direction.
+		 *
+		 * @type {('auto'|'both'|'horizontal'|'vertical')}
+		 * @public
+		 */
+		iconFlip: PropTypes.oneOf(['auto', 'both', 'horizontal', 'vertical']),
+
+		/**
 		 * The component used to render the [icon]{@link ui/Button.ButtonBase.icon}.
 		 *
 		 * This component will receive the `icon` class to customize its styling.
@@ -175,7 +186,7 @@ const ButtonBase = kind({
 			pressed,
 			selected
 		}, size),
-		icon: ({css, icon, iconComponent, size}) => {
+		icon: ({css, icon, iconComponent, iconFlip, size}) => {
 			if (icon == null || icon === false) return;
 
 			// Establish the base collection of props for the moost basic `iconComponent` type, an
@@ -189,6 +200,7 @@ const ButtonBase = kind({
 			// configured to handle.
 			if (typeof iconComponent !== 'string') {
 				props.size = size;
+				props.flip = iconFlip;
 			}
 
 			return (
@@ -201,6 +213,7 @@ const ButtonBase = kind({
 
 	render: ({children, css, decoration, disabled, icon, ...rest}) => {
 		delete rest.iconComponent;
+		delete rest.iconFlip;
 		delete rest.minWidth;
 		delete rest.pressed;
 		delete rest.selected;

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,11 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Added
+
+- `ui/Button` prop `iconFlip` to set the `flip` prop of `iconComponent`
+- `ui/Icon` prop `flip` value "auto" to horizontally flip the icon for locales that use right-to-left text direction
+
 ### Fixed
 
 - `ui/Scroller` and `ui/VirtualList` to not horizontally scroll by clicking in RTL locales

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Added
 
 - `ui/Button` prop `iconFlip` to set the `flip` prop of `iconComponent`
-- `ui/Icon` prop `flip` value "auto" to horizontally flip the icon for locales that use right-to-left text direction
 
 ### Fixed
 

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -5,10 +5,8 @@
  * @exports Icon
  */
 
-import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
-import {useI18nContext} from '@enact/i18n/I18nDecorator';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -53,12 +51,12 @@ const isUri = function (c) {
 /**
  * A basic icon component structure without any behaviors applied to it.
  *
- * @class IconBase
+ * @class Icon
  * @memberof ui/Icon
  * @ui
  * @public
  */
-const IconBase = kind({
+const Icon = kind({
 	name: 'ui:Icon',
 
 	propTypes: /** @lends ui/Icon.Icon.prototype */ {
@@ -205,7 +203,6 @@ const IconBase = kind({
 	},
 
 	render: ({iconProps, ...rest}) => {
-		delete rest.flip;
 		delete rest.iconList;
 		delete rest.pressed;
 		delete rest.size;
@@ -220,54 +217,7 @@ const IconBase = kind({
 	}
 });
 
-/**
- * Adds support for auto-flipping icons by locale
- *
- * @hoc
- * @memberof ui/Icon
- * @public
- */
-const IconDecorator = hoc((config, Wrapped) => {
-	function IconDecorator ({flip, ...rest}) {
-		const {rtl} = useI18nContext();
-
-		if (flip === 'auto' && rtl) {
-			flip = 'horizontal';
-		}
-
-		return <Wrapped {...rest} flip={flip} />;
-	}
-
-	IconDecorator.propTypes = /** @lends ui/Icon.IconDecorator.prototype */ {
-		/**
-		 * Flips the icon
-		 *
-		 * When `'auto'`, the icon is flipped horizontally for locales that use right-to-left text
-		 * direction.
-		 *
-		 * @type {('auto'|'both'|'horizontal'|'vertical')}
-		 * @public
-		 */
-		flip: PropTypes.oneOf(['auto', 'both', 'horizontal', 'vertical'])
-	}
-
-	return IconDecorator;
-});
-
-/**
- * An icon component with support for auto-flipping icons.
- *
- * @class Icon
- * @memberof ui/Icon
- * @mixes ui/Icon.IconDecorator
- * @ui
- * @public
- */
-const Icon = IconDecorator(IconBase);
-
 export default Icon;
 export {
-	Icon,
-	IconBase,
-	IconDecorator
+	Icon
 };

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -5,6 +5,7 @@
  * @exports Icon
  */
 
+import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
 import {useI18nContext} from '@enact/i18n/I18nDecorator';
@@ -14,7 +15,6 @@ import React from 'react';
 import ri from '../resolution';
 
 import componentCss from './Icon.module.less';
-import hoc from '@enact/core/hoc';
 
 /**
  * Merges consumer styles with the image `src` resolved through the resolution independence module.

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -7,12 +7,14 @@
 
 import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
+import {useI18nContext} from '@enact/i18n/I18nDecorator';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import ri from '../resolution';
 
 import componentCss from './Icon.module.less';
+import hoc from '@enact/core/hoc';
 
 /**
  * Merges consumer styles with the image `src` resolved through the resolution independence module.
@@ -51,12 +53,12 @@ const isUri = function (c) {
 /**
  * A basic icon component structure without any behaviors applied to it.
  *
- * @class Icon
+ * @class IconBase
  * @memberof ui/Icon
  * @ui
  * @public
  */
-const Icon = kind({
+const IconBase = kind({
 	name: 'ui:Icon',
 
 	propTypes: /** @lends ui/Icon.Icon.prototype */ {
@@ -203,6 +205,7 @@ const Icon = kind({
 	},
 
 	render: ({iconProps, ...rest}) => {
+		delete rest.flip;
 		delete rest.iconList;
 		delete rest.pressed;
 		delete rest.size;
@@ -217,7 +220,54 @@ const Icon = kind({
 	}
 });
 
+/**
+ * Adds support for auto-flipping icons by locale
+ *
+ * @hoc
+ * @memberof ui/Icon
+ * @public
+ */
+const IconDecorator = hoc((config, Wrapped) => {
+	function IconDecorator ({flip, ...rest}) {
+		const {rtl} = useI18nContext();
+
+		if (flip === 'auto' && rtl) {
+			flip = 'horizontal';
+		}
+
+		return <Wrapped {...rest} flip={flip} />;
+	}
+
+	IconDecorator.propTypes = /** @lends ui/Icon.IconDecorator.prototype */ {
+		/**
+		 * Flips the icon
+		 *
+		 * When `'auto'`, the icon is flipped horizontally for locales that use right-to-left text
+		 * direction.
+		 *
+		 * @type {('auto'|'both'|'horizontal'|'vertical')}
+		 * @public
+		 */
+		flip: PropTypes.oneOf(['auto', 'both', 'horizontal', 'vertical'])
+	}
+
+	return IconDecorator;
+});
+
+/**
+ * An icon component with support for auto-flipping icons.
+ *
+ * @class Icon
+ * @memberof ui/Icon
+ * @mixes ui/Icon.IconDecorator
+ * @ui
+ * @public
+ */
+const Icon = IconDecorator(IconBase);
+
 export default Icon;
 export {
-	Icon
+	Icon,
+	IconBase,
+	IconDecorator
 };


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
* Users of `ui/Button` cannot easily flip the icon without overriding `iconComponent`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add `ui/Button.iconFlip` to forward `flip` to `Icon`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
