### PR TITLE
WRN-12676: Fix .buildFontFace font mixins to work properly with multiple weight values

### DIFF
--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -360,13 +360,22 @@
 .buildFontFace(@name; @src; @weight: normal; @style: "") when (default()) {
 	.buildFontFace(@name; @src; {
 		// Conditionally add the following
-		// `length()` below refers to specifying font-weight ranges: `600 900`.
-		& when ((iskeyword(@weight)) or (isnumber(@weight)) or (length(@weight) > 1)) {
+		& when ((iskeyword(@weight)) or (isnumber(@weight))) {
 			font-weight: @weight;
 		}
 		& when (iskeyword(@style)) {
 			font-style: @style;
 		}
+	});
+}
+
+// `length()` below refers to specifying font-weight ranges: `600 900`.
+// Ex: 
+//   .buildFontFace("fontName"; local("name"); 400 600); 
+//   -> .buildFontFace("fontName"; local("name"); 400); .buildFontFace("fontName"; local("name"); 600);
+.buildFontFace(@name; @src; @weight: normal) when (length(@weight) > 1) {
+	each(@weight, {
+		.buildFontFace(@name; @src; @value);
 	});
 }
 

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -356,6 +356,19 @@
 		@rules();
 	}
 }
+
+// `length()` below refers to specifying font-weight ranges: `600 900`.
+// Ex: 
+//   .buildFontFace("fontName"; local("name"); 400 600); 
+//   -> .buildFontFace("fontName"; local("name"); 400); .buildFontFace("fontName"; local("name"); 600);
+//   .buildFontFace("fontName"; local("name"); 400 600; normal);
+//   -> .buildFontFace("fontName"; local("name"); 400; normal); .buildFontFace("fontName"; local("name"); 600; normal);
+.buildFontFace(@name; @src; @weight: normal; @style: "") when (length(@weight) > 1) {
+	each(@weight, {
+		.buildFontFace(@name; @src; @value; @style);
+	});
+}
+
 // The default version of this mixin (below) is the shorthand version, which rearranges its arguments into the format the above mixin expects.
 .buildFontFace(@name; @src; @weight: normal; @style: "") when (default()) {
 	.buildFontFace(@name; @src; {
@@ -366,16 +379,6 @@
 		& when (iskeyword(@style)) {
 			font-style: @style;
 		}
-	});
-}
-
-// `length()` below refers to specifying font-weight ranges: `600 900`.
-// Ex: 
-//   .buildFontFace("fontName"; local("name"); 400 600); 
-//   -> .buildFontFace("fontName"; local("name"); 400); .buildFontFace("fontName"; local("name"); 600);
-.buildFontFace(@name; @src; @weight: normal) when (length(@weight) > 1) {
-	each(@weight, {
-		.buildFontFace(@name; @src; @value);
 	});
 }
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix .buildFontFace font mixins to work with multiple weight values.
As-Is
.buildFontFace("fontName", local("name"), 400 600) generates one font-face rule like below.
`@font-face {
  font-family: "fontName";
  src: local("name");
  font-weight: 400 600;
}`


To-Be
.buildFontFace("fontName", local("name"), 400 600) generates multiple font-face rules like below.
`@font-face {
  font-family: "fontName";
  src: local("name");
  font-weight: 400;
}
`
`
@font-face {
  font-family: "fontName";
  src: local("name");
  font-weight: 600;
}
`
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix .buildFontFace mixins to generate @font-face rules with each font-weight. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12676

### Comments
