### PR TITLE
WRN-6365: Fixed Marquee to not separate layer when short text

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [unreleased]
-
-### Changed
-
-- `ui/MarqueeDecorator` to not separate layer when short text
-
 ## [4.0.5] - 2021-08-02
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/MarqueeDecorator` to not separate layer when short text
+
 ## [4.0.5] - 2021-08-02
 
 No significant changes.

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -327,7 +327,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.sync = false;
 			this.timerState = TimerState.CLEAR;
 			this.distance = null;
-			this.contentFits = false;
+			this.contentFits = null;
 			this.resizeRegistry = null;
 		}
 
@@ -406,7 +406,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		promoteJob = new Job(() => {
-			if (!this.contentFits) {
+			if (this.contentFits === false) {
 				this.setState(state => state.promoted ? null : {promoted: true});
 			}
 		});
@@ -485,7 +485,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// Null distance is the special value to allow recalculation
 			this.distance = null;
 			// Assume the marquee does not fit until calculations show otherwise
-			this.contentFits = false;
+			this.contentFits = null;
 
 			this.setState(state => {
 				if (state.overflow === 'ellipsis' && state.promoted === false) return null;
@@ -626,7 +626,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				// our group already did it.
 				this.setTimeout(() => {
 					this.calculateMetrics();
-					if (!this.contentFits) {
+					if (this.contentFits === false) {
 						this.setState({
 							promoted: true,
 							animating: true


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Marquee text with short content has willAnimate class

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`willAnimate` prop follows `state.promoted`.

Logic about `promoted` It came from #1959, but the text length was not considered  from the beginning. It make  `state.promoted=true`  according to marqueeOn condition.

`state.promoted` prop becomes `true` in almost case by `promoteJob`. This is because the default value of `contentFits` was `false`. it was set on `invalidateMetrics()`;
on the other side, `InvalidateMetrics()` set `state.promoted` to `false` for reset, but in `promotedJob()` it is set to true because of the contentFit=false, so this has wrong logic.
`contentFits` is calculated on `calculateMetrics` . We should refer the value after calculating. 

In this PR, I set `null` for default `contentFits` value

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6365

### Comments
