### PR TITLE
PLAT-120781: Fix console error when flick

### DIFF
--- a/packages/ui/Touchable/Flick.js
+++ b/packages/ui/Touchable/Flick.js
@@ -31,7 +31,7 @@ class Flick {
 		if (!this.tracking) return;
 
 		// This will update the `flickConfig` with the new value
-		this.flickConfig.onFlick = onFlick;
+		this.onFlick = onFlick;
 	};
 
 	move = ({x, y}) => {

--- a/packages/ui/Touchable/Flick.js
+++ b/packages/ui/Touchable/Flick.js
@@ -25,12 +25,12 @@ class Flick {
 		this.move(coords);
 	};
 
-	// This method will get the `onFlick` props in the existing `flickConfig` values.
+	// This method will get the `onFlick` props.
 	updateProps = ({onFlick}) => {
-		// Check `tracking` gesture is not in progress. Check if gesture exists before updating the references to the `flickConfig`
+		// Check `tracking` gesture is not in progress. Check if gesture exists before updating the references to the `onFlick`
 		if (!this.tracking) return;
 
-		// This will update the `flickConfig` with the new value
+		// This will update the `onFlick` with the new value
 		this.onFlick = onFlick;
 	};
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is console error when flick Agate Picker. 
 - TypeError: Cannot set property 'onFlick' of undefined

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change unintended assigned.
- It looks like regression from https://github.com/enactjs/enact/pull/2836/
- Flick.js has different structure with Drag.js and Hold.js. Flick store own config in `this` not `this.flickConfig`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-120781

### Comments
