### PR TITLE
PLAT-116312: Fix spotlight next target to include all eligible elements

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to correctly prioritize next spottable elements when wrapped by a container that does not also wrap the currently focused element
+
 ## [3.4.4] - 2020-08-17
 
 No significant changes.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -1113,6 +1113,7 @@ export {
 	getContainerFocusTarget,
 	getContainerId,
 	getContainerPreviousTarget,
+	getDeepSpottableDescendants,
 	getDefaultContainer,
 	getLastContainer,
 	getNavigableContainersForNode,

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -9,10 +9,10 @@ import {
 	getContainerNode,
 	getContainerPreviousTarget,
 	getContainersForNode,
+	getDeepSpottableDescendants,
 	getDefaultContainer,
 	getLastContainer,
 	getNavigableContainersForNode,
-	getSpottableDescendants,
 	isContainer,
 	isNavigable
 } from './container';
@@ -102,12 +102,6 @@ function isRestrictedContainer (containerId) {
 	return config && (config.enterTo === 'last-focused' || config.enterTo === 'default-element');
 }
 
-function getSpottableDescendantsWithoutContainers (containerId, containerIds) {
-	return getSpottableDescendants(containerId).filter(n => {
-		return !isContainer(n) || containerIds.indexOf(n.dataset.spotlightId) === -1;
-	});
-}
-
 function filterRects (elementRects, boundingRect) {
 	if (!boundingRect) {
 		return elementRects;
@@ -183,7 +177,7 @@ function getOverflowContainerRect (containerId) {
 }
 
 function getTargetInContainerByDirectionFromPosition (direction, containerId, positionRect, elementContainerIds, boundingRect) {
-	const elements = getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
+	const elements = getDeepSpottableDescendants(containerId);
 	let elementRects = filterRects(getRects(elements), boundingRect);
 
 	let next = null;
@@ -254,7 +248,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 
 
 function getTargetInContainerByDirectionFromElement (direction, containerId, element, elementRect, elementContainerIds, boundingRect) {
-	const elements = getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
+	const elements = getDeepSpottableDescendants(containerId);
 
 	// shortcut for previous target from element if it were saved
 	const previous = getContainerPreviousTarget(containerId, direction, element);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
When determining the next target based on a direction from an element, spotlight treats containers as elements and based on the container's position, spotlight may not allow focus to change to an expected element within the container.


### Resolution
Allow all spottable elements within a given container to be treated as eligible targets, in order to determine the next target based on direction.
