### PR TITLE
PLAT-141617: Fixed ViewManager state when noAnimation is changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `ui/ViewManager` to set `state.entering` to `false` when `noAnimation` prop is changed to `true`
-
 ## [4.0.5] - 2021-08-02
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -21,6 +21,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/FloatingLayerDecorator` to render floating node properly
 - `ui/Touchable' to handle touch related events only for valid targets
+- `ui/ViewManager` to set `state.entering` to `false` when `noAnimation` prop is changed to `true`
 
 ## [4.0.0-alpha.1] - 2021-02-24
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/ViewManager` to set `state.entering` to `false` when `noAnimation` prop is changed to `true`
+
 ## [4.0.5] - 2021-08-02
 
 No significant changes.
@@ -43,7 +49,6 @@ No significant changes.
 
 - `ui/FloatingLayerDecorator` to render floating node properly
 - `ui/Touchable' to handle touch related events only for valid targets
-- `ui/ViewManager` to set `state.entering` to `false` when `noAnimation` prop is changed to `true`
 
 ## [4.0.0-alpha.1] - 2021-02-24
 

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -163,6 +163,12 @@ class View extends Component {
 
 	componentDidUpdate (prevProps) {
 		this.changeDirection = this.shouldChangeDirection(prevProps, this.props);
+
+		// this is needed to avoid setting enteringProp to true in the render method when noAnimation is true
+		if (prevProps.noAnimation !== this.props.noAnimation && this.state.entering) {
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState({entering: false});
+		}
 	}
 
 	componentWillUnmount () {

--- a/packages/ui/ViewManager/View.js
+++ b/packages/ui/ViewManager/View.js
@@ -163,12 +163,6 @@ class View extends Component {
 
 	componentDidUpdate (prevProps) {
 		this.changeDirection = this.shouldChangeDirection(prevProps, this.props);
-
-		// this is needed to avoid setting enteringProp to true in the render method when noAnimation is true
-		if (prevProps.noAnimation !== this.props.noAnimation && this.state.entering) {
-			// eslint-disable-next-line react/no-did-update-set-state
-			this.setState({entering: false});
-		}
 	}
 
 	componentWillUnmount () {
@@ -224,6 +218,8 @@ class View extends Component {
 			// FIXME: `startRafAfter` is a temporary solution using rAF. We need a better way to handle
 			// transition cycle and component life cycle to be in sync. See ENYO-4835.
 			this.enteringJob.startRafAfter(enteringDelay);
+		} else {
+			this.enteringJob.start();
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The issue can be seen in agate and sandstone samplers. The Panel body becomes hidden once noAnimation knob is unchecked/
Open sampler --> Panels --> Click on "Click me" button > Check 'noAnimation' knob> Click on "Click me" button > Uncheck 'noAnimation' prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated ui/ViewManager/View state to set `entering` to `false` when `noAnimation` prop becomes `true`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141617

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com