### PR TITLE
PLAT-110767: Add spotlight container option straightOnlyLeave

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `spotlight` container config prop `straightOnlyLeave` to prevent navigation to oblique containers when leaving the current container
+
 ## [3.3.0-alpha.13] - 2020-06-22
 
 ### Fixed

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -73,6 +73,7 @@ let GlobalConfig = {
 	selectorDisabled: false,
 	straightMultiplier: 1,
 	straightOnly: false,
+	straightOnlyLeave: false, // prevents navigation to oblique containers when leaving the current container
 	straightOverlapThreshold: 0.5,
 	tabIndexIgnoreList: 'a, input, select, textarea, button, iframe, [contentEditable=true]'
 };

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -336,11 +336,11 @@ const Spotlight = (function () {
 					return false;
 				}
 
-				if (getContainerConfig(currentContainerId).straightOnlyLeave) {	
+				if (getContainerConfig(currentContainerId).straightOnlyLeave) {
 					const currentContainerRect = getContainerRect(currentContainerId);
 					const nextContainerRect = getContainerRect(last(nextContainerIds));
 
-					// prevent focus for straightOnlyLeave containers 
+					// prevent focus for obliquely leaving straightOnlyLeave containers
 					if (
 						(
 							(direction === 'left' || direction === 'right') &&

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -329,14 +329,19 @@ const Spotlight = (function () {
 			const nextContainerIds = getContainersForNode(next);
 
 			if (nextContainerIds.indexOf(currentContainerId) < 0) {
-				const currentContainerRect = getContainerRect(currentContainerId);
-				const nextContainerRect = getContainerRect(last(nextContainerIds));
 
-				if (
-					// prevent focus if 5-way is being held and the next element isn't wrapped by
-					// the current element's immediate container
-					(_5WayKeyHold && !isContainer5WayHoldable(currentContainerId)) ||
-					getContainerConfig(currentContainerId).straightOnlyLeave && (
+				// prevent focus if 5-way is being held and the next element isn't wrapped by
+				// the current element's immediate container
+				if (_5WayKeyHold && !isContainer5WayHoldable(currentContainerId)) {
+					return false;
+				}
+
+				if (getContainerConfig(currentContainerId).straightOnlyLeave) {	
+					const currentContainerRect = getContainerRect(currentContainerId);
+					const nextContainerRect = getContainerRect(last(nextContainerIds));
+
+					// prevent focus for straightOnlyLeave containers 
+					if (
 						(
 							(direction === 'left' || direction === 'right') &&
 							(nextContainerRect.bottom < currentContainerRect.top || nextContainerRect.top > currentContainerRect.bottom)
@@ -345,9 +350,9 @@ const Spotlight = (function () {
 							(direction === 'up' || direction === 'down') &&
 							(nextContainerRect.right < currentContainerRect.left || nextContainerRect.left > currentContainerRect.right)
 						)
-					)
-				) {
-					return false;
+					) {
+						return false;
+					}
 				}
 			}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -78,6 +78,7 @@ import {
 } from './target';
 
 import {
+	getContainerRect,
 	matchSelector,
 	parseSelector
 } from './utils';
@@ -327,10 +328,27 @@ const Spotlight = (function () {
 			const currentContainerId = last(currentContainerIds);
 			const nextContainerIds = getContainersForNode(next);
 
-			// prevent focus if 5-way is being held and the next element isn't wrapped by
-			// the current element's immediate container
-			if (_5WayKeyHold && nextContainerIds.indexOf(currentContainerId) < 0 && !isContainer5WayHoldable(currentContainerId)) {
-				return false;
+			if (nextContainerIds.indexOf(currentContainerId) < 0) {
+				const currentContainerRect = getContainerRect(currentContainerId);
+				const nextContainerRect = getContainerRect(last(nextContainerIds));
+
+				if (
+					// prevent focus if 5-way is being held and the next element isn't wrapped by
+					// the current element's immediate container
+					(_5WayKeyHold && !isContainer5WayHoldable(currentContainerId)) ||
+					getContainerConfig(currentContainerId).straightOnlyLeave && (
+						(
+							(direction === 'left' || direction === 'right') &&
+							(nextContainerRect.bottom < currentContainerRect.top || nextContainerRect.top > currentContainerRect.bottom)
+						) ||
+						(
+							(direction === 'up' || direction === 'down') &&
+							(nextContainerRect.right < currentContainerRect.left || nextContainerRect.left > currentContainerRect.right)
+						)
+					)
+				) {
+					return false;
+				}
 			}
 
 			notifyLeaveContainer(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
This adds a container config option `straightOnlyLeave` that prevents navigation to oblique containers when leaving the current container (as opposed to `straightOnly`, which prevents navigation to elements in an oblique position to the currently focused element).
