### PR TITLE
PLAT-124525: Media `play` function returns a Promise to see if it was rejected

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Changed
+
+- `ui/Media` play function to return promise
+
 ### Fixed
 
 - `ui/Routable` to respect the current path on first render when using relative paths in links

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Media` play function to return promise
+- `ui/Media` `play` function to return promise
 
 ### Fixed
 

--- a/packages/ui/Media/Media.js
+++ b/packages/ui/Media/Media.js
@@ -244,7 +244,7 @@ class Media extends React.Component {
 	};
 
 	play () {
-		this.media.play();
+		return this.media.play();
 	}
 
 	pause () {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: ui/Media `play` function does not return anything. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Changed `play` function in ui/Media component in order to return promise.

### Links
[//]: # (Related issues, references)
PLAT-124525
https://github.com/enactjs/agate/tree/feature/PLAT-124525

### Comments
