### PR TITLE
PLAT-123775: Spotlight is on a component when it is active in touch mode

### DIFF
--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -98,7 +98,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				document.querySelector('#root > div').classList.remove('mouse-mode');
 				document.querySelector('#root > div').classList.remove('touch-mode');
 			}
-		}
+		};
 
 		navigableFilter = (elem) => {
 			while (elem && elem !== document && elem.nodeType === 1) {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -104,7 +104,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		};
 
-		handleKeyDown = (ev) => {
+		handleKeyDown = () => {
 			this.rootContainer.classList.add('mouse-mode');
 			this.rootContainer.classList.remove('touch-mode');
 		};

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -77,10 +77,27 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (!noAutoFocus) {
 				Spotlight.focus();
 			}
+
+			document.addEventListener('pointerover', this.handleMode);
 		}
 
 		componentWillUnmount () {
 			Spotlight.terminate();
+
+			document.removeEventListener('pointerover', this.handleMode);
+		}
+
+		handleMode = (ev) => {
+			if (ev.pointerType === 'touch') {
+				document.querySelector('#root > div').classList.remove('mouse-mode');
+				document.querySelector('#root > div').classList.add('touch-mode');
+			} else if (ev.pointerType === 'mouse') {
+				document.querySelector('#root > div').classList.add('mouse-mode');
+				document.querySelector('#root > div').classList.remove('touch-mode');
+			} else {
+				document.querySelector('#root > div').classList.remove('mouse-mode');
+				document.querySelector('#root > div').classList.remove('touch-mode');
+			}
 		}
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -78,6 +78,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.focus();
 			}
 
+			this.rootContainer = document.querySelector('#root > div');
+
 			document.addEventListener('pointerover', this.handleMouseTouch);
 			document.addEventListener('keydown', this.handleKeyDown);
 		}
@@ -91,20 +93,20 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleMouseTouch = (ev) => {
 			if (ev.pointerType === 'touch') {
-				document.querySelector('#root > div').classList.remove('mouse-mode');
-				document.querySelector('#root > div').classList.add('touch-mode');
+				this.rootContainer.classList.remove('mouse-mode');
+				this.rootContainer.classList.add('touch-mode');
 			} else if (ev.pointerType === 'mouse') {
-				document.querySelector('#root > div').classList.add('mouse-mode');
-				document.querySelector('#root > div').classList.remove('touch-mode');
+				this.rootContainer.classList.add('mouse-mode');
+				this.rootContainer.classList.remove('touch-mode');
 			} else {
-				document.querySelector('#root > div').classList.remove('mouse-mode');
-				document.querySelector('#root > div').classList.remove('touch-mode');
+				this.rootContainer.classList.remove('mouse-mode');
+				this.rootContainer.classList.remove('touch-mode');
 			}
 		};
 
 		handleKeyDown = (ev) => {
-			document.querySelector('#root > div').classList.add('mouse-mode');
-			document.querySelector('#root > div').classList.remove('touch-mode');
+			this.rootContainer.classList.add('mouse-mode');
+			this.rootContainer.classList.remove('touch-mode');
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -80,15 +80,15 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.rootContainer = document.querySelector('#root > div');
 
-			document.addEventListener('pointerover', this.handleMouseTouch);
-			document.addEventListener('keydown', this.handleKeyDown);
+			document.addEventListener('pointerover', this.handleMouseTouch, {capture: true});
+			document.addEventListener('keydown', this.handleKeyDown, {capture: true});
 		}
 
 		componentWillUnmount () {
 			Spotlight.terminate();
 
-			document.removeEventListener('pointerover', this.handleMouseTouch);
-			document.removeEventListener('keydown', this.handleKeyDown);
+			document.removeEventListener('pointerover', this.handleMouseTouch, {capture: true});
+			document.removeEventListener('keydown', this.handleKeyDown, {capture: true});
 		}
 
 		handleMouseTouch = (ev) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -78,16 +78,18 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.focus();
 			}
 
-			document.addEventListener('pointerover', this.handleMode);
+			document.addEventListener('pointerover', this.handleMouseTouch);
+			document.addEventListener('keydown', this.handleKeyDown);
 		}
 
 		componentWillUnmount () {
 			Spotlight.terminate();
 
-			document.removeEventListener('pointerover', this.handleMode);
+			document.removeEventListener('pointerover', this.handleMouseTouch);
+			document.removeEventListener('keydown', this.handleKeyDown);
 		}
 
-		handleMode = (ev) => {
+		handleMouseTouch = (ev) => {
 			if (ev.pointerType === 'touch') {
 				document.querySelector('#root > div').classList.remove('mouse-mode');
 				document.querySelector('#root > div').classList.add('touch-mode');
@@ -98,6 +100,11 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				document.querySelector('#root > div').classList.remove('mouse-mode');
 				document.querySelector('#root > div').classList.remove('touch-mode');
 			}
+		};
+
+		handleKeyDown = (ev) => {
+			document.querySelector('#root > div').classList.add('mouse-mode');
+			document.querySelector('#root > div').classList.remove('touch-mode');
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/styles/mixins.less
+++ b/packages/spotlight/styles/mixins.less
@@ -16,18 +16,38 @@
 
 // Focused Spottable elements
 .focus(@rules; @target) when (isruleset(@rules)) and (@target = parent) {
-	.spottable({
-		&:focus {
-			@rules();
-		}
-	}, @target);
+	:global(.mouse-mode) & {
+		.spottable({
+			&:focus {
+				@rules();
+			}
+		}, @target);
+	}
+
+	:global(.touch-mode) & {
+		.spottable({
+			&:active {
+				@rules();
+			}
+		}, @target);
+	}
 }
 .focus(@rules) when (isruleset(@rules)) {
-	.spottable({
-		&:focus {
-			@rules();
-		}
-	});
+	:global(.mouse-mode) & {
+		.spottable({
+			&:focus {
+				@rules();
+			}
+		});
+	}
+
+	:global(.touch-mode) & {
+		.spottable({
+			&:active {
+				@rules();
+			}
+		});
+	}
 }
 
 // Muted elements


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If touch events generates, then spottable visual effect should be shown when it is not focus but only active.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

When pointerMode is `touch`, then Spotlight is on a component when it is active

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-123775

### Comments
