### PR TITLE
PLAT-114518: Fix Dropdown to not lose focus when dataSize has changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/VirtualList` with scrollMode `native` to not scrollTo bottom when dataSize changed to smaller and scrollTo called with `animate: false` option
 - `ui/Scroller` and `ui/VirtualList` to not fire `onScrollStop` event redundantly
 
 ## [3.3.1] - 2020-07-20

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -584,8 +584,7 @@ class VirtualListBasic extends Component {
 			offset = primary.clientSize - primary.itemSize - optionalOffset;
 		}
 
-		position.primaryPosition -= offset;
-		position.primaryPosition = clamp(0, maxPos, position.primaryPosition);
+		position.primaryPosition = clamp(0, maxPos, position.primaryPosition - offset);
 
 		return this.gridPositionToItemPosition(position);
 	}

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1255,15 +1255,22 @@ const useScrollBase = (props) => {
 	function scrollTo (opt) {
 		if (!mutableRef.current.deferScrollTo) {
 			const {left, top} = getPositionForScrollTo(opt);
+			const targetX = (left !== null) ? left : mutableRef.current.scrollLeft;
+			const targetY = (top !== null) ? top : mutableRef.current.scrollTop;
 
 			if (props.scrollTo) {
 				props.scrollTo(opt);
 			}
 
 			mutableRef.current.scrollToInfo = null;
+
+			if (scrollMode === 'native' && scrollContentHandle.current && scrollContentHandle.current.setScrollToPositionTarget) {
+				scrollContentHandle.current.setScrollToPositionTarget(targetX, targetY);
+			}
+
 			start({
-				targetX: (left !== null) ? left : mutableRef.current.scrollLeft,
-				targetY: (top !== null) ? top : mutableRef.current.scrollTop,
+				targetX,
+				targetY,
 				animate: opt.animate
 			});
 		} else {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Sandstone Dropdown loses its focus when `dataSize`  of VL has changed to smaller.
The reason why Dropdown loses its focus is after calling `scrollTo` 0 index from Dropdown, VirtualList itself calls `scrollTo` to adjust its `scrollPosition` to update it with shrunk `maxPos` due to shrunk `dataSize`.
Before calling `scrollTo`, VirtualList checks current `scrollPosition` is bigger than `masPos`.
At this point, `scrollPosition` supposed to be '0' and VL shouldn't call `scrollTo` because Dropdown called `scrollTo` with `animate: false` option. However, by the nature of "native" scroller, `onScroll` event happens asynchronously and `scrollPosition` had the wrong value and unnecessary `scrollTo` happened from VirtualList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I introduced `scrollToPositionTarget` in VirtualListBasic. When scrollTo called with `animate: false` in scrollMode native, we set this variable and see this value from componentDidUpdate phase to determine to call `scrollTo` or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-114518

### Comments
