### PR TITLE
PLAT-114531: Add rtl prop to ViewManager

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
-- `ui/ViewManager` prop `rtl` to allow arrangers to adjust animations to be locale aware
+- `ui/ViewManager` prop and `ui/ViewManager.Arranger` callback config prop `rtl` to allow arrangers to adjust animations to be locale aware
 
 ### Fixed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
-- `ui/ViewManager` prop `rtl` to adjust arranger animations for locales that use right-to-left reading order
+- `ui/ViewManager` prop `rtl` to allow arrangers to adjust animations to be locale aware
 
 ### Fixed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Added
+
+- `ui/ViewManager` prop `rtl` to adjust arranger animations for locales that use right-to-left reading order
+
 ### Fixed
 
 - `ui/Scroller` and `ui/VirtualList` to re-render when its size changed

--- a/packages/ui/ViewManager/Arranger.js
+++ b/packages/ui/ViewManager/Arranger.js
@@ -37,6 +37,10 @@ export const arrange = ({duration, node, reverse}, keyframes, options) => {
  * @param {Node} config.node                                   - DOM node to be animated.
  * @param {Boolean} config.reverse                             - `true` when the animation should be
  *                                                               reversed.
+ * @param {Boolean} config.rtl                                 - `true` when the ViewManager was
+ *                                                                configured with `rtl` for locales
+ *                                                                that use right-to-left reading
+ *                                                                order.
  * @param {Number} config.to                                   - Index to which the ViewManager is
  *                                                               transitioning.
  * @returns {Animation} An `Animation`-compatible object

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -125,12 +125,11 @@ class View extends React.Component {
 		reverseTransition: PropTypes.bool,
 
 		/**
-		 * When `true`, indicates the current locale uses right-to-eft reading order.
+		 * When `true`, indicates the current locale uses right-to-left reading order.
 		 *
 		 * The effect depends on how the provided `arranger` handles this option.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 */
 		rtl: PropTypes.bool
 	}

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -122,7 +122,17 @@ class View extends React.Component {
 		 * @type {Boolean}
 		 * @default false
 		 */
-		reverseTransition: PropTypes.bool
+		reverseTransition: PropTypes.bool,
+
+		/**
+		 * When `true`, indicates the current locale uses right-to-eft reading order.
+		 *
+		 * The effect depends on how the provided `arranger` handles this option.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 */
+		rtl: PropTypes.bool
 	}
 
 	static defaultProps = {
@@ -231,7 +241,7 @@ class View extends React.Component {
 	 * @private
 	 */
 	prepareTransition = (arranger, callback, noAnimation) => {
-		const {duration, index, previousIndex = index, reverseTransition} = this.props;
+		const {duration, index, previousIndex = index, reverseTransition, rtl} = this.props;
 
 		// Need to ensure that we have a valid node reference before we animation. Sometimes, React
 		// will replace the node after mount causing a reference cached there to be invalid.
@@ -245,6 +255,7 @@ class View extends React.Component {
 				from: previousIndex,
 				node: this.node,
 				reverse: reverseTransition,
+				rtl,
 				to: index,
 				fill: 'forwards',
 				duration

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -276,7 +276,7 @@ const ViewManagerBase = class extends React.Component {
 			enteringDelay,
 			enteringProp,
 			childProps,
-			rtl
+			rtl: Boolean(rtl)
 		});
 
 		delete rest.end;

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -187,6 +187,16 @@ const ViewManagerBase = class extends React.Component {
 		reverseTransition: PropTypes.bool,
 
 		/**
+		 * Indicates the current locale uses right-to-left reading order.
+		 *
+		 * `rtl` is passed to the `arranger` in order to alter the animation (e.g. reversing the
+		 * horizontal direction).
+		 *
+		 * @type {Boolean}
+		 */
+		rtl: PropTypes.bool,
+
+		/**
 		 * Index of first visible view. Defaults to the current value of `index`.
 		 *
 		 * @type {Number}
@@ -244,7 +254,7 @@ const ViewManagerBase = class extends React.Component {
 	).bindAs(this, 'handleWillTransition')
 
 	render () {
-		const {arranger, childProps, children, duration, index, noAnimation, enteringDelay, enteringProp, ...rest} = this.props;
+		const {arranger, childProps, children, duration, index, noAnimation, enteringDelay, enteringProp, rtl, ...rest} = this.props;
 		let {end = index, start = index} = this.props;
 		const {prevIndex: previousIndex, reverseTransition} = this.state;
 		const childrenList = React.Children.toArray(children);
@@ -265,7 +275,8 @@ const ViewManagerBase = class extends React.Component {
 			reverseTransition,
 			enteringDelay,
 			enteringProp,
-			childProps
+			childProps,
+			rtl
 		});
 
 		delete rest.end;

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -434,4 +434,38 @@ describe('ViewManager', () => {
 
 		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1});
 	});
+
+	test('should pass `rtl` prop to arranger when `true`', () => {
+		const spy = jest.spyOn(MockArranger, 'stay');
+		mount(
+			<ViewManager arranger={MockArranger} index={0} rtl>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		const expected = {rtl: true};
+		const actual = spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+
+		spy.mockRestore();
+	});
+
+	test('should pass `rtl` prop to arranger when unset', () => {
+		const spy = jest.spyOn(MockArranger, 'stay');
+		mount(
+			<ViewManager arranger={MockArranger} index={0}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		const expected = {rtl: false};
+		const actual = spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+
+		spy.mockRestore();
+	});
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Arrangers lack the data necessary to adjust their animation for locales with right-to-left reading order

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `rtl` prop to `ViewManager` and the arranger config.