### PR TITLE
WRN-2132: Replaced recompose usages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-is": "^17.0.1",
-    "recompose": "^0.30.0",
     "warning": "^4.0.3"
   }
 }

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -13,6 +13,7 @@
  * @exports mergeClassNameMaps
  * @exports perfNow
  * @exports mapAndFilterChildren
+ * @exports shallowEqual
  */
 import always from 'ramda/src/always';
 import isType from 'ramda/src/is';
@@ -264,6 +265,41 @@ const mapAndFilterChildren = (children, callback, filter) => {
 	}
 };
 
+/**
+ * Performs shallow comparison for given objects.
+ *
+ * @function
+ * @param {Obejct}        a    An object to compare.
+ * @param {Obejct}        b    An object to compare.
+ *
+ * @returns {Boolean}          `true` if the values of all keys are strictly equal.
+ * @memberof core/util
+ * @public
+ */
+const shallowEqual = (a, b) => {
+	if (Object.is(a, b)) {
+		return true;
+	}
+
+	const aKeys = Object.keys(a);
+	const bKeys = Object.keys(b);
+
+	// early bail out if the objects have a different number of keys
+	if (aKeys.length !== bKeys.length) {
+		return false;
+	}
+
+	const hasOwn = Object.prototype.hasOwnProperty.bind(b);
+	for (let i = 0; i < aKeys.length; i++) {
+		const prop = aKeys[i];
+		if (!hasOwn(prop) || !Object.is(a[prop], b[prop])) {
+			return false;
+		}
+	}
+
+	return true;
+};
+
 export {
 	cap,
 	clamp,
@@ -275,5 +311,6 @@ export {
 	memoize,
 	mergeClassNameMaps,
 	perfNow,
-	mapAndFilterChildren
+	mapAndFilterChildren,
+	shallowEqual
 };

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -281,6 +281,10 @@ const shallowEqual = (a, b) => {
 		return true;
 	}
 
+	if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+		return false;
+	}
+
 	const aKeys = Object.keys(a);
 	const bKeys = Object.keys(b);
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -3,10 +3,9 @@ import {on, off} from '@enact/core/dispatcher';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
-import {Job} from '@enact/core/util';
+import {Job, shallowEqual} from '@enact/core/util';
 import PropTypes from 'prop-types';
-import {Component} from 'react';
-import shallowEqual from 'recompose/shallowEqual';
+import {PureComponent} from 'react';
 import warning from 'warning';
 
 import {scale} from '../resolution';
@@ -160,7 +159,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		return rtl;
 	};
 
-	return class extends Component {
+	return class extends PureComponent {
 		static displayName = 'ui:MarqueeDecorator';
 
 		static propTypes = /** @lends ui/Marquee.MarqueeDecorator.prototype */ {
@@ -345,13 +344,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.startAnimation(this.props.marqueeOnRenderDelay);
 			}
 			on('keydown', this.handlePointerHide, document);
-		}
-
-		shouldComponentUpdate (nextProps, nextState) {
-			return (
-				!shallowEqual(this.state, nextState) ||
-				!shallowEqual(this.props, nextProps)
-			);
 		}
 
 		componentDidUpdate (prevProps) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-is": "^17.0.1",
-    "recompose": "^0.30.0",
     "warning": "^3.0.0"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`recompose` has not been updated over 3 years and its dependencies have been made some troubles.
So, we'd like to replace `recompose` with other modules.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Enact has only 1 usage from `recompose`, `shallowEqual`.
I've made a utility function that performs the equivalent functionality.
And replaced `Component` with `PureComponent`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-2132

### Comments
