### PR TITLE
PLAT-110252: Sampler - WizardPanel: 'onTransition' event emit in Actions when story first loads

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/ViewManager.TransitionGroup` to suppres `onTransition` events when a view appears or stays
+
 ## [3.3.0-alpha.15] - 2020-07-07
 
 No significant changes.

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -227,7 +227,7 @@ class TransitionGroup extends React.Component {
 		// that have fallen out of the `children` array and manually clean them up from the map.
 		prevChildKeys
 			.filter(key => !nextChildKeys.includes(key))
-			.forEach(key => this.completeTransition(key));
+			.forEach(key => this.completeTransition({key}));
 	}
 
 	reconcileChildren (prevActiveChildMapping, nextActiveChildMapping) {
@@ -243,7 +243,7 @@ class TransitionGroup extends React.Component {
 		}
 
 		// remove any "dropped" children from the list of transitioning children
-		droppedKeys.forEach(key => this.completeTransition(key));
+		droppedKeys.forEach(key => this.completeTransition({key}));
 
 		// mark any new child as entering
 		nextChildKeys.forEach((key, index) => {
@@ -292,11 +292,11 @@ class TransitionGroup extends React.Component {
 		keysToLeave.forEach(this.performLeave);
 	}
 
-	completeTransition (key) {
+	completeTransition ({key, noForwarding = false}) {
 		if (key in this.currentlyTransitioningKeys) {
 			delete this.currentlyTransitioningKeys[key];
 
-			if (Object.keys(this.currentlyTransitioningKeys).length === 0) {
+			if (!noForwarding && Object.keys(this.currentlyTransitioningKeys).length === 0) {
 				forwardOnTransition(null, this.props);
 			}
 		}
@@ -326,7 +326,7 @@ class TransitionGroup extends React.Component {
 			view: component
 		}, this.props);
 
-		this.completeTransition(key);
+		this.completeTransition({key, noForwarding: true});
 
 		let currentChildMapping = mapChildren(this.props.children);
 
@@ -360,7 +360,7 @@ class TransitionGroup extends React.Component {
 			view: component
 		}, this.props);
 
-		this.completeTransition(key);
+		this.completeTransition({key});
 	}
 
 	performStay = (key) => {
@@ -411,7 +411,7 @@ class TransitionGroup extends React.Component {
 			view: component
 		}, this.props);
 
-		this.completeTransition(key);
+		this.completeTransition({key});
 
 		this.setState(function (state) {
 			const index = indexOfChild(key, state.children);

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -367,6 +367,22 @@ describe('ViewManager', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
+	it('should not receive onTransition event on mount', () => {
+		const spy = jest.fn();
+
+		mount(
+			<ViewManager index={0} onTransition={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		const expected = 0;
+		const actual = spy.mock.calls.length;
+
+		expect(actual).toBe(expected);
+	});
+
 	test('should include the current index and previous index in onTransition event payload', () => {
 		const spy = jest.fn();
 		const subject = mount(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the `stay` transition was added to `ui/ViewManager.Arranger.BasicArranger` it caused `onTransition` events to be sent even when no transition had actually occurred (i.e. on mount) for consumers using `BasicArranger`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The fix is to modify `ui/ViewManager.TransitionGroup` to not send transition events when a view "appears" so that only `leave` and `enter` will send them.

### Links
[//]: # (Related issues, references)
PLAT-110252
