### PR TITLE
PLAT-115093: Fix Marquee measurements for sub-pixel differences

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Marquee` to correctly animation when scaled or when less than 1px longer than its container
 - `ui/VirtualList` with scrollMode `native` to not scrollTo bottom when dataSize changed to smaller and scrollTo called with `animate: false` option
 - `ui/Scroller` and `ui/VirtualList` to re-render when its size changed
 - `ui/Scroller` and `ui/VirtualList` to not fire `onScrollStop` event redundantly

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee` to correctly animation when scaled or when less than 1px longer than its container
+- `ui/Marquee` to correctly animate when scaled or when less than 1px longer than its container
 - `ui/VirtualList` with scrollMode `native` to not scrollTo bottom when dataSize changed to smaller and scrollTo called with `animate: false` option
 - `ui/Scroller` and `ui/VirtualList` to re-render when its size changed
 - `ui/Scroller` and `ui/VirtualList` to not fire `onScrollStop` event redundantly

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -876,9 +876,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 						speed={marqueeSpeed}
 						willAnimate={this.state.promoted}
 					>
-						<span>
-							{children}
-						</span>
+						{children}
 					</MarqueeComponent>
 				</Wrapped>
 			);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -505,7 +505,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// TODO: absolute showing check (or assume that it won't be rendered if it isn't showing?)
 			if (node && this.distance == null && !this.props.marqueeDisabled) {
 				const {width} = node.getBoundingClientRect();
-				const {scrollWidth} = node;
+				const {width: scrollWidth} = node.firstChild.getBoundingClientRect();
 
 				this.spacing = this.getSpacing(width);
 				this.distance = this.calculateDistance(width, scrollWidth, this.spacing);
@@ -549,7 +549,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{String}				text-overflow value
 		 */
 		calculateTextOverflow (distance) {
-			return distance < 1 ? 'clip' : 'ellipsis';
+			return distance < 0 ? 'clip' : 'ellipsis';
 		}
 
 		getSpacing (width) {
@@ -574,7 +574,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{Boolean}				`true` if it should animated
 		 */
 		shouldAnimate (distance) {
-			return distance >= 1;
+			return distance >= 0;
 		}
 
 		/*
@@ -854,7 +854,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 						speed={marqueeSpeed}
 						willAnimate={this.state.promoted}
 					>
-						{children}
+						<span>
+							{children}
+						</span>
 					</MarqueeComponent>
 				</Wrapped>
 			);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -500,20 +500,21 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		}
 
-		measureScrollWidth () {
+		measureWidths () {
 			// move all the children into the wrapper node ...
 			const wrapper = document.createElement('span');
 			this.moveChildren(this.node, wrapper);
 			this.node.appendChild(wrapper);
 
 			// measure it to find the precise floating point width of the content ...
-			const {width} = wrapper.getBoundingClientRect();
+			const {width: scrollWidth} = wrapper.getBoundingClientRect();
+			const {width} = this.node.getBoundingClientRect();
 
 			// and move all the children back and remove the wrapper
 			this.node.removeChild(wrapper);
 			this.moveChildren(wrapper, this.node);
 
-			return width;
+			return {scrollWidth, width};
 		}
 
 		/*
@@ -526,8 +527,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			// TODO: absolute showing check (or assume that it won't be rendered if it isn't showing?)
 			if (node && this.distance == null && !this.props.marqueeDisabled) {
-				const {width} = node.getBoundingClientRect();
-				const scrollWidth = this.measureScrollWidth();
+				const {width, scrollWidth} = this.measureWidths();
 
 				this.spacing = this.getSpacing(width);
 				this.distance = this.calculateDistance(width, scrollWidth, this.spacing);

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -494,6 +494,28 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			});
 		}
 
+		moveChildren (from, to) {
+			for (let n of from.childNodes) {
+				to.appendChild(n);
+			}
+		}
+
+		measureScrollWidth () {
+			// move all the children into the wrapper node ...
+			const wrapper = document.createElement('span');
+			this.moveChildren(this.node, wrapper);
+			this.node.appendChild(wrapper);
+
+			// measure it to find the precise floating point width of the content ...
+			const {width} = wrapper.getBoundingClientRect();
+
+			// and move all the children back and remove the wrapper
+			this.node.removeChild(wrapper);
+			this.moveChildren(wrapper, this.node);
+
+			return width;
+		}
+
 		/*
 		* Determines if the component should marquee and the distance to animate
 		*
@@ -505,7 +527,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// TODO: absolute showing check (or assume that it won't be rendered if it isn't showing?)
 			if (node && this.distance == null && !this.props.marqueeDisabled) {
 				const {width} = node.getBoundingClientRect();
-				const {width: scrollWidth} = node.firstChild.getBoundingClientRect();
+				const scrollWidth = this.measureScrollWidth();
 
 				this.spacing = this.getSpacing(width);
 				this.distance = this.calculateDistance(width, scrollWidth, this.spacing);
@@ -549,7 +571,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{String}				text-overflow value
 		 */
 		calculateTextOverflow (distance) {
-			return distance < 0 ? 'clip' : 'ellipsis';
+			return distance === 0 ? 'clip' : 'ellipsis';
 		}
 
 		getSpacing (width) {
@@ -574,7 +596,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{Boolean}				`true` if it should animated
 		 */
 		shouldAnimate (distance) {
-			return distance >= 0;
+			return distance > 0;
 		}
 
 		/*


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
* If the length of the text is < 1px longer than the size of the container, marquee will show an ellipsis initially and then switch to clipping
* If the marquee instance is within a scaled container, the measurements are incorrect resulting in the wrong animation behavior

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Wrap the text in another DOM node for measurement so `getBoundingClientRect()` (which handles subpixel measurements and includes the effects of a transform) can be used for both the container and the content sizing.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Single instance case:
![image](https://user-images.githubusercontent.com/788456/88724396-3f822680-d0df-11ea-8920-7898d9afb136.png)

Also created 11 copies of the below two instances of marquee which consumed an average of 5.5ms (most of which was in layout / recalc style).
 
```jsx
<Marquee marqueeOn="render">short</Marquee>
<Marquee marqueeOn="render">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id blandit nunc. Donec lacinia nisi vitae mi dictum, eget pulvinar nunc tincidunt. Integer vehicula tempus rutrum. Sed efficitur neque in arcu dignissim cursus.</Marquee>
```

I consolidated the measurements into `measureWidths` to avoid multiple layouts. I didn't see any instances in my above sample in which additional layout was required during measurement.