### PR TITLE
PLAT-113895: Fix Spottable hovered state

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spottable` to correctly manage focus after updating
+
 ## [3.3.0] - 2020-07-13
 
 No significant changes.

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -14,7 +14,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import {getContainersForNode} from '../src/container';
-import {hasPointerMoved} from '../src/pointer';
 import {getDirection, Spotlight} from '../src/spotlight';
 
 /**
@@ -394,16 +393,12 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleEnter = (ev) => {
 			forward('onMouseEnter', ev, this.props);
-			if (hasPointerMoved(ev.clientX, ev.clientY)) {
-				this.isHovered = true;
-			}
+			this.isHovered = true;
 		}
 
 		handleLeave = (ev) => {
 			forward('onMouseLeave', ev, this.props);
-			if (hasPointerMoved(ev.clientX, ev.clientY)) {
-				this.isHovered = false;
-			}
+			this.isHovered = false;
 		}
 
 		render () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
`Spottable` does not update its `isHovered` state correctly in all cases


### Resolution
A change in https://github.com/enactjs/enact/pull/1667 added guards to ensure the pointer moved before changing the hovered state during mouse enter/leave events. This apparently was due to maintain consistency with webOS, which originally did not fire mouse enter/leave events when a background spottable element moved/transitioned past a stationary pointer. That does not appear to be the case in webOS now, so we can remove these guards.

### Links
https://github.com/enactjs/enact/pull/1667

### Comments
I've run UI tests and they all pass with this change.