### PR TITLE
PLAT-107982: Removed Button, Icon, IconButton, and LabeledIcon default size values

### DIFF
--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -158,7 +158,6 @@ const ButtonBase = kind({
 		 * [theming]{@link /docs/developer-guide/theming/}.
 		 *
 		 * @type {String}
-		 * @default 'large'
 		 * @public
 		 */
 		size: PropTypes.string

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` default size values
+
 ## [4.0.0-alpha.1] - 2021-02-24
 
 No significant changes.

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -130,7 +130,6 @@ const Icon = kind({
 		 * [theming]{@link /docs/developer-guide/theming/}.
 		 *
 		 * @type {String}
-		 * @default 'small'
 		 * @public
 		 */
 		size: PropTypes.string
@@ -138,8 +137,7 @@ const Icon = kind({
 
 	defaultProps: {
 		iconList: {},
-		pressed: false,
-		size: 'small'
+		pressed: false
 	},
 
 	styles: {

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -138,7 +138,6 @@ const IconButtonBase = kind({
 		 * [theming]{@link /docs/developer-guide/theming/}.
 		 *
 		 * @type {String}
-		 * @default 'large'
 		 * @public
 		 */
 		size: PropTypes.string
@@ -147,8 +146,7 @@ const IconButtonBase = kind({
 	defaultProps: {
 		disabled: false,
 		pressed: false,
-		selected: false,
-		size: 'large'
+		selected: false
 	},
 
 	styles: {

--- a/packages/ui/LabeledIcon/LabeledIcon.js
+++ b/packages/ui/LabeledIcon/LabeledIcon.js
@@ -144,7 +144,6 @@ const LabeledIconBase = kind({
 		 * [theming]{@link /docs/developer-guide/theming/}.
 		 *
 		 * @type {String}
-		 * @default 'large'
 		 * @public
 		 */
 		size: PropTypes.string
@@ -152,8 +151,7 @@ const LabeledIconBase = kind({
 
 	defaultProps: {
 		labelPosition: 'below',
-		inline: false,
-		size: 'large'
+		inline: false
 	},
 
 	styles: {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We've changed `size` prop values of `Button`, `Icon`, `IconButton`, and `LabeledIcon` to `String` from PLAT-105260.
We didn't change the default size value since it's API changing.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Now, we are in the alpha phase for 4.0.0, we'd like to remove default size values from them.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-107982

### Comments
