### PR TITLE
PLAT-109024: Added "tallglyph" locale support

### DIFF
--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -1,3 +1,6 @@
+@import "./variables.less";
+
+
 // Disabled elements
 .disabled(@rules; @target) when (isruleset(@rules)) and (@target = parent) {
 	[disabled] {
@@ -345,8 +348,89 @@
 	});
 }
 
-.locale-japanese-line-break() {
-	:global(.enact-locale-ja) & {
-		line-break: strict;
+//
+// Locale Mixins
+//
+
+// .enact-locale-line-height()
+//
+// Assign line-height rules specifically to the languages designated
+// as needing special support for tall-glyphs.
+//
+// Set line-height for normal and tallglyphs with 1 list argument
+// Ex:
+//   .enact-locale-line-height(1.4em 1.6em);
+// Or:
+//   @lineheight: 1.4em 1.6em;
+//   .enact-locale-line-height(@lineheight);
+.enact-locale-line-height(@both) when (length(@both) = 2) {
+	.enact-locale-tallglyph(line-height, @both);
+}
+
+
+// .enact-locale-tallglyph()
+//
+// Rulename and a normal value followed by a tallglyph value (3 arguments)
+// Ex:
+//   .enact-locale-tallglyph(font-size; 1.4em; 1.6em);  ->  normal font-size: 1.4em; tallglyphs font-size: 1.6em;
+.enact-locale-tallglyph(@rule; @normal; @tallglyph) {
+	@{rule}: @normal;
+	.enact-locale-tallglyph(@rule, @tallglyph);
+}
+
+// Rulename and 2 value second variable (2 arguments, 2nd being a list)
+// Ex:
+//   .enact-locale-tallglyph(font-size; 1.4em 1.6em);  ->  normal font-size: 1.4em; tallglyphs font-size: 1.6em;
+// Or:
+//   @fontsize: 1.4em 1.6em;
+//   .enact-locale-tallglyph(font-size, @fontsize);    ->  normal font-size: 1.4em; tallglyphs font-size: 1.6em;
+.enact-locale-tallglyph(@rule; @val) when (length(@val) = 2) {
+	@{rule}: extract(@val, 1);
+	.enact-locale-tallglyph(@rule, extract(@val, 2));
+}
+
+// Rulename and a tallglyph value
+// Ex:
+//   .enact-locale-tallglyph(font-size; 1.6em);  ->  tallglyphs font-size: 1.6em;
+.enact-locale-tallglyph(@rule; @val) when (default()) {
+	.enact-locale-tallglyph({
+		@{rule}: @val;
+	});
+}
+
+// Accept a ruleset and apply it to the list of tall-glyph languages
+// Ex:
+//   .enact-locale-tallglyph({
+//     font-size: 1.6em;
+//   });
+.enact-locale-tallglyph(@rules) when (isruleset(@rules)) {
+	// :global(.enact-locale-th) &,
+	// :global(.enact-locale-si) & {
+	// 	@rules();
+	// }
+	each(@locale-tallglyph-languages, {
+		// Take each language in the list, apply the @rules to them.
+		// @value is used to generate an appropriate selector for the @rules.
+		// Ex: `.enact-locale-th { @rules(); }`
+		.enact-locale(@value, @rules);
+	});
+}
+
+// Assign rules specifically to RTL locales with a convenient shorthand.
+.enact-locale-rtl(@rules) when (isruleset(@rules)) {
+	.enact-locale(right-to-left, @rules);
+}
+
+// Generates an appropriate selector given the locale-target, and injects the given rules into it.
+.enact-locale(@locale-target; @rules) when (iskeyword(@locale-target)) and (isruleset(@rules)) {
+	:global(.enact-locale-@{locale-target}) & {
+		@rules();
+		// content: 'you got it';
 	}
+}
+
+.locale-japanese-line-break() {
+	.enact-locale(ja, {
+		line-break: strict;
+	});
 }

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -364,7 +364,7 @@
 //   @lineheight: 1.4em 1.6em;
 //   .enact-locale-line-height(@lineheight);
 .enact-locale-line-height(@both) when (length(@both) = 2) {
-	.enact-locale-tallglyph(line-height, @both);
+	.enact-locale-tallglyph(line-height; @both);
 }
 
 
@@ -375,7 +375,7 @@
 //   .enact-locale-tallglyph(font-size; 1.4em; 1.6em);  ->  normal font-size: 1.4em; tallglyphs font-size: 1.6em;
 .enact-locale-tallglyph(@rule; @normal; @tallglyph) {
 	@{rule}: @normal;
-	.enact-locale-tallglyph(@rule, @tallglyph);
+	.enact-locale-tallglyph(@rule; @tallglyph);
 }
 
 // Rulename and 2 value second variable (2 arguments, 2nd being a list)
@@ -386,7 +386,7 @@
 //   .enact-locale-tallglyph(font-size, @fontsize);    ->  normal font-size: 1.4em; tallglyphs font-size: 1.6em;
 .enact-locale-tallglyph(@rule; @val) when (length(@val) = 2) {
 	@{rule}: extract(@val, 1);
-	.enact-locale-tallglyph(@rule, extract(@val, 2));
+	.enact-locale-tallglyph(@rule; extract(@val, 2));
 }
 
 // Rulename and a tallglyph value
@@ -408,24 +408,37 @@
 		// Take each language in the list, apply the @rules to them.
 		// @value is used to generate an appropriate selector for the @rules.
 		// Ex: `.enact-locale-th & { @rules(); }`
-		.enact-locale(@value, @rules);
+		.enact-locale(@value; @rules);
 	});
 }
 
+
 // Assign rules specifically to RTL locales with a convenient shorthand.
-.enact-locale-rtl(@rules) when (isruleset(@rules)) {
-	.enact-locale(right-to-left, @rules);
+// Apply these rules to the current selector, not the general parent.
+.enact-locale-rtl(@rules; @target) when (isruleset(@rules)) and (@target = self) {
+	.enact-locale(right-to-left; @rules; @target);
+}
+// Assign rules specifically to RTL locales with a convenient shorthand.
+.enact-locale-rtl(@rules; @target: normal) when (isruleset(@rules)) and (default()) {
+	.enact-locale(right-to-left; @rules; @target);
 }
 
 // Generates an appropriate selector given the locale-target, and injects the given rules into it.
-.enact-locale(@locale-target; @rules) when (iskeyword(@locale-target)) and (isruleset(@rules)) {
+// Apply these rules to the current selector, not the general parent.
+.enact-locale(@locale-target; @rules; @target) when (iskeyword(@locale-target)) and (isruleset(@rules)) and (@target = self) {
+	&:global(.enact-locale-@{locale-target}) {
+		@rules();
+	}
+}
+// Generates an appropriate selector given the locale-target, and injects the given rules into it.
+.enact-locale(@locale-target; @rules; @target: normal) when (iskeyword(@locale-target)) and (isruleset(@rules)) and (default()) {
 	:global(.enact-locale-@{locale-target}) & {
 		@rules();
 	}
 }
 
 .locale-japanese-line-break() {
-	.enact-locale(ja, {
+	.enact-locale(ja; {
 		line-break: strict;
 	});
 }

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -404,14 +404,10 @@
 //     font-size: 1.6em;
 //   });
 .enact-locale-tallglyph(@rules) when (isruleset(@rules)) {
-	// :global(.enact-locale-th) &,
-	// :global(.enact-locale-si) & {
-	// 	@rules();
-	// }
 	each(@locale-tallglyph-languages, {
 		// Take each language in the list, apply the @rules to them.
 		// @value is used to generate an appropriate selector for the @rules.
-		// Ex: `.enact-locale-th { @rules(); }`
+		// Ex: `.enact-locale-th & { @rules(); }`
 		.enact-locale(@value, @rules);
 	});
 }
@@ -425,7 +421,6 @@
 .enact-locale(@locale-target; @rules) when (iskeyword(@locale-target)) and (isruleset(@rules)) {
 	:global(.enact-locale-@{locale-target}) & {
 		@rules();
-		// content: 'you got it';
 	}
 }
 

--- a/packages/ui/styles/variables.less
+++ b/packages/ui/styles/variables.less
@@ -1,0 +1,7 @@
+// UI Variables
+// These represent visually-agnostic values. They should not be measurements, sizes, or colors.
+// Variables set in this file are used (and overridable) by __every__ theme.
+
+// Locale
+// --------------------------
+@locale-tallglyph-languages: th, si;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Often, languages are given incorrect rules due to a naive categorization which states that all non-Latin languages are tall-height glyph languages. This isn't true and we need a more granular way to group these languages that need some extra height for tall glyphs vs languages that fit within the bounds of "normal" glyph metrics.


### Resolution
This PR adds a mechanism in LESS to apply rules to those languages specifically. This also updates the base-approach of how to access the `:global(.enact-locale-*) &` selector by adding a mixin that can target any feature of the localization classes.

The new mixins are as follows:
* `.enact-locale-line-height()` - A convenience function, since this is one of the most common cases
* `.enact-locale-tallglyph()` - A generalized function that has both shorthand and full rule support
* `.enact-locale-rtl()` - A convenience function, since this is one of the most common cases
* `.enact-locale()` - A generalized metod to add rulesets to a given locale case (e.g. `right-to-left`, `ar`, `en-US`, etc)

This also includes a new `variables.less` file which contains a necessary variable for the `tallglyph` set of mixins. This variable is a list of language codes that should be included when generating rules. This variable can be overridden by a theme.

### Additional Considerations
An additional PR can be created for the conversion of all existing references of the global class name to the new mixin format. This could additionally be bundled with this PR, but was left out to keep the focus of the review on the "work" parts of the change, rather than the conversion.