### PR TITLE
Feature/marqueeoncontroller

### DIFF
--- a/packages/ui/Marquee/MarqueeController.js
+++ b/packages/ui/Marquee/MarqueeController.js
@@ -1,6 +1,7 @@
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {Job} from '@enact/core/util';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const STATE = {
@@ -45,6 +46,20 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 
 	return class extends React.Component {
 		static displayName = 'MarqueeController'
+
+		static propTypes = /** @lends ui/Marquee.MarqueeController.prototype */ {
+			/**
+			 * Determines what triggers the marquee to start its animation.
+			 *
+			 * This property is passed down to any chirdren Marquee components, and is used there,
+			 * unless `marqueeOn` is specified for them as well.
+			 *
+			 * @type {('focus'|'hover'|'render')}
+			 * @default 'focus'
+			 * @public
+			 */
+			marqueeOn: PropTypes.oneOf(['focus', 'hover', 'render'])
+		}
 
 		constructor (props) {
 			super(props);

--- a/packages/ui/Marquee/MarqueeController.js
+++ b/packages/ui/Marquee/MarqueeController.js
@@ -56,6 +56,7 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 				complete: this.handleComplete,
 				enter: this.handleEnter,
 				leave: this.handleLeave,
+				marqueeOn: props.marqueeOn,
 				register: this.handleRegister,
 				start: this.handleStart,
 				unregister: this.handleUnregister
@@ -284,7 +285,7 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		render () {
-			let props = this.props;
+			let {...props} = this.props;
 
 			if (marqueeOnFocus) {
 				props = {
@@ -293,6 +294,8 @@ const MarqueeController = hoc(defaultConfig, (config, Wrapped) => {
 					onFocus: this.handleFocus
 				};
 			}
+
+			delete props.marqueeOn;
 
 			return (
 				<MarqueeControllerContext.Provider value={this.childContext}>

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -114,6 +114,10 @@ const didPropChange = (propList, prev, next) => {
 	return hasPropsChanged.indexOf(true) !== -1;
 };
 
+const getMarqueeOn = function (props, context, marqueeOnDefault = 'focus') {
+	return (props.marqueeOn || (context && context.marqueeOn) || marqueeOnDefault);
+};
+
 /*
  * There's only one timer shared for Marquee so we need to keep track of what we may be using it
  * for. We may need to clean up certain things as we move among states.
@@ -304,14 +308,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static defaultProps = {
 			marqueeDelay: 1000,
-			marqueeOn: 'focus',
+			// marqueeOn: 'focus',
 			marqueeOnRenderDelay: 1000,
 			marqueeResetDelay: 1000,
 			marqueeSpacing: '50%',
 			marqueeSpeed: 60
 		}
-
-		static contextType = MarqueeControllerContext
 
 		constructor (props) {
 			super(props);
@@ -338,7 +340,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
-			if (this.props.marqueeOn === 'render') {
+			if (getMarqueeOn(this.props, this.context) === 'render') {
 				this.startAnimation(this.props.marqueeOnRenderDelay);
 			}
 			on('keydown', this.handlePointerHide);
@@ -352,7 +354,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps) {
-			const {children, disabled, forceDirection, locale, marqueeOn, marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
+			const {children, disabled, forceDirection, locale, marqueeOn = getMarqueeOn(this.props, this.context), marqueeDisabled, marqueeSpacing, marqueeSpeed, rtl} = this.props;
 
 			let forceRestartMarquee = false;
 
@@ -371,7 +373,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.invalidateMetrics();
 				this.cancelAnimation();
 			} else if (
-				prevProps.marqueeOn !== marqueeOn ||
+				// prevProps.marqueeOn !== marqueeOn ||
+				getMarqueeOn(prevProps, this.context) !== marqueeOn ||
 				prevProps.marqueeDisabled !== marqueeDisabled ||
 				prevProps.marqueeSpeed !== marqueeSpeed ||
 				prevProps.forceDirection !== forceDirection
@@ -383,7 +386,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.validateTextDirection();
 			if (forceRestartMarquee || this.shouldStartMarquee()) {
-				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
+				this.tryStartingAnimation(marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
 			}
 		}
 
@@ -401,6 +404,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			off('keydown', this.handlePointerHide);
 		}
+
+		static contextType = MarqueeControllerContext
 
 		promoteJob = new Job(() => {
 			this.setState(state => state.promoted ? null : {promoted: true});
@@ -460,7 +465,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {Boolean} - `true` if a possible marquee condition exists
 		 */
 		shouldStartMarquee () {
-			const {disabled, marqueeDisabled, marqueeOn} = this.props;
+			const {disabled, marqueeDisabled, marqueeOn = getMarqueeOn(this.props, this.context)} = this.props;
 			return !marqueeDisabled && (
 				marqueeOn === 'render' ||
 				!this.sync && (
@@ -745,7 +750,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			forwardBlur(ev, this.props);
 			if (this.isFocused) {
 				this.isFocused = false;
-				if (!this.sync && !(this.isHovered && this.props.marqueeOn === 'hover')) {
+				if (!this.sync && !(this.isHovered && getMarqueeOn(this.props, this.context) === 'hover')) {
 					this.cancelAnimation();
 				}
 			}
@@ -753,7 +758,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleEnter = (ev) => {
 			this.isHovered = true;
-			if (this.props.marqueeOn === 'hover') {
+			if (getMarqueeOn(this.props, this.context) === 'hover') {
 				if (this.sync) {
 					this.context.enter(this);
 				} else if (!this.state.animating) {
@@ -777,7 +782,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleUnhover () {
 			this.isHovered = false;
-			if (this.props.marqueeOn === 'hover') {
+			if (getMarqueeOn(this.props, this.context) === 'hover') {
 				if (this.sync) {
 					this.context.leave(this);
 				} else {
@@ -802,10 +807,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				alignment,
 				children,
 				disabled,
-				marqueeOn,
+				marqueeOn = getMarqueeOn(this.props, this.context),
 				marqueeSpeed,
 				...rest
 			} = this.props;
+
+			console.log('marqueeOn:', marqueeOn, this.context && this.context.marqueeOn, children);
 
 			const marqueeOnFocus = marqueeOn === 'focus';
 			const marqueeOnHover = marqueeOn === 'hover';

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -308,12 +308,13 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		static defaultProps = {
 			marqueeDelay: 1000,
-			// marqueeOn: 'focus',
 			marqueeOnRenderDelay: 1000,
 			marqueeResetDelay: 1000,
 			marqueeSpacing: '50%',
 			marqueeSpeed: 60
 		}
+
+		static contextType = MarqueeControllerContext
 
 		constructor (props) {
 			super(props);
@@ -404,8 +405,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			off('keydown', this.handlePointerHide);
 		}
-
-		static contextType = MarqueeControllerContext
 
 		promoteJob = new Job(() => {
 			this.setState(state => state.promoted ? null : {promoted: true});
@@ -811,8 +810,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				marqueeSpeed,
 				...rest
 			} = this.props;
-
-			console.log('marqueeOn:', marqueeOn, this.context && this.context.marqueeOn, children);
 
 			const marqueeOnFocus = marqueeOn === 'focus';
 			const marqueeOnHover = marqueeOn === 'hover';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
It's not currently possible to set the `marqueeOn` prop on a container, which then informs all of the children marquees.


### Resolution
This adds support to `MarqueeController` to support setting `marqueeOn` on the controller and having all of the children respond, unless they'd been given explicit instructions of their own.


### Additional Considerations
This branch is 6 months old. I figured I might as well open a PR.