### PR TITLE
PLAT-125337: Wrap the enact root DOM element with touch related CSS class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `spotlight/SpotlightRootDecorator` to call stopPropagation when `enter` key is pressed in touch mode
-
 ## [3.4.9] - 2020-10-30
 
 ### Fixed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight/SpotlightRootDecorator` to remove focus effect when touching up
+- `spotlight/SpotlightRootDecorator` to call stopPropagation when `enter` key is pressed in touch mode
+
 ## [3.4.9] - 2020-10-30
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Changed
 
 - `spotlight/SpotlightRootDecorator` to remove focus effect when touching up
-- `spotlight/SpotlightRootDecorator` to call stopPropagation when `enter` key is pressed in touch mode
+- `spotlight/SpotlightRootDecorator` to ignore `enter` key when the key is pressed in touch mode
 
 ## [3.4.9] - 2020-10-30
 

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -62,6 +62,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
+			this.containerRef = React.createRef();
+
 			if (typeof window === 'object') {
 				Spotlight.initialize({
 					selector: '.' + spottableClass,
@@ -79,8 +81,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.focus();
 			}
 
-			this.rootContainer = document.querySelector('#root > div');
-			this.rootContainer.classList.add('non-touch-mode');
+			this.containerRef.current.classList.add('non-touch-mode');
 
 			document.addEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.addEventListener('keydown', this.handleKeyDown, {capture: true});
@@ -95,25 +96,25 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handlePointerOver = (ev) => {
 			if (ev.pointerType === 'touch') {
-				this.rootContainer.classList.remove('non-touch-mode');
-				this.rootContainer.classList.add('touch-mode');
+				this.containerRef.current.classList.remove('non-touch-mode');
+				this.containerRef.current.classList.add('touch-mode');
 			} else if (ev.pointerType === 'mouse') {
-				this.rootContainer.classList.add('non-touch-mode');
-				this.rootContainer.classList.remove('touch-mode');
+				this.containerRef.current.classList.add('non-touch-mode');
+				this.containerRef.current.classList.remove('touch-mode');
 			} else {
-				this.rootContainer.classList.remove('non-touch-mode');
-				this.rootContainer.classList.remove('touch-mode');
+				this.containerRef.current.classList.remove('non-touch-mode');
+				this.containerRef.current.classList.remove('touch-mode');
 			}
 		};
 
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
 
-			if (is('enter', keyCode) && this.rootContainer.classList.contains('touch-mode')) {
+			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
 				ev.stopPropagation();
 			} else {
-				this.rootContainer.classList.add('non-touch-mode');
-				this.rootContainer.classList.remove('touch-mode');
+				this.containerRef.current.classList.add('non-touch-mode');
+				this.containerRef.current.classList.remove('touch-mode');
 			}
 		};
 
@@ -125,7 +126,11 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		render () {
-			return <Wrapped {...this.props} />;
+			return (
+				<div ref={this.containerRef}>
+					<Wrapped {...this.props} />
+				</div>
+			);
 		}
 	};
 });

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -62,6 +62,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
+			// In other modules, this reference DOM element could be referred by `#root > div`.
 			this.containerRef = React.createRef();
 
 			if (typeof window === 'object') {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In High Contrast mode, the font color doesn't change in a Button when tapping.
Then there are many screenshot test fails.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`enact-a11y-high-contrast` and `non-touch-mode` CSS classes are in one DOM element. But the CSS selector related with focus effect was defined as if in different DOM elements. So I wrapped the Enact root DOM element with a div element including `non-touch-mode` or `touch-mode` CSS class.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-125337

### Comments

I think that CHANGELOG is not needed in this PR. But if having a different opinion, please let me know.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)
