### PR TITLE
WRN-14604: Fixed Panel to restore focus properly when it has Scroller with `focusableScrollbar`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enactjs/cli#2.7.1
+    - npm install -g enactjs/cli@2.7.1
     - npm install -g codecov
     - npm install
     - npm run bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enactjs/cli#3.0.6
+    - npm install -g enactjs/cli#2.7.1
     - npm install -g codecov
     - npm install
     - npm run bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
 node_js:
-    - "lts/*"
+    - "14"
 sudo: false
 cache:
   directories:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enactjs/cli#develop
+    - npm install -g enactjs/cli#3.0.6
     - npm install -g codecov
     - npm install
     - npm run bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $(npm config get cache)
 install:
     - npm config set prefer-offline true
-    - npm install -g enactjs/cli@2.7.1
+    - npm install -g enactjs/cli#2.7.1
     - npm install -g codecov
     - npm install
     - npm run bootstrap

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact moonstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `moonstone/Panels.Panel` to restore focus properly when panel has `moonstone/Scroller` with `focusableScrollbar`
+
 ## [3.2.6] - 2020-03-26
 
 No significant changes.

--- a/packages/moonstone/CHANGELOG.md
+++ b/packages/moonstone/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact moonstone module, newest
 
 ### Fixed
 
-- `moonstone/Panels.Panel` to restore focus properly when panel has `moonstone/Scroller` with `focusableScrollbar`
+- `moonstone/Panels.Panel` to restore focus properly when it has `moonstone/Scroller` with `focusableScrollbar`
 
 ## [3.2.6] - 2020-03-26
 

--- a/packages/moonstone/Panels/Panel.js
+++ b/packages/moonstone/Panels/Panel.js
@@ -202,6 +202,15 @@ const Panel = SharedStateDecorator(
 			continue5WayHold: true,
 			defaultElement: [`.${spotlightDefaultClass}`, `.${css.body} *`],
 			enterTo: 'last-focused',
+			lastFocusedPersist: (lastFocusNode, all) => {
+				all = all.filter(element => !element.dataset.spotlightIgnoreRestore);
+				const container = typeof lastFocusNode === 'string';
+				return {
+					container,
+					element: !container,
+					key: container ? lastFocusNode : all.indexOf(lastFocusNode)
+				};
+			},
 			preserveId: true
 		},
 		Slottable(

--- a/packages/moonstone/Panels/Panel.js
+++ b/packages/moonstone/Panels/Panel.js
@@ -203,12 +203,13 @@ const Panel = SharedStateDecorator(
 			defaultElement: [`.${spotlightDefaultClass}`, `.${css.body} *`],
 			enterTo: 'last-focused',
 			lastFocusedPersist: (lastFocusNode, all) => {
-				all = all.filter(element => !element.dataset.spotlightIgnoreRestore);
+				const filtered = all.filter(element => !element.dataset.spotlightIgnoreRestore);
 				const container = typeof lastFocusNode === 'string';
+
 				return {
 					container,
 					element: !container,
-					key: container ? lastFocusNode : all.indexOf(lastFocusNode)
+					key: container ? lastFocusNode : filtered.indexOf(lastFocusNode)
 				};
 			},
 			preserveId: true

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -76,7 +76,6 @@ class ScrollButtons extends Component {
 		 * This value is set by `Scrollable`.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @private
 		 */
 		focusableScrollButtons: PropTypes.bool,
@@ -85,7 +84,6 @@ class ScrollButtons extends Component {
 		 * When it is `true`, spotlight ignore the scrollbar button on persist last focused element
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @private
 		 */
 		ignoreRestoreSpotlight: PropTypes.bool,

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -82,6 +82,15 @@ class ScrollButtons extends Component {
 		focusableScrollButtons: PropTypes.bool,
 
 		/**
+		 * When it is `true`, spotlight ignore the scrollbar button on persist last focused element
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		ignoreRestoreSpotlight: PropTypes.bool,
+
+		/**
 		* Sets the hint string read when focusing the next button in the scroll bar.
 		*
 		* @type {String}
@@ -355,7 +364,7 @@ class ScrollButtons extends Component {
 
 	render () {
 		const
-			{disabled, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
+			{disabled, ignoreRestoreSpotlight, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
 			prevIcon = preparePrevButton(vertical),
 			nextIcon = prepareNextButton(vertical);
@@ -363,6 +372,7 @@ class ScrollButtons extends Component {
 		return [
 			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
+				{...ignoreRestoreSpotlight ? {'data-spotlight-ignore-restore': true} : {}}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || prevButtonDisabled}
 				key="prevButton"
@@ -376,6 +386,7 @@ class ScrollButtons extends Component {
 			thumbRenderer(),
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
+				{...ignoreRestoreSpotlight ? {'data-spotlight-ignore-restore': true} : {}}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || nextButtonDisabled}
 				key="nextButton"

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -86,7 +86,7 @@ class ScrollButtons extends Component {
 		 * @type {Boolean}
 		 * @private
 		 */
-		ignoreRestoreSpotlight: PropTypes.bool,
+		ignoreSpotlightRestore: PropTypes.bool,
 
 		/**
 		* Sets the hint string read when focusing the next button in the scroll bar.
@@ -362,7 +362,7 @@ class ScrollButtons extends Component {
 
 	render () {
 		const
-			{disabled, ignoreRestoreSpotlight, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
+			{disabled, ignoreSpotlightRestore, nextButtonAriaLabel, previousButtonAriaLabel, rtl, thumbRenderer, vertical} = this.props,
 			{prevButtonDisabled, nextButtonDisabled} = this.state,
 			prevIcon = preparePrevButton(vertical),
 			nextIcon = prepareNextButton(vertical);
@@ -370,7 +370,7 @@ class ScrollButtons extends Component {
 		return [
 			<ScrollButton
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
-				{...ignoreRestoreSpotlight ? {'data-spotlight-ignore-restore': true} : {}}
+				{...ignoreSpotlightRestore ? {'data-spotlight-ignore-restore': true} : {}}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || prevButtonDisabled}
 				key="prevButton"
@@ -384,7 +384,7 @@ class ScrollButtons extends Component {
 			thumbRenderer(),
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
-				{...ignoreRestoreSpotlight ? {'data-spotlight-ignore-restore': true} : {}}
+				{...ignoreSpotlightRestore ? {'data-spotlight-ignore-restore': true} : {}}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || nextButtonDisabled}
 				key="nextButton"

--- a/packages/moonstone/Scrollable/ScrollButtons.js
+++ b/packages/moonstone/Scrollable/ScrollButtons.js
@@ -81,7 +81,7 @@ class ScrollButtons extends Component {
 		focusableScrollButtons: PropTypes.bool,
 
 		/**
-		 * When it is `true`, spotlight ignore the scrollbar button on persist last focused element
+		 * When it is `true`, spotlight ignore the scrollbar button on persisting last focused element
 		 *
 		 * @type {Boolean}
 		 * @private

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -1025,6 +1025,7 @@ class ScrollableBase extends Component {
 								<Scrollbar
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
+									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
@@ -1040,6 +1041,7 @@ class ScrollableBase extends Component {
 							<Scrollbar
 								{...horizontalScrollbarProps}
 								{...this.scrollbarProps}
+								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -1025,9 +1025,9 @@ class ScrollableBase extends Component {
 								<Scrollbar
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
-									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
+									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
@@ -1041,10 +1041,10 @@ class ScrollableBase extends Component {
 							<Scrollbar
 								{...horizontalScrollbarProps}
 								{...this.scrollbarProps}
-								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
+								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								onKeyDownButton={this.onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}

--- a/packages/moonstone/Scrollable/Scrollable.js
+++ b/packages/moonstone/Scrollable/Scrollable.js
@@ -1027,7 +1027,7 @@ class ScrollableBase extends Component {
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
-									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
+									ignoreSpotlightRestore={rest.verticalScrollbar !== 'visible'}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
@@ -1044,7 +1044,7 @@ class ScrollableBase extends Component {
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
-								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
+								ignoreSpotlightRestore={rest.horizontalScrollbar !== 'visible'}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								onKeyDownButton={this.onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -1088,9 +1088,9 @@ class ScrollableBaseNative extends Component {
 								<Scrollbar
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
-									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
+									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
@@ -1104,10 +1104,10 @@ class ScrollableBaseNative extends Component {
 							<Scrollbar
 								{...horizontalScrollbarProps}
 								{...this.scrollbarProps}
-								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
+								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								onKeyDownButton={this.onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -1088,6 +1088,7 @@ class ScrollableBaseNative extends Component {
 								<Scrollbar
 									{...verticalScrollbarProps}
 									{...this.scrollbarProps}
+									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
 									nextButtonAriaLabel={downButtonAriaLabel}
@@ -1103,6 +1104,7 @@ class ScrollableBaseNative extends Component {
 							<Scrollbar
 								{...horizontalScrollbarProps}
 								{...this.scrollbarProps}
+								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}

--- a/packages/moonstone/Scrollable/ScrollableNative.js
+++ b/packages/moonstone/Scrollable/ScrollableNative.js
@@ -1090,7 +1090,7 @@ class ScrollableBaseNative extends Component {
 									{...this.scrollbarProps}
 									disabled={!isVerticalScrollbarVisible}
 									focusableScrollButtons={focusableScrollbar}
-									ignoreRestoreSpotlight={rest.verticalScrollbar !== 'visible'}
+									ignoreSpotlightRestore={rest.verticalScrollbar !== 'visible'}
 									nextButtonAriaLabel={downButtonAriaLabel}
 									onKeyDownButton={this.onKeyDown}
 									preventBubblingOnKeyDown={preventBubblingOnKeyDown}
@@ -1107,7 +1107,7 @@ class ScrollableBaseNative extends Component {
 								corner={isVerticalScrollbarVisible}
 								disabled={!isHorizontalScrollbarVisible}
 								focusableScrollButtons={focusableScrollbar}
-								ignoreRestoreSpotlight={rest.horizontalScrollbar !== 'visible'}
+								ignoreSpotlightRestore={rest.horizontalScrollbar !== 'visible'}
 								nextButtonAriaLabel={rightButtonAriaLabel}
 								onKeyDownButton={this.onKeyDown}
 								preventBubblingOnKeyDown={preventBubblingOnKeyDown}

--- a/packages/sampler/stories/qa/ActivityPanels.js
+++ b/packages/sampler/stories/qa/ActivityPanels.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+import Button from '@enact/moonstone/Button';
+import Item from '@enact/moonstone/Item';
+import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
+import {ScrollableBase} from '@enact/moonstone/Scrollable';
+import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
+import Scroller from '@enact/moonstone/Scroller';
+
+import {boolean, select} from '../../src/enact-knobs';
+import {mergeComponentMetadata} from '../../src/utils';
+
+ActivityPanels.displayName = 'ActivityPanels';
+
+const prop = {
+	scrollbarOption: ['auto', 'hidden', 'visible']
+};
+
+const ScrollerConfig = mergeComponentMetadata('Scroller', UiScrollableBase, ScrollableBase, Scroller);
+
+class ActivityPanelsWithScroller extends React.Component {
+	constructor () {
+		super();
+		this.state = {
+			index: 1
+		};
+
+		this.items = [];
+		for (let i = 0; i < 15; i++) {
+			this.items.push(i);
+		}
+	}
+
+	nextPanel = () => {
+		this.setState((state) => ({index: state.index + 1}));
+	};
+
+	prevPanel = () => {
+		this.setState((state) => ({index: state.index - 1}));
+	};
+
+	render () {
+		return (
+			<ActivityPanels index={this.state.index} onSelectBreadcrumb={this.prevPanel}>
+				<Panel>
+					<Item onClick={this.nextPanel}>dummy</Item>
+				</Panel>
+				<Panel>
+					<Header title={'panel 1'} />
+					<div>
+						<Scroller
+							style={{height: 400}}
+							focusableScrollbar={boolean('focusableScrollbar', ScrollerConfig)}
+							horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, ScrollerConfig)}
+							verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}
+						>
+							{this.items.map((index)=>(<Item onClick={this.nextPanel} key={index}>{'Item' + index}</Item>))}
+						</Scroller>
+					</div>
+					<div>
+						<Button onClick={this.nextPanel}>A</Button>
+						<Button onClick={this.nextPanel}>B</Button>
+						<Button onClick={this.nextPanel}>C</Button>
+					</div>
+				</Panel>
+				<Panel>
+					<Header title={'panel 2'} />
+					<Item onClick={this.prevPanel}>{'go back'}</Item>
+				</Panel>
+			</ActivityPanels>
+		);
+	}
+}
+
+storiesOf('ActivityPanels', module)
+	.add(
+		'with scroller',
+		(context) => {
+			context.noPanels = true;
+			return (
+				<ActivityPanelsWithScroller />
+			);
+		},
+		{noPanel: true}
+	);

--- a/packages/sampler/stories/qa/ActivityPanels.js
+++ b/packages/sampler/stories/qa/ActivityPanels.js
@@ -59,6 +59,7 @@ class ActivityPanelsWithScroller extends React.Component {
 							{this.items.map((index) => (<Item onClick={this.nextPanel} key={index}>{'Item' + index}</Item>))}
 						</Scroller>
 					</div>
+					<br />
 					<div>
 						<Button onClick={this.nextPanel}>A</Button>
 						<Button onClick={this.nextPanel}>B</Button>

--- a/packages/sampler/stories/qa/ActivityPanels.js
+++ b/packages/sampler/stories/qa/ActivityPanels.js
@@ -55,7 +55,7 @@ class ActivityPanelsWithScroller extends React.Component {
 							horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 							verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 						>
-							{this.items.map((index)=>(<Item onClick={this.nextPanel} key={index}>{'Item' + index}</Item>))}
+							{this.items.map((index) => (<Item onClick={this.nextPanel} key={index}>{'Item' + index}</Item>))}
 						</Scroller>
 					</div>
 					<div>

--- a/packages/sampler/stories/qa/ActivityPanels.js
+++ b/packages/sampler/stories/qa/ActivityPanels.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import ri from '@enact/ui/resolution';
 
 import Button from '@enact/moonstone/Button';
 import Item from '@enact/moonstone/Item';
@@ -50,7 +51,7 @@ class ActivityPanelsWithScroller extends React.Component {
 					<Header title={'panel 1'} />
 					<div>
 						<Scroller
-							style={{height: 400}}
+							style={{height: ri.scaleToRem(400)}}
 							focusableScrollbar={boolean('focusableScrollbar', ScrollerConfig)}
 							horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 							verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}

--- a/packages/sampler/stories/qa/ActivityPanels.js
+++ b/packages/sampler/stories/qa/ActivityPanels.js
@@ -81,6 +81,5 @@ storiesOf('ActivityPanels', module)
 			return (
 				<ActivityPanelsWithScroller />
 			);
-		},
-		{noPanel: true}
+		}
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After navigating panel with some button below the `Scroller`, focus is restored to another node.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Except for scrollbar buttons when restore focus

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In version 4, spotlight and spottable should provide this feature.

### Links
[//]: # (Related issues, references)
WRN-14604

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
