### PR TITLE
PLAT-112054: Fix Scroller to update clientSize when it's changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Scroller` to update clientSize when it's changed
 - `ui/VirtualList` to reset scroll position when client size changed
 
 ## [3.3.0-alpha.13] - 2020-06-22

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -163,6 +163,25 @@ class ScrollerBasic extends Component {
 		scrollBounds.maxTop = Math.max(0, scrollHeight - clientHeight);
 	}
 
+	syncClientSize = () => {
+		const node = this.props.scrollContentRef.current;
+
+		if (!node) {
+			return false;
+		}
+
+		const
+			{clientWidth, clientHeight} = node,
+			{scrollBounds} = this;
+
+		if (clientWidth !== scrollBounds.clientWidth || clientHeight !== scrollBounds.clientHeight) {
+			this.calculateMetrics();
+			return true;
+		}
+
+		return false;
+	}
+
 	render () {
 		const
 			{className, style, ...rest} = this.props,


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When client size changed from outside, Scroller couldn't recalculate its scrollBounds unless it's rerendered.
VirtualList on the other hand has `syncClientSize` function to handle this.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `syncClientSize` function to Scroller.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-112054

### Comments
