### PR TITLE
PLAT-113142: Use ilib-webos NPM package in webOS templates and framework setup

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -52,7 +52,7 @@
     "xhr": "^2.4.1"
   },
   "peerDependencies": {
-    "ilib": "^14.4.0 || ^14.4.0-webostv1"
+    "ilib": "^14.4.0 || ^14.6.0-webos"
   },
   "devDependencies": {
     "@enact/ui-test-utils": "^0.3.2",


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* Previously only supported peer dependency of ilib `^14.4.0` (`ilib`) or `^14.4.0-webostv1` (`ilib-webos-tv`). Need to support `ilib-webos` as well (aka `#.#.#-webos#` versioning format).

### Resolution
* Use a general `^14.4.0 || ^14.6.0-webos` to support all webosa ilib variant version numbers. Then NPM aliases will work correctly.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>