### PR TITLE
PLAT-115093: Fix Marquee to move all nodes

### DIFF
--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -495,8 +495,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		moveChildren (from, to) {
-			for (let n of from.childNodes) {
-				to.appendChild(n);
+			while (from.childNodes.length) {
+				to.appendChild(from.childNodes.item(0));
 			}
 		}
 


### PR DESCRIPTION
### Issue

I though `for / of` not be a live iterator and therefore not update when nodes were moved. It seems that it is so the method fails to move multiple children into and back out of the wrapper.

### Resolution

Use a `while` loop instead!