### PR TITLE
PLAT-110785: Fix useFloatingLayer to defer update until mounted

### DIFF
--- a/packages/ui/FloatingLayer/useFloatingLayer.js
+++ b/packages/ui/FloatingLayer/useFloatingLayer.js
@@ -11,9 +11,12 @@ function useFloatingLayer () {
 	}, [setId]);
 
 	const registerFloatingLayer = React.useContext(FloatingLayerContext);
-	if (registerFloatingLayer) {
-		registerFloatingLayer(handler);
-	}
+
+	React.useEffect(() => {
+		if (registerFloatingLayer) {
+			registerFloatingLayer(handler);
+		}
+	}, [handler, registerFloatingLayer]);
 
 	return {floatingLayerId};
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`useFloatingLayer` could cause a state change during render.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Defer registering until the component is mounted.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There are other instances of registry use that seem like they could cause problems but those instances don't handle the `'register'` event which is what causes the problem.  `PlacholderControllerDecorator` does handle `register` but it doesn't update state directly and instead starts a job.

I did not add a CHANGELOG entry since this feature is still private.

### Links
[//]: # (Related issues, references)
PLAT-110785

### Comments
