### PR TITLE
PLAT-114699: Add `clear` option in the ui/AnnounceDecorator.Announce.announce()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ## [unrelease]
 
+### Fixed
+
+- `ui/AnnounceDecorator` to clear previously read string by calling announce with the `clear` property
+
 ### Added
 
 - `ui/Scroller` prop `data-webos-voice-focused`, `data-webos-voice-disabled`, and `data-webos-voice-group-label`

--- a/packages/ui/AnnounceDecorator/Announce.js
+++ b/packages/ui/AnnounceDecorator/Announce.js
@@ -61,6 +61,10 @@ const Announce = class extends React.Component {
 	}
 
 	componentWillUnmount () {
+		this.clearTimeout();
+	}
+
+	clearTimeout () {
 		if (this.alertTimeout) {
 			clearTimeout(this.alertTimeout);
 		}
@@ -79,7 +83,12 @@ const Announce = class extends React.Component {
 	 * @returns {undefined}
 	 * @public
 	 */
-	announce = (message) => {
+	announce = (message, clear = false) => {
+		if (clear) {
+			this.clearTimeout();
+			this.resetAlert();
+		}
+
 		if (this.alert && !this.alertTimeout && message) {
 			this.alert.setAttribute('aria-label', message);
 			this.alertTimeout = setTimeout(this.resetAlert, this.props.timeout);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
If the announce function is called quickly (within 500 ms), the announce function call is ignored.

### Resolution
- Add `clear` property for the announce function.
- Initialize the existing setTimeout.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
PLAT-114699