### PR TITLE
PLAT-116068: Fixed Scroller to detect children change

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` to update scroll bounds when children had changed
+
 ## [3.4.2] - 2020-08-05
 
 No significant changes.

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -1,3 +1,4 @@
+/* global MutationObserver */
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {platform} from '@enact/core/platform';
 import classNames from 'classnames';
@@ -94,6 +95,13 @@ class ScrollerBasic extends Component {
 
 	componentDidMount () {
 		this.calculateMetrics();
+		if (typeof MutationObserver === 'function') {
+			this.mutationObserver = new MutationObserver(() => {
+				this.calculateMetrics();
+			});
+
+			this.mutationObserver.observe(this.props.scrollContentRef.current, {childList: true, subtree: true});
+		}
 	}
 
 	componentDidUpdate (prevProps) {
@@ -101,6 +109,11 @@ class ScrollerBasic extends Component {
 		if (this.props.isVerticalScrollbarVisible && !prevProps.isVerticalScrollbarVisible) {
 			this.forceUpdate();
 		}
+	}
+
+	componentWillUnMount () {
+		this.mutationObserver.disconnect();
+		this.mutationObserver = null;
 	}
 
 	scrollBounds = {
@@ -116,6 +129,8 @@ class ScrollerBasic extends Component {
 		top: 0,
 		left: 0
 	};
+
+	mutationObserver = null;
 
 	getScrollBounds = () => this.scrollBounds;
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When children of `Scroller` changed by its own state, `Scroller` cannot detect the changing of `scrollHeight` and has the wrong size.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `MutationObserver` to observe its `childList` so that it can detect changed `scrollHeight`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-116068

### Comments
