### PR TITLE
PLAT-113458: Replace straightOnlyLeave with partition config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ No significant changes.
 ### Added
 
 - `core/util` function `mapAndFilterChildren` to safely iterate over React `children`
-- `spotlight` container config prop `straightOnlyLeave` to prevent navigation to oblique containers when leaving the current container
 
 ### Fixed
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` behavior when navigating from a container within a `straightOnlyLeave` container
+
 ## [3.3.0-alpha.15] - 2020-07-07
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,21 +2,13 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `spotlight` behavior when navigating from a container within a `straightOnlyLeave` container
-
 ## [3.3.0-alpha.15] - 2020-07-07
 
 No significant changes.
 
 ## [3.3.0-alpha.14] - 2020-06-29
 
-### Added
-
-- `spotlight` container config prop `straightOnlyLeave` to prevent navigation to oblique containers when leaving the current container
+No significant changes.
 
 ## [3.3.0-alpha.13] - 2020-06-22
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -67,13 +67,13 @@ let GlobalConfig = {
 	onLeaveContainer: null,      // @private - notify the container when leaving via 5-way
 	onLeaveContainerFail: null,  // @private - notify the container when failing to leave via 5-way
 	overflow: false,
+	partition: false, // use the container bounds for partitioning when leaving
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
 	selector: '',           // can be a valid <extSelector> except "@" syntax.
 	selectorDisabled: false,
 	straightMultiplier: 1,
 	straightOnly: false,
-	straightOnlyLeave: false, // prevents navigation to oblique containers when leaving the current container
 	straightOverlapThreshold: 0.5,
 	tabIndexIgnoreList: 'a, input, select, textarea, button, iframe, [contentEditable=true]'
 };

--- a/packages/spotlight/src/navigate.js
+++ b/packages/spotlight/src/navigate.js
@@ -217,7 +217,7 @@ function generateDistancefunction (targetRect) {
 	};
 }
 
-function navigate (targetRect, direction, rects, config) {
+function navigate (targetRect, direction, rects, config, partitionRect = targetRect) {
 	if (!targetRect || !direction || !rects || !rects.length || !config) {
 		return null;
 	}
@@ -227,7 +227,7 @@ function navigate (targetRect, direction, rects, config) {
 
 	const groups = partition(
 		rects,
-		targetRect,
+		partitionRect,
 		straightOverlapThreshold,
 		(rect, destRect) => (
 			calcGroupId(

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -352,22 +352,28 @@ const Spotlight = (function () {
 						if (config && config.enterTo) {
 							return getContainerRect(id);
 						}
-					}, null) || getRect(next);
+					}, null);
 
-					const currentContainerRect = getContainerRect(straighOnlyLeaveContainer);
+					// If we find a container around the target that is within the first shared
+					// container and is a restricted container, verify that it matches straightOnly
+					// rules. If we don't find one, it means that the target is not within a
+					// restricted container and normal 5-way rules should apply so we bail out.
+					if (nextRect) {
+						const currentContainerRect = getContainerRect(straighOnlyLeaveContainer);
 
-					// prevent focus for obliquely leaving straightOnlyLeave containers
-					if (
-						(
-							(direction === 'left' || direction === 'right') &&
-							(nextRect.bottom < currentContainerRect.top || nextRect.top > currentContainerRect.bottom)
-						) ||
-						(
-							(direction === 'up' || direction === 'down') &&
-							(nextRect.right < currentContainerRect.left || nextRect.left > currentContainerRect.right)
-						)
-					) {
-						return false;
+						// prevent focus for obliquely leaving straightOnlyLeave containers
+						if (
+							(
+								(direction === 'left' || direction === 'right') &&
+								(nextRect.bottom < currentContainerRect.top || nextRect.top > currentContainerRect.bottom)
+							) ||
+							(
+								(direction === 'up' || direction === 'down') &&
+								(nextRect.right < currentContainerRect.left || nextRect.left > currentContainerRect.right)
+							)
+						) {
+							return false;
+						}
 					}
 				}
 			}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -336,40 +336,6 @@ const Spotlight = (function () {
 				if (_5WayKeyHold && !isContainer5WayHoldable(currentContainerId)) {
 					return false;
 				}
-
-				// find the nearest ancestral container that is configured for `straightOnlyLeave`
-				const straighOnlyLeaveContainer = currentContainerIds.slice().reverse().find(id => getContainerConfig(id).straightOnlyLeave);
-
-				if (straighOnlyLeaveContainer) {
-					// find the bounds of either the closest non-shared restricted container or, if
-					// none exists, the bounds of the next target
-					const uniqueNextContainers = nextContainerIds.filter(id => !currentContainerIds.includes(id));
-					const nextRect = uniqueNextContainers.reduceRight((result, id) => {
-						if (result) return result;
-
-						const config = getContainerConfig(id);
-
-						if (config && config.enterTo) {
-							return getContainerRect(id);
-						}
-					}, null) || getRect(next);
-
-					const currentContainerRect = getContainerRect(straighOnlyLeaveContainer);
-
-					// prevent focus for obliquely leaving straightOnlyLeave containers
-					if (
-						(
-							(direction === 'left' || direction === 'right') &&
-							(nextRect.bottom < currentContainerRect.top || nextRect.top > currentContainerRect.bottom)
-						) ||
-						(
-							(direction === 'up' || direction === 'down') &&
-							(nextRect.right < currentContainerRect.left || nextRect.left > currentContainerRect.right)
-						)
-					) {
-						return false;
-					}
-				}
 			}
 
 			notifyLeaveContainer(

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -327,13 +327,10 @@ const Spotlight = (function () {
 			const currentContainerId = last(currentContainerIds);
 			const nextContainerIds = getContainersForNode(next);
 
-			if (nextContainerIds.indexOf(currentContainerId) < 0) {
-
-				// prevent focus if 5-way is being held and the next element isn't wrapped by
-				// the current element's immediate container
-				if (_5WayKeyHold && !isContainer5WayHoldable(currentContainerId)) {
-					return false;
-				}
+			// prevent focus if 5-way is being held and the next element isn't wrapped by
+			// the current element's immediate container
+			if (_5WayKeyHold && nextContainerIds.indexOf(currentContainerId) < 0 && !isContainer5WayHoldable(currentContainerId)) {
+				return false;
 			}
 
 			notifyLeaveContainer(

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -78,8 +78,6 @@ import {
 } from './target';
 
 import {
-	getContainerRect,
-	getRect,
 	matchSelector,
 	parseSelector
 } from './utils';

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -352,28 +352,22 @@ const Spotlight = (function () {
 						if (config && config.enterTo) {
 							return getContainerRect(id);
 						}
-					}, null);
+					}, null) || getRect(next);
 
-					// If we find a container around the target that is within the first shared
-					// container and is a restricted container, verify that it matches straightOnly
-					// rules. If we don't find one, it means that the target is not within a
-					// restricted container and normal 5-way rules should apply so we bail out.
-					if (nextRect) {
-						const currentContainerRect = getContainerRect(straighOnlyLeaveContainer);
+					const currentContainerRect = getContainerRect(straighOnlyLeaveContainer);
 
-						// prevent focus for obliquely leaving straightOnlyLeave containers
-						if (
-							(
-								(direction === 'left' || direction === 'right') &&
-								(nextRect.bottom < currentContainerRect.top || nextRect.top > currentContainerRect.bottom)
-							) ||
-							(
-								(direction === 'up' || direction === 'down') &&
-								(nextRect.right < currentContainerRect.left || nextRect.left > currentContainerRect.right)
-							)
-						) {
-							return false;
-						}
+					// prevent focus for obliquely leaving straightOnlyLeave containers
+					if (
+						(
+							(direction === 'left' || direction === 'right') &&
+							(nextRect.bottom < currentContainerRect.top || nextRect.top > currentContainerRect.bottom)
+						) ||
+						(
+							(direction === 'up' || direction === 'down') &&
+							(nextRect.right < currentContainerRect.left || nextRect.left > currentContainerRect.right)
+						)
+					) {
+						return false;
 					}
 				}
 			}

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -311,7 +311,7 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 		const straighOnlyLeaveContainer = elementContainerIds
 			.slice(elementContainerIds.indexOf(containerId) + 1)
 			.find(id => {
-				const cfg = getContainerConfig(id)
+				const cfg = getContainerConfig(id);
 				return cfg && cfg.straightOnlyLeave;
 			});
 

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -305,18 +305,18 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 			break;
 		}
 
-		// If one of the downstream containers is configured for straightOnlyLeave, we use that
+		// If one of the downstream containers is configured for partition, we use that
 		// container's bounds as the partition rect for navigation.
-		const straightOnlyLeaveContainer = elementContainerIds
+		const partitionContainer = elementContainerIds
 			.slice(elementContainerIds.indexOf(containerId) + 1)
 			.find(id => {
 				const cfg = getContainerConfig(id);
-				return cfg && cfg.straightOnlyLeave;
+				return cfg && cfg.partition;
 			});
 
 		let partitionRect = elementRect;
-		if (straightOnlyLeaveContainer) {
-			partitionRect = getContainerRect(straightOnlyLeaveContainer);
+		if (partitionContainer) {
+			partitionRect = getContainerRect(partitionContainer);
 		}
 
 		// try to navigate from element to one of the candidates in containerId

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -305,6 +305,20 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 			break;
 		}
 
+		// If one of the downstream containers is configured for straightOnlyLeave, we use that
+		// container's bounds as the source rect for navigation. It's not really "straight only" but
+		// more like `enterTo` causing spotlight to treat the container as a unit (but for leaving).
+		const straighOnlyLeaveContainer = elementContainerIds
+			.slice(elementContainerIds.indexOf(containerId) + 1)
+			.find(id => {
+				const cfg = getContainerConfig(id)
+				return cfg && cfg.straightOnlyLeave;
+			});
+
+		if (straighOnlyLeaveContainer) {
+			elementRect = getContainerRect(straighOnlyLeaveContainer);
+		}
+
 		// try to navigate from element to one of the candidates in containerId
 		next = navigate(
 			elementRect,

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -306,8 +306,7 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 		}
 
 		// If one of the downstream containers is configured for straightOnlyLeave, we use that
-		// container's bounds as the source rect for navigation. It's not really "straight only" but
-		// more like `enterTo` causing spotlight to treat the container as a unit (but for leaving).
+		// container's bounds as the partition rect for navigation.
 		const straighOnlyLeaveContainer = elementContainerIds
 			.slice(elementContainerIds.indexOf(containerId) + 1)
 			.find(id => {
@@ -315,8 +314,9 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 				return cfg && cfg.straightOnlyLeave;
 			});
 
+		let partitionRect = elementRect;
 		if (straighOnlyLeaveContainer) {
-			elementRect = getContainerRect(straighOnlyLeaveContainer);
+			partitionRect = getContainerRect(straighOnlyLeaveContainer);
 		}
 
 		// try to navigate from element to one of the candidates in containerId
@@ -324,7 +324,8 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 			elementRect,
 			direction,
 			elementRects,
-			getContainerConfig(containerId)
+			getContainerConfig(containerId),
+			partitionRect
 		);
 
 		// if we match a container,

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -307,7 +307,7 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 
 		// If one of the downstream containers is configured for straightOnlyLeave, we use that
 		// container's bounds as the partition rect for navigation.
-		const straighOnlyLeaveContainer = elementContainerIds
+		const straightOnlyLeaveContainer = elementContainerIds
 			.slice(elementContainerIds.indexOf(containerId) + 1)
 			.find(id => {
 				const cfg = getContainerConfig(id);
@@ -315,8 +315,8 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 			});
 
 		let partitionRect = elementRect;
-		if (straighOnlyLeaveContainer) {
-			partitionRect = getContainerRect(straighOnlyLeaveContainer);
+		if (straightOnlyLeaveContainer) {
+			partitionRect = getContainerRect(straightOnlyLeaveContainer);
 		}
 
 		// try to navigate from element to one of the candidates in containerId

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -169,6 +169,14 @@ class VirtualListBasic extends Component {
 		direction: PropTypes.oneOf(['horizontal', 'vertical']),
 
 		/**
+		 * Called to get the scroll affordance from themed component.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		getAffordance: PropTypes.func,
+
+		/**
 		 * Called to get the props for list items.
 		 *
 		 * @type {Function}
@@ -291,6 +299,7 @@ class VirtualListBasic extends Component {
 		cbScrollTo: nop,
 		dataSize: 0,
 		direction: 'vertical',
+		getAffordance: () => (0),
 		overhang: 3,
 		pageScroll: false,
 		scrollMode: 'translate',
@@ -1148,7 +1157,7 @@ class VirtualListBasic extends Component {
 		}
 	}
 
-	getScrollHeight = () => (this.isPrimaryDirectionVertical ? this.getVirtualScrollDimension() : this.scrollBounds.clientHeight)
+	getScrollHeight = () => (this.isPrimaryDirectionVertical ? this.getVirtualScrollDimension() + this.props.getAffordance() : this.scrollBounds.clientHeight)
 
 	getScrollWidth = () => (this.isPrimaryDirectionVertical ? this.scrollBounds.clientWidth : this.getVirtualScrollDimension())
 
@@ -1207,6 +1216,7 @@ class VirtualListBasic extends Component {
 		delete rest.clientSize;
 		delete rest.dataSize;
 		delete rest.direction;
+		delete rest.getAffordance;
 		delete rest.getComponentProps;
 		delete rest.isHorizontalScrollbarVisible;
 		delete rest.isVerticalScrollbarVisible;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When navigating from a container within a `straightOnlyLeave` container, the straight-only would be ignored.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Update the logic to:
* check upstream containers to find the first with `straightOnlyLeave` configured rather than only checkout the nearest container
* treat restricted containers (those with `enterTo` configured) as the "straight only" comparisons falling back to the target itself if it doesn't exist in any restricted containers
* limit the container search to those unique to the target to avoid comparing bounds of shared upstream containers

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

* We should refactor this logic somewhere else later. It's too much (imo) to be embedded within `spotNext`
* This lacks any automated testing atm which is definitely suboptimal but out of scope for now
