### PR TITLE
WRN-8879: Migrated unit tests for Skinnable to testing-library

### DIFF
--- a/packages/ui/Skinnable/tests/Skinnable-specs.js
+++ b/packages/ui/Skinnable/tests/Skinnable-specs.js
@@ -1,23 +1,23 @@
-import {mount} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+
 import Skinnable from '../Skinnable';
 
 describe('Skinnable Specs', () => {
-
 	test('should do nothing when nothing is specified', () => {
 		const config = {};
+		let data = [];
 
-		const Component = (props) => (
-			<div {...props} />
-		);
+		const Component = (props) => {
+			data = props;
+			return <div {...props} />;
+		};
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent />);
+		render(<SkinnableComponent />);
 
-		const expected = 0;
-		const actual = Object.keys(subject.find('div').props()).length;
-
-		expect(actual).toEqual(expected);
+		expect(data).toMatchObject({});
 	});
 
 	test('should add a default skin class when no skin prop is specified', () => {
@@ -35,12 +35,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent />);
+		render(<SkinnableComponent data-testid="skinnableComponent" />);
 
 		const expected = 'darkSkin';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should add the preferred skin class when the skin prop is specified', () => {
@@ -58,12 +58,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skin="light" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skin="light" />);
 
 		const expected = 'lightSkin';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should ignore the preferred skin prop if it\'s not one of the available skins', () => {
@@ -74,19 +74,18 @@ describe('Skinnable Specs', () => {
 				light: 'lightSkin'
 			}
 		};
+		let data = [];
 
-		const Component = (props) => (
-			<div {...props} />
-		);
+		const Component = (props) => {
+			data = props;
+			return <div {...props} />;
+		};
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skin="potato" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skin="potato" />);
 
-		const expected = void 0;
-		const actual = subject.find('div').prop('className');
-
-		expect(actual).toEqual(expected);
+		expect(data).toMatchObject({});
 	});
 
 	test('should ignore the preferred skin prop if it\'s not one of the available skins and not interfere with the className prop', () => {
@@ -104,12 +103,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skin="potato" className="cheatingComponent" />);
+		render(<SkinnableComponent className="cheatingComponent" data-testid="skinnableComponent" skin="potato" />);
 
 		const expected = 'cheatingComponent';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should ignore the skinVariants prop if there are no defined allowedVariants', () => {
@@ -127,12 +126,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants="potato" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants="potato" />);
 
 		const expected = 'darkSkin';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should only apply allowed variants assigned by the skinVariants prop', () => {
@@ -151,12 +150,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants="normal potato unicase" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants="normal potato unicase" />);
 
 		const expected = 'darkSkin normal unicase';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should apply default variants even if the skinVariants prop is explicitly empty', () => {
@@ -176,12 +175,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants="" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants="" />);
 
 		const expected = 'darkSkin normal';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should apply default variants and the skinVariants if both are defined', () => {
@@ -201,12 +200,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants="unicase" />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants="unicase" />);
 
 		const expected = 'darkSkin normal unicase';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should apply variants supplied via an array or a string in the same way', () => {
@@ -226,10 +225,13 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subjectA = mount(<SkinnableComponent skinVariants="normal unicase" />);
-		const subjectB = mount(<SkinnableComponent skinVariants={['normal', 'unicase']} />);
+		const {rerender} = render(<SkinnableComponent data-testid="skinnableComponent1" skinVariants="normal unicase" />);
+		const component1ClassNames = screen.getByTestId('skinnableComponent1').className;
 
-		expect(subjectA.find('div')).toEqual(subjectB.find('div'));
+		rerender(<SkinnableComponent data-testid="skinnableComponent2" skinVariants={['normal', 'unicase']} />);
+		const component2ClassNames = screen.getByTestId('skinnableComponent2').className;
+
+		expect(component1ClassNames).toEqual(component2ClassNames);
 	});
 
 	test('should allow opting out of the default variants if an object is supplied to skinVariants with false as variant-key values', () => {
@@ -249,12 +251,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants={{normal: false, unicase: true}} />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants={{normal: false, unicase: true}} />);
 
 		const expected = 'darkSkin unicase';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should ignore variants, sent by an object, equaling null, undefined, or empty string', () => {
@@ -274,12 +276,12 @@ describe('Skinnable Specs', () => {
 
 		const SkinnableComponent = Skinnable(config, Component);
 
-		const subject = mount(<SkinnableComponent skinVariants={{normal: null, smallCaps: void 0, unicase: ''}} />);
+		render(<SkinnableComponent data-testid="skinnableComponent" skinVariants={{normal: null, smallCaps: void 0, unicase: ''}} />);
 
 		const expected = 'darkSkin normal';
-		const actual = subject.find('div').prop('className');
+		const component = screen.getByTestId('skinnableComponent');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should apply parent variants', () => {
@@ -300,16 +302,16 @@ describe('Skinnable Specs', () => {
 		const SkinnableParent = Skinnable(config, Component);
 		const SkinnableChild = Skinnable(config, Component);
 
-		const subject = mount(
+		render(
 			<SkinnableParent skinVariants="unicase">
-				<SkinnableChild skinVariants="smallCaps" />
+				<SkinnableChild data-testid="skinnableChild" skinVariants="smallCaps" />
 			</SkinnableParent>
 		);
 
 		const expected = 'darkSkin normal unicase smallCaps';
-		const actual = subject.find('div').last().prop('className');
+		const component = screen.getByTestId('skinnableChild');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should be able to override a parent\'s variants by assigning a false skinVariant', () => {
@@ -330,16 +332,16 @@ describe('Skinnable Specs', () => {
 		const SkinnableParent = Skinnable(config, Component);
 		const SkinnableChild = Skinnable(config, Component);
 
-		const subject = mount(
+		render(
 			<SkinnableParent skinVariants="smallCaps unicase">
-				<SkinnableChild skinVariants={{unicase: false}} />
+				<SkinnableChild data-testid="skinnableChild" skinVariants={{unicase: false}} />
 			</SkinnableParent>
 		);
 
 		const expected = 'darkSkin normal smallCaps';
-		const actual = subject.find('div').last().prop('className');
+		const component = screen.getByTestId('skinnableChild');
 
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 
 	test('should inherit an overridden default variant', () => {
@@ -360,56 +362,17 @@ describe('Skinnable Specs', () => {
 		const SkinnableParent = Skinnable(config, Component);
 		const SkinnableChild = Skinnable(config, Component);
 
-		const subject = mount(
+		render(
 			<SkinnableParent>
 				<SkinnableChild skinVariants={{normal: false}}>
-					<SkinnableChild id="innerChild" />
+					<SkinnableChild data-testid="innerChild" />
 				</SkinnableChild>
 			</SkinnableParent>
 		);
 
 		const expected = 'darkSkin';
-		const actual = subject.find('div#innerChild').prop('className');
+		const component = screen.getByTestId('innerChild');
 
-		expect(actual).toEqual(expected);
-	});
-
-	test('should not force re-render of child if child unaffected', () => {
-		const config = {
-			defaultSkin: 'dark',
-			defaultVariants: 'normal',
-			skins: {
-				dark: 'darkSkin',
-				light: 'lightSkin'
-			},
-			allowedVariants: ['normal', 'smallCaps', 'unicase']
-		};
-		const wasRendered = jest.fn();
-
-		const Component = (props) => (
-			<div {...props} />
-		);
-
-		const ChildComponent = () => {
-			wasRendered();
-			return <div>Hello</div>;
-		};
-
-		const SkinnableParent = Skinnable(config, Component);
-		const SkinnableChild = Skinnable(config, ChildComponent);
-
-		const subject = mount(
-			<SkinnableParent>
-				<SkinnableChild />
-			</SkinnableParent>
-		);
-
-		// Sending props to force parent to re-render
-		subject.setProps({className: 'foo'});
-
-		const expected = 1;
-		const actual = wasRendered.mock.calls.length;
-
-		expect(actual).toEqual(expected);
+		expect(component).toHaveClass(expected);
 	});
 });

--- a/packages/ui/Skinnable/tests/useSkins-specs.js
+++ b/packages/ui/Skinnable/tests/useSkins-specs.js
@@ -1,12 +1,15 @@
-import {mount, shallow} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
 
 import useSkins from '../useSkins';
 
 describe('Skinnable Specs', () => {
+	let data = [];
 
-	function Base () {
+	const Base = (props) => {
+		data = props;
 		return null;
-	}
+	};
 	function Component ({config}) {
 		const skins = useSkins(config);
 		return (
@@ -29,12 +32,11 @@ describe('Skinnable Specs', () => {
 			}
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should add the preferred skin class when the skin prop is specified', () => {
@@ -47,12 +49,11 @@ describe('Skinnable Specs', () => {
 			}
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'lightSkin';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should ignore the preferred skin prop if it\'s not one of the available skins', () => {
@@ -65,12 +66,11 @@ describe('Skinnable Specs', () => {
 			}
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = '';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should ignore the skinVariants prop if there are no defined allowedVariants', () => {
@@ -83,12 +83,11 @@ describe('Skinnable Specs', () => {
 			}
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should only apply allowed variants assigned by the skinVariants prop', () => {
@@ -102,12 +101,11 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin normal unicase';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should apply default variants even if the skinVariants prop is explicitly empty', () => {
@@ -122,12 +120,11 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin normal';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should apply default variants and the skinVariants if both are defined', () => {
@@ -142,12 +139,11 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin normal unicase';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should apply variants supplied via an array or a string in the same way', () => {
@@ -161,10 +157,13 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subjectA = shallow(<Component config={{...config, skinVariants: 'normal unicase'}} />);
-		const subjectB = shallow(<Component config={{...config, skinVariants: ['normal', 'unicase']}} />);
+		const {rerender} = render(<Component config={{...config, skinVariants: 'normal unicase'}} />);
+		const component1Class = data.className;
 
-		expect(subjectA.find(Base).prop('className')).toBe(subjectB.find(Base).prop('className'));
+		rerender(<Component config={{...config, skinVariants: ['normal', 'unicase']}} />);
+		const component2Class = data.className;
+
+		expect(component1Class).toBe(component2Class);
 	});
 
 	test('should allow opting out of the default variants if an object is supplied to skinVariants with false as variant-key values', () => {
@@ -179,12 +178,11 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin unicase';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should ignore variants, sent by an object, equaling null, undefined, or empty string', () => {
@@ -199,12 +197,11 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = shallow(<Component config={config} />);
+		render(<Component config={config} />);
 
 		const expected = 'darkSkin normal';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should apply parent variants', () => {
@@ -218,16 +215,15 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = mount(
+		render(
 			<Parent config={{...config, skinVariants: 'unicase'}}>
 				<Component config={{...config, skinVariants: 'smallCaps'}} />
 			</Parent>
 		);
 
 		const expected = 'darkSkin normal unicase smallCaps';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should be able to override a parent\'s variants by assigning a false skinVariant', () => {
@@ -241,16 +237,15 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = mount(
+		render(
 			<Parent config={{...config, skinVariants: 'smallCaps unicase'}}>
 				<Component config={{...config, skinVariants: {unicase: false}}} />
 			</Parent>
 		);
 
 		const expected = 'darkSkin normal smallCaps';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 
 	test('should inherit an overridden default variant', () => {
@@ -264,7 +259,7 @@ describe('Skinnable Specs', () => {
 			variants: ['normal', 'smallCaps', 'unicase']
 		};
 
-		const subject = mount(
+		render(
 			<Parent config={config}>
 				<Parent config={{...config, skinVariants: {normal: false}}}>
 					<Component config={config} />
@@ -273,8 +268,7 @@ describe('Skinnable Specs', () => {
 		);
 
 		const expected = 'darkSkin';
-		const actual = subject.find(Base).prop('className');
 
-		expect(actual).toBe(expected);
+		expect(data).toHaveProperty('className', expected);
 	});
 });

--- a/packages/ui/Skinnable/tests/util-specs.js
+++ b/packages/ui/Skinnable/tests/util-specs.js
@@ -1,7 +1,6 @@
 import {objectify, preferDefined} from '../util';
 
 describe('Skinnable/util/objectify Specs', () => {
-
 	test('should convert a plain string to an object with one key and value true', () => {
 		const subject = 'string1';
 
@@ -68,7 +67,6 @@ describe('Skinnable/util/objectify Specs', () => {
 });
 
 describe('Skinnable/util/preferDefined Specs', () => {
-
 	test('should return the first element if it is a normal string', () => {
 		const subject = ['string1', 'string2'];
 
@@ -122,5 +120,4 @@ describe('Skinnable/util/preferDefined Specs', () => {
 
 		expect(actual).toEqual(expected);
 	});
-
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated unit tests for Skinnable to testing-library

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Note: there are no UI tests for RTL locale because the pickers behave the same as on LTR at the moment.

### Links
[//]: # (Related issues, references)
WRN-8879

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com