### PR TITLE
WRN-844: Unify config structure of Flick, Drag, and Hold

### DIFF
--- a/packages/ui/Touchable/Drag.js
+++ b/packages/ui/Touchable/Drag.js
@@ -71,31 +71,32 @@ class Drag {
 		this.dragConfig = {
 			...config,
 			node,
-			onDragStart,
-			onDragEnd,
-			onDrag,
 			resume: !noResume
 		};
+
+		this.onDrag = onDrag;
+		this.onDragStart = onDragStart;
+		this.onDragEnd = onDragEnd;
 
 		this.setContainerBounds(node);
 		this.move(coords);
 	};
 
-	// This method will get the `onDrag`, `onDragEnd`, `onDragStart` props in the existing `dragConfig`.
+	// This method will get the `onDrag`, `onDragEnd`, `onDragStart` props.
 	updateProps = ({onDrag, onDragEnd, onDragStart}) => {
 		// Check `isDragging` gesture is not in progress. Check if gesture exists before updating the references to the `dragConfig`
 		if (!this.isDragging()) return;
 
 		// This will update the `dragConfig` with the new value
-		this.dragConfig.onDragStart = onDragStart;
-		this.dragConfig.onDrag = onDrag;
-		this.dragConfig.onDragEnd = onDragEnd;
+		this.onDrag = onDrag;
+		this.onDragStart = onDragStart;
+		this.onDragEnd = onDragEnd;
 	};
 
 	move = (coords) => {
 		if (!this.isDragging()) return;
 
-		const {moveTolerance, onDrag, onDragStart} = this.dragConfig;
+		const {moveTolerance} = this.dragConfig;
 
 		if (this.tracking === Tracking.Untracked) {
 			const dx = coords.x - this.startX;
@@ -104,15 +105,15 @@ class Drag {
 			if (Math.sqrt(dx * dx + dy * dy) >= moveTolerance) {
 				this.tracking = Tracking.Active;
 
-				if (onDragStart) {
-					onDragStart({
+				if (this.onDragStart) {
+					this.onDragStart({
 						type: 'onDragStart',
 						...coords
 					});
 				}
 			}
-		} else if (onDrag && this.tracking === Tracking.Active && this.updatePosition(coords)) {
-			onDrag({
+		} else if (this.onDrag && this.tracking === Tracking.Active && this.updatePosition(coords)) {
+			this.onDrag({
 				type: 'onDrag',
 				...coords
 			});
@@ -130,9 +131,8 @@ class Drag {
 	end = () => {
 		if (!this.isDragging()) return;
 
-		const {onDragEnd} = this.dragConfig;
-		if (onDragEnd && this.tracking !== Tracking.Untracked) {
-			onDragEnd({type: 'onDragEnd'});
+		if (this.onDragEnd && this.tracking !== Tracking.Untracked) {
+			this.onDragEnd({type: 'onDragEnd'});
 		}
 
 		this.tracking = Tracking.Untracked;

--- a/packages/ui/Touchable/Flick.js
+++ b/packages/ui/Touchable/Flick.js
@@ -11,13 +11,15 @@ class Flick {
 		return this.tracking;
 	}
 
-	begin = ({maxDuration, maxMoves, minVelocity}, {onFlick}, coords) => {
-		this.minVelocity = minVelocity;
-		this.maxMoves = maxMoves;
+	begin = (config, {onFlick}, coords) => {
+		this.flickConfig = {
+			...config
+		};
 
-		if (maxDuration !== null) {
-			this.cancelJob.startAfter(maxDuration);
+		if (this.flickConfig.maxDuration !== null) {
+			this.cancelJob.startAfter(this.flickConfig.maxDuration);
 		}
+
 		this.tracking = !!onFlick;
 		this.moves.length = 0;
 		this.onFlick = onFlick;
@@ -37,6 +39,8 @@ class Flick {
 	move = ({x, y}) => {
 		if (!this.tracking) return;
 
+		const {maxMoves} = this.flickConfig;
+
 		this.moves.push({
 			x,
 			y,
@@ -44,7 +48,7 @@ class Flick {
 		});
 
 		// track specified # of points
-		if (this.moves.length > this.maxMoves) {
+		if (this.moves.length > maxMoves) {
 			this.moves.shift();
 		}
 	};
@@ -61,6 +65,8 @@ class Flick {
 
 	end = () => {
 		if (!this.tracking) return;
+
+		const {minVelocity} = this.flickConfig;
 
 		this.cancelJob.stop();
 
@@ -88,7 +94,7 @@ class Flick {
 			}
 
 			const v = Math.sqrt(x * x + y * y);
-			if (v > this.minVelocity) {
+			if (v > minVelocity) {
 				const vertical = Math.abs(y) > Math.abs(x);
 				// generate the flick using the start event so it has those coordinates
 				// this.sendFlick(ti.startEvent, x, y, v);

--- a/packages/ui/Touchable/Hold.js
+++ b/packages/ui/Touchable/Hold.js
@@ -27,11 +27,12 @@ class Hold {
 		this.holdConfig = {
 			...defaultConfig,
 			...holdConfig,
-			onHoldStart,
-			onHoldEnd,
-			onHold,
 			resume: !noResume
 		};
+
+		this.onHold = onHold;
+		this.onHoldStart = onHoldStart;
+		this.onHoldEnd = onHoldEnd;
 
 		// copy the events array since it is mutated for each hold
 		this.holdConfig.events = this.holdConfig.events.slice();
@@ -49,15 +50,15 @@ class Hold {
 		}
 	};
 
-	// This method will get the `onHoldStart`, `onHoldEnd`, `onHold` props and update in the existing `holdConfig`.
+	// This method will get the `onHoldStart`, `onHoldEnd`, `onHold` props.
 	updateProps = ({onHoldStart, onHoldEnd, onHold}) => {
 		// check `isHolding` gesture is not in progress. Check if gesture exists before updating the references to the `holdConfig`
 		if (!this.isHolding()) return;
 
 		// Update the original values with new values of the gestures
-		this.holdConfig.onHold = onHold;
-		this.holdConfig.onHoldStart = onHoldStart;
-		this.holdConfig.onHoldEnd = onHoldEnd;
+		this.onHold = onHold;
+		this.onHoldStart = onHoldStart;
+		this.onHoldEnd = onHoldEnd;
 	};
 
 	move = (coords) => {
@@ -91,10 +92,9 @@ class Hold {
 	end = () => {
 		if (!this.isHolding()) return;
 
-		const {onHoldEnd} = this.holdConfig;
-		if (this.pulsing && onHoldEnd) {
+		if (this.pulsing && this.onHoldEnd) {
 			const time = window.performance.now() - this.holdStart;
-			onHoldEnd({
+			this.onHoldEnd({
 				type: 'onHoldEnd',
 				time
 			});
@@ -154,10 +154,10 @@ class Hold {
 
 		let n = this.next;
 		while (n && n.time <= holdTime) {
-			const {events, onHoldStart} = this.holdConfig;
+			const {events} = this.holdConfig;
 			this.pulsing = true;
-			if (onHoldStart) {
-				onHoldStart({
+			if (this.onHoldStart) {
+				this.onHoldStart({
 					type: 'onHoldStart',
 					...n
 				});
@@ -174,10 +174,8 @@ class Hold {
 		}
 
 		if (this.pulsing) {
-			const {onHold} = this.holdConfig;
-
-			if (onHold) {
-				onHold({
+			if (this.onHold) {
+				this.onHold({
 					type: 'onHold',
 					time: holdTime
 				});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Refactoring Flick.js, Drag.js, and Hold.js

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Unify config structure of Flick.js, Drag.js, and Hold.js
- Fix Hold.js and Drag.js to not store handler function in `Config`
- Fix Flick.js to store variables(`maxDuration`, `maxMoves`, `minVelocity`) in `flickConfig`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-844

### Comments
