### PR TITLE
PLAT-115947 Add missing prop-types dependency

### DIFF
--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -19,6 +19,7 @@
     "@enact/webos": "^3.4.0",
     "classnames": "^2.2.6",
     "ilib": "^14.4.0",
+    "prop-types": "^15.7.2",
     "query-string": "^6.7.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`prop-types` module is used by `sampler` but is not included in the dependencies.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added dependency

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-115947

### Comments
