### PR TITLE
WIP: Safer cell sizing option

### DIFF
--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -58,7 +58,7 @@ const CellBase = kind({
 		 * @default 'div'
 		 * @public
 		 */
-		component:  EnactPropTypes.renderable,
+		component: EnactPropTypes.renderable,
 
 		/**
 		 * Called with a reference to [component]{@link ui/Cell.Cell#component}
@@ -116,17 +116,19 @@ const CellBase = kind({
 	},
 
 	computed: {
-		className: ({shrink, size, styler}) => styler.append({shrink, grow: (!shrink && !size)}),
+		className: ({shrink, size, styler}) => styler.append({shrink, grow: (!shrink && !size), content: (size === 'content')}),
 		style: ({align, shrink, size, style}) => {
-			if (typeof size === 'number') size = ri.unit(ri.scale(size), 'rem');
+			if (typeof size === 'number') size = ri.scaleToRem(size);
 
-			let cellSize = size;
-			if (!size) {
-				if (shrink) {
-					cellSize = '100%';
+			let cellSize;
+			if (size) {
+				if (size === 'content') {
+					size = 'auto';
 				} else {
-					cellSize = 'none';
+					cellSize = size;
 				}
+			} else if (shrink) {
+				cellSize = '100%';
 			}
 
 			return {
@@ -134,7 +136,7 @@ const CellBase = kind({
 				alignSelf: toFlexAlign(align),
 				flexBasis: (shrink ? null : size),
 				// Setting 100% below in the presence of `shrink`` and absense of `size` prevents overflow
-				'--cell-size': cellSize
+				'--cell-size': (cellSize || 'initial')
 			};
 		}
 	},

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -203,7 +203,7 @@ const LayoutBase = kind({
 		 * @default 'div'
 		 * @public
 		 */
-		component:  EnactPropTypes.renderable,
+		component: EnactPropTypes.renderable,
 
 		/**
 		 * Called with a reference to [component]{@link ui/Layout.Layout#component}

--- a/packages/ui/Layout/Layout.module.less
+++ b/packages/ui/Layout/Layout.module.less
@@ -18,6 +18,10 @@
 		&.shrink {
 			flex: 0 0 auto;
 		}
+
+		&.content {
+			flex: 0 1 auto;
+		}
 	}
 
 	// Modes


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Cell` doesn't allow for an option that shrinks to the size of the content, but stops at the boundary for the `Layout`.


### Resolution
`Cell` now supports a `size="content"` option which does exactly that. The layout is allowed to flex in height while the cell fits the available space without going over.