### PR TITLE
PLAT-123726: Heading: italic style font cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `i18n/I18nDecorator` to add class `non-italic` for scriptName `Kore`
-
 ## [3.4.8] - 2020-10-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n/I18nDecorator` to add class `non-italic` for scriptName `Kore`
+
 ## [3.4.8] - 2020-10-08
 
 ### Fixed

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `i18n/I18nDecorator` to add class `non-italic` for scriptName `Kore`
+
 ## [3.4.8] - 2020-10-08
 
 No significant changes.

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact i18n module, newest chan
 
 ### Added
 
-- `i18n/I18nDecorator` to add class `non-italic` for scriptName `Kore`
+- `i18n/I18nDecorator` global class `enact-locale-non-italic` for scriptName `Kore`
 
 ## [3.4.8] - 2020-10-08
 

--- a/packages/i18n/I18nDecorator/getI18nClasses.js
+++ b/packages/i18n/I18nDecorator/getI18nClasses.js
@@ -45,7 +45,7 @@ function getClassesForLocale (li, options) {
 		})
 	], function (classes) {
 		const scriptName = li.getScript();
-		if (scriptName !== 'Latn' && scriptName !== 'Cyrl' && scriptName !== 'Grek') {
+		if (scriptName !== 'Latn' && scriptName !== 'Cyrl' && scriptName !== 'Grek' && scriptName !== 'Kore') {
 			// GF-45884: allow enact to avoid setting italic fonts for those scripts that do not
 			// commonly use italics
 			classes.push(base + 'non-italic');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Although Korean is a language to which italic font styles can be applied, non-italic classes are being added.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It is deciding whether to add the `non-italic` class by checking the `scriptName`. 
We can check `Kore` to apply the italic font style to Korean.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-123726

### Comments
