### PR TITLE
PLAT-112393: Prevent unnecessary renders

### DIFF
--- a/packages/i18n/I18nDecorator/I18n.js
+++ b/packages/i18n/I18nDecorator/I18n.js
@@ -70,7 +70,7 @@ class I18n {
 	}
 
 	/**
-	 * Adds the `languagechange` event listener and initiaties async resource retrieval.
+	 * Adds the `languagechange` event listener and initiates async resource retrieval.
 	 *
 	 * Should only be called after `window` is available and the DOM is ready.
 	 *
@@ -155,7 +155,7 @@ class I18n {
 					rtl: rtlResult
 				};
 			});
-			// TODO: Resolve how to handle failed resource resquests
+			// TODO: Resolve how to handle failed resource requests
 			// .catch(...);
 
 			this.loadResourceJob.promise(resources);

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -170,7 +170,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 			forward(change),
 			({[prop]: value}) => {
 				if (!this.state.controlled) {
-					this.setState({value});
+					this.setState(({value: oldValue}) => value !== oldValue ? {value} : null);
 				}
 			}
 		)

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -148,9 +148,13 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 					value: props[prop] != null ? props[prop] : props[defaultPropKey]
 				};
 			} else if (state.controlled) {
-				return {
-					value: props[prop]
-				};
+				if (state.value !== props[prop]) {
+					return {
+						value: props[prop]
+					};
+				} else {
+					return null;
+				}
 			}
 
 			warning(

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -117,7 +117,7 @@ const defaultConfig = {
  * Its default event and property can be configured when applied to a component.
  *
  * Note: This HoC passes a number of props to the wrapped component that should be passed to the
- * main DOM node or consumed by the wrapped compoment.
+ * main DOM node or consumed by the wrapped component.
  *
  * Example:
  * ```

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -5,8 +5,9 @@
  * @exports Toggleable
  */
 
-import {adaptEvent, forward} from '@enact/core/handle';
+import handle, {adaptEvent, forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import pick from 'ramda/src/pick';
@@ -144,6 +145,21 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 	const forwardToggle = forwardWithEventProps(toggle);
 	const forwardToggleProp = forwardWithEventProps(toggleProp);
 
+	const toggleHandlers = {
+		onToggle: handle(
+			(ev, props, context) => (context.toggle()),
+			forwardToggleProp
+		),
+		onActivate: handle(
+			(ev, props, context) => (context.activate()),
+			forwardActivate
+		),
+		onDeactivate: handle(
+			(ev, props, context) => (context.deactivate()),
+			forwardDeactivate
+		)
+	};
+
 	function Toggleable (props) {
 		const updated = {...props};
 		const propSelected = props[prop];
@@ -159,6 +175,7 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 			// eslint-disable-next-line no-undefined
 			selected: propSelected == null ? undefined : propSelected
 		});
+		const handlers = useHandlers(toggleHandlers, props, hook);
 
 		warning(
 			!(prop in props && defaultPropKey in props),
@@ -178,21 +195,15 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		if (toggleProp || toggle) {
-			updated[toggleProp || toggle] = (ev) => {
-				if (hook.toggle()) forwardToggleProp(ev, props);
-			};
+			updated[toggleProp || toggle] = handlers.onToggle;
 		}
 
 		if (activate) {
-			updated[activate] = (ev) => {
-				if (hook.activate()) forwardActivate(ev, props);
-			};
+			updated[activate] = handlers.onActivate;
 		}
 
 		if (deactivate) {
-			updated[deactivate] = (ev) => {
-				if (hook.deactivate()) forwardDeactivate(ev, props);
-			};
+			updated[deactivate] = handlers.onDeactivate;
 		}
 
 		delete updated[defaultPropKey];

--- a/packages/ui/useControlledState/useControlledState.js
+++ b/packages/ui/useControlledState/useControlledState.js
@@ -5,7 +5,7 @@ import React from 'react';
 function createHandler () {
 	return (onChange) => (value) => {
 		onChange(prevState => {
-			const newValue = typeof value === 'function' ? value(prevState.value) : value
+			const newValue = typeof value === 'function' ? value(prevState.value) : value;
 
 			if (newValue !== prevState.value) {
 				return ({

--- a/packages/ui/useControlledState/useControlledState.js
+++ b/packages/ui/useControlledState/useControlledState.js
@@ -7,7 +7,7 @@ function createHandler () {
 		onChange(prevState => {
 			const newValue = typeof value === 'function' ? value(prevState.value) : value;
 
-			if (newValue !== prevState.value) {
+			if (!prevState.controlled && newValue !== prevState.value) {
 				return ({
 					value: typeof value === 'function' ? value(prevState.value) : value,
 					controlled: prevState.controlled

--- a/packages/ui/useControlledState/useControlledState.js
+++ b/packages/ui/useControlledState/useControlledState.js
@@ -4,10 +4,18 @@ import React from 'react';
 // and is memoized by the onChange provided by useState
 function createHandler () {
 	return (onChange) => (value) => {
-		onChange(prevState => ({
-			value: typeof value === 'function' ? value(prevState.value) : value,
-			controlled: prevState.controlled
-		}));
+		onChange(prevState => {
+			const newValue = typeof value === 'function' ? value(prevState.value) : value
+
+			if (newValue !== prevState.value) {
+				return ({
+					value: typeof value === 'function' ? value(prevState.value) : value,
+					controlled: prevState.controlled
+				});
+			} else {
+				return prevState;
+			}
+		});
 	};
 }
 

--- a/packages/ui/useControlledState/useControlledState.js
+++ b/packages/ui/useControlledState/useControlledState.js
@@ -1,21 +1,20 @@
 import React from 'react';
 
+function nop () {}
+
 // Generate a handler that hides the controlled value from users, supports functional callbacks,
 // and is memoized by the onChange provided by useState
 function createHandler () {
-	return (onChange) => (value) => {
-		onChange(prevState => {
-			const newValue = typeof value === 'function' ? value(prevState.value) : value;
+	return (onChange, currentValue, controlled) => {
+		if (controlled) {
+			return nop;
+		}
 
-			if (!prevState.controlled && newValue !== prevState.value) {
-				return ({
-					value: typeof value === 'function' ? value(prevState.value) : value,
-					controlled: prevState.controlled
-				});
-			} else {
-				return prevState;
+		return (value) => {
+			if (value !== currentValue) {
+				onChange(value);
 			}
-		});
+		};
 	};
 }
 
@@ -30,15 +29,18 @@ function calcValue (defaultValue, propValue, stateValue, controlled) {
 }
 
 function useControlledState (defaultValue, propValue, controlled) {
+	const isControlled = React.useRef(controlled);
+
 	// Store both the value and the "controlled" flag in a state hook
-	const [state, onChange] = React.useState({
-		value: defaultValue,
-		controlled
-	});
+	const [value, onChange] = React.useState(defaultValue);
+
+	const memoOnChange = React.useMemo(
+		createHandler, [onChange, value, isControlled.current]
+	);
 
 	return [
-		calcValue(defaultValue, propValue, state.value, state.controlled),
-		React.useMemo(createHandler, [onChange])(onChange)
+		calcValue(defaultValue, propValue, value, isControlled.current),
+		memoOnChange(onChange, value, isControlled.current)
 	];
 }
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Several HOCs seem to be causing unnecessary re-renders by permuting props or updating state.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Avoid updating state or generating new props when not needed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
No regressions have been seen from this but if components were counting on the unnecessary re-renders, they could have problems.

### Links
[//]: # (Related issues, references)
PLAT-112393

### Comments
