### PR TITLE
PLAT-134190: Apply the last Input type to show spotlight when app launches on webOS

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to refer the last input type from webos
+
 ## [3.4.9-experimental-3] - 2021-01-26
 
 ### Fixed

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -56,6 +56,7 @@ const defaultConfig = {
  */
 const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {noAutoFocus} = config;
+	let lastInputType = 'key';
 
 	return class extends React.Component {
 		static displayName = 'SpotlightRootDecorator';
@@ -79,13 +80,14 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			this.getLastInputType();
-
-			if (!noAutoFocus) {
-				Spotlight.focus();
-			}
-
-			this.containerRef.current.classList.add('non-touch-mode');
+			this.getLastInputType().finally(() => {
+				if (!noAutoFocus && lastInputType !== 'touch') {
+					Spotlight.focus();
+				}
+				if (lastInputType === 'touch') {
+					this.containerRef.current.classList.add('non-touch-mode');
+				}
+			});
 
 			document.addEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.addEventListener('keydown', this.handleKeyDown, {capture: true});
@@ -107,11 +109,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					method: 'getLastInputType',
 					subscribe: true,
 					onSuccess: function (res) {
-						console.log('onSucess');
 						console.log(res);
-						console.log(res.lastInputType);
-
-						// TODO : Change touch mode
+						lastInputType = res.lastInputType;
 						resolve();
 					},
 					onFailure: function (err) {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -8,6 +8,7 @@
 
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
+import LS2Request from '@enact/webos/LS2Request/LS2Request';
 import React from 'react';
 
 import Spotlight from '../src/spotlight';
@@ -78,6 +79,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidMount () {
+			this.getLastInputType();
+
 			if (!noAutoFocus) {
 				Spotlight.focus();
 			}
@@ -94,6 +97,31 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			document.removeEventListener('pointerover', this.handlePointerOver, {capture: true});
 			document.removeEventListener('keydown', this.handleKeyDown, {capture: true});
 		}
+
+		// FIXME: This is a temporary support for NMRM
+		getLastInputType = () => new Promise((resolve, reject) => {
+			console.log('getLastInputType');
+			if (window.PalmSystem) {
+				new LS2Request().send({
+					service: 'luna://com.webos.surfacemanager',
+					method: 'getLastInputType',
+					subscribe: true,
+					onSuccess: function (res) {
+						console.log('onSucess');
+						console.log(res);
+						console.log(res.lastInputType);
+
+						// TODO : Change touch mode
+						resolve();
+					},
+					onFailure: function (err) {
+						reject('Failed to get system LastInputType: ' + JSON.stringify(err));
+					}
+				});
+			} else {
+				resolve();
+			}
+		});
 
 		handlePointerOver = (ev) => {
 			if (ev.pointerType === 'touch') {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -128,8 +128,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				} else {
 					resolve();
 				}
-			}
-			);
+			});
 		};
 
 		handleVisibilityChange = () => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -111,7 +111,6 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		// FIXME: This is a temporary support for NMRM
 		getLastInputType = () => {
-			const that = this;
 			return new Promise(function (resolve, reject) {
 				if (window.PalmSystem) {
 					new LS2Request().send({


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Input type does not match when app launches on webOS

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Invoke luna call for get last input type

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-134190

### Comments
