### PR TITLE
PLAT-105596: Fix a touchable control to be clicked properly when pressed

### DIFF
--- a/packages/ui/Button/Button.module.less
+++ b/packages/ui/Button/Button.module.less
@@ -11,6 +11,7 @@
 	width: auto;
 	z-index: 0;
 	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
 
 	//**
 	//* Classes to apply to the background of the button, used on a child of button.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Button` to be clicked properly when pressed by touch
+
 ## [3.4.7] - 2020-09-01
 
 ### Fixed

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -9,7 +9,6 @@
 import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {on, off} from '@enact/core/dispatcher';
-import complement from 'ramda/src/complement';
 import platform from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -156,7 +156,7 @@ const handleTouchEnd = handle(
 	// block the next mousedown to prevent duplicate touchable events
 	returnsTrue(call('setLastTouchEnd')),
 	call('isTracking'),
-	complement(call('hasTouchLeftTarget')),
+	call('isActive'),
 	returnsTrue(call('endTouch')),
 	handleUp
 );
@@ -588,6 +588,10 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		isTracking () {
 			// verify we had a target and the up target is still within the current node
 			return this.target;
+		}
+
+		isActive () {
+			return this.state.active === States.Active;
 		}
 
 		isPaused () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On touch devices, a button is pressed visually but not clicked in behavior when a user presses slightly out of a button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed with an updated condition to decide 'click' in `Touchable`.
Also fixed buttons not to have a browser-default press effect which is enabled only in a touch environment.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-115596

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
