### PR TITLE
PLAT-111880: Fix restoring focus when last focused is container

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -265,13 +265,18 @@ const Spotlight = (function () {
 
 			// only prepend last focused if it exists so that Spotlight.focus() doesn't receive
 			// a falsy target
-			let lastFocused = getContainerLastFocusedElement(lastContainerId);
-			if (!lastFocused || !contains(getContainerNode(lastContainerId).getBoundingClientRect(), lastFocused.getBoundingClientRect())) {
-				lastFocused = getContainerConfig(lastContainerId).overflow && getNearestTargetFromPosition(position, lastContainerId);
+			let lastFocusedElement = getContainerLastFocusedElement(lastContainerId);
+
+			while (isContainer(lastFocusedElement)) {
+				({lastFocusedElement} = getContainerConfig(lastFocusedElement));
 			}
 
-			if (lastFocused) {
-				next.unshift(lastFocused);
+			if (!lastFocusedElement || !contains(getContainerNode(lastContainerId).getBoundingClientRect(), lastFocusedElement.getBoundingClientRect())) {
+				lastFocusedElement = getContainerConfig(lastContainerId).overflow && getNearestTargetFromPosition(position, lastContainerId);
+			}
+
+			if (lastFocusedElement) {
+				next.unshift(lastFocusedElement);
 			}
 		} else {
 			next = [rootContainerId];


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Could not restore focus when the last focused element was a container id (string)


### Resolution
We need to recurse into the container to find the last focused element