### PR TITLE
WRN-12780: Add topmost option for preferredEnterTo for getContainerFocusTarget

### DIFF
--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.1"
   },
   "devDependencies": {
-    "@enact/storybook-utils": "^4.0.5",
+    "@enact/storybook-utils": "4.0.5",
     "@storybook/addons": "6.2.9",
     "@storybook/react": "6.2.9",
     "@storybook/theming": "6.2.9",

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -722,9 +722,8 @@ function setContainerLastFocusedElement (node, containerIds) {
  * return that element as the only element in an array. If that fails or if navigation is not
  * restricted, it will return an array of all possible navigable nodes.
  *
- * @param   {String}                             containerId        			Container ID
- * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo]	Prefer the given enterTo configuration
-
+ * @param   {String}                                        containerId        Container ID
+ * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo configuration
  *
  * @returns {Node[]}             Navigable elements within container
  * @memberof spotlight/container
@@ -771,9 +770,7 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
 			});
 
 			if (next && preferredEnterTo === 'top-most') {
-				next.sort(function(elem1, elem2) {
-					return getRect(elem1).top - getRect(elem2).top;
-				});
+				next.sort((a, b) => (getRect(a).top - getRect(b).top));
 			}
 		}
 
@@ -790,8 +787,8 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
  * Determines the preferred focus target, traversing any sub-containers as necessary, for the given
  * container.
  *
- * @param   {String}                             containerId        			ID of container
- * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo]	Prefer the given enterTo configuration
+ * @param   {String}                                        containerId        Container ID
+ * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo configuration
  *
  * @returns {Node}                 Preferred target as either a DOM node or container-id
  * @memberof spotlight/container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -623,9 +623,8 @@ const getAllContainerIds = () => {
 /**
  * Returns the default focus element for a container
  *
- * @param   {String}                             containerId        ID of container
- * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
- *                                                                  configuration
+ * @param   {String}                                       containerId        Container ID
+ * @param   {('last-focused'|'default-element'|'topmost')} [preferredEnterTo] Prefer the given enterTo configuration
  *
  * @returns {Node|null}                 Default focus element
  * @memberof spotlight/container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -723,7 +723,7 @@ function setContainerLastFocusedElement (node, containerIds) {
  * restricted, it will return an array of all possible navigable nodes.
  *
  * @param   {String}                             containerId        Container ID
- * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
+ * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo
  *                                                                  configuration
  *
  * @returns {Node[]}             Navigable elements within container
@@ -769,6 +769,12 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
 
 				return contains(containerRect, getRect(element));
 			});
+
+			if (next && preferredEnterTo === 'top-most') {
+				next.sort(function(elem1, elem2) {
+					return getRect(elem1).top - getRect(elem2).top;
+				});
+			}
 		}
 
 		// otherwise, return all spottables within the container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -723,7 +723,7 @@ function setContainerLastFocusedElement (node, containerIds) {
  * restricted, it will return an array of all possible navigable nodes.
  *
  * @param   {String}                                        containerId        Container ID
- * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo configuration
+ * @param   {('last-focused'|'default-element'|'topmost')} [preferredEnterTo] Prefer the given enterTo configuration
  *
  * @returns {Node[]}             Navigable elements within container
  * @memberof spotlight/container
@@ -769,7 +769,7 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
 				return contains(containerRect, getRect(element));
 			});
 
-			if (next && preferredEnterTo === 'top-most') {
+			if (next && preferredEnterTo === 'topmost') {
 				next.sort((a, b) => (getRect(a).top - getRect(b).top));
 			}
 		}
@@ -788,7 +788,7 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
  * container.
  *
  * @param   {String}                                        containerId        Container ID
- * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo configuration
+ * @param   {('last-focused'|'default-element'|'topmost')} [preferredEnterTo] Prefer the given enterTo configuration
  *
  * @returns {Node}                 Preferred target as either a DOM node or container-id
  * @memberof spotlight/container

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -722,9 +722,9 @@ function setContainerLastFocusedElement (node, containerIds) {
  * return that element as the only element in an array. If that fails or if navigation is not
  * restricted, it will return an array of all possible navigable nodes.
  *
- * @param   {String}                             containerId        Container ID
- * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo] Prefer the given enterTo
- *                                                                  configuration
+ * @param   {String}                             containerId        			Container ID
+ * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo]	Prefer the given enterTo configuration
+
  *
  * @returns {Node[]}             Navigable elements within container
  * @memberof spotlight/container
@@ -790,9 +790,8 @@ function getContainerNavigableElements (containerId, preferredEnterTo) {
  * Determines the preferred focus target, traversing any sub-containers as necessary, for the given
  * container.
  *
- * @param   {String}                             containerId        ID of container
- * @param   {('last-focused'|'default-element')} [preferredEnterTo] Prefer the given enterTo
- *                                                                  configuration
+ * @param   {String}                             containerId        			ID of container
+ * @param   {('last-focused'|'default-element'|'top-most')} [preferredEnterTo]	Prefer the given enterTo configuration
  *
  * @returns {Node}                 Preferred target as either a DOM node or container-id
  * @memberof spotlight/container


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When reset the focus using spotlight.focus(container, 'default-focus');, the 'default-focus' option returns the first node in DOM order if no default is specified. 
When the visual order and DOM order do not match(ex `VirtualList`), the focus could be moved to somewhere in middle.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I add a new `topmost` option to decide the container target.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-12780

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)