### PR TITLE
PLAT-136893: Fix console error when scrolling and close Dropdown

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/FloatingLayerDecorator` to render floating node properly
+- `ui/Scroller` and `ui/VirtualList` to unmount it properly
 - `ui/Touchable' to handle touch related events only for valid targets
 
 ## [4.0.0-alpha.1] - 2021-02-24

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,7 +19,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/FloatingLayerDecorator` to render floating node properly
-- `ui/Scroller` and `ui/VirtualList` to unmount it properly
 - `ui/Touchable' to handle touch related events only for valid targets
 
 ## [4.0.0-alpha.1] - 2021-02-24

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -311,7 +311,7 @@ const useScrollBase = (props) => {
 		}
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		mutableRef.current.resizeRegistry.parent = context;
 
 		// componentWillUnmount
@@ -382,7 +382,7 @@ const useScrollBase = (props) => {
 		mutableRef.current.resizeRegistry = Registry.create(handleResize);
 	}
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const ref = mutableRef.current;
 
 		if (scrollMode === 'translate') {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was console error when scrolling and close Dropdown

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

![image](https://user-images.githubusercontent.com/34676178/112073959-7fd76d00-8bb8-11eb-98db-5491a0c82c99.png)

After the Scroller in DropDown has already been removed, the return part of useEffect is performed. So the bound value became undefined.
This is because the useEffect() is not synchronous so the scroll-related cleanup part is executed too late.
So I changed useEffect to useLayoutEffect

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-136893
https://github.com/enactjs/sandstone/pull/852

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)