### PR TITLE
WRN-2791: Fix SpotlightRootDecorator to not have an extra DOM

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` not to add locale specific classes in the wrong DOM after isomorphic build with multi locales
+
 ## [4.0.3] - 2021-07-02
 
 No significant changes.

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -8,7 +8,7 @@
 
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
-import {Component, createRef} from 'react';
+import {Component} from 'react';
 
 import Spotlight from '../src/spotlight';
 import {spottableClass} from '../Spottable';

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -91,7 +91,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
-			this.containerRef = createRef();
+			this.containerRef = null;
 
 			if (typeof window === 'object') {
 				Spotlight.initialize({
@@ -108,6 +108,10 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		componentDidMount () {
 			if (!noAutoFocus) {
 				Spotlight.focus();
+			}
+
+			if (this.containerRef === null && typeof document === 'object') {
+				this.containerRef = document.querySelector('#root > div');
 			}
 
 			if (typeof document === 'object') {
@@ -130,9 +134,9 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		applyInputType = () => {
-			if (this && this.containerRef && this.containerRef.current) {
+			if (this && this.containerRef) {
 				Object.keys(input.types).map((type) => {
-					this.containerRef.current.classList.toggle('spotlight-input-' + type, input.types[type]);
+					this.containerRef.classList.toggle('spotlight-input-' + type, input.types[type]);
 				});
 				input.applied = true;
 			}
@@ -147,7 +151,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		// For key input
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
-			if (is('enter', keyCode) && this.containerRef.current.classList.contains('spotlight-input-touch')) {
+			if (is('enter', keyCode) && this.containerRef.classList.contains('spotlight-input-touch')) {
 				// Prevent onclick event trigger by enter key
 				ev.preventDefault();
 			}
@@ -185,9 +189,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		render () {
 			return (
-				<div ref={this.containerRef}>
-					<Wrapped {...this.props} />
-				</div>
+				<Wrapped {...this.props} />
 			);
 		}
 	};

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -111,7 +111,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			if (this.containerRef === null && typeof document === 'object') {
-				this.containerRef = document.querySelector('#root > div');
+				this.containerRef = document.querySelector('#root');
 			}
 
 			if (typeof document === 'object') {

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -91,7 +91,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 
-			this.containerRef = null;
+			this.containerNode = null;
 
 			if (typeof window === 'object') {
 				Spotlight.initialize({
@@ -110,11 +110,9 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.focus();
 			}
 
-			if (this.containerRef === null && typeof document === 'object') {
-				this.containerRef = document.querySelector('#root');
-			}
-
 			if (typeof document === 'object') {
+				this.containerNode = document.querySelector('#root');
+
 				document.addEventListener('focusin', this.handleFocusIn, {capture: true});
 				document.addEventListener('keydown', this.handleKeyDown, {capture: true});
 				document.addEventListener('pointermove', this.handlePointerMove, {capture: true});
@@ -134,9 +132,9 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		applyInputType = () => {
-			if (this && this.containerRef) {
+			if (this && this.containerNode) {
 				Object.keys(input.types).map((type) => {
-					this.containerRef.classList.toggle('spotlight-input-' + type, input.types[type]);
+					this.containerNode.classList.toggle('spotlight-input-' + type, input.types[type]);
 				});
 				input.applied = true;
 			}
@@ -151,7 +149,7 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		// For key input
 		handleKeyDown = (ev) => {
 			const {keyCode} = ev;
-			if (is('enter', keyCode) && this.containerRef.classList.contains('spotlight-input-touch')) {
+			if (is('enter', keyCode) && this.containerNode.classList.contains('spotlight-input-touch')) {
 				// Prevent onclick event trigger by enter key
 				ev.preventDefault();
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we build in isomorphic option with multiple locales, index.multi.html has important classes in the wrong div. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Since we've added an extra 'div' from https://github.com/enactjs/enact/pull/2914 the issue occurred. So I've changed the containerRef to "root" dom.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-2791

### Comments
