### PR TITLE
WRN-6761: VirtualGridListNative keeps scrolling after rotated while scrolling in Android

### DIFF
--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -489,9 +489,20 @@ class ScrollableBaseNative extends Component {
 			if (handleResizeWindow) {
 				handleResizeWindow();
 			}
+			if ( platform.platformName === 'androidChrome' || platform.platformName === 'ios' ) {
+				this.childRefCurrent.containerRef.current.style.overflow = 'hidden';
+
+			}
 			this.childRefCurrent.containerRef.current.style.scrollBehavior = null;
+
 			this.childRefCurrent.scrollToPosition(0, 0);
-			this.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
+
+			setTimeout(() => {
+				if ( platform.platformName === 'androidChrome' || platform.platformName === 'ios' ) {
+					this.childRefCurrent.containerRef.current.style.overflow = '';
+				}
+				this.childRefCurrent.containerRef.current.style.scrollBehavior = 'smooth';
+			}, 100);
 
 			this.enqueueForceUpdate();
 		});

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -368,9 +368,20 @@ const useScrollBase = (props) => {
 			if (scrollMode === 'translate') {
 				scrollTo({position: {x: 0, y: 0}, animate: false});
 			} else {
+				if ( platform.platformName === 'androidChrome' || platform.platformName === 'ios' ) {
+					scrollContentRef.current.style.overflow = 'hidden';
+
+				}
 				scrollContentRef.current.style.scrollBehavior = null;
+
 				scrollContentHandle.current.scrollToPosition(0, 0);
-				scrollContentRef.current.style.scrollBehavior = 'smooth';
+
+				setTimeout(() => {
+					if ( platform.platformName === 'androidChrome' || platform.platformName === 'ios' ) {
+						scrollContentRef.current.style.overflow = '';
+					}
+					scrollContentRef.current.style.scrollBehavior = 'smooth';
+				}, 100);
 			}
 
 			enqueueForceUpdate();


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changed the structure of the handleResizeWinodw from both Scrollable Native and useScroll so that the problem is less visible.
This problem was reproduced on all the components that used Scrollable Native and useScroll across all the libraries. This solution does not cover the Safari browser for IOS because of a strange interaction between overflow hidden and it (the items remain invisible until you scroll a bit).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The solution is not a perfect fix as in some rare cases the list is not 100% at the top(the worst I've seen it was a little bit past it but the first element was still visible) but it should stop the scrolling effect from after the screen was rotated.

### Links
[//]: # (Related issues, references)
WRN-6761

### Comments
