### PR TITLE
PLAT-105596: Revert Touchable fix for button click to avoid error on controls

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Button` to be clicked properly when pressed by touch
+- `ui/Button` to prevent browser's default styling when pressed by touch
 
 ## [3.4.7] - 2020-09-01
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -9,6 +9,7 @@
 import {adaptEvent, call, forward, forwardWithPrevent, forProp, handle, oneOf, preventDefault, returnsTrue} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {on, off} from '@enact/core/dispatcher';
+import complement from 'ramda/src/complement';
 import platform from '@enact/core/platform';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -155,7 +156,7 @@ const handleTouchEnd = handle(
 	// block the next mousedown to prevent duplicate touchable events
 	returnsTrue(call('setLastTouchEnd')),
 	call('isTracking'),
-	call('isActive'),
+	complement(call('hasTouchLeftTarget')),
 	returnsTrue(call('endTouch')),
 	handleUp
 );
@@ -587,10 +588,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		isTracking () {
 			// verify we had a target and the up target is still within the current node
 			return this.target;
-		}
-
-		isActive () {
-			return this.state.active === States.Active;
 		}
 
 		isPaused () {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After #2862 is merged, `onTab` is not fired properly on controls that do not set `activeProp` for `Touchable`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We still need a fix for CSS to prevent browser's default style, so revert only Touchable changes from #2862.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-105596

### Comments
