### PR TITLE
WRN-11336: Fixed spotlightRootDecorator to show focus when last input type is `none`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "lts/*"
+    - "14"
 sudo: false
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/SpotlightRootDecorator` to show focus when last input type is `none`
+
 ## [3.4.9-experimental-6] - 2021-04-07
 
 ### Fixed

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
-    "@enact/storybook-utils": "^2.0.0",
+    "@enact/storybook-utils": "2.0.1",
     "@storybook/addons": "5.3.5",
     "@storybook/react": "5.3.5",
     "@storybook/theming": "5.3.5",

--- a/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
+++ b/packages/spotlight/SpotlightRootDecorator/SpotlightRootDecorator.js
@@ -132,11 +132,8 @@ const SpotlightRootDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (inputType === 'touch') {
 				this.containerRef.current.classList.remove('non-touch-mode');
 				this.containerRef.current.classList.add('touch-mode');
-			} else if (inputType === 'mouse' || inputType === 'key') {
-				this.containerRef.current.classList.add('non-touch-mode');
-				this.containerRef.current.classList.remove('touch-mode');
 			} else {
-				this.containerRef.current.classList.remove('non-touch-mode');
+				this.containerRef.current.classList.add('non-touch-mode');
 				this.containerRef.current.classList.remove('touch-mode');
 			}
 			needChangeTouchMode = false;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed `spotlightRootDecorator` to show focus when last input type is none

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set class to `non-touch-mode` when last input type is none (when tv is reboot)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-11336

### Comments
