### PR TITLE
PLAT-111149: Replace Cell and Row to div for performance

### DIFF
--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -26,8 +26,8 @@ const
 		return (
 			<UiImageItem
 				{...rest}
-				style={{width: '100%'}}
 				src={source}
+				style={{width: '100%'}}
 			>
 				{text}
 			</UiImageItem>

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -26,6 +26,7 @@ const
 		return (
 			<UiImageItem
 				{...rest}
+				style={{width: '100%'}}
 				src={source}
 			>
 				{text}

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -27,7 +27,6 @@ const
 			<UiImageItem
 				{...rest}
 				src={source}
-				style={{width: '100%'}}
 			>
 				{text}
 			</UiImageItem>

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -12,7 +12,6 @@ import React from 'react';
 
 import ComponentOverride from '../ComponentOverride';
 import Image from '../Image';
-import {Cell, Column, Row} from '../Layout';
 
 import componentCss from './ImageItem.module.less';
 
@@ -126,33 +125,29 @@ const ImageItemBase = kind({
 		})
 	},
 
-	render: ({children, css, imageComponent, orientation, placeholder, src, ...rest}) => {
+	render: ({children, css, imageComponent: ImageComponent, orientation, placeholder, src, ...rest}) => {
 		delete rest.selected;
-
 		const isHorizontal = orientation === 'horizontal';
-		const Component = isHorizontal ? Row : Column;
 
 		return (
-			<Component {...rest}>
-				<Cell
+			<div {...rest}>
+				<ImageOverride
+					component={ImageComponent}
 					className={css.image}
-					component={ImageOverride}
-					imageComponent={imageComponent}
 					placeholder={placeholder}
-					shrink={isHorizontal}
 					src={src}
 				/>
 				{children ? (
-					<Cell
+					<div
 						className={css.caption}
-						shrink={!isHorizontal}
 						// eslint-disable-next-line no-undefined
 						align={isHorizontal ? 'center' : undefined}
 					>
 						{children}
-					</Cell>
+					</div>
+
 				) : null}
-			</Component>
+			</div>
 		);
 	}
 });

--- a/packages/ui/ImageItem/ImageItem.module.less
+++ b/packages/ui/ImageItem/ImageItem.module.less
@@ -2,8 +2,6 @@
 //
 .imageItem {
 	box-sizing: border-box;
-	width: 100%;
-	height: 100%;
 
 	.image {
 		position: relative;
@@ -13,6 +11,7 @@
 
 	.caption,
 	&.selected {
+		width: 100%;
 		/* Public Class Names */
 	}
 
@@ -25,14 +24,19 @@
 		}
 		.image+div {
 			display: inline-block;
+			width: 75%;
 			vertical-align: middle;
 		}
 	}
 
 	&.vertical {
+		height: 100%;
 		.image {
 			width: 100%;
 			height: calc(100% - 50px);
+		}
+		.image+div {
+			height: 50px;
 		}
 	}
 }

--- a/packages/ui/ImageItem/ImageItem.module.less
+++ b/packages/ui/ImageItem/ImageItem.module.less
@@ -24,8 +24,8 @@
 		}
 		.image+div {
 			display: inline-block;
-			width: 75%;
 			vertical-align: middle;
+			width: 75%;
 		}
 	}
 

--- a/packages/ui/ImageItem/ImageItem.module.less
+++ b/packages/ui/ImageItem/ImageItem.module.less
@@ -4,22 +4,29 @@
 	box-sizing: border-box;
 
 	.image {
+		position: relative;
 		display: block; // leaving this to prevent whitespace between inline-block elements
 		margin: 0;
 	}
-	
+
 	.caption,
 	&.selected {
 		/* Public Class Names */
 	}
-	
+
 	&.horizontal {
 		.image {
+			display: inline-block;
+			vertical-align: top;	 //TODO : adjust align.
+			// TODO fix marque bug
 			width: 25%;
 			height: 100%;
 		}
+		.image+div {
+			display: inline-block;
+		}
 	}
-	
+
 	&.vertical {
 		.image {
 			width: 100%;

--- a/packages/ui/ImageItem/ImageItem.module.less
+++ b/packages/ui/ImageItem/ImageItem.module.less
@@ -2,6 +2,8 @@
 //
 .imageItem {
 	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
 
 	.image {
 		position: relative;
@@ -30,7 +32,7 @@
 	&.vertical {
 		.image {
 			width: 100%;
-			height: 100%;
+			height: calc(100% - 50px);
 		}
 	}
 }

--- a/packages/ui/ImageItem/ImageItem.module.less
+++ b/packages/ui/ImageItem/ImageItem.module.less
@@ -17,13 +17,13 @@
 	&.horizontal {
 		.image {
 			display: inline-block;
-			vertical-align: top;	 //TODO : adjust align.
-			// TODO fix marque bug
+			vertical-align: middle;
 			width: 25%;
 			height: 100%;
 		}
 		.image+div {
 			display: inline-block;
+			vertical-align: middle;
 		}
 	}
 

--- a/packages/ui/ImageItem/tests/ImageItem-specs.js
+++ b/packages/ui/ImageItem/tests/ImageItem-specs.js
@@ -35,12 +35,12 @@ describe('ImageItem', () => {
 		expect(actual).toHaveLength(0);
 	});
 
-	test('should use a `Row` when `orientation="horizontal"`', () => {
+	test('should use a `div` when `orientation="horizontal"`', () => {
 		const subject = shallow(
 			<ImageItemBase orientation="horizontal" />
 		);
 
-		const actual = subject.find('Row.imageItem');
+		const actual = subject.find('div.imageItem');
 
 		expect(actual).toHaveLength(1);
 	});
@@ -56,12 +56,12 @@ describe('ImageItem', () => {
 		expect(actual).toContain(expected);
 	});
 
-	test('should use a `Column` when `orientation="vertical"`', () => {
+	test('should use a `div` when `orientation="vertical"`', () => {
 		const subject = shallow(
 			<ImageItemBase orientation="vertical" />
 		);
 
-		const actual = subject.find('Column.imageItem');
+		const actual = subject.find('div.imageItem');
 
 		expect(actual).toHaveLength(1);
 	});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Current ImageItem has a performance issue in VirtualList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace "Cell" and "Row" to "div" to become a performance

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-111149

### Comments
