### PR TITLE
WRN-9789: Apply React testing lib to Enact internal/ApiDecorator and useHandlers

### DIFF
--- a/packages/core/internal/ApiDecorator/tests/ApiDecorator-specs.js
+++ b/packages/core/internal/ApiDecorator/tests/ApiDecorator-specs.js
@@ -1,8 +1,10 @@
+import {render} from '@testing-library/react';
 import {Component as ReactComponent} from 'react';
-import {mount} from 'enzyme';
+
 import ApiDecorator from '../ApiDecorator';
 
 describe('ApiDecorator', () => {
+	let data = [];
 
 	const ApiProvider = class extends ReactComponent {
 		static displayName = 'ApiProvider';
@@ -22,9 +24,13 @@ describe('ApiDecorator', () => {
 		instanceProperty = 'property';
 
 		render () {
-			return (
-				<div />
-			);
+			data = {
+				arrowFunction: this.arrowFunction,
+				instanceFunction: this.instanceFunction,
+				instanceProperty: this.instanceProperty
+			};
+
+			return (<div />);
 		}
 	};
 
@@ -34,12 +40,10 @@ describe('ApiDecorator', () => {
 			ApiProvider
 		);
 
-		const subject = mount(
-			<Component />
-		);
+		render(<Component />);
 
 		const expected = 'arrow';
-		const actual = subject.instance().arrowFunction();
+		const actual = data.arrowFunction();
 
 		expect(actual).toBe(expected);
 	});
@@ -50,12 +54,10 @@ describe('ApiDecorator', () => {
 			ApiProvider
 		);
 
-		const subject = mount(
-			<Component />
-		);
+		render(<Component />);
 
 		const expected = 'instance';
-		const actual = subject.instance().instanceFunction();
+		const actual = data.instanceFunction();
 
 		expect(actual).toBe(expected);
 	});
@@ -66,12 +68,10 @@ describe('ApiDecorator', () => {
 			ApiProvider
 		);
 
-		const subject = mount(
-			<Component />
-		);
+		render(<Component />);
 
 		const expected = 'property';
-		const actual = subject.instance().instanceProperty;
+		const actual = data.instanceProperty;
 
 		expect(actual).toBe(expected);
 	});
@@ -82,14 +82,12 @@ describe('ApiDecorator', () => {
 			ApiProvider
 		);
 
-		const subject = mount(
-			<Component />
-		);
+		render(<Component />);
 
-		subject.instance().instanceProperty = 'updated';
+		data.instanceProperty = 'updated';
 
 		const expected = 'updated';
-		const actual = subject.instance().instanceProperty;
+		const actual = data.instanceProperty;
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/core/useHandlers/tests/useHandlers-specs.js
+++ b/packages/core/useHandlers/tests/useHandlers-specs.js
@@ -19,7 +19,7 @@ describe('useHandlers', () => {
 
 		data = {
 			handlers
-		}
+		};
 
 		return (
 			<div {...props} data-testid="divComponent" />

--- a/packages/core/useHandlers/tests/useHandlers-specs.js
+++ b/packages/core/useHandlers/tests/useHandlers-specs.js
@@ -4,7 +4,7 @@ import {render} from '@testing-library/react';
 import useHandlers from '../useHandlers';
 
 describe('useHandlers', () => {
-	let data = [];
+	let data = {};
 
 	const context = {
 		value: 1
@@ -17,20 +17,20 @@ describe('useHandlers', () => {
 			}
 		}, props, context);
 
-		data.push(handlers);
+		data = {
+			handlers
+		}
 
 		return (
 			<div {...props} data-testid="divComponent" />
 		);
 	}
 
-	afterEach(() => data.splice(0, data.length));
-
 	// Sanity test for Component moreso than useHandlers test
 	test('should include handlers in props', () => {
 		render(<Component />);
 
-		const actual = data[0].testEvent;
+		const actual = data.handlers.testEvent;
 
 		expect(actual).toBeDefined();
 	});
@@ -38,11 +38,11 @@ describe('useHandlers', () => {
 	test('should have the same reference across renders', () => {
 		const {rerender} = render(<Component />);
 
-		const expected = data[0].testEvent;
+		const expected = data.handlers.testEvent;
 
 		rerender(<Component />);
 
-		const actual =  data[1].testEvent;
+		const actual = data.handlers.testEvent;
 
 		expect(actual).toBe(expected);
 	});
@@ -53,7 +53,7 @@ describe('useHandlers', () => {
 
 		rerender(<Component>{'updated'}</Component>);
 
-		data[0].testEvent(spy);
+		data.handlers.testEvent(spy);
 
 		expect(spy).toHaveBeenCalled();
 	});
@@ -64,7 +64,7 @@ describe('useHandlers', () => {
 
 		rerender(<Component>{'updated'}</Component>);
 
-		data[0].testEvent(spy);
+		data.handlers.testEvent(spy);
 
 		const expected = {children: 'updated'};
 		const actual = spy.mock.calls[0][0];
@@ -76,7 +76,7 @@ describe('useHandlers', () => {
 		const spy = jest.fn();
 		render(<Component />);
 
-		data[0].testEvent(spy);
+		data.handlers.testEvent(spy);
 
 		// defined a "global" context to ease testability but this isn't representative of the
 		// expected use case of this feature.
@@ -90,7 +90,7 @@ describe('useHandlers', () => {
 		const spy = jest.fn().mockImplementation(() => 'ok');
 		render(<Component />);
 
-		const returnValue = data[0].testEvent(spy);
+		const returnValue = data.handlers.testEvent(spy);
 
 		// defined a "global" context to ease testability but this isn't representative of the
 		// expected use case of this feature.

--- a/packages/core/useHandlers/tests/useHandlers-specs.js
+++ b/packages/core/useHandlers/tests/useHandlers-specs.js
@@ -95,8 +95,7 @@ describe('useHandlers', () => {
 		// defined a "global" context to ease testability but this isn't representative of the
 		// expected use case of this feature.
 		const expected = 'ok';
-		const actual = returnValue;
 
-		expect(actual).toBe(expected);
+		expect(returnValue).toBe(expected);
 	});
 });

--- a/packages/core/useHandlers/tests/useHandlers-specs.js
+++ b/packages/core/useHandlers/tests/useHandlers-specs.js
@@ -1,11 +1,15 @@
-import {shallow} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
 
 import useHandlers from '../useHandlers';
 
 describe('useHandlers', () => {
+	let data = [];
+
 	const context = {
 		value: 1
 	};
+
 	function Component (props) {
 		const handlers = useHandlers({
 			testEvent: (ev, p, c) => {
@@ -13,55 +17,56 @@ describe('useHandlers', () => {
 			}
 		}, props, context);
 
+		data.push(handlers);
+
 		return (
-			<div {...props} {...handlers} />
+			<div {...props} data-testid="divComponent" />
 		);
 	}
 
+	afterEach(() => data.splice(0, data.length));
+
 	// Sanity test for Component moreso than useHandlers test
 	test('should include handlers in props', () => {
-		const subject = shallow(<Component />);
+		render(<Component />);
 
-		const expected = 'testEvent';
-		const actual = subject.props();
+		const actual = data[0].testEvent;
 
-		expect(actual).toHaveProperty(expected);
+		expect(actual).toBeDefined();
 	});
 
 	test('should have the same reference across renders', () => {
-		const subject = shallow(<Component />);
+		const {rerender} = render(<Component />);
 
-		const expected = subject.prop('testEvent');
+		const expected = data[0].testEvent;
 
-		subject.setProps({});
+		rerender(<Component />);
 
-		const actual = subject.prop('testEvent');
+		const actual =  data[1].testEvent;
 
 		expect(actual).toBe(expected);
 	});
 
 	test('should receive the event', () => {
 		const spy = jest.fn();
-		const subject = shallow(<Component />);
+		const {rerender} = render(<Component />);
 
-		const props = {children: 'updated'};
-		subject.setProps(props);
+		rerender(<Component>{'updated'}</Component>);
 
-		subject.find('div').invoke('testEvent')(spy);
+		data[0].testEvent(spy);
 
 		expect(spy).toHaveBeenCalled();
 	});
 
 	test('should reflect the latest props', () => {
 		const spy = jest.fn();
-		const subject = shallow(<Component />);
+		const {rerender} = render(<Component />);
 
-		const props = {children: 'updated'};
-		subject.setProps(props);
+		rerender(<Component>{'updated'}</Component>);
 
-		subject.find('div').invoke('testEvent')(spy);
+		data[0].testEvent(spy);
 
-		const expected = props;
+		const expected = {children: 'updated'};
 		const actual = spy.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expected);
@@ -69,9 +74,9 @@ describe('useHandlers', () => {
 
 	test('should support component-driven context', () => {
 		const spy = jest.fn();
-		const subject = shallow(<Component />);
+		render(<Component />);
 
-		subject.find('div').invoke('testEvent')(spy);
+		data[0].testEvent(spy);
 
 		// defined a "global" context to ease testability but this isn't representative of the
 		// expected use case of this feature.
@@ -83,9 +88,9 @@ describe('useHandlers', () => {
 
 	test('should return the value from the handler', () => {
 		const spy = jest.fn().mockImplementation(() => 'ok');
-		const subject = shallow(<Component />);
+		render(<Component />);
 
-		const returnValue = subject.find('div').invoke('testEvent')(spy);
+		const returnValue = data[0].testEvent(spy);
 
 		// defined a "global" context to ease testability but this isn't representative of the
 		// expected use case of this feature.


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated `internal/ApiDecorator` and `useHandlers` unit tests to React Testing Library

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-9789

### Comments
