### PR TITLE
PLAT-125200: Call stopPropagation when enter key is pressed in touch mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
-- `spotlight` to call stopPropagation when `enter` key is pressed in touch mode
+- `spotlight/SpotlightRootDecorator` to call stopPropagation when `enter` key is pressed in touch mode
 
 ## [3.4.9] - 2020-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to call stopPropagation when `enter` key is pressed in touch mode
+
 ## [3.4.9] - 2020-10-30
 
 ### Fixed

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -6,8 +6,8 @@
  * @exports SpotlightRootDecorator
  */
 
-import {is} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
+import {is} from '@enact/core/keymap';
 import React from 'react';
 
 import Spotlight from '../src/spotlight';

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -80,6 +80,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.rootContainer = document.querySelector('#root > div');
+			this.rootContainer.classList.add('non-touch-mode');
 
 			document.addEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.addEventListener('keydown', this.handleKeyDown, {capture: true});

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -108,7 +108,6 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
-			console.log(keyCode)
 
 			if (is('enter', keyCode) && this.rootContainer.classList.contains('touch-mode')) {
 				ev.stopPropagation();

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -104,9 +104,15 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		};
 
-		handleKeyDown = () => {
-			this.rootContainer.classList.add('mouse-mode');
-			this.rootContainer.classList.remove('touch-mode');
+		handleKeyDown = (ev) => {
+			const {keyCode} = ev;
+
+			if (keyCode === 13 && this.rootContainer.classList.contains('touch-mode')) {
+				ev.stopPropagation();
+			} else {
+				this.rootContainer.classList.add('mouse-mode');
+				this.rootContainer.classList.remove('touch-mode');
+			}
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -6,6 +6,7 @@
  * @exports SpotlightRootDecorator
  */
 
+import {is} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
 import React from 'react';
 
@@ -80,37 +81,38 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.rootContainer = document.querySelector('#root > div');
 
-			document.addEventListener('pointerover', this.handleMouseTouch, {capture: true});
+			document.addEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.addEventListener('keydown', this.handleKeyDown, {capture: true});
 		}
 
 		componentWillUnmount () {
 			Spotlight.terminate();
 
-			document.removeEventListener('pointerover', this.handleMouseTouch, {capture: true});
+			document.removeEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.removeEventListener('keydown', this.handleKeyDown, {capture: true});
 		}
 
-		handleMouseTouch = (ev) => {
+		handlePointerOver = (ev) => {
 			if (ev.pointerType === 'touch') {
-				this.rootContainer.classList.remove('mouse-mode');
+				this.rootContainer.classList.remove('non-touch-mode');
 				this.rootContainer.classList.add('touch-mode');
 			} else if (ev.pointerType === 'mouse') {
-				this.rootContainer.classList.add('mouse-mode');
+				this.rootContainer.classList.add('non-touch-mode');
 				this.rootContainer.classList.remove('touch-mode');
 			} else {
-				this.rootContainer.classList.remove('mouse-mode');
+				this.rootContainer.classList.remove('non-touch-mode');
 				this.rootContainer.classList.remove('touch-mode');
 			}
 		};
 
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
+			console.log(keyCode)
 
-			if (keyCode === 13 && this.rootContainer.classList.contains('touch-mode')) {
+			if (is('enter', keyCode) && this.rootContainer.classList.contains('touch-mode')) {
 				ev.stopPropagation();
 			} else {
-				this.rootContainer.classList.add('mouse-mode');
+				this.rootContainer.classList.add('non-touch-mode');
 				this.rootContainer.classList.remove('touch-mode');
 			}
 		};

--- a/packages/spotlight/styles/mixins.less
+++ b/packages/spotlight/styles/mixins.less
@@ -16,7 +16,7 @@
 
 // Focused Spottable elements
 .focus(@rules; @target) when (isruleset(@rules)) and (@target = parent) {
-	:global(.mouse-mode) & {
+	:global(.non-touch-mode) & {
 		.spottable({
 			&:focus {
 				@rules();
@@ -33,7 +33,7 @@
 	}
 }
 .focus(@rules) when (isruleset(@rules)) {
-	:global(.mouse-mode) & {
+	:global(.non-touch-mode) & {
 		.spottable({
 			&:focus {
 				@rules();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When touching a component, focus effect has been gone, but focus is still on the component. So if pressing an `enter` key, the, the component receives the key and could execute something.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If pressing an `enter` key after touching, the key is ignored.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-125200

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)