### PR TITLE
PLAT-128518: Update ui/Transition duration prop description

### DIFF
--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -133,8 +133,8 @@ const TransitionBase = kind({
 		 * Controls how long the transition should take.
 		 * Supported preset durations are: `'short'` (250ms), `'medium'` (500ms), and `'long'` (1s).
 		 * `'medium'` (500ms) is default when no others are specified.
-		 * Any valid CSS duration value is also accepted, e.g. "200ms" or "3s". Pure numeric values
-		 * are also supported and treated as milliseconds.
+		 * Any valid CSS duration value is also accepted when `type` is set to `'clip'`,
+		 * e.g. "200ms" or "3s". Pure numeric values are also supported and treated as milliseconds.
 		 *
 		 * @type {String|Number}
 		 * @default 'medium'


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

A valid CSS duration value is only supported when `type` prop is `slide` or `fade`. But there is the following documentation.
```
Any valid CSS duration value is also accepted,
```
App developers could misunderstand that a valid CSS duration is used with `clip` type.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Added the condition in the documentation.
```
Any valid CSS duration value is also accepted when `type` is set to `'clip'`,
```

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-128518

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)