### PR TITLE
PLAT-113646: [VirtualList and Scroller] Extend the time for showing scrollbar

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` scrollbar to be visible for 1000 ms
+
 ## [3.3.0] - 2020-07-13
 
 ### Changed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Scroller`, `ui/VirtualList.VirtualGridList`, and `ui/VirtualList.VirtualList` scrollbar to be visible for 1000 ms
+- `ui/Scroller`, `ui/VirtualList` scrollbar to be shown for 1000 ms
 
 ## [3.3.0] - 2020-07-13
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Scroller`, `ui/VirtualList` scrollbar to be shown for 1000 ms
+- `ui/Scroller` and `ui/VirtualList` scrollbar to be shown for 1000 ms
 
 ## [3.3.0] - 2020-07-13
 

--- a/packages/ui/useScroll/Scrollbar.js
+++ b/packages/ui/useScroll/Scrollbar.js
@@ -10,7 +10,7 @@ import ScrollbarTrack from './ScrollbarTrack';
 
 import componentCss from './Scrollbar.module.less';
 
-const scrollbarTrackHidingDelay = 400; // in milliseconds
+const scrollbarTrackHidingDelay = 1000; // in milliseconds
 
 const addClass = (element, className) => {
 	ReactDOM.findDOMNode(element).classList.add(className); // eslint-disable-line react/no-find-dom-node


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TV requested to extend the time for showing scrollbar.
GUI confirmed the time to 1000ms instead of 400ms.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change the time for exposing scrollbar to 1000ms from 400ms. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-113646

### Comments
