### PR TITLE
PLAT-126948: Allow number type value for frequency

### DIFF
--- a/packages/spotlight/Accelerator/Accelerator.js
+++ b/packages/spotlight/Accelerator/Accelerator.js
@@ -63,7 +63,7 @@ class Accelerator {
 		 * Controls the frequency with which the acceleration will "freeze". While frozen,
 		 * the current target item cannot change, and all events are directed to it.
 		 *
-		 * @type {Number[]}
+		 * @type {Number|Number[]}
 		 * @default [3, 3, 3, 2, 2, 2, 1]
 		 * @public
 		 */
@@ -99,10 +99,14 @@ class Accelerator {
 						seconds = Math.floor(elapsedTime / 1000),
 						toSkip = 0;
 
-					seconds = seconds > this.frequency.length - 1 ? this.frequency.length - 1 : seconds;
+					if (Array.isArray(this.frequency)) {
+						seconds = seconds > this.frequency.length - 1 ? this.frequency.length - 1 : seconds;
+						toSkip = this.frequency[seconds] - 1;
+					} else {
+						toSkip = this.frequency - 1;
+					}
 
-					toSkip = this.frequency[seconds] - 1;
-					if (toSkip < 0) {
+					if (isNaN(toSkip) || toSkip < 0) {
 						toSkip = 0;
 					}
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight/Accelerator` to allow not only number array type but also number type variable for `frequency`.
+
 ## [4.0.0-alpha.1] - 2021-02-24
 
 ### Fixed


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Provide prop to control the accelerating speed when key hold.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Allow number type value for frequency

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-126948

### Comments
