### PR TITLE
PLAT-125327: Fix condition of .position-start-end mixin for backward compatibility

### DIFF
--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -24,7 +24,7 @@
 // Applies RTL-compatible start and end position to a selector
 // Simple "when" here just assumes that if the first argument is a list with more than 1 entry,
 // then units are correct. If it's just 1, then we varify the value is a number (measurement).
-.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
+.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (@target = parent) or (@target = self) or (@target = "") {
 	.position(@trbl);
 
 	.enact-locale-rtl({
@@ -49,7 +49,7 @@
 }
 
 // Applies RTL-compatible start and end margins to a selector
-.margin-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
+.margin-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (@target = parent) or (@target = self) or (@target = "") {
 	margin: @trbl;
 
 	.enact-locale-rtl({
@@ -73,7 +73,7 @@
 }
 
 // Applies RTL-compatible start and end padding to a selector
-.padding-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
+.padding-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (@target = parent) or (@target = self) or (@target = "") {
 	padding: @trbl;
 
 	.enact-locale-rtl({

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -24,7 +24,7 @@
 // Applies RTL-compatible start and end position to a selector
 // Simple "when" here just assumes that if the first argument is a list with more than 1 entry,
 // then units are correct. If it's just 1, then we varify the value is a number (measurement).
-.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
+.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (@target = "") {
 	.position(@trbl);
 
 	.enact-locale-rtl({

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -24,7 +24,7 @@
 // Applies RTL-compatible start and end position to a selector
 // Simple "when" here just assumes that if the first argument is a list with more than 1 entry,
 // then units are correct. If it's just 1, then we varify the value is a number (measurement).
-.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or (@target = "") {
+.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
 	.position(@trbl);
 
 	.enact-locale-rtl({


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Newly added `.position-start-end` mixin broke the layout of `sandstone/Button` with `color` prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`sandstone/Button` uses `.position-start-end(-@sand-button-colordot-width, initial)` to set `left` and `right` styles to the color bar. But after the https://github.com/enactjs/enact/pull/2859/ PR, `top` and `bottom` styles were also added to the color bar and the position was broken. Because the following new mixin was called unexpectedly.

```
.position-start-end (@trbl; @target: "") when (length(@trbl) > 1) or ((iskeyword(@target)) or (@target = "")) {
	.position(@trbl);

	.enact-locale-rtl({
		.position(
			// Note: swapping left and right values
			.extract(@trbl; top)[]
			.extract(@trbl; left)[]
			.extract(@trbl; bottom)[]
			.extract(@trbl; right)[]
		);
	}; @target);
}
```

The new mixin's condition seems wrong. If passing the `initial` as the second parameter in the mixin to set the `end` value, then the second parameter will be treated as a `@target` since it is a `keyword` and the first parameter will be assigned to top, left, right, and bottom. That's the reason why unexpected top and bottom were added.

So I fixed the condition of `.position-start-end` so that the right mixin could be called.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-125327

### Comments
