### PR TITLE
WRN-13462: Use standard `scrollTo` option for lists and scrollers

### DIFF
--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -126,6 +126,7 @@ class ScrollerBasic extends Component {
 		return x;
 	};
 
+	// scrollMode 'translate'
 	setScrollPosition (x, y) {
 		const node = this.props.scrollContentRef.current;
 
@@ -139,9 +140,9 @@ class ScrollerBasic extends Component {
 		}
 	}
 
-	// scrollMode 'translate'
-	scrollToPosition (x, y) {
-		this.props.scrollContentRef.current.scrollTo(this.getRtlPositionX(x), y);
+	// scrollMode 'native'
+	scrollToPosition (left, top, behavior) {
+		this.props.scrollContentRef.current.scrollTo({left: this.getRtlPositionX(left), top, behavior});
 	}
 
 	// scrollMode 'native'

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -853,7 +853,7 @@ class VirtualListBasic extends Component {
 	};
 
 	// scrollMode 'native' only
-	scrollToPosition (left, top, behavior) { // TARGET FUNCTION
+	scrollToPosition (left, top, behavior) {
 		if (this.props.scrollContentRef.current && this.props.scrollContentRef.current.scrollTo) {
 			this.props.scrollContentRef.current.scrollTo({left: this.getRtlPositionX(left), top, behavior});
 		}

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -356,6 +356,7 @@ const useScrollBase = (props) => {
 		scrollContentHandle.current.calculateMetrics(scrollContentHandle.current.props);
 		forceUpdate();
 	}, [forceUpdate, scrollContentHandle]);
+	// scrollMode 'translate' ]]
 
 	function handleResizeWindow () {
 		const propsHandleResizeWindow = props.handleResizeWindow;
@@ -368,15 +369,14 @@ const useScrollBase = (props) => {
 			if (scrollMode === 'translate') {
 				scrollTo({position: {x: 0, y: 0}, animate: false});
 			} else {
-				scrollContentRef.current.style.scrollBehavior = null;
-				scrollContentHandle.current.scrollToPosition(0, 0);
-				scrollContentRef.current.style.scrollBehavior = 'smooth';
+				scrollContentHandle.current.scrollToPosition(0, 0, 'instant');
 			}
 
 			enqueueForceUpdate();
 		});
 	}
 
+	// scrollMode 'translate' [[
 	const handleResize = useCallback((ev) => {
 		if (ev.action === 'invalidateBounds') {
 			enqueueForceUpdate();
@@ -1133,11 +1133,9 @@ const useScrollBase = (props) => {
 			}
 		} else { // scrollMode 'native'
 			if (animate) {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY);
+				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth');
 			} else {
-				scrollContentRef.current.style.scrollBehavior = null;
-				scrollContentHandle.current.scrollToPosition(targetX, targetY);
-				scrollContentRef.current.style.scrollBehavior = 'smooth';
+				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant');
 			}
 
 			if (props.start) {
@@ -1200,7 +1198,7 @@ const useScrollBase = (props) => {
 			setScrollTop(top);
 		}
 
-		scrollContentHandle.current.setScrollPosition(mutableRef.current.scrollLeft, mutableRef.current.scrollTop, rtl);
+		scrollContentHandle.current.setScrollPosition(mutableRef.current.scrollLeft, mutableRef.current.scrollTop);
 		forwardScrollEvent('onScroll');
 	}
 	// scrollMode 'translate' ]]
@@ -1225,9 +1223,11 @@ const useScrollBase = (props) => {
 	}
 
 	function stopForNative () {
-		scrollContentRef.current.style.scrollBehavior = null;
-		scrollContentHandle.current.scrollToPosition(mutableRef.current.scrollLeft + (rtl ? -0.1 : 0.1), mutableRef.current.scrollTop + 0.1);
-		scrollContentRef.current.style.scrollBehavior = 'smooth';
+		scrollContentHandle.current.scrollToPosition(
+			mutableRef.current.scrollLeft + (rtl ? -0.1 : 0.1),
+			mutableRef.current.scrollTop + 0.1,
+			'instant'
+		);
 	}
 
 	function stop () {
@@ -1447,7 +1447,6 @@ const useScrollBase = (props) => {
 		// scrollMode 'native' [[
 		if (scrollMode === 'native' && scrollContentRef.current) {
 			utilEvent('scroll').addEventListener(scrollContentRef, onScroll, {passive: true});
-			scrollContentRef.current.style.scrollBehavior = 'smooth';
 		}
 		// scrollMode 'native' ]]
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Lists and scrollers of Enact use the `scroll-behavior` CSS attribute to control `smooth` scrolling in a tricky way for legacy browsers that Enact supported. Now, it is time to focus on more modern browsers and to use the standard `scrollTo` option for elements.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace `scroll-behavior` based code with `scrollTo` option.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This PR works on browsers below:
- Chrome 61 or higher (including all versions of Chromium-based Edge)
- Firefox 36 or higher
- Safari 14 or higher

### Links
[//]: # (Related issues, references)
WRN-13462
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo

### Comments
