### PR TITLE
PLAT-111880 Fix pointer time out focus restore

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to restore focus to last focused elements in an overflow container if they are visible
+
 ## [3.4.3] - 2020-08-10
 
 No significant changes.

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -26,6 +26,7 @@ import last from 'ramda/src/last';
 import Accelerator from '../Accelerator';
 import {spottableClass} from '../Spottable';
 import {isPaused, pause, resume} from '../Pause';
+import {contains} from './utils';
 
 import {
 	addContainer,
@@ -264,8 +265,10 @@ const Spotlight = (function () {
 
 			// only prepend last focused if it exists so that Spotlight.focus() doesn't receive
 			// a falsy target
-			const lastFocused = getContainerConfig(lastContainerId).overflow && getNearestTargetFromPosition(position, lastContainerId) ||
-				getContainerLastFocusedElement(lastContainerId);
+			let lastFocused = getContainerLastFocusedElement(lastContainerId);
+			if (!lastFocused || !contains(getContainerNode(lastContainerId).getBoundingClientRect(), lastFocused.getBoundingClientRect())) {
+				lastFocused = getContainerConfig(lastContainerId).overflow && getNearestTargetFromPosition(position, lastContainerId);
+			}
 
 			if (lastFocused) {
 				next.unshift(lastFocused);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In `Dropdown`, if the dropdown was opened by pointer and the pointer is allowed to timeout, the focus would be restored close to the pointer instead of to the selected item.  This is caused by #2481, which forces overflow containers to target the pointer, to avoid focusing an item off-screen and causing a scroll.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Check to see if the last focused item is visible inside the container before resorting to using the pointer for focus.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

We have no testing around this sort of scenario and it looks to be non-trivial within this repo, particularly because it relies on a webOS event (pointer timeout). We could certainly fake this event but I think we'll need a real DOM, so it would probably have to live in UI tests, which currently don't exist for spotlight.

### Links
[//]: # (Related issues, references)
PLAT-111880

### Comments
