### PR TITLE
PLAT-111999: VirtualList: Fix stopping scrollStopJob on every render

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -369,7 +369,7 @@ const useScrollBase = (props) => {
 		return () => {
 			ref.scrollStopJob.stop();
 		};
-	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [direction, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, rtl, scrollMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		const

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -344,7 +344,7 @@ const useScrollBase = (props) => {
 
 			enqueueForceUpdate();
 		});
-	} // esline-disable-line react-hooks/exhaustive-deps
+	}
 
 	const handleResize = useCallback((ev) => {
 		if (ev.action === 'invalidateBounds') {
@@ -369,7 +369,7 @@ const useScrollBase = (props) => {
 		return () => {
 			ref.scrollStopJob.stop();
 		};
-	}); // esline-disable-next-line react-hooks/exhaustive-deps
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		const
@@ -409,7 +409,7 @@ const useScrollBase = (props) => {
 		if (horizontal || vertical) {
 			resizeRegistry.notify({});
 		}
-	}); // esline-disable-next-line react-hooks/exhaustive-deps
+	});
 
 	// scrollMode 'translate' [[
 	function clampScrollPosition () {
@@ -435,7 +435,7 @@ const useScrollBase = (props) => {
 		if (forwardWithPrevent('onMouseDown', ev, props)) {
 			stop();
 		}
-	} // esline-disable-next-line react-hooks/exhaustive-deps
+	}
 
 	// scrollMode 'native' [[
 	function onTouchStart () {
@@ -592,7 +592,6 @@ const useScrollBase = (props) => {
 	* - for horizontal scroll, supports wheel action on any children nodes since web engine cannot support this
 	* - for vertical scroll, supports wheel action on scrollbars only
 	*/
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function onWheel (ev) {
 		if (mutableRef.current.isDragging) {
 			ev.preventDefault();
@@ -722,7 +721,6 @@ const useScrollBase = (props) => {
 	// scrollMode 'translate' ]]
 
 	// scrollMode 'native' [[
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function onScroll (ev) {
 		let {scrollLeft, scrollTop} = ev.target;
 
@@ -764,7 +762,7 @@ const useScrollBase = (props) => {
 		} else {
 			forward('onKeyDown', ev, props);
 		}
-	} // esline-disable-line react-hooks/exhaustive-deps
+	}
 
 	function scrollToAccumulatedTarget (delta, vertical, overscrollEffect) {
 		if (!mutableRef.current.isScrollAnimationTargetAccumulated) {
@@ -912,7 +910,6 @@ const useScrollBase = (props) => {
 
 	// call scroll callbacks
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function forwardScrollEvent (overscrollEffectType, reachedEdgeInfo) {
 		forward(overscrollEffectType, {scrollLeft: mutableRef.current.scrollLeft, scrollTop: mutableRef.current.scrollTop, moreInfo: getMoreInfo(), reachedEdgeInfo}, props);
 	}
@@ -971,7 +968,6 @@ const useScrollBase = (props) => {
 		}
 	}
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function getReachedEdgeInfo () {
 		const
 			bounds = getScrollBounds(),
@@ -1183,7 +1179,6 @@ const useScrollBase = (props) => {
 		scrollContentRef.current.style.scrollBehavior = 'smooth';
 	}
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function stop () {
 		if (scrollMode === 'translate') {
 			stopForTranslate();
@@ -1258,7 +1253,6 @@ const useScrollBase = (props) => {
 		return {left, top};
 	}
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function scrollTo (opt) {
 		if (!mutableRef.current.deferScrollTo) {
 			const {left, top} = getPositionForScrollTo(opt);
@@ -1316,7 +1310,6 @@ const useScrollBase = (props) => {
 		}
 	}
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function updateScrollbars () {
 		const
 			bounds = getScrollBounds(),
@@ -1342,7 +1335,6 @@ const useScrollBase = (props) => {
 		}
 	}
 
-	// esline-disable-next-line react-hooks/exhaustive-deps
 	function updateScrollbarTrackSize () {
 		const
 			bounds = getScrollBounds(),


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When re-render happens, scrollStopJob was stopped and created a new one.
This caused the status variable `scrolling` never set to `false` again.
`scrolling` variable is used when bailing out a scroll to the same position.
Since this variable set to the wrong value, the scroll that needs to occur didn't fire and caused problems.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Keep scrollStopJob instance instead of stopping and creating a new one on every render.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-111999

### Comments
