### PR TITLE
PLAT-145128: Fix VirtualList to not stop scrolling to center by mouse down

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -463,7 +463,11 @@ const useScrollBase = (props) => {
 	}
 
 	function onMouseDown (ev) {
-		if (forwardWithPrevent('onMouseDown', ev, props)) {
+		if (snapToCenter) {
+			ev.preventDefault();
+		}
+
+		if (forwardWithPrevent('onMouseDown', ev, props) && !snapToCenter) {
 			stop();
 		}
 	}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualList should not stop scrolling to center by mouse down

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If `snapToCenter` is true, calls prevent default and stops call stop function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-145128

### Comments
