### PR TITLE
PLAT-111891: Fix mapAndFilterChildren to pass index to callback

### DIFF
--- a/packages/core/util/tests/util-specs.js
+++ b/packages/core/util/tests/util-specs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {memoize, isRenderable} from '../util';
+import {mapAndFilterChildren, memoize, isRenderable} from '../util';
 
 describe('util', () => {
 	describe('isRenderable', () => {
@@ -65,6 +65,47 @@ describe('util', () => {
 			const actual = spy.mock.calls[0];
 
 			expect(expected).toEqual(actual);
+		});
+	});
+
+	describe('mapAndFilterChildren', () => {
+		test('should omit false and null-ish values', () => {
+			// eslint-disable-next-line no-undefined
+			const result = mapAndFilterChildren([1, null, false, undefined, '', NaN], v => v);
+
+			const expected = [1, '', NaN];
+			const actual = result;
+
+			expect(expected).toEqual(actual);
+		});
+
+		test('should not invoke callback for false and null-ish values', () => {
+			const spy = jest.fn();
+
+			// eslint-disable-next-line no-undefined
+			mapAndFilterChildren([1, null, false, undefined, '', NaN], spy);
+
+			expect(spy).toBeCalledTimes(3);
+		});
+
+		test('should forward value and index to callback', () => {
+			const spy = jest.fn();
+			mapAndFilterChildren([1], spy);
+
+			const expected = [
+				1, // value
+				0 // index
+			];
+			const actual = spy.mock.calls[0];
+
+			expect(expected).toEqual(actual);
+		});
+
+		test('should invoke filter', () => {
+			const spy = jest.fn().mockImplementation(() => true);
+			mapAndFilterChildren([1], v => v, spy);
+
+			expect(spy).toBeCalledTimes(1);
 		});
 	});
 });

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -250,9 +250,9 @@ const memoize = (fn) => {
  * @public
  */
 const mapAndFilterChildren = (children, callback, filter) => {
-	const result = React.Children.map(children, (child) => {
+	const result = React.Children.map(children, (child, ...rest) => {
 		if (child != null) {
-			return callback(child);
+			return callback(child, ...rest);
 		} else {
 			return child;
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some consumers of `React.Children.map` rely on the index arg of the callback to operate but `mapAndFilterChildren` did not forward it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Forward `...rest` for safety to callback

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Added unit tests!
