### PR TITLE
PLAT-130899: Warn ui/A11yDecorator deprercation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Deprecated
+
+- `ui/A11yDecorator`, to be removed in 4.0.0
+
 ## [3.4.11] - 2020-12-11
 
 ### Fixed

--- a/packages/ui/A11yDecorator/A11yDecorator.js
+++ b/packages/ui/A11yDecorator/A11yDecorator.js
@@ -6,6 +6,7 @@
  */
 
 import hoc from '@enact/core/hoc';
+import deprecate from '@enact/core/internal/deprecate';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -108,14 +109,17 @@ const A11yDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		},
 
-		render: (props) => {
+		render: deprecate((props) => {
 			delete props.accessibilityPreHint;
 			delete props.accessibilityHint;
 
 			return (
 				<Wrapped {...props} />
 			);
-		}
+		}, {
+			name: 'ui/A11yDecorator',
+			until: '4.0.0'
+		})
 	});
 });
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

`ui/A11yDecorator` will be deprecated in Enact 4.0. So it is needed to warn it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Warn ui/A11yDecorator deprercation

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-130899

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)