### PR TITLE
PLAT-125057: Add `containerOption` param in spotlight.focus function

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `spotlight` an optional `containerOption` parameter to `focus` function
+
 ## [4.0.2] - 2021-05-24
 
 ### Fixed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -730,8 +730,8 @@ const Spotlight = (function () {
 		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
 		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
-		 * @param {Object} [containerOption] A object containing `enterTo`.(optional)
-		 *  It will be passed to the getTargetByContainer when `elem` is container.
+		 * @param {Object} [containerOption] An object containing preferred `enterTo`. (optional)
+		 *  It will be passed to the `getTargetByContainer` when `elem` is a container.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -730,7 +730,7 @@ const Spotlight = (function () {
 		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
 		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
-		 * @param {Object} [containerOption] An object containing preferred `enterTo`. (optional)
+		 * @param {Object} [containerOption] An optional object containing preferred `enterTo`.
 		 *  It will be passed to the `getTargetByContainer` when `elem` is a container.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -730,10 +730,12 @@ const Spotlight = (function () {
 		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
 		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
+		 * @param {Object} [conatinerOption] A object containing `enterTo`.(optional)
+		 *  It will be passed to the getTargetByContainer when `elem` is container.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */
-		focus: function (elem, enterTo) {
+		focus: function (elem, conatinerOption = {}) {
 			let target = elem;
 			let wasContainerId = false;
 
@@ -741,7 +743,7 @@ const Spotlight = (function () {
 				target = getTargetByContainer();
 			} else if (typeof elem === 'string') {
 				if (getContainerConfig(elem)) {
-					target = getTargetByContainer(elem, enterTo);
+					target = getTargetByContainer(elem, conatinerOption.enterTo);
 					wasContainerId = true;
 				} else if (/^[\w\d-]+$/.test(elem)) {
 					// support component IDs consisting of alphanumeric, dash, or underscore
@@ -750,7 +752,7 @@ const Spotlight = (function () {
 					target = getTargetBySelector(elem);
 				}
 			} else if (isContainer(elem)) {
-				target = getTargetByContainer(getContainerId(elem), enterTo);
+				target = getTargetByContainer(getContainerId(elem), conatinerOption.enterTo);
 			}
 
 			const nextContainerIds = getContainersForNode(target);

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -730,12 +730,12 @@ const Spotlight = (function () {
 		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
 		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
-		 * @param {Object} [conatinerOption] A object containing `enterTo`.(optional)
+		 * @param {Object} [containerOption] A object containing `enterTo`.(optional)
 		 *  It will be passed to the getTargetByContainer when `elem` is container.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */
-		focus: function (elem, conatinerOption = {}) {
+		focus: function (elem, containerOption = {}) {
 			let target = elem;
 			let wasContainerId = false;
 
@@ -743,7 +743,7 @@ const Spotlight = (function () {
 				target = getTargetByContainer();
 			} else if (typeof elem === 'string') {
 				if (getContainerConfig(elem)) {
-					target = getTargetByContainer(elem, conatinerOption.enterTo);
+					target = getTargetByContainer(elem, containerOption.enterTo);
 					wasContainerId = true;
 				} else if (/^[\w\d-]+$/.test(elem)) {
 					// support component IDs consisting of alphanumeric, dash, or underscore
@@ -752,7 +752,7 @@ const Spotlight = (function () {
 					target = getTargetBySelector(elem);
 				}
 			} else if (isContainer(elem)) {
-				target = getTargetByContainer(getContainerId(elem), conatinerOption.enterTo);
+				target = getTargetByContainer(getContainerId(elem), containerOption.enterTo);
 			}
 
 			const nextContainerIds = getContainersForNode(target);

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -733,7 +733,7 @@ const Spotlight = (function () {
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */
-		focus: function (elem) {
+		focus: function (elem, enterTo) {
 			let target = elem;
 			let wasContainerId = false;
 
@@ -741,7 +741,7 @@ const Spotlight = (function () {
 				target = getTargetByContainer();
 			} else if (typeof elem === 'string') {
 				if (getContainerConfig(elem)) {
-					target = getTargetByContainer(elem);
+					target = getTargetByContainer(elem, enterTo);
 					wasContainerId = true;
 				} else if (/^[\w\d-]+$/.test(elem)) {
 					// support component IDs consisting of alphanumeric, dash, or underscore
@@ -750,7 +750,7 @@ const Spotlight = (function () {
 					target = getTargetBySelector(elem);
 				}
 			} else if (isContainer(elem)) {
-				target = getTargetByContainer(getContainerId(elem));
+				target = getTargetByContainer(getContainerId(elem), enterTo);
 			}
 
 			const nextContainerIds = getContainersForNode(target);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight exits out of `FixedPopupPanels`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`enterTo` parameter was added on `getTargetByContainer` (https://github.com/enactjs/enact/pull/2839)
I added `containerOption` parameter containing `enterTo`  on `Spotlight.focus` to passing the param to `getTargetByContainer `

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-125057

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
