### PR TITLE
PLAT-112276: Fixed to provide `stopPropagation` methods in key down hander from `Spottable`

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to enable `stopPropagation` method from forwarding keydown events
+
 ## [3.3.0-alpha.14] - 2020-06-29
 
 ### Added

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight/Spottable` to enable `stopPropagation` method from forwarding keydown events
+- `spotlight/Spottable` to enable `stopPropagation` method from forwarding keyup and keydown events
 
 ## [3.3.0-alpha.14] - 2020-06-29
 

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -307,27 +307,12 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			return true;
 		}
 
-		forwardWithPrevent = (name, ev, props) => {
-			let allow = true;
-			forward(name, new Proxy(ev, {
-				get (original, member) {
-					if (member === 'preventDefault') {
-						return () => {
-							allow = false;
-							original.preventDefault();
-						};
-					}
-					return original[member];
-				}
-			}), props);
-			return allow;
-		}
-
 		forwardAndResetLastSelectTarget = (ev, props) => {
 			const {keyCode} = ev;
 			const {selectionKeys} = props;
 			const key = selectionKeys.find((value) => keyCode === value);
-			const notPrevented = this.forwardWithPrevent('onKeyUp', ev, props);
+			forward('onKeyUp', ev, props);
+			const notPrevented = !ev.defaultPrevented;
 
 			// bail early for non-selection keyup to avoid clearing lastSelectTarget prematurely
 			if (!key && (!is('enter', keyCode) || !getDirection(keyCode))) {
@@ -345,7 +330,8 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		handle = handle.bind(this)
 
 		handleKeyDown = this.handle(
-			(ev, props) => this.forwardWithPrevent('onKeyDown', ev, props),
+			forward('onKeyDown'),
+			(ev) => !ev.defaultPrevented,
 			this.forwardSpotlightEvents,
 			this.isActionable,
 			this.handleSelect,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Spottable` uses `forwardWithPrevent` to handle key events, so an outer component cannot call `stopPropagation` method. (e.g. ev.stopPropagation()) `forwardWithPrevent` is designed for a custom event, so it supports just `preventDefault` and does not provide other methods of a native event or a React synthetic event.
To make the outer component able to stop propagation, `Spottable` should not use `forwardWithPrevent` from `handle`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated `Spottable` logic to use `forward` and check `defaultPrevented`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
To avoid any unexpected impact on `handle` module, the original `forwardWithPrevent` is not changed.

### Links
[//]: # (Related issues, references)
PLAT-112276

### Comments
This PR replaces #2808 