### PR TITLE
WRN-13623: Fix touch detection condition logic in spotlight and ui/Touchable

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -554,7 +554,7 @@ const Spotlight = (function () {
 				window.addEventListener('mouseover', onMouseOver);
 				window.addEventListener('mousemove', onMouseMove);
 
-				if (platform.touch) {
+				if (platform.touchscreen) {
 					window.addEventListener('touchend', onTouchEnd);
 				}
 
@@ -586,7 +586,7 @@ const Spotlight = (function () {
 			window.removeEventListener('mouseover', onMouseOver);
 			window.removeEventListener('mousemove', onMouseMove);
 
-			if (platform.touch) {
+			if (platform.touchscreen) {
 				window.removeEventListener('touchend', onTouchEnd);
 			}
 

--- a/packages/ui/Touchable/Touch.js
+++ b/packages/ui/Touchable/Touch.js
@@ -191,7 +191,7 @@ class Touch {
 			onMouseUp: handleMouseUp.bindAs(this, 'handleMouseUp')
 		};
 
-		if (platform.touch) {
+		if (platform.touchscreen) {
 			Object.assign(this.handlers, {
 				onTouchStart: handleTouchStart.bindAs(this, 'handleTouchStart'),
 				onTouchMove: handleTouchMove.bindAs(this, 'handleTouchMove'),
@@ -220,7 +220,7 @@ class Touch {
 
 	addGlobalHandlers () {
 		// ensure we clean up our internal state
-		if (platform.touch) {
+		if (platform.touchscreen) {
 			on('touchend', this.handleGlobalUp, document);
 		}
 		on('mouseup', this.handleGlobalUp, document);
@@ -228,7 +228,7 @@ class Touch {
 	}
 
 	removeGlobalHandlers () {
-		if (platform.touch) {
+		if (platform.touchscreen) {
 			off('touchend', this.handleGlobalUp, document);
 		}
 		off('mouseup', this.handleGlobalUp, document);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`enact/core/platform` provides information(e.g., touch, touchscreen) about the running platform.
- `platform.touch`: returned true when browser supports the Touch Events specs, not meaning platform has a touchscreen devices.
- `platform.touchscreen`: returned true if the platform has a touchscreen.

Whether to enable touch-related logic in spotlight and ui/Touchable should be determined by `platform.touchscreen` instead of `platform.touch`.
(As fixed in https://github.com/enactjs/enact/pull/2571)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `platform.touchscreen` instead of `platform.touch` to invoke touch-related logic only in the touchscreen environments.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-13623

### Comments
