### PR TITLE
PLAT-109019: Correctly maintain pointer mode on webOS

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Fixed
 
 - `spotlight` to trigger `onLeaveContainerFail` when `leaveFor` prevents navigation
+- `spotlight` to correctly maintain pointer mode on webOS
 
 ## [3.3.0-alpha.12] - 2020-06-15
 

--- a/packages/spotlight/src/pointer.js
+++ b/packages/spotlight/src/pointer.js
@@ -144,6 +144,8 @@ const notifyPointerMove = (current, target, x, y) => {
  * @private
  */
 const notifyKeyDown = (keyCode, callback) => {
+	const palmSystem = window.PalmSystem;
+
 	// for hide/show pointer events, handle them and return true
 	if (is('pointerHide', keyCode)) {
 		hidePointerJob.start(callback);
@@ -151,7 +153,11 @@ const notifyKeyDown = (keyCode, callback) => {
 	} else if (is('pointerShow', keyCode)) {
 		setPointerMode(true);
 		return true;
-	} else if (!is('nonModal', keyCode) && !is('cancel', keyCode)) {
+	} else if (
+		!is('nonModal', keyCode) &&
+		!is('cancel', keyCode) &&
+		!(is('enter', keyCode) && palmSystem && palmSystem.cursor && palmSystem.cursor.visibility)
+	) {
 		setPointerMode(false);
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
On webOS, spotlight will turn off pointer mode while the pointer is active when using the pointer to select the VKB "enter" key. This can lead to inadvertently setting focus to on-screen elements when the window gains focus while the pointer is active.


### Resolution
We need to handle the specific case on webOS where the "enter" keyCode is the cause of a keydown event that was triggered while the pointer is active.
