### PR TITLE
PLAT-139332: Get Chromium version on webOS

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/platform` to detect chromium version for webOS
+
 ## [4.0.0] - 2021-03-26
 
 No significant changes.

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -40,6 +40,13 @@ const hasTouchScreen = () => {
 	);
 };
 
+const webOSVersion = {
+	38: 3,
+	53: 4,
+	68: 5,
+	79: 6
+};
+
 const platforms = [
 	// Windows Phone 7 - 10
 	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
@@ -66,11 +73,7 @@ const platforms = [
 	// LG webOS
 	{platform: 'webos', regex: /Web0S;.*Safari\/537.41/, forceVersion: 1},
 	{platform: 'webos', regex: /Web0S;.*Safari\/538.2/, forceVersion: 2},
-	{platform: 'webos', regex: /Web0S;.*Chrome\/38/, forceVersion: 3},
-	{platform: 'webos', regex: /Web0S;.*Chrome\/53/, forceVersion: 4},
-	{platform: 'webos', regex: /Web0S;.*Chrome\/68/, forceVersion: 5},
-	{platform: 'webos', regex: /Web0S;.*Chrome\/79/, forceVersion: 6},
-	{platform: 'webos', regex: /Web0S;.*Chrome\/(\d+)/, forceVersion: 7},
+	{platform: 'webos', regex: /Web0S;.*Chrome\/(\d+)/},
 	// LG webOS of indeterminate versionre
 	{platform: 'webos', regex: /Web0S;/, forceVersion: -1},
 	// LuneOS
@@ -121,8 +124,10 @@ const parseUserAgent = (userAgent) => {
 
 			if ('forceVersion' in p) {
 				v = p.forceVersion;
+			} else if (p.platform  === 'webos') {
+				v = webOSVersion[m[1]] || -1;
 
-				if (p.platform  === 'webos' && v >= 7) {
+				if (v >= 7 || v === -1) {
 					plat.chrome = Number(m[1]);
 				}
 			} else {

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -69,7 +69,9 @@ const platforms = [
 	{platform: 'webos', regex: /Web0S;.*Chrome\/38/, forceVersion: 3},
 	{platform: 'webos', regex: /Web0S;.*Chrome\/53/, forceVersion: 4},
 	{platform: 'webos', regex: /Web0S;.*Chrome\/68/, forceVersion: 5},
-	// LG webOS of indeterminate version
+	{platform: 'webos', regex: /Web0S;.*Chrome\/79/, forceVersion: 6},
+	{platform: 'webos', regex: /Web0S;.*Chrome\/(\d+)/, forceVersion: 7},
+	// LG webOS of indeterminate versionre
 	{platform: 'webos', regex: /Web0S;/, forceVersion: -1},
 	// LuneOS
 	{platform: 'webos', regex: /LuneOS/, forceVersion: -1, extra: {luneos: 1}},
@@ -119,6 +121,10 @@ const parseUserAgent = (userAgent) => {
 
 			if ('forceVersion' in p) {
 				v = p.forceVersion;
+
+				if (p.platform  === 'webos' && v >= 7) {
+					plat.chrome = m[1];
+				}
 			} else {
 				v = Number(m[1]);
 			}

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -123,7 +123,7 @@ const parseUserAgent = (userAgent) => {
 				v = p.forceVersion;
 
 				if (p.platform  === 'webos' && v >= 7) {
-					plat.chrome = m[1];
+					plat.chrome = Number(m[1]);
 				}
 			} else {
 				v = Number(m[1]);

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -4,6 +4,7 @@ describe('platform', () => {
 
 	describe('webOS', () => {
 		// From http://webostv.developer.lge.com/discover/specifications/web-engine/
+		const webOSTV6 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.1785.34 Safari/537.36 WebAppManager';
 		const webOSTV3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.1.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
@@ -20,7 +21,7 @@ describe('platform', () => {
 		const webOS1351 = 'Mozilla/5.0 (webOS/1.3.5.1; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.1';
 		const webOS2 = 'Mozilla/5.0 (webOS/2.0.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.2';
 
-		const webOSOther = 'Mozilla/5.0 (Web0S; Linux) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3440.106 Safari/537.36 WebAppManager';
+		const webOSOther = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager';
 
 		test('should return webOS 1', () => {
 			const expected = {webos: 1};
@@ -57,8 +58,15 @@ describe('platform', () => {
 			expect(actual).toMatchObject(expected);
 		});
 
-		test('should return webOS -1', () => {
-			const expected = {webos: -1};
+		test('should return webOS 6', () => {
+			const expected = {webos: 6};
+			const actual = parseUserAgent(webOSTV6);
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		test('should return webOS 7 and chrome 87', () => {
+			const expected = {webos: 7, chrome: 87};
 			const actual = parseUserAgent(webOSOther);
 
 			expect(actual).toMatchObject(expected);

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -4,7 +4,7 @@ describe('platform', () => {
 
 	describe('webOS', () => {
 		// From http://webostv.developer.lge.com/discover/specifications/web-engine/
-		const webOSTV7 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager';
+		const webOSTVNext = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager';
 		const webOSTV6 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.1785.34 Safari/537.36 WebAppManager';
@@ -66,9 +66,9 @@ describe('platform', () => {
 			expect(actual).toMatchObject(expected);
 		});
 
-		test('should return webOS 7 and chrome 87', () => {
+		test('should return webOS Next and chrome 87', () => {
 			const expected = {webos: -1, chrome: 87};
-			const actual = parseUserAgent(webOSTV7);
+			const actual = parseUserAgent(webOSTVNext);
 
 			expect(actual).toMatchObject(expected);
 		});

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -4,6 +4,7 @@ describe('platform', () => {
 
 	describe('webOS', () => {
 		// From http://webostv.developer.lge.com/discover/specifications/web-engine/
+		const webOSTV7 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager';
 		const webOSTV6 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
 		const webOSTV4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.1785.34 Safari/537.36 WebAppManager';
@@ -21,7 +22,7 @@ describe('platform', () => {
 		const webOS1351 = 'Mozilla/5.0 (webOS/1.3.5.1; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.1';
 		const webOS2 = 'Mozilla/5.0 (webOS/2.0.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.2';
 
-		const webOSOther = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager';
+		const webOSOther = 'Mozilla/5.0 (Web0S; Linux) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 WebAppManager';
 
 		test('should return webOS 1', () => {
 			const expected = {webos: 1};
@@ -66,7 +67,14 @@ describe('platform', () => {
 		});
 
 		test('should return webOS 7 and chrome 87', () => {
-			const expected = {webos: 7, chrome: 87};
+			const expected = {webos: -1, chrome: 87};
+			const actual = parseUserAgent(webOSTV7);
+
+			expect(actual).toMatchObject(expected);
+		});
+
+		test('should return webOS -1', () => {
+			const expected = {webos: -1};
 			const actual = parseUserAgent(webOSOther);
 
 			expect(actual).toMatchObject(expected);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The list is not scrolling to right while wheeling down through MRCU.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue is related with https://github.com/enactjs/enact/pull/2874
To detect the chromium version in webOS, I set it into the platform variable.

```
userAgent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 WebAppManager
==> 
platform = {
 chrome: "87"	// This was added
 gesture: false
 node: false
 platformName: "webos"
 touch: true
 touchscreen: true
 unknown: false 
 webos: 7
}
```

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-139332

### Comments
