### PR TITLE
PLAT-111413: create scrollStopJob when changing spotlightContainerDisabled

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -108,6 +108,7 @@ const useScrollBase = (props) => {
 			scrollMode,
 			setScrollContainerHandle,
 			spacing,
+			spotlightContainerDisabled,
 			verticalScrollbar,
 			verticalScrollbarHandle,
 			wrap,
@@ -369,7 +370,7 @@ const useScrollBase = (props) => {
 		return () => {
 			ref.scrollStopJob.stop();
 		};
-	}, [direction, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, rtl, scrollMode]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [direction, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, rtl, scrollMode, spotlightContainerDisabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		const


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>


### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
[Enact QA Sampler] sandstone/Scroller>List of things: 'spotlightDisabled' dosen't take Spotlight on X Closing button
Spotlight Container Disabled prop does not work properly on Scroller and VirtualList

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Because 'data-spotlight-container-disabled' prop is used in stop function of Scroller and VirtualList, the scrollStopJob function needs to be updated when the 'data-spotlight-container-disabled' prop is changed. 
But there was no dependency of 'data-spotlight-container-disabled' to create scrollStopJob.

This patch receives the `spotlightContainerDisabled` prop from Sandstone and creates scrollStopJob. 
Otherwise, because the previously bounded scrollStopOnScroll is called, sandstone scrollStopOnScroll will use the old closure prop, so it will not refer to the latest `spotlightContainerDisabled` prop.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-111413

### Comments
