### PR TITLE
PLAT-124923: Fixed Scroller and VirtualList not to scroll diagonally by flick

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Scroller` and `ui/VirtualList` not to scroll diagonally by flick
+- `ui/Scroller` and `ui/VirtualList` to not scroll diagonally by flick
 
 ## [3.4.9] - 2020-10-30
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Scroller` and `ui/VirtualList` not to scroll diagonally by flick
+
 ## [3.4.9] - 2020-10-30
 
 No significant changes.

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -575,25 +575,27 @@ const useScrollBase = (props) => {
 	}
 
 	function onFlick (ev) {
+		const isVerticalFlick = ev.direction === 'vertical';
+
 		if (scrollMode === 'translate') {
 			mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 				mutableRef.current.scrollLeft,
 				mutableRef.current.scrollTop,
-				(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
-				(direction !== 'horizontal') ? -ev.velocityY : 0
+				(direction !== 'vertical' && !isVerticalFlick) ? getRtlX(-ev.velocityX) : 0,
+				(direction !== 'horizontal' && isVerticalFlick) ? -ev.velocityY : 0
 			);
 		} else if (scrollMode === 'native') {
 			if (!mutableRef.current.isTouching) {
 				mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 					mutableRef.current.scrollLeft,
 					mutableRef.current.scrollTop,
-					(direction !== 'vertical') ? getRtlX(-ev.velocityX) : 0,
-					(direction !== 'horizontal') ? -ev.velocityY : 0
+					(direction !== 'vertical' && !isVerticalFlick) ? getRtlX(-ev.velocityX) : 0,
+					(direction !== 'horizontal' && isVerticalFlick) ? -ev.velocityY : 0
 				);
 			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) {
 				mutableRef.current.flickTarget = {
-					targetX: mutableRef.current.scrollLeft + getRtlX(-ev.velocityX) * overscrollVelocityFactor, // 'horizontal' or 'both'
-					targetY: mutableRef.current.scrollTop + -ev.velocityY * overscrollVelocityFactor // 'vertical' or 'both'
+					targetX: mutableRef.current.scrollLeft + (!isVerticalFlick ? getRtlX(-ev.velocityX) : 0) * overscrollVelocityFactor, // 'horizontal' or 'both'
+					targetY: mutableRef.current.scrollTop + (isVerticalFlick ? -ev.velocityY : 0) * overscrollVelocityFactor // 'vertical' or 'both'
 				};
 			}
 		}

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -577,27 +577,18 @@ const useScrollBase = (props) => {
 	function onFlick (ev) {
 		const isVerticalFlick = ev.direction === 'vertical';
 
-		if (scrollMode === 'translate') {
+		if (scrollMode === 'translate' || !mutableRef.current.isTouching) { // except touch input in 'native' mode
 			mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
 				mutableRef.current.scrollLeft,
 				mutableRef.current.scrollTop,
 				(direction !== 'vertical' && !isVerticalFlick) ? getRtlX(-ev.velocityX) : 0,
 				(direction !== 'horizontal' && isVerticalFlick) ? -ev.velocityY : 0
 			);
-		} else if (scrollMode === 'native') {
-			if (!mutableRef.current.isTouching) {
-				mutableRef.current.flickTarget = mutableRef.current.animator.simulate(
-					mutableRef.current.scrollLeft,
-					mutableRef.current.scrollTop,
-					(direction !== 'vertical' && !isVerticalFlick) ? getRtlX(-ev.velocityX) : 0,
-					(direction !== 'horizontal' && isVerticalFlick) ? -ev.velocityY : 0
-				);
-			} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) {
-				mutableRef.current.flickTarget = {
-					targetX: mutableRef.current.scrollLeft + (!isVerticalFlick ? getRtlX(-ev.velocityX) : 0) * overscrollVelocityFactor, // 'horizontal' or 'both'
-					targetY: mutableRef.current.scrollTop + (isVerticalFlick ? -ev.velocityY : 0) * overscrollVelocityFactor // 'vertical' or 'both'
-				};
-			}
+		} else if (mutableRef.current.overscrollEnabled && overscrollEffectOn && overscrollEffectOn.drag) { // overscroll is required on touch input in 'native' mode
+			mutableRef.current.flickTarget = {
+				targetX: mutableRef.current.scrollLeft + (!isVerticalFlick ? getRtlX(-ev.velocityX) : 0) * overscrollVelocityFactor, // 'horizontal' or 'both'
+				targetY: mutableRef.current.scrollTop + (isVerticalFlick ? -ev.velocityY : 0) * overscrollVelocityFactor // 'vertical' or 'both'
+			};
 		}
 
 		if (props.onFlick) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A scroller/list reacts for `onFlick` event unexpectedly when outer component catches also `onFlick` for the orthogonal direction since a scroller/list was designed to scroll diagonally by flick if possible. For now, we don't have any request for diagonal scrolling, so it looks better to limit scrolling directions by flicking direction.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated scrolling logic to only react for flicking direction which is provided as a property of event object.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-124923

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)