### PR TITLE
WRN-3773: Fix VirtualList not to provide invalid item refs to theme libraries

### DIFF
--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -1096,15 +1096,8 @@ class VirtualListBasic extends Component {
 			key = index % this.state.numOfItems,
 			componentProps = getComponentProps && getComponentProps(index) || {},
 			itemContainerRef = (ref) => {
-				if (ref === null) {
-					itemRefs.current[key] = ref;
-				} else {
-					const itemNode = ref.children[0];
-
-					itemRefs.current[key] = (parseInt(itemNode.dataset.index) === index) ?
-						itemNode :
-						ref.querySelector(`[data-index="${index}"]`);
-
+				itemRefs.current[key] = ref;
+				if (ref !== null) {
 					this.itemContainerRefs[key] = ref;
 				}
 			};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Theme libraries cannot access item's rendered DOM node when item's content is updated without updating a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`enact/ui` provides rendered item nodes to theme libraries to help access those DOM nodes.
If item's DOM node is updated by content update without updating a list (by prop changing or any other reason), a list does NOT refresh nodes' info so theme libraries tries to access invalid DOM nodes which are not on the DOM tree anymore.
In this PR, `enact/ui` provides rendered item *container* nodes instead of item nodes. Since item container nodes are not updated by item renderers, theme libraries are able to valid DOM nodes through item container nodes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-3773

### Comments
