### PR TITLE
PLAT-121331: Pass the status whether or not the component is focused in Spottable

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `spotlight/Spottable` HOC config prop `focusedProp` to pass the status whether or not the component is focused
+
 ## [3.4.9] - 2020-10-30
 
 No significant changes.

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -68,7 +68,17 @@ const defaultConfig = {
 	 * @public
 	 * @memberof spotlight/Spottable.Spottable.defaultConfig
 	 */
-	emulateMouse: true
+	emulateMouse: true,
+
+	/**
+	 * Prop to pass the status whether or not the component is focused.
+	 *
+	 * @type {String}
+	 * @default null
+	 * @public
+	 * @memberof spotlight/Spottable.Spottable.defaultConfig
+	 */
+	focusedProp: '',
 };
 
 /**
@@ -94,7 +104,7 @@ const defaultConfig = {
  * @returns {Function} Spottable
  */
 const Spottable = hoc(defaultConfig, (config, Wrapped) => {
-	const {emulateMouse} = config;
+	const {emulateMouse, focusedProp} = config;
 
 	return class extends React.Component {
 		static displayName = 'Spottable';
@@ -430,6 +440,10 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (spotlightId) {
 				rest['data-spotlight-id'] = spotlightId;
+			}
+
+			if (focusedProp) {
+				rest[focusedProp] = this.isFocused;
 			}
 
 			return (


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

It is hard to know whether the `kind` based component wrapped with Spottable is focused or not.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

If passing `focusedProp` as the default config of the Spottable, then the Spottable will pass the prop ( which name is the `focusedProp` ) to the kind component.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-121331

### Comments
