### PR TITLE
PLAT-112276: Provides `stopPropagation` methods from `forwardWithPrevent` handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/handle.forwardWithPrevent` handler to provide `stopPropagation` and `persist` method for compatibility React synthetic event
+
 ## [3.3.0-alpha.14] - 2020-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `core/handle.forwardWithPrevent` handler to provide `stopPropagation` and `persist` method for compatibility React synthetic event
-
 ## [3.3.0-alpha.14] - 2020-06-29
 
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/handle.forwardWithPrevent` handler to provide `stopPropagation` and `persist` method for compatibility React synthetic event
+
 ## [3.3.0-alpha.14] - 2020-06-29
 
 ### Added

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -415,6 +415,29 @@ const forward = handle.forward = curry(named((name, ev, props) => {
 const preventDefault = handle.preventDefault = callOnEvent('preventDefault');
 
 /**
+ * Calls `event.stopPropagation()` and returns `true`
+ *
+ * Example:
+ * ```
+ * import {handle, stop} from '@enact/core/handle';
+ *
+ * const stopAndLog = handle(
+ *   stop,
+ *   (ev) => console.log('stopPropagation called', ev)
+ * );
+ * ```
+ *
+ * @method   stop
+ * @param    {Object}   ev  Event payload
+ *
+ * @returns  {true}         Always returns `true`
+ * @curried
+ * @memberof core/handle
+ * @public
+ */
+const stop = handle.stop = named(callOnEvent('stopPropagation'), 'stop');
+
+/**
  * Forwards the event to a function at `name` on `props` with capability to prevent default
  * behavior. If the specified prop is `undefined` or is not a function, it is ignored. Returns
  * `false` when `event.preventDefault()` has been called in a handler.
@@ -442,38 +465,21 @@ const preventDefault = handle.preventDefault = callOnEvent('preventDefault');
 const forwardWithPrevent = handle.forwardWithPrevent = curry(named((name, ev, props) => {
 	let prevented = false;
 	const wrappedEvent = Object.assign({}, ev, {
+		persist: () => {
+			callOnEvent('persist', ev);
+		},
 		preventDefault: () => {
 			prevented = true;
 			preventDefault(ev);
+		},
+		stopPropagation: () => {
+			stop(ev);
 		}
 	});
 	forward(name, wrappedEvent, props);
 
 	return !prevented;
 }, 'forwardWithPrevent'));
-
-/**
- * Calls `event.stopPropagation()` and returns `true`
- *
- * Example:
- * ```
- * import {handle, stop} from '@enact/core/handle';
- *
- * const stopAndLog = handle(
- *   stop,
- *   (ev) => console.log('stopPropagation called', ev)
- * );
- * ```
- *
- * @method   stop
- * @param    {Object}   ev  Event payload
- *
- * @returns  {true}         Always returns `true`
- * @curried
- * @memberof core/handle
- * @public
- */
-const stop = handle.stop = named(callOnEvent('stopPropagation'), 'stop');
 
 /**
  * Calls `event.stopImmediatePropagation()` and returns `true`


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`forwardWithPrevent` handler provides most required event info including `preventDefault` function, but not `stopPropagation` and `persist` functions. So if a parent component uses `onKeyDown` prop for a child component that forwards event via `forwardWithPrevent`, it is impossible to call `stopPropagation` or `persist` function in the parent component's scope.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`stopPropagation` and `persist` functions are added to the forwarded event info from `forwardWithPrevent`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Not like `stopPropagation`, `persist` is not so essential since we provide cloned event info rather than the original info. But, in a viewpoint of _API compatibility_, it looks better to provide `persist` also.

### Links
[//]: # (Related issues, references)
PLAT-112276

### Comments
