### PR TITLE
PLAT-139608: SpotlightRootDecorator: Fixed setTouchMode in KeyDown to refer the lastInputType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enactjs/cli#develop
+    - npm install -g enactjs/cli#3.0.5
     - npm install -g codecov
     - npm install
     - npm run bootstrap

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to not change to none touch mode when tapping VKB button
+
 ## [3.4.9-experimental-5] - 2021-03-17
 
 No significant changes.

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -146,18 +146,21 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleFocusIn = () => {
 			if (needChangeTouchMode) {
-				this.setTouchModeClass (lastInputType);
+				this.setTouchModeClass(lastInputType);
 			}
 		};
 
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
-			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
-				// Prevent onclick event trigger by enter key
-				ev.preventDefault();
+			if (this.containerRef.current.classList.contains('touch-mode')) {
+				if (is('enter', keyCode)) {
+					// Prevent onclick event trigger by enter key
+					ev.preventDefault();
+				}
+				setTimeout(() => {
+					this.setTouchModeClass(lastInputType);
+				}, 0);
 			}
-
-			this.setTouchModeClass('key');
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -157,10 +157,10 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					// Prevent onclick event trigger by enter key
 					ev.preventDefault();
 				}
-				setTimeout(() => {
-					this.setTouchModeClass(lastInputType);
-				}, 0);
 			}
+			setTimeout(() => {
+				this.setTouchModeClass(lastInputType);
+			}, 0);
 		};
 
 		navigableFilter = (elem) => {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -152,12 +152,11 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
-			if (this.containerRef.current.classList.contains('touch-mode')) {
-				if (is('enter', keyCode)) {
-					// Prevent onclick event trigger by enter key
-					ev.preventDefault();
-				}
+			if (is('enter', keyCode) && this.containerRef.current.classList.contains('touch-mode')) {
+				// Prevent onclick event trigger by enter key
+				ev.preventDefault();
 			}
+
 			setTimeout(() => {
 				this.setTouchModeClass(lastInputType);
 			}, 0);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus exist after input text with touch using VKB.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
**AS-IS**: Set "key" mode unconditionally after KeyDown.
(https://github.com/enactjs/enact/pull/2892)
(https://github.com/enactjs/enact/pull/2897)
**TO-BE**:  Set key mode using lastInputType value. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
To invoke the setTouchMede function after receiving the lastInputType result, I used the setTimeout.

### Links
[//]: # (Related issues, references)
PLAT-139608

### Comments
