### PR TITLE
PLAT-137759: Fix FloatingLayerDecorator to render the floating node properly

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,13 +4,17 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Removed
+
+- `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` default size values
+
 ### Changed
 
 - `ui/Touchable` event `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively to match with the naming convention
 
-### Removed
+### Fixed
 
-- `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` default size values
+- `ui/FloatingLayerDecorator` to render floating node properly
 
 ## [4.0.0-alpha.1] - 2021-02-24
 

--- a/packages/ui/FloatingLayer/FloatingLayerContainer.js
+++ b/packages/ui/FloatingLayer/FloatingLayerContainer.js
@@ -1,7 +1,4 @@
-import {call, forEventProp, oneOf} from '@enact/core/handle';
 import Registry from '@enact/core/internal/Registry';
-
-const forAction = forEventProp('action');
 
 class FloatingLayerContainer {
 	constructor (config) {
@@ -29,10 +26,13 @@ class FloatingLayerContainer {
 		);
 	};
 
-	handleNotify = oneOf(
-		[forAction('register'), call('notifyMount')],
-		[forAction('closeAll'), call('handleCloseAll')]
-	).bind(this);
+	handleNotify = ({action}) => {
+		if (action === 'register') {
+			this.notifyMount();
+		} else if (action === 'closeAll') {
+			this.handleCloseAll();
+		}
+	};
 
 	handleCloseAll () {
 		this.registry.notify({action: 'close'});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
From the theme libs, the Popup kind is not opened in some samples.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
While we migrated `FloatingLayerDecorator` to use hooks, handler that uses modules from `@enact/core/handle` had some problem with binding `this`. So I replaced the related logic to not use the related modules. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-137759

### Comments
