### PR TITLE
PLAT-125200: Fix SpotlightRootDecorator to ignore `enter` key in touch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to call preventDefault when `enter` key is pressed in touch mode
+
 ## [3.4.9-experimental-1] - 2020-11-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
-- `spotlight/SpotlightRootDecorator` to call preventDefault when `enter` key is pressed in touch mode
+- `spotlight/SpotlightRootDecorator` to ignore `enter` key in touch mode
 
 ## [3.4.9-experimental-1] - 2020-11-19
 

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -7,6 +7,7 @@
  */
 
 import hoc from '@enact/core/hoc';
+import {is} from '@enact/core/keymap';
 import React from 'react';
 
 import Spotlight from '../src/spotlight';
@@ -107,9 +108,15 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		};
 
-		handleKeyDown = () => {
-			this.containerRef.current.classList.add('non-touch-mode');
-			this.containerRef.current.classList.remove('touch-mode');
+		handleKeyDown = (ev) => {
+			const {keyCode} = ev;
+			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
+				// Prevent onclick event trigger by enter key
+				ev.preventDefault();
+			} else {
+				this.containerRef.current.classList.add('non-touch-mode');
+				this.containerRef.current.classList.remove('touch-mode');
+			}
 		};
 
 		navigableFilter = (elem) => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Image Item is checked when pressing an enter key in touch mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Prevent default to prevent `onClick` event when pressing an enter key in touch mode

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This patch preventDefault onKeyDown, it can block further `onClick` event firing.
But it does not call propergation, because key event is necessary when closing an input by enter.

Since the keyDown event is propagated as it is, the side effects of it have not yet been found, but it can be careful. 
App should use the onClick event as possible.

### Links
[//]: # (Related issues, references)
PLAT-125200

### Comments
