### PR TITLE
PLAT-113577: Remove Spottable workaround for binding preventDefault

### DIFF
--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -311,11 +311,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 			const {selectionKeys} = props;
 			const key = selectionKeys.find((value) => keyCode === value);
 
-			// FIXME: temporary patch to maintain compatibility with moonstone 3.2.5 which
-			// deconstructs `preventDefault` from the event which is incompatible with React's
-			// synthetic event.
-			ev.preventDefault = ev.preventDefault.bind(ev);
-
 			forward('onKeyUp', ev, props);
 			const notPrevented = !ev.defaultPrevented;
 


### PR DESCRIPTION
Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Workaround to bind `preventDefault` was added to ensure compatibility with `@enact/moonstone` 3.2.5.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the workaround with the release of enactjs/moonstone#29 and 3.2.6 
