### PR TITLE
PLAT-116511 Fix a view re-entering

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Scroller` and `ui/VirtualList` to call `onScrollStop` when scrollbar's visibility changed while scrolling
+- `ui/ViewManager` to handle transitioning away and back to a view before a transition completes
 
 ## [3.4.6] - 2020-08-24
 

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -190,7 +190,12 @@ class View extends React.Component {
 	// TransitionGroup. It will block other animations from occurring until callback is called. It
 	// will not be called on the initial render of a TransitionGroup.
 	componentWillEnter (callback) {
-		const {arranger, reverseTransition} = this.props;
+		const {appearing, arranger, reverseTransition, enteringProp} = this.props;
+		// This can happen if the panel was going to be removed and the animation was canceled,
+		// causing this panel to re-enter.
+		if (!appearing && enteringProp && !this.state.entering) {
+			this.setState({entering: true});
+		}
 		if (arranger) {
 			this.prepareTransition(reverseTransition ? arranger.leave : arranger.enter, callback);
 		} else {
@@ -265,7 +270,7 @@ class View extends React.Component {
 		this.animation.onfinish = () => {
 			this.animation = null;
 			// Possible for the animation callback to still be fired after the node has been
-			// umounted if it finished before the unmount can cancel it so we check for that.
+			// unmounted if it finished before the unmount can cancel it so we check for that.
 			if (this.node) {
 				callback();
 			}

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -151,6 +151,10 @@ class View extends React.Component {
 
 	shouldComponentUpdate (nextProps) {
 		if (nextProps.leaving) {
+			// FIXME: This is generally a bad practice to mutate local state in sCU but is necessary
+			// for the time being to ensure that a view that is reversed before it completes
+			// entering will transition correctly out of the viewport.
+			this.changeDirection = this.shouldChangeDirection(this.props, nextProps);
 			return false;
 		}
 
@@ -158,7 +162,7 @@ class View extends React.Component {
 	}
 
 	componentDidUpdate (prevProps) {
-		this.changeDirection = this.animation ? this.props.reverseTransition !== prevProps.reverseTransition : false;
+		this.changeDirection = this.shouldChangeDirection(prevProps, this.props);
 	}
 
 	componentWillUnmount () {
@@ -167,6 +171,10 @@ class View extends React.Component {
 		if (this.animation) {
 			this.animation.cancel();
 		}
+	}
+
+	shouldChangeDirection (prevProps, nextProps) {
+		return this.animation ? prevProps.reverseTransition !== nextProps.reverseTransition : false;
 	}
 
 	enteringJob = new Job(() => {

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -179,7 +179,7 @@ const ViewManagerBase = class extends React.Component {
 		/**
 		 * Explicitly sets the transition direction.
 		 *
-		 * If omitted, the direction is determined automaticallly based on the change of index or a
+		 * If omitted, the direction is determined automatically based on the change of index or a
 		 * string comparison of the first child's key.
 		 *
 		 * @type {Boolean}

--- a/packages/ui/ViewManager/tests/View-specs.js
+++ b/packages/ui/ViewManager/tests/View-specs.js
@@ -24,7 +24,7 @@ describe('View', () => {
 	);
 
 	test(
-		'should pass the value of appearing to its child in enteringProp',
+		'should pass the value of entering to its child in enteringProp',
 		() => {
 			const subject = mount(
 				<View duration={1000} enteringProp="data-entering">
@@ -110,6 +110,36 @@ describe('View', () => {
 
 				const expected = true;
 				const actual = spy.mock.calls.length === 1;
+
+				expect(actual).toBe(expected);
+			}
+		);
+
+		test(
+			'should reset entering if a rendered panel re-enters',
+			() => {
+				const spy = jest.fn();
+				const subject = mount(
+					<View duration={16} enteringProp="data-entering" >
+						<span />
+					</View>
+				);
+
+				// This is a bit bad, but we need to clear entering without waiting
+				// Could be updated to use `enteringDelay` and a small timeout
+				subject.instance().componentDidAppear(spy);
+				subject.update();
+
+				const firstExpected = false;
+				const firstActual = subject.find('span').prop('data-entering');
+
+				expect(firstActual).toBe(firstExpected);
+
+				subject.instance().componentWillEnter(spy);
+				subject.update();
+
+				const expected = true;
+				const actual = subject.find('span').prop('data-entering');
 
 				expect(actual).toBe(expected);
 			}

--- a/packages/ui/ViewManager/tests/View-specs.js
+++ b/packages/ui/ViewManager/tests/View-specs.js
@@ -43,7 +43,7 @@ describe('View', () => {
 		'should pass enteringProp as false for an appearing view',
 		() => {
 			// Views visible on mount are "appearing" and shouldn't perform "entering" logic like
-			// defering children rendering
+			// deferring children rendering
 			const subject = mount(
 				<View duration={1000} enteringProp="data-entering" appearing>
 					<span />


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If a `View` was transitioning out and then was transitioned back before it was completely removed, the `enteringProp` was not reset.  This could cause the children to not update when the view arrived.  In `Panels`, this caused the child `Panel` to not get its `hideChildren` prop set and then cleared.  Because the view did not re-render after transitioning back, auto focus logic could not fire to focus the panel contents.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If `componentWillEnter` is called and `entering` isn't set, set it to allow for component to re-enter.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Conceivably, this could cause regressions in cases not considered.  In theory, it shouldn't cause problems if a view wasn't already being removed from the active children and then added back.

### Links
[//]: # (Related issues, references)
PLAT-115879

### Comments
