### PR TITLE
PLAT-115535: Wrap the created portal with div having `aria-owns`

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -122,6 +122,7 @@ class FloatingLayerBase extends React.Component {
 	constructor (props) {
 		super(props);
 		this.node = null;
+		this.id = this.generateId();
 		this.state = {
 			nodeRendered: false
 		};
@@ -178,6 +179,10 @@ class FloatingLayerBase extends React.Component {
 			this.controller.unregister();
 		}
 	}
+
+	generateId = () => {
+		return Math.random().toString(36).substr(2, 8);
+	};
 
 	handleNotify = oneOf(
 		[forEventProp('action', 'close'), call('handleClose')],
@@ -252,13 +257,15 @@ class FloatingLayerBase extends React.Component {
 		delete rest.onOpen;
 
 		if (open && this.state.nodeRendered) {
-			return ReactDOM.createPortal(
-				<div {...rest}>
+			const portal = ReactDOM.createPortal(
+				<div {...rest} id={this.id}>
 					{scrimType !== 'none' ? <Scrim type={scrimType} onClick={this.handleClick} /> : null}
 					{React.cloneElement(children, {onClick: this.stopPropagation})}
 				</div>,
 				this.node
 			);
+
+			return <div aria-owns={this.id}>{portal}</div>;
 		}
 
 		return null;

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -122,7 +122,6 @@ class FloatingLayerBase extends React.Component {
 	constructor (props) {
 		super(props);
 		this.node = null;
-		this.id = this.generateId();
 		this.state = {
 			nodeRendered: false
 		};
@@ -248,6 +247,7 @@ class FloatingLayerBase extends React.Component {
 
 	render () {
 		const {children, open, scrimType, ...rest} = this.props;
+		const id = this.generateId();
 
 		delete rest.floatLayerClassName;
 		delete rest.floatLayerId;
@@ -258,14 +258,14 @@ class FloatingLayerBase extends React.Component {
 
 		if (open && this.state.nodeRendered) {
 			const portal = ReactDOM.createPortal(
-				<div {...rest} id={this.id}>
+				<div {...rest} id={id}>
 					{scrimType !== 'none' ? <Scrim type={scrimType} onClick={this.handleClick} /> : null}
 					{React.cloneElement(children, {onClick: this.stopPropagation})}
 				</div>,
 				this.node
 			);
 
-			return <div aria-owns={this.id}>{portal}</div>;
+			return <div aria-owns={id}>{portal}</div>;
 		}
 
 		return null;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When moving focus from the component in the panel to the component in the floatLayer and moving back,
the screen reader doesn't read out the panel header because the panel has `aria-owns="floatLayer"` prop.

But when the panel is in the floatLayer like `PopupTabLayout`, the `aria-owns` won't work. Then the screen reader reads the panel title first, then a focused component when moving focus from out of the panel to in the panel.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When creating a component in the floatLayer, the component has the id and is wrapped with `div` including `aria-owns` prop of the id.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-115535

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)