### PR TITLE
PLAT-137855: Fixed `Touchable` to handle touch-related events only for valid targets

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Touchable` event `onHold` and `onHoldPulse` to `onHoldStart` and `onHold` respectively to match with the naming convention
 
+### Fixed
+
+- `ui/Touchable' to handle touch related events only for valid targets
+
 ### Removed
 
 - `ui/Button`, `ui/Icon`, `ui/IconButton`, and `ui/LabeledIcon` default size values

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -133,7 +133,7 @@ const handleClick = handle(
 
 const handleTouchStart = handle(
 	forward('onTouchStart'),
-	returnsTrue(call('startTouch')),
+	call('startTouch'),
 	handleDown
 );
 
@@ -516,9 +516,13 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 
 		// Gesture Support
 
-		startTouch ({currentTarget}) {
-			on('contextmenu', preventDefault);
-			this.targetBounds = currentTarget.getBoundingClientRect();
+		startTouch ({target, currentTarget}) {
+			if (currentTarget.contains(target)) {
+				on('contextmenu', preventDefault);
+				this.targetBounds = currentTarget.getBoundingClientRect();
+				return true;
+			}
+			return false;
 		}
 
 		endTouch () {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When popup is open, a touchable component underlying an open popup catches `onDrag` and `onFlick` events.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
There was no target element checking in `Touchable`.
In this PR, `Touchable` checks whether `currentTarget` contains `target` or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-137855

### Comments
