### PR TITLE
PLAT-104511: Fixed Scroller and VirtualList to not firing `onScrollStop` event redundantly

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unrelease]
+
+### Fixed
+
+- `ui/Scroller` and `ui/VirtualList` to not fire `onScrollStop` event redundantly
+
 ## [3.3.1] - 2020-07-20
 
 ### Changed

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1088,8 +1088,6 @@ const useScrollBase = (props) => {
 				scrollContentRef.current.style.scrollBehavior = 'smooth';
 			}
 
-			mutableRef.current.scrollStopJob.start();
-
 			if (props.start) {
 				props.start(animate);
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Sometimes, with a slow system, `onScrollStop` event fired redundantly when scrolling by 5 way

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed unnecessary scrollStopJob start.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-104511

### Comments
