### PR TITLE
PLAT-111412: VirtualList: Fix items are not shown when changing RTL locales

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` to reset scroll position when client size changed
+
 ## [3.3.0-alpha.13] - 2020-06-22
 
 No significant changes.

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -594,7 +594,7 @@ class VirtualListBasic extends Component {
 
 	calculateMetrics (props) {
 		const
-			{clientSize, direction, itemSize, overhang, spacing} = props,
+			{clientSize, direction, itemSize, overhang, scrollMode, spacing} = props,
 			node = this.props.scrollContentRef.current;
 
 		if (!clientSize && !node) {
@@ -651,8 +651,12 @@ class VirtualListBasic extends Component {
 
 		// reset
 		this.scrollPosition = 0;
-		if (this.props.scrollMode === 'translate' && this.contentRef.current) {
+		if (scrollMode === 'translate' && this.contentRef.current) {
 			this.contentRef.current.style.transform = null;
+		} else if (scrollMode === 'native' && node) {
+			node.style.scrollBehavior = null;
+			this.updateScrollPosition(this.getXY(this.scrollPosition, 0));
+			node.style.scrollBehavior = 'smooth';
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The items are gone when changing RTL locales.
The issue is only for scrollMode="native".
The internal scrollPosition was reset by 0 but the actual native scroller didn't scroll to 0.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Make the native scroller scroll to 0 position.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-111412

### Comments
