### PR TITLE
PLAT-124534: Support new RTL scroller coordinate of Chrome 85

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to scroll correctly on latest Chrome
+- `ui/Scroller` and `ui/VirtualList` to scroll correctly on Chrome 85 or higher in RTL locales
 
 ### Changed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Fixed
+
+- `ui/Scroller`, `ui/VirtualList`, and `ui/VirtualGridList` to scroll correctly on latest Chrome
+
 ### Changed
 
 - `ui/Media` `play` function to return promise

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -760,7 +760,7 @@ class ScrollableBaseNative extends Component {
 		}
 
 		if (this.props.rtl && canScrollHorizontally) {
-			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
+			scrollLeft = (platform.ios || platform.safari || platform.chrome >= 85) ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
 		if (scrollLeft !== this.scrollLeft) {

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -121,7 +121,7 @@ class ScrollerBasic extends Component {
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			return (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+			return (platform.ios || platform.safari || platform.chrome >= 85) ? -x : this.scrollBounds.maxLeft - x;
 		}
 		return x;
 	};

--- a/packages/ui/Scroller/UiScrollerBase.js
+++ b/packages/ui/Scroller/UiScrollerBase.js
@@ -100,7 +100,7 @@ class ScrollerBase extends Component {
 
 	getRtlPositionX = (x) => {
 		if (this.props.rtl) {
-			return (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+			return (platform.ios || platform.safari || platform.chrome >= 85) ? -x : this.scrollBounds.maxLeft - x;
 		}
 		return x;
 	};

--- a/packages/ui/VirtualList/UiVirtualListBase.js
+++ b/packages/ui/VirtualList/UiVirtualListBase.js
@@ -762,7 +762,7 @@ const VirtualListBaseFactory = (type) => {
 				}
 
 				if (rtl) {
-					x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+					x = (platform.ios || platform.safari || platform.chrome >= 85) ? -x : this.scrollBounds.maxLeft - x;
 				}
 
 				this.containerRef.current.scrollTo(x, y);

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -846,7 +846,7 @@ class VirtualListBasic extends Component {
 	scrollToPosition (x, y, rtl = this.props.rtl) {
 		if (this.props.scrollContentRef.current && this.props.scrollContentRef.current.scrollTo) {
 			if (rtl) {
-				x = (platform.ios || platform.safari) ? -x : this.scrollBounds.maxLeft - x;
+				x = (platform.ios || platform.safari || platform.chrome >= 85) ? -x : this.scrollBounds.maxLeft - x;
 			}
 
 			this.props.scrollContentRef.current.scrollTo(x, y);

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -761,7 +761,7 @@ const useScrollBase = (props) => {
 		}
 
 		if (rtl && canScrollH) {
-			scrollLeft = (platform.ios || platform.safari) ? -scrollLeft : bounds.maxLeft - scrollLeft;
+			scrollLeft = (platform.ios || platform.safari || platform.chrome >= 85) ? -scrollLeft : bounds.maxLeft - scrollLeft;
 		}
 
 		if (scrollLeft !== mutableRef.current.scrollLeft) {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ScrollThumb in horizontalScrollbar is located abnormal position when clicking scrolltrack  with RTL.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Support new RLT scroller coordinate of Chrome 85 (https://www.chromestatus.com/feature/5759578031521792)
- Horizontal (or vertical) scroll position will be zero at its initial position and negative when scrolled leftward (or upward).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-124534

### Comments
