### PR TITLE
PLAT-110783: Fix spotlight to trigger onLeaveContainerFail when leaveFor is configured

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to trigger `onContainerLeaveFail` when `leaveFor` prevents navigation
+
 ## [3.3.0-alpha.12] - 2020-06-15
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` to trigger `onContainerLeaveFail` when `leaveFor` prevents navigation
+- `spotlight` to trigger `onLeaveContainerFail` when `leaveFor` prevents navigation
 
 ## [3.3.0-alpha.12] - 2020-06-15
 

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -357,7 +357,7 @@ function getTargetByDirectionFromElement (direction, element) {
 
 	const elementRect = getRect(element);
 
-	return getNavigableContainersForNode(element)
+	const next = getNavigableContainersForNode(element)
 		.reduceRight((result, containerId, index, elementContainerIds) => {
 			result = result || getTargetInContainerByDirectionFromElement(
 				direction,
@@ -380,6 +380,10 @@ function getTargetByDirectionFromElement (direction, element) {
 
 			return result;
 		}, null);
+
+	// if the reduce above returns the original element, it means it hit a `leaveFor` config that
+	// prevents navigation so we enforce that here by returning null.
+	return next !== element ? next : null;
 }
 
 function getTargetByDirectionFromPosition (direction, position, containerId) {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `leaveFor` for a container, failing to navigating in a direction due to that configuration should emit `onLeaveContainerFail `.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Return `null` when the earlier bail-out returning the source element occurs.
