### PR TITLE
WRN-848: Updated to use `forwardCustom` and add `type` when forwarding custom events

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `spotlight/Spottable` to forward `onSelectionCancel` and `onSpotlightDisappear` with event type
+
 ## [4.1.1] - 2021-11-30
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,9 +4,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
-### Changed
-
-- `spotlight/Spottable` to forward `onSelectionCancel` and `onSpotlightDisappear` with event type
+- Updated to use `forwardCustom` and add `type` when forwarding custom events
 
 ### Fixed
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact spotlight module, newest
 ### Changed
 
 - `spotlight/Spottable` to forward `onSelectionCancel` and `onSpotlightDisappear` with event type
-## [unreleased] 
 
 ### Fixed
 

--- a/packages/spotlight/Spottable/SpottableCore.js
+++ b/packages/spotlight/Spottable/SpottableCore.js
@@ -1,4 +1,4 @@
-import {forward, handle, preventDefault, stop} from '@enact/core/handle';
+import {forwardCustom, handle, preventDefault, stop} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 
 import {getContainersForNode} from '../src/container';
@@ -71,7 +71,7 @@ class SpottableCore {
 
 	unload () {
 		if (this.isFocused) {
-			forward('onSpotlightDisappear', null, this.props);
+			forwardCustom('onSpotlightDisappear')(null, this.props);
 		}
 		if (lastSelectTarget === this) {
 			lastSelectTarget = null;
@@ -84,7 +84,7 @@ class SpottableCore {
 		// if the component is focused and became disabled
 		if (this.isFocused && this.props.disabled && lastSelectTarget === this && !selectCancelled) {
 			selectCancelled = true;
-			forward('onSelectionCancel', null, this.props);
+			forwardCustom('onSelectionCancel')(null, this.props);
 		}
 
 		// if the component became enabled, notify spotlight to enable restoring "lost" focus

--- a/packages/spotlight/Spottable/tests/Spottable-specs.js
+++ b/packages/spotlight/Spottable/tests/Spottable-specs.js
@@ -48,6 +48,7 @@ describe('Spottable', () => {
 		const expected = 1;
 
 		expect(spy).toHaveBeenCalledTimes(expected);
+		expect(spy).toBeCalledWith({type: 'onSpotlightDisappear'});
 	});
 
 	describe('shouldComponentUpdate', () => {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+- Updated to use `forwardCustom` and add `type` when forwarding custom events
+
 ## [4.1.2] - 2021-12-22
 
 ### Fixed

--- a/packages/ui/Cancelable/Cancelable.js
+++ b/packages/ui/Cancelable/Cancelable.js
@@ -7,7 +7,7 @@
  * @exports removeCancelHandle
  */
 
-import {forward, handle, stop, stopImmediate} from '@enact/core/handle';
+import {forward, forwardCustom, handle, stop, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {add} from '@enact/core/keymap';
 import invariant from 'invariant';
@@ -184,7 +184,7 @@ const Cancelable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleCancel = this.handle(
 			forCancel,
-			forward('onCancel'),
+			forwardCustom('onCancel'),
 			dispatchCancelToConfig,
 			stop,
 			stopImmediate

--- a/packages/ui/Cancelable/tests/Cancelable-specs.js
+++ b/packages/ui/Cancelable/tests/Cancelable-specs.js
@@ -22,7 +22,7 @@ describe('Cancelable', () => {
 	const returnsTrue = () => true;
 	const stop = (ev) => ev.stopPropagation();
 
-	test('should call onCancel from prop for escape key', () => {
+	test('should call onCancel with type from prop for escape key', () => {
 		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: 'onCustomEvent'},
@@ -34,11 +34,14 @@ describe('Cancelable', () => {
 		fireEvent.keyUp(component, makeKeyEvent(27));
 
 		const expected = 1;
+		const expectedType = {type: 'onCustomEvent'};
+		const actual = handleCancel.mock.calls.length && handleCancel.mock.calls[0][0];
 
 		expect(handleCancel).toHaveBeenCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
 	});
 
-	test('should only call onCancel for escape key by default', () => {
+	test('should only call onCancel with type for escape key by default', () => {
 		const handleCancel = jest.fn(returnsTrue);
 		const Comp = Cancelable(
 			{onCancel: handleCancel},
@@ -51,8 +54,11 @@ describe('Cancelable', () => {
 		fireEvent.keyUp(component, makeKeyEvent(27));
 
 		const expected = 1;
+		const expectedType = {type: 'onCancel'};
+		const actual = handleCancel.mock.calls.length && handleCancel.mock.calls[0][0];
 
 		expect(handleCancel).toHaveBeenCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
 	});
 
 	test('should not call onCancel for non-escape key', () => {

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -7,7 +7,7 @@
  * @exports Changeable
  */
 
-import {forProp, forwardCustom, handle} from '@enact/core/handle';
+import {forProp, forward, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {cap} from '@enact/core/util';
 import PropTypes from 'prop-types';
@@ -171,7 +171,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleChange = this.handle(
 			forProp('disabled', false),
-			forwardCustom(change),
+			forward(change),
 			({[prop]: value}) => {
 				if (!this.state.controlled) {
 					this.setState(({value: oldValue}) => value !== oldValue ? {value} : null);

--- a/packages/ui/Changeable/Changeable.js
+++ b/packages/ui/Changeable/Changeable.js
@@ -7,7 +7,7 @@
  * @exports Changeable
  */
 
-import {forProp, forward, handle} from '@enact/core/handle';
+import {forProp, forwardCustom, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {cap} from '@enact/core/util';
 import PropTypes from 'prop-types';
@@ -171,7 +171,7 @@ const Changeable = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleChange = this.handle(
 			forProp('disabled', false),
-			forward(change),
+			forwardCustom(change),
 			({[prop]: value}) => {
 				if (!this.state.controlled) {
 					this.setState(({value: oldValue}) => value !== oldValue ? {value} : null);

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -1,5 +1,5 @@
 import {on, off} from '@enact/core/dispatcher';
-import {adaptEvent, forward, forProp, handle, oneOf, stop, forEventProp, call} from '@enact/core/handle';
+import {forwardCustom, forProp, handle, oneOf, stop, forEventProp, call} from '@enact/core/handle';
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
 import {cloneElement, Component} from 'react';
@@ -9,15 +9,6 @@ import Cancelable from '../Cancelable';
 
 import {FloatingLayerContext} from './FloatingLayerDecorator';
 import Scrim from './Scrim';
-
-const forwardWithType = type => adaptEvent(
-	() => ({type}),
-	forward(type)
-);
-
-const forwardDismiss = forwardWithType('onDismiss');
-const forwardClose = forwardWithType('onClose');
-const forwardOpen = forwardWithType('onOpen');
 
 /**
  * A component that creates an entry point to the new render tree.
@@ -144,7 +135,7 @@ class FloatingLayerBase extends Component {
 
 		if (prevProps.open && !open) {
 			// when open changes to false, forward close
-			forwardClose(null, this.props);
+			forwardCustom('onClose')(null, this.props);
 		} else if (!prevProps.open && open && !this.state.nodeRendered) {
 			// when open changes to true and node hasn't rendered, render it
 			this.renderNode();
@@ -153,7 +144,7 @@ class FloatingLayerBase extends Component {
 		) {
 			// when node has been rendered and either it was just rendered in this update cycle or
 			// the open prop changed in this cycle, forward open
-			forwardOpen(null, this.props);
+			forwardCustom('onOpen')(null, this.props);
 		}
 
 		if (scrimType === 'none') {
@@ -197,13 +188,13 @@ class FloatingLayerBase extends Component {
 
 	handleClose = handle(
 		forProp('open', true),
-		forwardDismiss
+		forwardCustom('onDismiss')
 	).bind(this);
 
 	handleClick = handle(
 		forProp('noAutoDismiss', false),
 		forProp('open', true),
-		forward('onDismiss')
+		forwardCustom('onDismiss')
 	).bind(this);
 
 	handleScroll = (ev) => {
@@ -268,7 +259,7 @@ class FloatingLayerBase extends Component {
 const handleCancel = handle(
 	// can't use forProp safely since either could be undefined ~= false
 	(ev, {open, noAutoDismiss, onDismiss}) => open && !noAutoDismiss && onDismiss,
-	forwardDismiss,
+	forwardCustom('onDismiss'),
 	stop
 );
 

--- a/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
+++ b/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
-import {FloatingLayerBase} from '../FloatingLayer';
+import {FloatingLayer, FloatingLayerBase} from '../FloatingLayer';
 import FloatingLayerDecorator from '../FloatingLayerDecorator';
 
 describe('FloatingLayer Specs', () => {
@@ -29,5 +29,60 @@ describe('FloatingLayer Specs', () => {
 		const floatingLayerContainer = screen.getByTestId('floatingLayer');
 
 		expect(floatingLayerContainer).toBeInTheDocument();
+	});
+
+	test('should fire onOpen event with type when FloatingLayer is open', () => {
+		const handleOpen = jest.fn();
+
+		render(
+			<Root>
+				<FloatingLayerBase onOpen={handleOpen} open><p>Hi</p></FloatingLayerBase>
+			</Root>
+		);
+
+		const expected = 1;
+		const expectedType = {type: 'onOpen'};
+		const actual = handleOpen.mock.calls.length && handleOpen.mock.calls[0][0];
+
+		expect(handleOpen).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+	});
+
+	test('should fire onClose event with type when FloatingLayer is open', () => {
+		const handleClose = jest.fn();
+
+		const {rerender} = render(
+			<Root>
+				<FloatingLayerBase onClose={handleClose} open><p>Hi</p></FloatingLayerBase>
+			</Root>
+		);
+
+		rerender(
+			<Root>
+				<FloatingLayerBase onClose={handleClose}><p>Hi</p></FloatingLayerBase>
+			</Root>
+		);
+
+		const expectedType = {type: 'onClose'};
+		const actual = handleClose.mock.calls.length && handleClose.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expectedType);
+	});
+
+	test('should fire onDimiss event with type when FloatingLayer is open', () => {
+		const handleDismiss = jest.fn();
+
+		render(
+			<Root>
+				<FloatingLayer onDismiss={handleDismiss} open><p>Hi</p></FloatingLayer>
+			</Root>
+		);
+
+		fireEvent.keyUp(screen.getByText('Hi'), {keyCode: 27});
+
+		const expectedType = {type: 'onDismiss'};
+		const actual = handleDismiss.mock.calls.length && handleDismiss.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expectedType);
 	});
 });

--- a/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
+++ b/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
@@ -48,7 +48,7 @@ describe('FloatingLayer Specs', () => {
 		expect(actual).toMatchObject(expectedType);
 	});
 
-	test('should fire onClose event with type when FloatingLayer is open', () => {
+	test('should fire onClose event with type when FloatingLayer is closed', () => {
 		const handleClose = jest.fn();
 
 		const {rerender} = render(
@@ -69,7 +69,7 @@ describe('FloatingLayer Specs', () => {
 		expect(actual).toMatchObject(expectedType);
 	});
 
-	test('should fire onDimiss event with type when FloatingLayer is open', () => {
+	test('should fire onDimiss event with type when FloatingLayer is closed', () => {
 		const handleDismiss = jest.fn();
 
 		render(

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -1,5 +1,5 @@
 import EnactPropTypes from '@enact/core/internal/prop-types';
-import {forProp, forward, handle, stop} from '@enact/core/handle';
+import {forProp, forwardCustom, handle, stop} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import {Children, Fragment} from 'react';
@@ -187,7 +187,7 @@ const MarqueeBase = kind({
 			forProp('animating', true),
 			isEventSource,
 			stop,
-			(ev, props) => forward('onMarqueeComplete', {type: 'onMarqueeComplete'}, props)
+			forwardCustom('onMarqueeComplete')
 		)
 	},
 

--- a/packages/ui/Media/Media.js
+++ b/packages/ui/Media/Media.js
@@ -9,7 +9,7 @@
  */
 
 import {on, off} from '@enact/core/dispatcher';
-import {forward} from '@enact/core/handle';
+import {forward, forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import PropTypes from 'prop-types';
 import {Children, isValidElement, Component as ReactComponent} from 'react';
@@ -230,7 +230,7 @@ class Media extends ReactComponent {
 	};
 
 	handleEvent = (ev) => {
-		forward('onUpdate', {type: 'onUpdate'}, this.props);
+		forwardCustom('onUpdate')(null, this.props);
 
 		// fetch the forward() we generated earlier, using the event type as a key to find the real event name.
 		const fwd = this.handledMediaForwards[handledMediaEventsMap[ev.type]];

--- a/packages/ui/RadioDecorator/RadioDecorator.js
+++ b/packages/ui/RadioDecorator/RadioDecorator.js
@@ -6,7 +6,7 @@
  * @exports RadioControllerDecorator
  */
 
-import {forward} from '@enact/core/handle';
+import {forwardCustom} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {Component} from 'react';
 
@@ -61,8 +61,6 @@ const defaultConfig = {
  */
 const RadioDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {activate, deactivate, prop} = config;
-	const forwardActivate = forward(activate);
-	const forwardDeactivate = forward(deactivate);
 
 	return class extends Component {
 		static displayName = 'RadioDecorator';
@@ -99,7 +97,7 @@ const RadioDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 */
 		deactivate = () => {
 			if (this.props[prop]) {
-				forwardDeactivate(null, this.props);
+				forwardCustom(deactivate)(null, this.props);
 			}
 		};
 
@@ -108,7 +106,7 @@ const RadioDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.controller.notify({action: 'activate'});
 			}
 
-			forwardActivate(null, this.props);
+			forwardCustom(activate)(null, this.props);
 		};
 
 		handleDeactivate = () => {
@@ -116,7 +114,7 @@ const RadioDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.controller.notify({action: 'deactivate'});
 			}
 
-			forwardDeactivate(null, this.props);
+			forwardCustom(deactivate)(null, this.props);
 		};
 
 		render () {

--- a/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
+++ b/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
@@ -25,7 +25,6 @@ describe('RadioDecorator', () => {
 		expect(component).toHaveTextContent('Active');
 	});
 
-
 	test('should not be activated when its prop is false on mount', () => {
 		const Component = RadioDecorator({prop: 'active'}, Item);
 		render(
@@ -81,7 +80,6 @@ describe('RadioDecorator', () => {
 
 		expect(handleActivate).toBeCalledTimes(expected);
 		expect(actual).toMatchObject(expectedType);
-
 	});
 
 	test('should fire `deactivate` event with type when become deactivated', () => {
@@ -105,7 +103,6 @@ describe('RadioDecorator', () => {
 
 		expect(handleDeactivate).toBeCalledTimes(expected);
 		expect(actual).toMatchObject(expectedType);
-
 	});
 
 	test('should not call deactivate callback on inactive items', () => {

--- a/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
+++ b/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
@@ -65,7 +65,7 @@ describe('RadioDecorator', () => {
 		const handleActivate = jest.fn();
 		const Wrapper = () => (
 			<Controller>
-				<Component onClick={handleActivate}/>
+				<Component onClick={handleActivate} />
 			</Controller>
 		);
 
@@ -89,7 +89,7 @@ describe('RadioDecorator', () => {
 		const handleDeactivate = jest.fn();
 		const Wrapper = () => (
 			<Controller>
-				<Component onClick={handleDeactivate}/>
+				<Component onClick={handleDeactivate} />
 			</Controller>
 		);
 

--- a/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
+++ b/packages/ui/RadioDecorator/tests/RadioDecorator-specs.js
@@ -60,6 +60,54 @@ describe('RadioDecorator', () => {
 		expect(component).toHaveTextContent(secondExpected);
 	});
 
+	test('should fire `activate` event with type when become activated', () => {
+		const Component = RadioDecorator({activate: 'onClick', prop: 'active'}, Item);
+		const handleActivate = jest.fn();
+		const Wrapper = () => (
+			<Controller>
+				<Component onClick={handleActivate}/>
+			</Controller>
+		);
+
+		render(<Wrapper />);
+
+		const component = screen.getByTestId('span-element');
+
+		userEvent.click(component);
+
+		const expected = 1;
+		const expectedType = {type: 'onClick'};
+		const actual = handleActivate.mock.calls.length && handleActivate.mock.calls[0][0];
+
+		expect(handleActivate).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+
+	});
+
+	test('should fire `deactivate` event with type when become deactivated', () => {
+		const Component = RadioDecorator({deactivate: 'onClick', prop: 'active'}, Item);
+		const handleDeactivate = jest.fn();
+		const Wrapper = () => (
+			<Controller>
+				<Component onClick={handleDeactivate}/>
+			</Controller>
+		);
+
+		render(<Wrapper />);
+
+		const component = screen.getByTestId('span-element');
+
+		userEvent.click(component);
+
+		const expected = 1;
+		const expectedType = {type: 'onClick'};
+		const actual = handleDeactivate.mock.calls.length && handleDeactivate.mock.calls[0][0];
+
+		expect(handleDeactivate).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+
+	});
+
 	test('should not call deactivate callback on inactive items', () => {
 		const handleDeactivate = jest.fn();
 		const Component = RadioDecorator({deactivate: 'onClick', prop: 'active'}, Item);

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -875,7 +875,7 @@ class ScrollableBase extends Component {
 	// call scroll callbacks
 
 	forwardScrollEvent (type, reachedEdgeInfo) {
-		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
+		forward(type, {type, scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
 	}
 
 	// update scroll position

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -923,7 +923,7 @@ class ScrollableBaseNative extends Component {
 	// call scroll callbacks
 
 	forwardScrollEvent (type, reachedEdgeInfo) {
-		forward(type, {scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
+		forward(type, {type, scrollLeft: this.scrollLeft, scrollTop: this.scrollTop, moreInfo: this.getMoreInfo(), reachedEdgeInfo}, this.props);
 	}
 
 	// call scroll callbacks and update scrollbars for native scroll

--- a/packages/ui/Toggleable/Toggle.js
+++ b/packages/ui/Toggleable/Toggle.js
@@ -1,4 +1,4 @@
-import {adaptEvent, forProp, forward, handle, not, returnsTrue} from '@enact/core/handle';
+import {forProp, forwardCustom, handle, not, returnsTrue} from '@enact/core/handle';
 
 const isEnabled = not(forProp('disabled', true));
 const makeEvent = (config, value) => ({
@@ -24,19 +24,19 @@ class Toggle {
 
 	handleActivate = handle(
 		isEnabled,
-		adaptEvent((ev, props) => makeEvent(props, true), forward('onToggle')),
+		forwardCustom('onToggle', (ev, props) => makeEvent(props, true)),
 		returnsTrue((ev, props, context) => context.onToggle(true))
 	).bindAs(this, 'handleActivate');
 
 	handleDeactivate = handle(
 		isEnabled,
-		adaptEvent((ev, props) => makeEvent(props, false), forward('onToggle')),
+		forwardCustom('onToggle', (ev, props) => makeEvent(props, false)),
 		returnsTrue((ev, props, context) => context.onToggle(false))
 	).bindAs(this, 'handleDeactivate');
 
 	handleToggle = handle(
 		isEnabled,
-		adaptEvent((ev, props, {value}) => makeEvent(props, !value), forward('onToggle')),
+		forwardCustom('onToggle', (ev, props, {value}) => makeEvent(props, !value)),
 		returnsTrue((ev, props, {onToggle, value}) => onToggle(!value))
 	).bindAs(this, 'handleToggle');
 }

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -143,7 +143,7 @@ describe('Toggleable', () => {
 	});
 
 	describe('#forwarding events', () => {
-		test('should invoke passed "onToggle" handler', () => {
+		test('should invoke passed "onToggle" handler with type', () => {
 			// eslint-disable-next-line
 			console.error = () => {};
 			const handleToggle = jest.fn();
@@ -152,11 +152,14 @@ describe('Toggleable', () => {
 			data.onToggle();
 
 			const expected = 1;
+			const expectedType = {type: 'onToggle'};
+			const actual = handleToggle.mock.calls.length && handleToggle.mock.calls[0][0];
 
 			expect(handleToggle).toHaveBeenCalledTimes(expected);
+			expect(actual).toMatchObject(expectedType);
 		});
 
-		test('should invoke passed "onActivate" handler', () => {
+		test('should invoke passed "onActivate" handler with type', () => {
 			// eslint-disable-next-line
 			console.error = () => {};
 			const handleActivate = jest.fn();
@@ -165,11 +168,14 @@ describe('Toggleable', () => {
 			data.onActivate();
 
 			const expected = 1;
+			const expectedType = {type: 'onActivate'};
+			const actual = handleActivate.mock.calls.length && handleActivate.mock.calls[0][0];
 
 			expect(handleActivate).toHaveBeenCalledTimes(expected);
+			expect(actual).toMatchObject(expectedType);
 		});
 
-		test('should invoke passed "onDeactivate" handler', () => {
+		test('should invoke passed "onDeactivate" handler with type', () => {
 			// eslint-disable-next-line
 			console.error = () => {};
 			const handleDeactivate = jest.fn();
@@ -178,8 +184,11 @@ describe('Toggleable', () => {
 			data.onDeactivate();
 
 			const expected = 1;
+			const expectedType = {type: 'onDeactivate'};
+			const actual = handleDeactivate.mock.calls.length && handleDeactivate.mock.calls[0][0];
 
 			expect(handleDeactivate).toHaveBeenCalledTimes(expected);
+			expect(actual).toMatchObject(expectedType);
 		});
 
 		test('should not invoke passed "onToggle" handler when disabled', () => {

--- a/packages/ui/Toggleable/tests/Toggleable-specs.js
+++ b/packages/ui/Toggleable/tests/Toggleable-specs.js
@@ -159,6 +159,22 @@ describe('Toggleable', () => {
 			expect(actual).toMatchObject(expectedType);
 		});
 
+		test('should invoke passed custom "onJiggle" handler with type', () => {
+			// eslint-disable-next-line
+			console.error = () => {};
+			const handleJiggle = jest.fn();
+			const Component = Toggleable({toggleProp: 'onJiggle'}, DivComponent);
+			render(<Component onJiggle={handleJiggle} />);
+			data.onJiggle();
+
+			const expected = 1;
+			const expectedType = {type: 'onJiggle'};
+			const actual = handleJiggle.mock.calls.length && handleJiggle.mock.calls[0][0];
+
+			expect(handleJiggle).toHaveBeenCalledTimes(expected);
+			expect(actual).toMatchObject(expectedType);
+		});
+
 		test('should invoke passed "onActivate" handler with type', () => {
 			// eslint-disable-next-line
 			console.error = () => {};

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -519,13 +519,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forwardCustom('onTransitionEnd')(ev, this.props);
+		forwardCustom('onTransitionEnd')(null, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forwardCustom('onHide')(ev, this.props);
+				forwardCustom('onHide')(null, this.props);
 			} else if (this.props.visible) {
-				forwardCustom('onShow')(ev, this.props);
+				forwardCustom('onShow')(null, this.props);
 			}
 		}
 	};

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -16,7 +16,7 @@
  * @exports TransitionBase
  */
 
-import {forward} from '@enact/core/handle';
+import {forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
 import {Job} from '@enact/core/util';
@@ -26,10 +26,6 @@ import PropTypes from 'prop-types';
 import {ResizeContext} from '../Resizable';
 
 import componentCss from './Transition.module.less';
-
-const forwardTransitionEnd = forward('onTransitionEnd');
-const forwardOnShow = forward('onShow');
-const forwardOnHide = forward('onHide');
 
 const formatter = (duration) => (typeof duration === 'number' ? duration + 'ms' : duration);
 /**
@@ -494,9 +490,9 @@ class Transition extends Component {
 
 		if (noAnimation) {
 			if (!prevProps.visible && visible) {
-				forwardOnShow({}, this.props);
+				forwardCustom('onShow')({}, this.props);
 			} else if (prevProps.visible && !visible) {
-				forwardOnHide({}, this.props);
+				forwardCustom('onHide')({}, this.props);
 			}
 		}
 	}
@@ -523,13 +519,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forwardTransitionEnd(ev, this.props);
+		forwardCustom('onTransitionEnd')(ev, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forwardOnHide(ev, this.props);
+				forwardCustom('onHide')(ev, this.props);
 			} else if (this.props.visible) {
-				forwardOnShow(ev, this.props);
+				forwardCustom('onShow')(ev, this.props);
 			}
 		}
 	};

--- a/packages/ui/Transition/tests/Transition-specs.js
+++ b/packages/ui/Transition/tests/Transition-specs.js
@@ -91,7 +91,7 @@ describe('Transition Specs', () => {
 		);
 
 		rerender(
-			<Transition noAnimation onShow={handleShow} visible={true}>
+			<Transition noAnimation onShow={handleShow} visible>
 				<ChildNode />
 			</Transition>
 		);
@@ -109,7 +109,7 @@ describe('Transition Specs', () => {
 		const ChildNode = (props) => <div {...props}>Body</div>;
 
 		const {rerender} = render(
-			<Transition noAnimation onHide={handleHide} visible={true}>
+			<Transition noAnimation onHide={handleHide} visible>
 				<ChildNode />
 			</Transition>
 		);

--- a/packages/ui/Transition/tests/Transition-specs.js
+++ b/packages/ui/Transition/tests/Transition-specs.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 import Transition, {TransitionBase} from '../Transition';
 
@@ -78,6 +78,74 @@ describe('Transition Specs', () => {
 		const actual = screen.getByTestId('transition');
 
 		expect(actual).toHaveClass(expected);
+	});
+
+	test('should fire \'onShow\' event with type when \'visible\' prop bacomes true ', () => {
+		const handleShow = jest.fn();
+		const ChildNode = (props) => <div {...props}>Body</div>;
+
+		const {rerender} = render(
+			<Transition noAnimation onShow={handleShow} visible={false}>
+				<ChildNode />
+			</Transition>
+		);
+
+		rerender(
+			<Transition noAnimation onShow={handleShow} visible={true}>
+				<ChildNode />
+			</Transition>
+		);
+
+		const expected = 1;
+		const expectedType = {type: 'onShow'};
+		const actual = handleShow.mock.calls.length && handleShow.mock.calls[0][0];
+
+		expect(handleShow).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+	});
+
+	test('should fire \'onHide\' event with type when \'visible\' prop bacomes false ', () => {
+		const handleHide = jest.fn();
+		const ChildNode = (props) => <div {...props}>Body</div>;
+
+		const {rerender} = render(
+			<Transition noAnimation onHide={handleHide} visible={true}>
+				<ChildNode />
+			</Transition>
+		);
+
+		rerender(
+			<Transition noAnimation onHide={handleHide} visible={false}>
+				<ChildNode />
+			</Transition>
+		);
+
+		const expected = 1;
+		const expectedType = {type: 'onHide'};
+		const actual = handleHide.mock.calls.length && handleHide.mock.calls[0][0];
+
+		expect(handleHide).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+	});
+
+	test('should fire \'onTransitionEnd\' event with type', () => {
+		const handleTransitionEnd = jest.fn();
+		const ChildNode = (props) => <div {...props}>Body</div>;
+
+		render(
+			<Transition onTransitionEnd={handleTransitionEnd}>
+				<ChildNode />
+			</Transition>
+		);
+
+		fireEvent.transitionEnd(screen.getByText('Body'));
+
+		const expected = 1;
+		const expectedType = {type: 'onTransitionEnd'};
+		const actual = handleTransitionEnd.mock.calls.length && handleTransitionEnd.mock.calls[0][0];
+
+		expect(handleTransitionEnd).toBeCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
 	});
 
 	// Tests for prop and className combinations

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -445,7 +445,6 @@ class TransitionGroup extends Component {
 		delete props.componentRef;
 		delete props.currentIndex;
 		delete props.onAppear;
-		delete props.onAppear;
 		delete props.onEnter;
 		delete props.onLeave;
 		delete props.onStay;

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -5,7 +5,7 @@
 // Using string refs from the source code of ReactTransitionGroup
 
 import EnactPropTypes from '@enact/core/internal/prop-types';
-import {forward} from '@enact/core/handle';
+import {forward, forwardCustom} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import eqBy from 'ramda/src/eqBy';
 import findIndex from 'ramda/src/findIndex';
@@ -58,8 +58,6 @@ const forwardOnAppear = forward('onAppear');
 const forwardOnEnter = forward('onEnter');
 const forwardOnLeave = forward('onLeave');
 const forwardOnStay = forward('onStay');
-const forwardOnTransition = forward('onTransition');
-const forwardOnWillTransition = forward('onWillTransition');
 
 /**
  * Manages the transition of added and removed child components. Children that are added are
@@ -273,7 +271,7 @@ class TransitionGroup extends Component {
 		});
 
 		if (this.keysToEnter.length || this.keysToLeave.length) {
-			forwardOnWillTransition(null, this.props);
+			forwardCustom('onWillTransition')(null, this.props);
 		}
 
 		// once the component has been updated, start the enter transition for new children,
@@ -297,7 +295,7 @@ class TransitionGroup extends Component {
 			delete this.currentlyTransitioningKeys[key];
 
 			if (!noForwarding && Object.keys(this.currentlyTransitioningKeys).length === 0) {
-				forwardOnTransition(null, this.props);
+				forwardCustom('onTransition')(null, this.props);
 			}
 		}
 	}
@@ -323,6 +321,7 @@ class TransitionGroup extends Component {
 		}
 
 		forwardOnAppear({
+			type: 'onAppear',
 			view: component
 		}, this.props);
 
@@ -357,6 +356,7 @@ class TransitionGroup extends Component {
 		}
 
 		forwardOnEnter({
+			type: 'onEnter',
 			view: component
 		}, this.props);
 
@@ -382,6 +382,7 @@ class TransitionGroup extends Component {
 		}
 
 		forwardOnStay({
+			type: 'onStay',
 			view: component
 		}, this.props);
 	};
@@ -408,6 +409,7 @@ class TransitionGroup extends Component {
 		}
 
 		forwardOnLeave({
+			type: 'onLeave',
 			view: component
 		}, this.props);
 

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -14,7 +14,7 @@
  */
 
 import EnactPropTypes from '@enact/core/internal/prop-types';
-import handle, {adaptEvent, call, forward} from '@enact/core/handle';
+import handle, {forwardCustom} from '@enact/core/handle';
 import PropTypes from 'prop-types';
 import {Children, Component} from 'react';
 
@@ -238,22 +238,16 @@ const ViewManagerBase = class extends Component {
 		return null;
 	}
 
-	makeTransitionEvent () {
+	makeTransitionEvent = () => {
 		return {index: this.props.index, previousIndex: this.state.prevIndex};
 	}
 
 	handleTransition = handle(
-		adaptEvent(
-			call('makeTransitionEvent'),
-			forward('onTransition')
-		)
+		forwardCustom('onTransition', this.makeTransitionEvent)
 	).bindAs(this, 'handleTransition');
 
 	handleWillTransition = handle(
-		adaptEvent(
-			call('makeTransitionEvent'),
-			forward('onWillTransition')
-		)
+		forwardCustom('onWillTransition', this.makeTransitionEvent)
 	).bindAs(this, 'handleWillTransition');
 
 	render () {

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -240,7 +240,7 @@ const ViewManagerBase = class extends Component {
 
 	makeTransitionEvent = () => {
 		return {index: this.props.index, previousIndex: this.state.prevIndex};
-	}
+	};
 
 	handleTransition = handle(
 		forwardCustom('onTransition', this.makeTransitionEvent)

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -395,11 +395,11 @@ describe('ViewManager', () => {
 
 		subject.setProps({index: 1});
 
-		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0});
+		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0, type: 'onTransition'});
 
 		subject.setProps({index: 0});
 
-		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1});
+		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1, type: 'onTransition'});
 	});
 
 	test('should fire onWillTransition once per transition', () => {
@@ -427,11 +427,11 @@ describe('ViewManager', () => {
 
 		subject.setProps({index: 1});
 
-		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0});
+		expect(spy).toHaveBeenLastCalledWith({index: 1, previousIndex: 0, type: 'onWillTransition'});
 
 		subject.setProps({index: 0});
 
-		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1});
+		expect(spy).toHaveBeenLastCalledWith({index: 0, previousIndex: 1, type: 'onWillTransition'});
 	});
 
 	test('should pass `rtl` prop to arranger when `true`', () => {

--- a/packages/ui/ViewManager/tests/ViewManager-specs.js
+++ b/packages/ui/ViewManager/tests/ViewManager-specs.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import {Component} from 'react';
 
 import ViewManager from '../';
@@ -417,6 +417,57 @@ describe('ViewManager', () => {
 		const expected = 3;
 
 		expect(children).toHaveLength(expected);
+	});
+
+	test('should fire onEnter with type once a view has entered', () => {
+		const spy = jest.fn();
+		const {rerender} = render(
+			<ViewManager index={0} noAnimation onEnter={spy}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		spy.mockClear();
+
+		rerender(
+			<ViewManager index={1} onEnter={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+		const expected = 1;
+		const expectedType = {type: 'onEnter'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(spy).toHaveBeenCalledTimes(expected);
+		expect(actual).toMatchObject(expectedType);
+	});
+
+	test('should fire onAppear with type once a view has appeared', async () => {
+		const spy = jest.fn();
+		const {rerender} = render(
+			<ViewManager index={0} noAnimation onAppear={spy}>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		rerender(
+			<ViewManager index={1} onAppear={spy} noAnimation>
+				<div key="view1">View 1</div>
+				<div key="view2">View 2</div>
+			</ViewManager>
+		);
+
+		await waitFor(() => {
+			const expected = 1;
+			const expectedType = {type: 'onAppear'};
+			const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+			expect(spy).toHaveBeenCalledTimes(expected);
+			expect(actual).toMatchObject(expectedType);
+		});
 	});
 
 	test('should fire onTransition once per transition', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We've added `forwardCustom` in https://github.com/enactjs/enact/pull/2773.
And some of the custom events have no `type` when firing.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to use `forwardCustom` and add `type` when forwarding custom events.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-848

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)