### PR TITLE
WRN-14854: Move focus properly when elements have non-integer boundaries

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ### Fixed
 
-- `spotlight` to correctly control focus when elements boundaries are not integer
+- `spotlight` to correctly control focus when boundaries of an element are not integers
 - Styles for `debug spotlight` option in samplers to work properly
 
 ## [4.1.2] - 2021-12-22

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
-## [unreleased] 
+## [unreleased]
 
 ### Fixed
 
+- `spotlight` to correctly control focus when elements boundaries are not integer
 - Styles for `debug spotlight` option in samplers to work properly
 
 ## [4.1.2] - 2021-12-22

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -46,7 +46,6 @@ function parseSelector (selector) {
 }
 
 const testIntersection = (type, containerRect, elementRect) => {
-	const epsilon = 1;
 	const {
 		left: L,
 		right: R,
@@ -61,18 +60,19 @@ const testIntersection = (type, containerRect, elementRect) => {
 		bottom: b
 	} = elementRect;
 
-	const right = r > L - epsilon && r < R + epsilon;
-	const left = l > L - epsilon && l < R + epsilon;
-	const top = t > T - epsilon && t < B + epsilon;
-	const bottom = b > T - epsilon && b < B + epsilon;
-
 	if (type === 'intersects') {
-		const aroundV = t < T && b > B;
-		const aroundH = l < L && r > R;
-
-		return (top || bottom || aroundV) && (left || right || aroundH);
+		// Test intersection by eliminating the area of the element that is outside of the container
+		return !(b < T || t > B || r < L || l > R);
 	} else if (type === 'contains') {
-		return top && bottom && left && right;
+		const epsilon = 1;
+
+		// Test whether all bounds are within the container
+		return (
+			r > L - epsilon && r < R + epsilon && // right
+			l > L - epsilon && l < R + epsilon && // left
+			t > T - epsilon && t < B + epsilon && // top
+			b > T - epsilon && b < B + epsilon    // bottom
+		);
 	}
 
 	return true;

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -46,6 +46,7 @@ function parseSelector (selector) {
 }
 
 const testIntersection = (type, containerRect, elementRect) => {
+	const epsilon = 1;
 	const {
 		left: L,
 		right: R,
@@ -60,10 +61,10 @@ const testIntersection = (type, containerRect, elementRect) => {
 		bottom: b
 	} = elementRect;
 
-	const right = r >= L && r <= R;
-	const left = l >= L && l <= R;
-	const top = t >= T && t <= B;
-	const bottom = b >= T && b <= B;
+	const right = r > L - epsilon && r < R + epsilon;
+	const left = l > L - epsilon && l < R + epsilon;
+	const top = t > T - epsilon && t < B + epsilon;
+	const bottom = b > T - epsilon && b < B + epsilon;
 
 	if (type === 'intersects') {
 		const aroundV = t < T && b > B;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When elements' boundaries are not an integer value as a result of browser rendering, `spotlight` may miss focus navigation target by key inputs.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply epsilon value to catch navigable target elements.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-14854

### Comments
