### PR TITLE
WRN-5341: use will-change: opacity instead of will-change: transform

### DIFF
--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -29,7 +29,7 @@
 		position: relative;
 
 		&.willAnimate {
-			will-change: transform;
+			will-change: opacity;
 			overflow: visible;
 		}
 


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Text flicker when starting marquee due to will-change:transform property


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use  will-change: opacity instead of will-change: transform

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-5341

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
