### PR TITLE
PLAT-142133: Added support for snapToCenter

### DIFF
--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -522,7 +522,7 @@ class VirtualListBasic extends Component {
 
 	getMoreInfo = () => this.moreInfo;
 
-	getCenterItemIndexFromScrollPosition = (scrollPosition) => Math.round((scrollPosition + (this.primary.clientSize / 2)) / this.primary.gridSize);
+	getCenterItemIndexFromScrollPosition = (scrollPosition) => Math.floor((scrollPosition + (this.primary.clientSize / 2)) / this.primary.gridSize) * this.dimensionToExtent + Math.floor(this.dimensionToExtent / 2);
 
 	getGridPosition (index) {
 		const

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -522,6 +522,8 @@ class VirtualListBasic extends Component {
 
 	getMoreInfo = () => this.moreInfo;
 
+	getCenterItemIndexFromScrollPosition = (scrollPosition) => Math.round((scrollPosition + (this.primary.clientSize / 2)) / this.primary.gridSize);
+
 	getGridPosition (index) {
 		const
 			{dataSize, itemSizes} = this.props,
@@ -580,6 +582,8 @@ class VirtualListBasic extends Component {
 			offset = optionalOffset;
 		} else if (this.props.itemSizes) {
 			offset = primary.clientSize - this.props.itemSizes[index] - optionalOffset;
+		} if (stickTo === 'center') {
+			offset = (primary.clientSize / 2) - (primary.gridSize / 2);
 		} else {
 			offset = primary.clientSize - primary.itemSize - optionalOffset;
 		}

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -640,7 +640,7 @@ const useScrollBase = (props) => {
 			}
 
 			if (snapToCenter) {
-				if (scrollMode === 'native' && canScrollV) {
+				if (scrollMode === 'native' && (canScrollV || canScrollH)) {
 					ev.preventDefault();
 					forward('onWheel', ev, props);
 					return;

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -110,6 +110,7 @@ const useScrollBase = (props) => {
 			scrollContentRef,
 			scrollMode,
 			setScrollContainerHandle,
+			snapToCenter,
 			spacing,
 			spotlightContainerDisabled,
 			verticalScrollbar,
@@ -636,6 +637,14 @@ const useScrollBase = (props) => {
 				}
 
 				return;
+			}
+
+			if (snapToCenter) {
+				if (scrollMode === 'native' && canScrollV) {
+					ev.preventDefault();
+					forward('onWheel', ev, props);
+					return;
+				}
 			}
 
 			if (scrollMode === 'translate') {


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added support for `snapToCenter` prop for VirtualList

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `center` for `stickTo` option of `scrollTo`
Added function `getCenterItemIndexFromScrollPosition`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-142133

### Comments
