### PR TITLE
PLAT-126934: Support scroll by hover

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -923,7 +923,16 @@ const Spotlight = (function () {
 			}
 
 			return getSpottableDescendants(containerId);
-		}
+		},
+
+		/**
+		 * Focuses the next spottable control from the position specified in the direction specified.
+		 *
+		 * @param {String} direction Direction to move, one of `'left'`, `'right'`, `'up'` or `'down'`
+		 * @param {Object} position `x` and `y` coordinates for the pointer
+		 * @private
+		 */
+		focusNextFromPoint: spotNextFromPoint
 	};
 
 	return exports;

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -928,7 +928,7 @@ const Spotlight = (function () {
 		/**
 		 * Focuses the next spottable control from the position specified in the direction specified.
 		 *
-		 * @param {String} direction Direction to move, one of `'left'`, `'right'`, `'up'` or `'down'`
+		 * @param {String} direction Direction to move, one of `'left'`, `'right'`, `'up'`, or `'down'`
 		 * @param {Object} position `x` and `y` coordinates for the pointer
 		 * @private
 		 */


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
New UX requirement to scroll a list by hover.
When a certain key input occurs during scrolling by hover, scrolling should stop and the focus needs to show on a spottable element near the last pointer position.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Implemented a new feature internally.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-126934
enactjs/sandstone/pull/947

### Comments
