### PR TITLE
PLAT-132612: Fix SpotlightRootDecorator to show focus effect when enter key is pressed in touch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `spotlight/SpotlightRootDecorator` to change non touch mode when `enter` key is down in touch mode
 
 
 ## [3.4.9-experimental-2] - 2020-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-
-
 ## [3.4.9-experimental-2] - 2020-12-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to change non touch mode when `enter` key is down in touch mode
+
+
 ## [3.4.9-experimental-2] - 2020-12-03
 
 ### Fixed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to change non touch mode when `enter` key is down in touch mode
+
 ## [3.4.9-experimental-2] - 2020-12-03
 
 ### Fixed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight/SpotlightRootDecorator` to change non touch mode when `enter` key is down in touch mode
+- `spotlight/SpotlightRootDecorator` to show focus effect when `enter` key is pressed in touch mode
 
 ## [3.4.9-experimental-2] - 2020-12-03
 

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -112,13 +112,11 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {keyCode} = ev;
 			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
 				// Prevent onclick event trigger by enter key
-				this.containerRef.current.classList.add('non-touch-mode');
-				this.containerRef.current.classList.remove('touch-mode');
 				ev.preventDefault();
-			} else {
-				this.containerRef.current.classList.add('non-touch-mode');
-				this.containerRef.current.classList.remove('touch-mode');
 			}
+
+			this.containerRef.current.classList.add('non-touch-mode');
+			this.containerRef.current.classList.remove('touch-mode');
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -112,6 +112,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {keyCode} = ev;
 			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
 				// Prevent onclick event trigger by enter key
+				this.containerRef.current.classList.add('non-touch-mode');
+				this.containerRef.current.classList.remove('touch-mode');
 				ev.preventDefault();
 			} else {
 				this.containerRef.current.classList.add('non-touch-mode');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When press enter in touch mode, focus is not restored

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change touch state when enter key is occur in touch mode

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-132612

### Comments
N/A