### PR TITLE
PLAT-129000: Apply voice intent only when scroll is possible

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Changed
 
 - `ui/Transition` prop `duration` to support any valid CSS value for `slide` and `fade` `type`
+- `ui/useScroll` to manage internal state `isScrollVertically` and `isScrollHorizontally`
 
 ## [3.4.11] - 2020-12-11
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1651,7 +1651,6 @@ const useScroll = (props) => {
 		scrollContentHandle,
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible,
-		checkScrollVertically,
 		isScrollVertically,
 		isScrollHorizontally
 	};

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -349,7 +349,7 @@ const useScrollBase = (props) => {
 		const bounds = getScrollBounds();
 		setIsScrollVertically(canScrollVertically(bounds));
 		setIsScrollHorizontally(canScrollHorizontally(bounds));
-	}, [])
+	}, [getScrollBounds, canScrollVertically, canScrollHorizontally]);
 
 
 	// scrollMode 'translate' [[

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -146,6 +146,8 @@ const useScrollBase = (props) => {
 
 	const [isHorizontalScrollbarVisible, setIsHorizontalScrollbarVisible] = useState(horizontalScrollbar === 'visible');
 	const [isVerticalScrollbarVisible, setIsVerticalScrollbarVisible] = useState(verticalScrollbar === 'visible');
+	const [isScrollVertically, setIsScrollVertically] = useState(false);
+	const [isScrollHorizontally, setIsScrollHorizontally] = useState(false);
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),
@@ -342,6 +344,13 @@ const useScrollBase = (props) => {
 			removeEventListeners();
 		};
 	});
+
+	useEffect(() => {
+		const bounds = getScrollBounds();
+		setIsScrollVertically(canScrollVertically(bounds));
+		setIsScrollHorizontally(canScrollHorizontally(bounds));
+	}, [])
+
 
 	// scrollMode 'translate' [[
 	// TODO: consider replacing forceUpdate() by storing bounds in state rather than a non-
@@ -1561,7 +1570,9 @@ const useScrollBase = (props) => {
 	return {
 		scrollContentWrapper: noScrollByDrag ? 'div' : TouchableDiv,
 		isHorizontalScrollbarVisible,
-		isVerticalScrollbarVisible
+		isVerticalScrollbarVisible,
+		isScrollVertically,
+		isScrollHorizontally
 	};
 };
 
@@ -1611,7 +1622,9 @@ const useScroll = (props) => {
 	const {
 		scrollContentWrapper,
 		isHorizontalScrollbarVisible,
-		isVerticalScrollbarVisible
+		isVerticalScrollbarVisible,
+		isScrollVertically,
+		isScrollHorizontally
 	} = useScrollBase({
 		...props,
 		assignProperties,
@@ -1637,7 +1650,10 @@ const useScroll = (props) => {
 		scrollContentWrapper,
 		scrollContentHandle,
 		isHorizontalScrollbarVisible,
-		isVerticalScrollbarVisible
+		isVerticalScrollbarVisible,
+		checkScrollVertically,
+		isScrollVertically,
+		isScrollHorizontally
 	};
 };
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -349,7 +349,7 @@ const useScrollBase = (props) => {
 		const bounds = getScrollBounds();
 		setIsScrollVertically(canScrollVertically(bounds));
 		setIsScrollHorizontally(canScrollHorizontally(bounds));
-	}, [getScrollBounds, canScrollVertically, canScrollHorizontally]);
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 
 	// scrollMode 'translate' [[


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In current status, voice intent is always declared

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply voice intent only when scroll is possible

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-129000

### Comments
N/A