### PR TITLE
PLAT-130865: Supports a custom default event dispatching target

### DIFF
--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -11,6 +11,21 @@ import curry from 'ramda/src/curry';
 
 import {getListeners, addListener} from './listeners';
 
+let defaultTarget = typeof document === 'object' && document;
+
+/*
+ * Sets a selector for the default target. If no selector is set, `document` is the default target.
+ *
+ * @function
+ *
+ * @returns {undefined}
+ * @memberof core/dispatcher
+ * @private
+ */
+const setRootId = (rootId) => {
+	defaultTarget = typeof document === 'object' && document.querySelector('#' + rootId) || false;
+};
+
 /*
  * Checks if the default target of `document` exists before returning it, otherwise returns `false`.
  *
@@ -20,7 +35,7 @@ import {getListeners, addListener} from './listeners';
  * @memberof core/dispatcher
  * @private
  */
-const getDefaultTarget = () => typeof document !== 'undefined' && document;
+const getDefaultTarget = () => defaultTarget;
 
 /*
  * Wraps event callbacks with a try-catch block to prevent unrelated code from blocking.
@@ -137,5 +152,6 @@ const once = function (name, fn, target) {
 export {
 	off,
 	on,
-	once
+	once,
+	setRootId
 };

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -22,8 +22,8 @@ let defaultTarget = typeof document === 'object' && document;
  * @memberof core/dispatcher
  * @private
  */
-const setRootId = (rootId) => {
-	defaultTarget = typeof document === 'object' && document.querySelector('#' + rootId) || defaultTarget;
+const setDefaultTargetById = (id) => {
+	defaultTarget = typeof document === 'object' && document.querySelector('#' + id) || defaultTarget;
 };
 
 /*
@@ -153,5 +153,5 @@ export {
 	off,
 	on,
 	once,
-	setRootId
+	setDefaultTargetById
 };

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -23,7 +23,7 @@ let defaultTarget = typeof document === 'object' && document;
  * @private
  */
 const setRootId = (rootId) => {
-	defaultTarget = typeof document === 'object' && document.querySelector('#' + rootId) || false;
+	defaultTarget = typeof document === 'object' && document.querySelector('#' + rootId) || defaultTarget;
 };
 
 /*

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -17,6 +17,7 @@ let defaultTarget = typeof document === 'object' && document;
  * Sets a selector for the default target. If no selector is set, `document` is the default target.
  *
  * @function
+ * @param	{String}	id	Node id of the default target
  *
  * @returns {undefined}
  * @memberof core/dispatcher


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Due to React's changes of event delegation from version 17, event callback order is changed in some components which add event handlers to `document`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
An API is added to set up React DOM tree root for internal components which cannot determine which node is the right event target.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
APIs to add/remove event handlers (`on` and `off`) already provide a parameter to specify the target node to attach or detach event handlers. So if an app uses Enact libraries without Enact CLI, it can simply use our existing APIs with the parameter without setting up the target node with the newly added API. The new API is for internal use.

### Links
[//]: # (Related issues, references)
PLAT-130865

### Comments
