### PR TITLE
PLAT-142964: Sampler: Fix global knob setting resets when component changes

### DIFF
--- a/packages/sampler/.storybook/manager.js
+++ b/packages/sampler/.storybook/manager.js
@@ -1,6 +1,5 @@
 import {addons} from '@storybook/addons';
-import {themes} from '@storybook/theming';
-import {create} from '@storybook/theming/create';
+import {create} from '@storybook/theming';
 
 addons.setConfig({
 	theme: create({

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -10,13 +10,18 @@ configureActions();
 addDecorator(withKnobs);
 export const parameters = {
 	knobs: {
-		timestamps: true,
+		timestamps: true
 	},
 	docs: {
 		container: DocsContainer,
 		page: DocsPage,
 		iframeHeight: 360,
 		theme: themes.light
+	},
+	options: {
+		storySort: {
+			method: 'alphabetical'
+		}
 	}
 };
 export const decorators = [Environment];

--- a/packages/sampler/src/Environment/Environment.js
+++ b/packages/sampler/src/Environment/Environment.js
@@ -107,12 +107,11 @@ const StorybookDecorator = (story, config) => {
 	// Executing `story` here allows the story knobs to register and render before the global knobs below.
 	const sample = story();
 
+	const {globals} = config;
+
 	const Config = {
 		defaultProps: {
-			locale: 'en-US',
-			'large text': false,
-			'high contrast': false,
-			skin: 'dark'
+			locale: 'en-US'
 		},
 		groupId: globalGroup
 	};
@@ -137,14 +136,17 @@ const StorybookDecorator = (story, config) => {
 		classes.debug = true;
 	}
 
+	globals.locale = select('locale', locales, Config, globals.locale);
+	globals.background = select('background', backgroundLabels, Config, getKnobFromArgs(args, 'background', globals.background));
+
 	return (
 		<PanelsBase
 			className={classnames(classes)}
 			title={`${config.kind}`.replace(/\//g, ' ').trim()}
 			description={hasText ? config.parameters.info.text : null}
-			locale={select('locale', locales, Config)}
+			locale={globals.locale}
 			style={{
-				'--env-background': backgroundLabelMap[select('background', backgroundLabels, Config, getKnobFromArgs(args, 'background'))]
+				'--env-background': backgroundLabelMap[globals.background]
 			}}
 			{...config.panelsProps}
 		>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The global knob setting stays even if the story changes.


### Resolution
Referred PR: https://github.com/enactjs/sandstone/pull/906


### Additional Considerations


### Links
PLAT-142964


### Comments
