### PR TITLE
PLAT-113429: Add preferredEnterTo parameter to getTargetByContainer

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -623,7 +623,9 @@ const getAllContainerIds = () => {
 /**
  * Returns the default focus element for a container
  *
- * @param   {String}  containerId  ID of container
+ * @param   {String}                             containerId        ID of container
+ * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
+ *                                                                  configuration
  *
  * @returns {Node|null}                 Default focus element
  * @memberof spotlight/container
@@ -717,10 +719,12 @@ function setContainerLastFocusedElement (node, containerIds) {
 /**
  * Returns all navigable nodes (spottable nodes or containers) visible from outside the container.
  * If the container is restricting navigation into itself via `enterTo`, this method will attempt to
- * return that element as the only element in an array. If that fails or if navigation is not restricted, it will return an
- * array of all possible navigable nodes.
+ * return that element as the only element in an array. If that fails or if navigation is not
+ * restricted, it will return an array of all possible navigable nodes.
  *
- * @param   {String} containerId Container ID
+ * @param   {String}                             containerId        Container ID
+ * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
+ *                                                                  configuration
  *
  * @returns {Node[]}             Navigable elements within container
  * @memberof spotlight/container
@@ -780,17 +784,19 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
  * Determines the preferred focus target, traversing any sub-containers as necessary, for the given
  * container.
  *
- * @param   {String}  containerId  ID of container
+ * @param   {String}                             containerId        ID of container
+ * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
+ *                                                                  configuration
  *
  * @returns {Node}                 Preferred target as either a DOM node or container-id
  * @memberof spotlight/container
  * @public
  */
-function getContainerFocusTarget (containerId, enterTo) {
+function getContainerFocusTarget (containerId, preferredEnterTo) {
 	// deferring restoration until it's requested to allow containers to prepare first
 	restoreLastFocusedElement(containerId);
 
-	let next = getContainerNavigableElements(containerId, enterTo);
+	let next = getContainerNavigableElements(containerId, preferredEnterTo);
 	// If multiple candidates returned, we need to find the first viable target since some may
 	// be empty containers which should be skipped.
 	return next.reduce((result, element) => {

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -629,7 +629,7 @@ const getAllContainerIds = () => {
  * @memberof spotlight/container
  * @public
  */
-function getContainerDefaultElement (containerId) {
+function getContainerDefaultElement (containerId, preferredEnterTo) {
 	const config = getContainerConfig(containerId);
 
 	let defaultElementSelector = config && config.defaultElement;
@@ -638,6 +638,12 @@ function getContainerDefaultElement (containerId) {
 	}
 
 	defaultElementSelector = coerceArray(defaultElementSelector);
+
+	// If a preferred enterTo has been provided, we will favor it by making it first in search array
+	if (preferredEnterTo && typeof preferredEnterTo === 'string' && preferredEnterTo !== 'default-element') {
+		defaultElementSelector.unshift(preferredEnterTo);
+	}
+
 	const spottables = getDeepSpottableDescendants(containerId);
 
 	return defaultElementSelector.reduce((result, selector) => {
@@ -720,7 +726,7 @@ function setContainerLastFocusedElement (node, containerIds) {
  * @memberof spotlight/container
  * @public
  */
-function getContainerNavigableElements (containerId) {
+function getContainerNavigableElements (containerId, preferredEnterTo) {
 	if (!isContainer(containerId)) {
 		return [];
 	}
@@ -728,7 +734,7 @@ function getContainerNavigableElements (containerId) {
 	const config = getContainerConfig(containerId);
 	const {enterTo, overflow} = config;
 
-	const enterLast = enterTo === 'last-focused';
+	const enterLast = enterTo === 'last-focused' || preferredEnterTo === 'last-focused';
 	let next;
 
 	// if the container has a preferred entry point, try to find it first
@@ -738,7 +744,7 @@ function getContainerNavigableElements (containerId) {
 
 	// try default element if last focused can't be focused
 	if (!next) {
-		next = getContainerDefaultElement(containerId);
+		next = getContainerDefaultElement(containerId, preferredEnterTo);
 	}
 
 	if (!next) {
@@ -780,11 +786,11 @@ function getContainerNavigableElements (containerId) {
  * @memberof spotlight/container
  * @public
  */
-function getContainerFocusTarget (containerId) {
+function getContainerFocusTarget (containerId, enterTo) {
 	// deferring restoration until it's requested to allow containers to prepare first
 	restoreLastFocusedElement(containerId);
 
-	let next = getContainerNavigableElements(containerId);
+	let next = getContainerNavigableElements(containerId, enterTo);
 	// If multiple candidates returned, we need to find the first viable target since some may
 	// be empty containers which should be skipped.
 	return next.reduce((result, element) => {

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -734,7 +734,7 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
 	const config = getContainerConfig(containerId);
 	const {enterTo, overflow} = config;
 
-	const enterLast = enterTo === 'last-focused' || preferredEnterTo === 'last-focused';
+	const enterLast = preferredEnterTo === 'last-focused' || (enterTo === 'last-focused' && !preferredEnterTo);
 	let next;
 
 	// if the container has a preferred entry point, try to find it first

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -65,10 +65,10 @@ function getContainersToSearch (containerId) {
 	return range;
 }
 
-function getTargetByContainer (containerId) {
+function getTargetByContainer (containerId, enterTo) {
 	return getContainersToSearch(containerId)
 		.reduce((next, id) => {
-			return next || getContainerFocusTarget(id);
+			return next || getContainerFocusTarget(id, enterTo);
 		}, null);
 }
 

--- a/packages/spotlight/src/tests/target-specs.js
+++ b/packages/spotlight/src/tests/target-specs.js
@@ -315,6 +315,79 @@ describe('target', () => {
 				}
 			)
 		);
+
+		test('should return `default-element` when last focused is unset', testScenario(
+			scenarios.grid,
+			() => {
+				configureContainer('grid', {
+					enterTo: 'last-focused',
+					defaultElement: '#middle-center'
+				});
+
+				const expected = 'middle-center';
+				const actual = safeTarget(
+					getTargetByContainer('grid'),
+					t => t.id
+				);
+
+				expect(actual).toBe(expected);
+			}
+		));
+
+		test('should return `default-element` when `last-focused` is requested but is unset', testScenario(
+			scenarios.grid,
+			() => {
+				configureContainer('grid', {
+					defaultElement: '#middle-center'
+				});
+
+				const expected = 'middle-center';
+				const actual = safeTarget(
+					getTargetByContainer('grid', 'last-focused'),
+					t => t.id
+				);
+
+				expect(actual).toBe(expected);
+			}
+		));
+
+		test('should return default element when configured for `last-focused` but requested `default-element`', testScenario(
+			scenarios.grid,
+			() => {
+				configureContainer('grid', {
+					enterTo: 'last-focused',
+					lastFocusedElement: document.querySelector('#top-left'),
+					defaultElement: '#middle-center'
+				});
+
+				const expected = 'middle-center';
+				const actual = safeTarget(
+					getTargetByContainer('grid', 'default-element'),
+					t => t.id
+				);
+
+				expect(actual).toBe(expected);
+			}
+		));
+
+		test('should return last focused element when configured for `default-element` but requested `last-focused`', testScenario(
+			scenarios.grid,
+			() => {
+				configureContainer('grid', {
+					enterTo: 'default-element',
+					lastFocusedElement: document.querySelector('#top-left'),
+					defaultElement: '#middle-center'
+				});
+
+				const expected = 'top-left';
+				const actual = safeTarget(
+					getTargetByContainer('grid', 'last-focused'),
+					t => t.id
+				);
+
+				expect(actual).toBe(expected);
+			}
+		));
 	});
 
 	describe('#getTargetBySelector', () => {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have cases (e.g. enyojs/sandstone#667) in which we want to imperatively focus either the last focused or default element of a container without requiring that the container always use that config for 5-way navigation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a `preferredEnterTo` parameter to `getTargetByContainer` (and downstream files) to favor a particular target.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We should consider making this a new top-level `Spotlight` API (e.g. `focusContainer`) in a future release.