### PR TITLE
PLAT-117036: Fix SpotlightContainerDecorator to allow use of ref

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightContainerDecorator` to allow use of `ref`
+
 ## [3.4.4] - 2020-08-17
 
 No significant changes.

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -8,6 +8,7 @@
 import handle, {forward} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import hoc from '@enact/core/hoc';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -149,7 +150,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 	// eslint-disable-next-line no-shadow
 	function SpotlightContainerDecorator (props) {
-		const {spotlightDisabled, spotlightId, spotlightMuted, spotlightRestrict, ...rest} = props;
+		const {componentRef, spotlightDisabled, spotlightId, spotlightMuted, spotlightRestrict, ...rest} = props;
 
 		const spotlightContainer = useSpotlightContainer({
 			id: spotlightId,
@@ -164,11 +165,19 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		const handlers = useHandlers(containerHandlers, props, spotlightContainer);
 
 		return (
-			<Wrapped {...rest} {...spotlightContainer.attributes} {...handlers} />
+			<Wrapped {...rest} {...spotlightContainer.attributes} {...handlers} ref={componentRef} />
 		);
 	}
 
 	SpotlightContainerDecorator.propTypes = /** @lends spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator.prototype */ {
+		/**
+		 * Forwarded ref
+		 *
+		 * @type {Function|Object}
+		 * @private
+		 */
+		componentRef: EnactPropTypes.ref,
+
 		/**
 		 * When `true`, controls in the container cannot be navigated.
 		 *
@@ -218,7 +227,11 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		spotlightRestrict: 'self-first'
 	};
 
-	return SpotlightContainerDecorator;
+	return React.forwardRef((props, ref) => {
+		return (
+			<SpotlightContainerDecorator {...props} componentRef={ref} />
+		);
+	});
 });
 
 export default SpotlightContainerDecorator;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Passing `ref` to a component wrapped with `SpotlightContainerDecorator` throws an error

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Wrap `SpotlightContainerDecorator` with `React.forwardRef` to restore support for the `ref` prop.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I had wanted to avoid adding `forwardRef` to all our HOCs during the hook migration but at least one regression surfaced with `SpotlightContainerDecorator` and it seemed appropriate to maintain compatibility here until we remove the HOC.
