### PR TITLE
PLAT-114153: Fix Scroller and VirtualList to re-render when its size changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` and `ui/VirtualList` to re-render when its size changed
+
 ## [3.3.1] - 2020-07-20
 
 ### Changed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,10 +7,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Scroller` and `ui/VirtualList` to re-render when its size changed
-## [unrelease]
-
-### Fixed
-
 - `ui/Scroller` and `ui/VirtualList` to not fire `onScrollStop` event redundantly
 
 ## [3.3.1] - 2020-07-20

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -297,6 +297,7 @@ const useScrollBase = (props) => {
 			const {animator, resizeRegistry, scrolling, scrollStopJob} = mutableRef.current; // eslint-disable-line react-hooks/exhaustive-deps
 
 			resizeRegistry.parent = null;
+			mutableRef.current.resizeObserver.unobserve(scrollContainerRef.current);
 
 			// Before call cancelAnimationFrame, you must send scrollStop Event.
 			if (scrolling) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -309,7 +309,6 @@ const useScrollBase = (props) => {
 				}
 			};
 		}
-
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -289,15 +289,17 @@ const useScrollBase = (props) => {
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
+		const containerRef = scrollContainerRef.current;
+
 		mutableRef.current.resizeRegistry.parent = context;
-		mutableRef.current.resizeObserver.observe(scrollContainerRef.current);
+		mutableRef.current.resizeObserver.observe(containerRef);
 
 		// componentWillUnmount
 		return () => {
-			const {animator, resizeRegistry, scrolling, scrollStopJob} = mutableRef.current; // eslint-disable-line react-hooks/exhaustive-deps
+			const {animator, resizeObserver, resizeRegistry, scrolling, scrollStopJob} = mutableRef.current; // eslint-disable-line react-hooks/exhaustive-deps
 
 			resizeRegistry.parent = null;
-			mutableRef.current.resizeObserver.unobserve(scrollContainerRef.current);
+			resizeObserver.unobserve(containerRef);
 
 			// Before call cancelAnimationFrame, you must send scrollStop Event.
 			if (scrolling) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -153,6 +153,7 @@ const useScrollBase = (props) => {
 		animationInfo: null,
 
 		resizeRegistry: null,
+		resizeObserver: null,
 
 		// constants
 		pixelPerLine: 39,
@@ -289,6 +290,7 @@ const useScrollBase = (props) => {
 
 	useEffect(() => {
 		mutableRef.current.resizeRegistry.parent = context;
+		mutableRef.current.resizeObserver.observe(scrollContainerRef.current);
 
 		// componentWillUnmount
 		return () => {
@@ -356,6 +358,11 @@ const useScrollBase = (props) => {
 
 	if (mutableRef.current.resizeRegistry == null) {
 		mutableRef.current.resizeRegistry = Registry.create(handleResize);
+	}
+
+	if (mutableRef.current.resizeObserver === null) {
+		// eslint-disable-next-line no-undef
+		mutableRef.current.resizeObserver = new ResizeObserver(() => enqueueForceUpdate());
 	}
 
 	useEffect(() => {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -362,7 +362,11 @@ const useScrollBase = (props) => {
 
 	if (mutableRef.current.resizeObserver === null) {
 		// eslint-disable-next-line no-undef
-		mutableRef.current.resizeObserver = new ResizeObserver(() => enqueueForceUpdate());
+		mutableRef.current.resizeObserver = new ResizeObserver(() => {
+			if (scrollContentHandle.current.syncClientSize) {
+				scrollContentHandle.current.syncClientSize();
+			}
+		});
 	}
 
 	useEffect(() => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a Scroller or VirtualList changed its size dynamically by other elements, for example, in Panel from header height changing, it is not re-rendered so focus can be truncated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `ResizeObserver` to make Scroller or VirtualList re-render when its size has been changed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I left `resize` handler as is because it has an additional feature like scrollTo 0 position logic.

### Links
[//]: # (Related issues, references)
PLAT-114153

### Comments
