### PR TITLE
PLAT-142904: Add documentation for Link and Linkable inside ui/Routable docs

### DIFF
--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -32,7 +32,6 @@ const LinkBase = kind({
 		 * Applies a disabled style and the control becomes non-interactive.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		disabled: PropTypes.bool
@@ -63,7 +62,7 @@ const LinkBase = kind({
  * A higher-order component adds support to a component to handle `navigate` from [`Routable`]{@link ui/Routable.Routable}.
  * It has configuration placed in the first argument to define which event will be used to navigate.
  * `onClick` event is used by default. Thus, if you don't configure it, the component should forward `onClick` event
- * to make [`Routable`]{@link ui/Routable.Routable} know when navigation is trigerred.
+ * to make [`Routable`]{@link ui/Routable.Routable} know when navigation is triggered.
  *
  * Example:
  * ```
@@ -171,6 +170,7 @@ const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
  *
  * @class Link
  * @ui
+ * @extends ui/Routable.LinkBase
  * @mixes ui/Routable.Linkable
  * @memberof ui/Routable
  * @public

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -28,8 +28,10 @@ import useLink from './useLink';
  * const Faq = () => (<div>List of FAQ</div>);
  *
  * const Sample = (props) => {
- *	  const [path, nav] = useState('main'); // use 'main' for the default path
- *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]); // if onNavigate is called with a new path, update the state
+ *	  // use 'main' for the default path
+ *	  const [path, nav] = useState('main');
+ *	  // if onNavigate is called with a new path, update the state
+ *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]);
  *
  *	  return (
  *		  <Views {...props} path={path} onNavigate={handleNavigate}>

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -8,43 +8,9 @@ import {Component} from 'react';
 import useLink from './useLink';
 
 /**
- * A component that is used to make a trigger to navigate inside of {@link ui/Routable.Routable} component.
+ * A base component that is used to make a link.
  *
- * In the following example, `Sample` would render `Main` with two Links for `About` and `FAQ`.
- * If `About` is clicked, the content of `About` would be displayed under `Main`.
- *
- * ```
- * const Views = Routable({navigate: 'onNavigate'}, ({children}) => <div>{children}</div>);
- *
- * const Main = () => (
- *	  <div>
- *		  <Link path="./about">About</Link>
- *		  <Link path="./faq">FAQ</Link>
- *	  </div>
- * );
- *
- * const About = () => (<div>Greetings! We are Enact team.</div>);
- *
- * const Faq = () => (<div>List of FAQ</div>);
- *
- * const Sample = (props) => {
- *	  // use 'main' for the default path
- *	  const [path, nav] = useState('main');
- *	  // if onNavigate is called with a new path, update the state
- *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]);
- *
- *	  return (
- *		  <Views {...props} path={path} onNavigate={handleNavigate}>
- *			  <Route path="main" component={Main}>
- *				  <Route path="about" component={About} />
- *				  <Route path="faq" component={Faq} />
- *			  </Route>
- *		  </Views>
- *	  );
- * };
- * ```
- *
- * @class Link
+ * @class LinkBase
  * @ui
  * @memberof ui/Routable
  * @public
@@ -52,14 +18,13 @@ import useLink from './useLink';
 const LinkBase = kind({
 	name: 'Link',
 
-	propTypes: {
+	propTypes: /** @lends ui/Routable.Link.prototype */ {
 		/**
-		 * The `path` to navigate matches the path of the {@link ui/Routable.Routable} container.
-		 *
+		 * The `path` to navigate that matches the path of the {@link ui/Routable.Routable} container.
+		 * 
 		 * @type {String}
 		 * @required
 		 * @public
-		 * @memberof ui/Routable.Link.prototype
 		 */
 		path: PropTypes.string.isRequired,
 
@@ -69,7 +34,6 @@ const LinkBase = kind({
 		 * @type {Boolean}
 		 * @default false
 		 * @public
-		 * @memberof ui/Routable.Link.prototype
 		 */
 		disabled: PropTypes.bool
 	},
@@ -96,9 +60,12 @@ const LinkBase = kind({
 });
 
 /**
- * A higher-order component that adds support to a component to handle navigates actions.
- * When using Linked component you must give the `path` property. And the component should forward `onClick` event.
+ * A higher-order component adds support to a component to handle `navigate` from [`Routable`]{@link ui/Routable.Routable}.
+ * It has configuration placed in the first argument to define which event will be used to navigate.
+ * `onClick` event is used by default. Thus, if you don't configure it, the component should forward `onClick` event
+ * to make [`Routable`]{@link ui/Routable.Routable} know when navigation is trigerred.
  *
+ * Example:
  * ```
  * const CustomItemBase = kind({
  *	  name: 'CustomItem',
@@ -116,7 +83,8 @@ const LinkBase = kind({
  *	  }
  * });
  *
- * const CustomItem = Linkable(CustomItemBase);
+ * const CustomItem = Linkable({navigate: 'onClick'}, CustomItemBase); 
+ * // same as const CustomItem = Linkable(CustomItemBase);
  *
  * const Main = () => (
  *	  <div>
@@ -163,6 +131,50 @@ const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
 	};
 });
 
+/**
+ * A component that is used to make a link to navigate among [`Route`]{@link ui/Routable.Route} components.
+ *
+ * In the following example, `Sample` would render `Main` with two Links for `About` and `FAQ`.
+ * If `About` is clicked, the content of `About` would be displayed under `Main`.
+ *
+ * Example:
+ * ```
+ * const Views = Routable({navigate: 'onNavigate'}, ({children}) => <div>{children}</div>);
+ *
+ * const Main = () => (
+ *	  <div>
+ *		  <Link path="./about">About</Link>
+ *		  <Link path="./faq">FAQ</Link>
+ *	  </div>
+ * );
+ *
+ * const About = () => (<div>Greetings! We are Enact team.</div>);
+ *
+ * const Faq = () => (<div>List of FAQ</div>);
+ *
+ * const Sample = (props) => {
+ *	  // use 'main' for the default path
+ *	  const [path, nav] = useState('main');
+ *	  // if onNavigate is called with a new path, update the state
+ *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]);
+ *
+ *	  return (
+ *		  <Views {...props} path={path} onNavigate={handleNavigate}>
+ *			  <Route path="main" component={Main}>
+ *				  <Route path="about" component={About} />
+ *				  <Route path="faq" component={Faq} />
+ *			  </Route>
+ *		  </Views>
+ *	  );
+ * };
+ * ```
+ *
+ * @class Link
+ * @ui
+ * @mixes ui/Routable.Linkable
+ * @memberof ui/Routable
+ * @public
+ */
 const Link = Linkable(LinkBase);
 
 export default Link;

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -21,7 +21,7 @@ const LinkBase = kind({
 	propTypes: /** @lends ui/Routable.Link.prototype */ {
 		/**
 		 * The `path` to navigate that matches the path of the {@link ui/Routable.Routable} container.
-		 * 
+		 *
 		 * @type {String}
 		 * @required
 		 * @public
@@ -83,7 +83,7 @@ const LinkBase = kind({
  *	  }
  * });
  *
- * const CustomItem = Linkable({navigate: 'onClick'}, CustomItemBase); 
+ * const CustomItem = Linkable({navigate: 'onClick'}, CustomItemBase);
  * // same as const CustomItem = Linkable(CustomItemBase);
  *
  * const Main = () => (

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -9,13 +9,13 @@ import useLink from './useLink';
 
 /**
  * A component that is used to make a trigger to navigate inside of {@link ui/Routable.Routable} component.
- * 
+ *
  * In the following example, `Sample` would render `Main` with two Links for `About` and `FAQ`.
  * If `About` is clicked, the content of `About` would be displayed under `Main`.
- * 
+ *
  * ```
  * const Views = Routable({navigate: 'onNavigate'}, ({children}) => <div>{children}</div>);
- * 
+ *
  * const Main = () => (
  *	  <div>
  *		  <Link path="./about">About</Link>
@@ -24,9 +24,9 @@ import useLink from './useLink';
  * );
  *
  * const About = () => (<div>Greetings! We are Enact team.</div>);
- * 
+ *
  * const Faq = () => (<div>List of FAQ</div>);
- * 
+ *
  * const Sample = (props) => {
  *	  const [path, nav] = useState('main'); // use 'main' for the default path
  *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]); // if onNavigate is called with a new path, update the state
@@ -96,7 +96,7 @@ const LinkBase = kind({
 /**
  * A higher-order component that adds support to a component to handle navigates actions.
  * When using Linked component you must give the `path` property. And the component should forward `onClick` event.
- * 
+ *
  * ```
  * const CustomItemBase = kind({
  *	  name: 'CustomItem',

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -7,11 +7,68 @@ import {Component} from 'react';
 
 import useLink from './useLink';
 
+/**
+ * A component that is used to make a trigger to navigate inside of {@link ui/Routable.Routable} component.
+ * 
+ * In the following example, `Sample` would render `Main` with two Links for `About` and `FAQ`.
+ * If `About` is clicked, the content of `About` would be displayed under `Main`.
+ * 
+ * ```
+ * const Views = Routable({navigate: 'onNavigate'}, ({children}) => <div>{children}</div>);
+ * 
+ * const Main = () => (
+ *	  <div>
+ *		  <Link path="./about">About</Link>
+ *		  <Link path="./faq">FAQ</Link>
+ *	  </div>
+ * );
+ *
+ * const About = () => (<div>Greetings! We are Enact team.</div>);
+ * 
+ * const Faq = () => (<div>List of FAQ</div>);
+ * 
+ * const Sample = (props) => {
+ *	  const [path, nav] = useState('main'); // use 'main' for the default path
+ *	  const handleNavigate = useCallback((ev) => nav(ev.path), [nav]); // if onNavigate is called with a new path, update the state
+ *
+ *	  return (
+ *		  <Views {...props} path={path} onNavigate={handleNavigate}>
+ *			  <Route path="main" component={Main}>
+ *				  <Route path="about" component={About} />
+ *				  <Route path="faq" component={Faq} />
+ *			  </Route>
+ *		  </Views>
+ *	  );
+ * };
+ * ```
+ *
+ * @class Link
+ * @ui
+ * @memberof ui/Routable
+ * @public
+ */
 const LinkBase = kind({
 	name: 'Link',
 
 	propTypes: {
+		/**
+		 * The `path` to navigate matches the path of the {@link ui/Routable.Routable} container.
+		 *
+		 * @type {String}
+		 * @required
+		 * @public
+		 * @memberof ui/Routable.Link.prototype
+		 */
 		path: PropTypes.string.isRequired,
+
+		/**
+		 * Applies a disabled style and the control becomes non-interactive.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 * @memberof ui/Routable.Link.prototype
+		 */
 		disabled: PropTypes.bool
 	},
 
@@ -36,6 +93,42 @@ const LinkBase = kind({
 	}
 });
 
+/**
+ * A higher-order component that adds support to a component to handle navigates actions.
+ * When using Linked component you must give the `path` property. And the component should forward `onClick` event.
+ * 
+ * ```
+ * const CustomItemBase = kind({
+ *	  name: 'CustomItem',
+ *
+ *	  handlers: {
+ *		  onClick: handle(
+ *			  forward('onClick')
+ *		  )
+ *	  },
+ *
+ *	  render: ({...rest}) => {
+ *		  return (
+ *			  <div {...rest} />
+ *		 );
+ *	  }
+ * });
+ *
+ * const CustomItem = Linkable(CustomItemBase);
+ *
+ * const Main = () => (
+ *	  <div>
+ *		  <CustomItem path="./about">About</CustomItem>
+ *		  <CustomItem path="./faq">FAQ</CustomItem>
+ *	  </div>
+ * );
+ * ```
+ *
+ * @class Linkable
+ * @memberof ui/Routable
+ * @hoc
+ * @public
+ */
 const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
 	const {navigate} = config;
 

--- a/packages/ui/Routable/Routable.js
+++ b/packages/ui/Routable/Routable.js
@@ -4,6 +4,8 @@
  * @module ui/Routable
  * @exports Routable
  * @exports Route
+ * @exports Link
+ * @exports Linkable
  */
 
 import hoc from '@enact/core/hoc';

--- a/packages/ui/Routable/Route.js
+++ b/packages/ui/Routable/Route.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
  * In the below example, `Panels` would render `SettingsPanel` with breadcrumbs to
  * navigate `AppPanel` and `HomePanel`.
  *
+ * Example:
  * ```
  *	<Panels path="/app/home/settings" onSelectBreadcrumb={this.handleNavigate}>
  *		<Route path="app" component={AppPanel}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Routable docs were incomplete. Link and Linkable inside Routable docs were not documented.
The documentation for Link and Linkable is added.


### Resolution
Write the document for them.


### Additional Considerations
The 'path' prop is not exposed explicitly in the Linkable HoC. It might need to be added with the documentation.


### Links
PLAT-142904


### Comments
