### PR TITLE
PLAT-73431: Rename `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -84,7 +84,7 @@ Below is an example of HOC declaration:
 /**
  * A higher-order component that provides a consistent set of pointer events -- `onDown`, `onUp`,
  * and `onTap` -- across mouse and touch interfaces along with support for common gestures including
- * `onFlick`, `onDrag`, `onHold`, and `onHoldPulse`.
+ * `onFlick`, `onDrag`, `onHoldStart`, `onHold`, and `onHoldEnd`.
  *
  * @class Touchable
  * @memberof ui/Touchable

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Changed
 
-- `ui/Touchable` event `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively to match with general event semantics
+- `ui/Touchable` event `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively to match with the naming convention
 
 ## [3.5.0] - 2021-02-05
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/Touchable` event `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively to match with general event semantics
+
 ## [3.5.0] - 2021-02-05
 
 ### Deprecated

--- a/packages/ui/Touchable/Hold.js
+++ b/packages/ui/Touchable/Hold.js
@@ -18,8 +18,8 @@ class Hold {
 		return Math.sqrt(dx * dx + dy * dy) < moveTolerance;
 	};
 
-	begin = (defaultConfig, {holdConfig, noResume, onHold, onHoldEnd, onHoldPulse}, {x, y}) => {
-		if (!onHold && !onHoldPulse) return;
+	begin = (defaultConfig, {holdConfig, noResume, onHoldStart, onHoldEnd, onHold}, {x, y}) => {
+		if (!onHoldStart && !onHold) return;
 
 		this.startX = x;
 		this.startY = y;
@@ -27,9 +27,9 @@ class Hold {
 		this.holdConfig = {
 			...defaultConfig,
 			...holdConfig,
-			onHold,
+			onHoldStart,
 			onHoldEnd,
-			onHoldPulse,
+			onHold,
 			resume: !noResume
 		};
 
@@ -49,14 +49,14 @@ class Hold {
 		}
 	};
 
-	// This method will get the `onHold`, `onHoldEnd`, `onHoldPulse` props and update in the existing `holdConfig`.
-	updateProps = ({onHold, onHoldEnd, onHoldPulse}) => {
+	// This method will get the `onHoldStart`, `onHoldEnd`, `onHold` props and update in the existing `holdConfig`.
+	updateProps = ({onHoldStart, onHoldEnd, onHold}) => {
 		// check `isHolding` gesture is not in progress. Check if gesture exists before updating the references to the `holdConfig`
 		if (!this.isHolding()) return;
 
 		// Update the original values with new values of the gestures
-		this.holdConfig.onHoldPulse = onHoldPulse;
 		this.holdConfig.onHold = onHold;
+		this.holdConfig.onHoldStart = onHoldStart;
 		this.holdConfig.onHoldEnd = onHoldEnd;
 	};
 
@@ -154,16 +154,16 @@ class Hold {
 
 		let n = this.next;
 		while (n && n.time <= holdTime) {
-			const {events, onHold} = this.holdConfig;
+			const {events, onHoldStart} = this.holdConfig;
 			this.pulsing = true;
-			if (onHold) {
-				onHold({
-					type: 'onHold',
+			if (onHoldStart) {
+				onHoldStart({
+					type: 'onHoldStart',
 					...n
 				});
 			}
 
-			// if the hold is canceled from the onHold handler, we should bail early and prevent
+			// if the hold is canceled from the onHoldStart handler, we should bail early and prevent
 			// additional hold/pulse events
 			if (!this.isHolding()) {
 				this.pulsing = false;
@@ -174,11 +174,11 @@ class Hold {
 		}
 
 		if (this.pulsing) {
-			const {onHoldPulse} = this.holdConfig;
+			const {onHold} = this.holdConfig;
 
-			if (onHoldPulse) {
-				onHoldPulse({
-					type: 'onHoldPulse',
+			if (onHold) {
+				onHold({
+					type: 'onHold',
 					time: holdTime
 				});
 			}

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -199,7 +199,7 @@ const defaultConfig = {
 /**
  * A higher-order component that provides a consistent set of pointer events -- `onDown`, `onUp`,
  * and `onTap` -- across mouse and touch interfaces along with support for common gestures including
- * `onFlick`, `onDrag`, `onHold`, and `onHoldPulse`.
+ * `onFlick`, `onDrag`, `onHoldStart`, `onHold`, and `onHoldEnd`.
  *
  * Note: This HoC passes a number of props to the wrapped component that should be passed to the
  * main DOM node or consumed by the wrapped component.
@@ -328,14 +328,12 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			onFlick: PropTypes.func,
 
 			/**
-			 * Event handler for hold events.
+			 * Event handler for hold pulse events
 			 *
 			 * Event payload includes:
 			 *
 			 * * `type` - Type of event, `'onHold'`
-			 * * `name` - The name of the hold as configured in the events list
-			 * * `time` - Time, in milliseconds, configured for this hold which may vary slightly
-			 *            from time since the hold began
+			 * * `time` - Time, in milliseconds, since the hold began
 			 *
 			 * @type {Function}
 			 * @public
@@ -356,17 +354,19 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			onHoldEnd: PropTypes.func,
 
 			/**
-			 * Event handler for hold pulse events
+			 * Event handler for hold events.
 			 *
 			 * Event payload includes:
 			 *
-			 * * `type` - Type of event, `'onHoldPulse'`
-			 * * `time` - Time, in milliseconds, since the hold began
+			 * * `type` - Type of event, `'onHoldStart'`
+			 * * `name` - The name of the hold as configured in the events list
+			 * * `time` - Time, in milliseconds, configured for this hold which may vary slightly
+			 *            from time since the hold began
 			 *
 			 * @type {Function}
 			 * @public
 			 */
-			onHoldPulse: PropTypes.func,
+			onHoldStart: PropTypes.func,
 
 			/**
 			 * Event handler for 'tap' pointer events
@@ -461,7 +461,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 				hold: this.props.holdConfig
 			});
 
-			// Update the props onHold, onHoldEnd, onHoldPulse on any gesture (hold, flick, drag).
+			// Update the props onHoldStart, onHoldEnd, onHold on any gesture (hold, flick, drag).
 			this.hold.updateProps(this.props);
 			this.flick.updateProps(this.props);
 			this.drag.updateProps(this.props);
@@ -654,7 +654,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			delete props.onFlick;
 			delete props.onHold;
 			delete props.onHoldEnd;
-			delete props.onHoldPulse;
+			delete props.onHoldStart;
 			delete props.onTap;
 			delete props.onUp;
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -328,7 +328,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 			onFlick: PropTypes.func,
 
 			/**
-			 * Event handler for hold pulse events
+			 * Event handler for hold pulse events.
 			 *
 			 * Event payload includes:
 			 *

--- a/packages/ui/Touchable/config.js
+++ b/packages/ui/Touchable/config.js
@@ -94,8 +94,8 @@ const mergeConfig = (cfg) => {
  *     may move before cancelling the hold. Ignored when `cancelOnMove` is `false`. Defaults to
  *     `16`.
  *   * `frequency` - The time, in milliseconds, to poll for hold events. Defaults to `200`.
- *   * `events` - An array of `onHold` events which each contain a `name` and `time`. The `time`
- *     controls the amount of time that must pass before this `onHold` event is fired and should
+ *   * `events` - An array of `onHoldStart` events which each contain a `name` and `time`. The `time`
+ *     controls the amount of time that must pass before this `onHoldStart` event is fired and should
  *     be a multiple of `frequency`.
  *
  * @function

--- a/packages/ui/Touchable/tests/Touchable-specs.js
+++ b/packages/ui/Touchable/tests/Touchable-specs.js
@@ -49,7 +49,36 @@ describe('Touchable', () => {
 		);
 
 		test(
-			'should update state configurations onHoldPulse events',
+			'should update state configurations onHold events',
+			(done) => {
+				const holdConfig = {
+					events: [
+						{name: 'hold', time: 10}
+					],
+					frequency: 10
+				};
+
+				const Component = Touchable(DivComponent);
+				const handler = jest.fn();
+				const subject = mount(
+					<Component onHoldStart={() => {}} holdConfig={holdConfig} />
+				);
+
+				const ev = {};
+				subject.simulate('mousedown', ev);
+				subject.setProps({
+					onHold: handler
+				});
+
+				setTimeout(() => {
+					expect(handler).toHaveBeenCalled();
+					done();
+				}, 20);
+			}
+		);
+
+		test(
+			'should update state configurations onHoldStart events',
 			(done) => {
 				const holdConfig = {
 					events: [
@@ -67,36 +96,7 @@ describe('Touchable', () => {
 				const ev = {};
 				subject.simulate('mousedown', ev);
 				subject.setProps({
-					onHoldPulse: handler
-				});
-
-				setTimeout(() => {
-					expect(handler).toHaveBeenCalled();
-					done();
-				}, 20);
-			}
-		);
-
-		test(
-			'should update state configurations onHold events',
-			(done) => {
-				const holdConfig = {
-					events: [
-						{name: 'hold', time: 10}
-					],
-					frequency: 10
-				};
-
-				const Component = Touchable(DivComponent);
-				const handler = jest.fn();
-				const subject = mount(
-					<Component onHoldPulse={() => {}} holdConfig={holdConfig} />
-				);
-
-				const ev = {};
-				subject.simulate('mousedown', ev);
-				subject.setProps({
-					onHold: handler
+					onHoldStart: handler
 				});
 
 				setTimeout(() => {
@@ -119,7 +119,7 @@ describe('Touchable', () => {
 				const Component = Touchable(DivComponent);
 				const handler = jest.fn();
 				const subject = mount(
-					<Component onHoldPulse={() => {}} holdConfig={holdConfig} />
+					<Component onHold={() => {}} holdConfig={holdConfig} />
 				);
 
 				const ev = {currentTarget: {}};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Currently, `Touchable` dispatches `onHold`, `onHoldPulse`, and `onHoldEnd` events for holding down events and events' names are not matched with other regular events like `TouchStart` and `TouchEnd`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To make the hold events to get the semantics the same, we'd like to rename `onHold` to `onHoldStart` and `onHoldPulse` to `onHold`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Since `onHold` will have a different meaning after this change, we need to ship this change in the major version update to minimize issues from backward compatibility.

### Links
[//]: # (Related issues, references)
PLAT-73431
https://github.com/enactjs/enact/pull/1965#issuecomment-427181674

### Comments
