### PR TITLE
PLAT-118682: Refactored RTL mixins for better interoperability added extract mixin

### DIFF
--- a/packages/ui/styles/internal/utils.less
+++ b/packages/ui/styles/internal/utils.less
@@ -1,0 +1,64 @@
+//
+// Computational mixins that return values
+//
+
+
+// Normalizes a list of values, using the logic from padding and margin short-hand, and expands it up
+// to the full long-hand representation, giving a consistent list length to extract from.
+// Supports 1, 2, 3, or 4 values in a space separated list.
+// Always returns a list of 4.
+// .normalize-shorthand(11px 21px 31px 41px)[]  -->  11px 21px 31px 41px
+// .normalize-shorthand(11px 21px 31px)[]       -->  11px 21px 31px 21px
+// .normalize-shorthand(11px 21px)[]            -->  11px 21px 11px 21px
+// .normalize-shorthand(11px)[]                 -->  11px 11px 11px 11px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
+.normalize-shorthand(@trbl) when ((length(@trbl) >= 1) and (length(@trbl) <= 4)) {
+	@result:
+		extract(@trbl, 1)
+		extract(@trbl, if((length(@trbl) >= 2), 2, 1) )
+		extract(@trbl, if((length(@trbl) >= 3), 3, 1) )
+		extract(@trbl, if((length(@trbl) >= 4), 4, if((length(@trbl) >= 2), 2, 1) ))
+	;
+}
+
+// Extracts one or all short-hand values out of a list (See `.normalize-shorthand`), returning all
+// values or a requested value.
+// padding-left: .extract(11px 21px 31px 41px, left)[]  -->  41px
+// padding-left: .extract(11px 21px 31px, left)[]       -->  21px
+// padding-left: .extract(11px 21px, left)[]            -->  21px
+// padding-left: .extract(11px, left)[]                 -->  11px
+// padding: .extract(11px 21px 31px 41px)[]             -->  11px 21px 31px 41px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
+.extract(@trbl; @position) when (@position = top) {
+	@result: extract(.normalize-shorthand(@trbl)[], 1);
+}
+.extract(@trbl; @position) when (@position = right) {
+	@result: extract(.normalize-shorthand(@trbl)[], 2);
+}
+.extract(@trbl; @position) when (@position = bottom) {
+	@result: extract(.normalize-shorthand(@trbl)[], 3);
+}
+.extract(@trbl; @position) when (@position = left) {
+	@result: extract(.normalize-shorthand(@trbl)[], 4);
+}
+.extract(@trbl) {
+	@result: .normalize-shorthand(@trbl)[];
+}
+
+// Extracts one value out of a short-hand list, given a position. Works like the built-in `extract`
+// LESS function, but is safe to use on lists of arbitrary or unknown length.
+// Always returns 1 value.
+// padding-left: .extract(11px 21px 31px 41px, 4)[]  -->  41px
+// padding-left: .extract(11px 21px 31px, 4)[]       -->  21px
+// padding-left: .extract(11px 21px, 4)[]            -->  21px
+// padding-left: .extract(11px, 4)[]                 -->  11px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
+.extract(@trbl; @position) when ((@position >= 1) and (@position <= 4)) {
+	@result: extract(.normalize-shorthand(@trbl)[], @position);
+}

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -1,5 +1,5 @@
+@import "./internal/utils.less";
 @import "./variables.less";
-
 
 // Disabled elements
 .disabled(@rules; @target) when (isruleset(@rules)) and (@target = parent) {
@@ -22,56 +22,78 @@
 }
 
 // Applies RTL-compatible start and end position to a selector
-.position-start-end (@start, @end) {
+// Simple "when" here just assumes that if the first argument is a list with more than 1 entry,
+// then units are correct. If it's just 1, then we varify the value is a number (measurement).
+.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+	.position(@trbl);
+
+	.enact-locale-rtl({
+		.position(
+			// Note: swapping left and right values
+			.extract(@trbl; top)[]
+			.extract(@trbl; left)[]
+			.extract(@trbl; bottom)[]
+			.extract(@trbl; right)[]
+		);
+	}; @target);
+}
+
+.position-start-end (@start; @end; @target: "") when (default()) {
 	left: @start;
 	right: @end;
 
-	:global(.enact-locale-right-to-left) & {
+	.enact-locale-rtl({
 		left: @end;
 		right: @start;
-	}
+	}, @target);
 }
 
 // Applies RTL-compatible start and end margins to a selector
-.margin-start-end(@start; @end; @target) when (@target = parent) {
-    margin-left: @start;
-    margin-right: @end;
+.margin-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+	margin: @trbl;
 
-    :global(.enact-locale-right-to-left)& {
-        margin-left: @end;
-        margin-right: @start;
-    }
+	.enact-locale-rtl({
+		margin:
+			// Note: swapping left and right values
+			.extract(@trbl; top)[]
+			.extract(@trbl; left)[]
+			.extract(@trbl; bottom)[]
+			.extract(@trbl; right)[]
+		;
+	}; @target);
 }
-
-.margin-start-end (@start, @end) {
+.margin-start-end(@start; @end; @target: "") when (default()) {
 	margin-left: @start;
 	margin-right: @end;
 
-	:global(.enact-locale-right-to-left) & {
+	.enact-locale-rtl({
 		margin-left: @end;
 		margin-right: @start;
-	}
+	}, @target);
 }
 
 // Applies RTL-compatible start and end padding to a selector
-.padding-start-end(@start; @end; @target) when (@target = parent) {
-    padding-left: @start;
-    padding-right: @end;
+.padding-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+	padding: @trbl;
 
-    :global(.enact-locale-right-to-left)& {
-        padding-left: @end;
-        padding-right: @start;
-    }
+	.enact-locale-rtl({
+		padding:
+			// Note: swapping left and right values
+			.extract(@trbl; top)[]
+			.extract(@trbl; left)[]
+			.extract(@trbl; bottom)[]
+			.extract(@trbl; right)[]
+		;
+	}; @target);
 }
-
-.padding-start-end (@start, @end) {
+.padding-start-end(@start; @end; @target: "") when (default()) {
 	padding-left: @start;
 	padding-right: @end;
 
-	:global(.enact-locale-right-to-left) & {
+	.enact-locale-rtl({
 		padding-left: @end;
 		padding-right: @start;
-	}
+	}, @target);
 }
 
 // NOTE: Until we are able to automatically remove these JSDoc-style comments, they should remain LESS-commented

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -24,7 +24,7 @@
 // Applies RTL-compatible start and end position to a selector
 // Simple "when" here just assumes that if the first argument is a list with more than 1 entry,
 // then units are correct. If it's just 1, then we varify the value is a number (measurement).
-.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
 	.position(@trbl);
 
 	.enact-locale-rtl({
@@ -49,7 +49,7 @@
 }
 
 // Applies RTL-compatible start and end margins to a selector
-.margin-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+.margin-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
 	margin: @trbl;
 
 	.enact-locale-rtl({
@@ -73,7 +73,7 @@
 }
 
 // Applies RTL-compatible start and end padding to a selector
-.padding-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (isnumber(@trbl)) {
+.padding-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
 	padding: @trbl;
 
 	.enact-locale-rtl({

--- a/packages/ui/styles/variables.less
+++ b/packages/ui/styles/variables.less
@@ -1,3 +1,5 @@
+@import "./internal/utils.less";
+
 // UI Variables
 // These represent visually-agnostic values. They should not be measurements, sizes, or colors.
 // Variables set in this file are used (and overridable) by __every__ theme.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
All themes deserve to use the `.extract` mixin, and the `*-start-end` mixins should work with the developer instead of against.


### Resolution
* Migrated style-utils from Sandstone into ui
* Updated the `position-start-end`, `margin-start-end`, and `padding-start-end` mixins to support a single variable containing a list of values that can be parsed as shorthand to apply RTL-safe rules using the associated values.

This is a good addition and causes no known negative side effects. It encourages better, more readable, more maintainable coding practices.

### Examples

Using `padding` as an example below, but `margin` and `position` work exactly the same way.

Here's the old usage, and the result:
```css
.padding-start-end(@start, @end);
.padding-start-end(12px, 24px);

.selector {
    padding-left: 12px;
    padding-right: 24px;
}
.enact-locale-right-to-left .selector {
    padding-right: 12px;
    padding-left: 24px;
}
```
This has the drawback of requiring two lines and multiple variables to pass around, especially if a vertical margin is desirable. It's also backward from standard shorthand.

The old way still works, but now the same mixin also supports the following arguments:
```css
.padding-start-end(@shorthand-paddings, @target);
.padding-start-end(12px);
.padding-start-end(12px 24px);
.padding-start-end(12px 24px 36px);
.padding-start-end(12px 24px 36px 48px);
.padding-start-end(12px 24px 36px 48px, self);

@my-component-padding: 12px;  // or
@my-component-padding: 12px 24px;  // or
@my-component-padding: 12px 24px 36px;  // or
@my-component-padding: 12px 24px 36px 48px;
.padding-start-end(@my-component-padding);
.padding-start-end(@my-component-padding, self);

// Resulting in:
.selector {
    padding: 12px 24px 36px 48px;
}
.enact-locale-right-to-left .selector {
    padding: 12px 48px 36px 24px;
}
// or in the case of `self`
.enact-locale-right-to-left.selector {  // note the lack of a space between the locale and selector.
    padding: 12px 48px 36px 24px;
}
```

### Important Note

* The old approach supports exactly and only 2 arguments.
* The new approach supports 1 or 2 arguments
   1. The first being a single value or a _(space separated)_ list of values.
   2. The second being an optional target to attach this to. "self" is the only supported value currently, but is valuable if you're trying to use the mixin on the root node which also has the `.enact-locale-right-to-left` class applied.

The new method effectively allows you to only have to specify one variable and one rule assignment to get automatic RTL support, just like a "smart" or RTL-safe `margin`/`padding`/`position`.