### PR TITLE
PLAT-113576: Fix Spottable to be compatible with moonstone 3.2.5

### DIFF
--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -311,7 +311,21 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			const {keyCode} = ev;
 			const {selectionKeys} = props;
 			const key = selectionKeys.find((value) => keyCode === value);
-			forward('onKeyUp', ev, props);
+
+			// FIXME: temporary patch to maintain compatibility with moonstone 3.2.5 which
+			// deconstructs `preventDefault` from the event which is incompatible with React's
+			// synthetic event.
+			const proxy = new Proxy(ev, {
+				get (target, name) {
+					if (name === 'preventDefault') {
+						return () => ev.preventDefault();
+					}
+
+					return ev[name];
+				}
+			});
+
+			forward('onKeyUp', proxy, props);
 			const notPrevented = !ev.defaultPrevented;
 
 			// bail early for non-selection keyup to avoid clearing lastSelectTarget prematurely

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -315,17 +315,9 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			// FIXME: temporary patch to maintain compatibility with moonstone 3.2.5 which
 			// deconstructs `preventDefault` from the event which is incompatible with React's
 			// synthetic event.
-			const proxy = new Proxy(ev, {
-				get (target, name) {
-					if (name === 'preventDefault') {
-						return () => ev.preventDefault();
-					}
+			ev.preventDefault = ev.preventDefault.bind(ev);
 
-					return ev[name];
-				}
-			});
-
-			forward('onKeyUp', proxy, props);
+			forward('onKeyUp', ev, props);
 			const notPrevented = !ev.defaultPrevented;
 
 			// bail early for non-selection keyup to avoid clearing lastSelectTarget prematurely


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Moonstone 3.2.5 deconstructs `preventDefault` from the event but React's synthetic event doesn't support this (because it attempts to update `this.defaultPrevented` but fails because `preventDefault` is no longer bound to anything.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a proxy with a bound handler for `preventDefault` so moonstone doesn't break


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

We'll need to fix this in 3.2.6 of moonstone and then remove this in > 3.3.0 of enact
