### PR TITLE
WRN-17780: Fix Transition to pass the right event object

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Button` not to pass `icon` prop as children when `icon` is true 
+- `ui/Transition` to pass the event when handling transition event  
 
 ## [4.1.3] - 2022-03-07
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,8 +10,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Button` not to pass `icon` prop as children when `icon` is true 
-- `ui/Transition` to pass the event when handling transition event  
+- `ui/Button` not to pass `icon` prop as children when `icon` is true
+- `ui/Transition` to pass the event when handling transition event
 
 ## [4.1.3] - 2022-03-07
 

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -27,10 +27,6 @@ import {ResizeContext} from '../Resizable';
 
 import componentCss from './Transition.module.less';
 
-const forwardTransitionEnd = forward('onTransitionEnd');
-const forwardOnShow = forward('onShow');
-const forwardOnHide = forward('onHide');
-
 const formatter = (duration) => (typeof duration === 'number' ? duration + 'ms' : duration);
 /**
  * The stateless structure of the component.
@@ -494,9 +490,9 @@ class Transition extends Component {
 
 		if (noAnimation) {
 			if (!prevProps.visible && visible) {
-				forwardOnShow({}, this.props);
+				forward('onShow', {type: 'onShow'}, this.props);
 			} else if (prevProps.visible && !visible) {
-				forwardOnHide({}, this.props);
+				forward('onHide', {type: 'onHide'}, this.props);
 			}
 		}
 	}
@@ -523,13 +519,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forwardTransitionEnd(ev, this.props);
+		forward('onTransitionEnd', {type: 'onTransitionEnd'}, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forwardOnHide(ev, this.props);
+				forward('onHide', {type: 'onHide'}, this.props);
 			} else if (this.props.visible) {
-				forwardOnShow(ev, this.props);
+				forward('onShow', {type: 'onShow'}, this.props);
 			}
 		}
 	};
@@ -585,4 +581,3 @@ class Transition extends Component {
 
 export default Transition;
 export {Transition, TransitionBase};
-

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -16,7 +16,7 @@
  * @exports TransitionBase
  */
 
-import {forwardCustom} from '@enact/core/handle';
+import {forward} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
 import {Job} from '@enact/core/util';
@@ -26,6 +26,10 @@ import PropTypes from 'prop-types';
 import {ResizeContext} from '../Resizable';
 
 import componentCss from './Transition.module.less';
+
+const forwardTransitionEnd = forward('onTransitionEnd');
+const forwardOnShow = forward('onShow');
+const forwardOnHide = forward('onHide');
 
 const formatter = (duration) => (typeof duration === 'number' ? duration + 'ms' : duration);
 /**
@@ -490,9 +494,9 @@ class Transition extends Component {
 
 		if (noAnimation) {
 			if (!prevProps.visible && visible) {
-				forwardCustom('onShow')({}, this.props);
+				forwardOnShow({}, this.props);
 			} else if (prevProps.visible && !visible) {
-				forwardCustom('onHide')({}, this.props);
+				forwardOnHide({}, this.props);
 			}
 		}
 	}
@@ -519,13 +523,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forwardCustom('onTransitionEnd')(ev, this.props);
+		forwardTransitionEnd(ev, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forwardCustom('onHide')(ev, this.props);
+				forwardOnHide(ev, this.props);
 			} else if (this.props.visible) {
-				forwardCustom('onShow')(ev, this.props);
+				forwardOnShow(ev, this.props);
 			}
 		}
 	};
@@ -581,3 +585,4 @@ class Transition extends Component {
 
 export default Transition;
 export {Transition, TransitionBase};
+

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -16,7 +16,7 @@
  * @exports TransitionBase
  */
 
-import {forward} from '@enact/core/handle';
+import {forward, forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
 import {Job} from '@enact/core/util';
@@ -490,9 +490,9 @@ class Transition extends Component {
 
 		if (noAnimation) {
 			if (!prevProps.visible && visible) {
-				forward('onShow', {type: 'onShow'}, this.props);
+				forwardCustom('onShow')({}, this.props);
 			} else if (prevProps.visible && !visible) {
-				forward('onHide', {type: 'onHide'}, this.props);
+				forwardCustom('onHide')({}, this.props);
 			}
 		}
 	}
@@ -523,9 +523,9 @@ class Transition extends Component {
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forward('onHide', {type: 'onHide', currentTarget:ev.currentTarget}, this.props);
+				forward('onHide', {type: 'onHide', currentTarget: ev.currentTarget}, this.props);
 			} else if (this.props.visible) {
-				forward('onShow', {type: 'onShow', currentTarget:ev.currentTarget}, this.props);
+				forward('onShow', {type: 'onShow', currentTarget: ev.currentTarget}, this.props);
 			}
 		}
 	};

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -519,7 +519,7 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forward('onTransitionEnd', {...ev, type: 'onTransitionEnd'}, this.props);
+		forward('onTransitionEnd', ev, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -519,13 +519,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forward('onTransitionEnd', {type: 'onTransitionEnd'}, this.props);
+		forward('onTransitionEnd', ev, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forward('onHide', {type: 'onHide'}, this.props);
+				forward('onHide', {type: 'onHide', currentTarget:ev.currentTarget}, this.props);
 			} else if (this.props.visible) {
-				forward('onShow', {type: 'onShow'}, this.props);
+				forward('onShow', {type: 'onShow', currentTarget:ev.currentTarget}, this.props);
 			}
 		}
 	};

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -519,7 +519,7 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forward('onTransitionEnd', ev, this.props);
+		forward('onTransitionEnd', {...ev, type: 'onTransitionEnd'}, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -519,13 +519,13 @@ class Transition extends Component {
 	};
 
 	handleTransitionEnd = (ev) => {
-		forwardCustom('onTransitionEnd')(null, this.props);
+		forwardCustom('onTransitionEnd')(ev, this.props);
 
 		if (ev.target === this.childNode) {
 			if (!this.props.visible) {
-				forwardCustom('onHide')(null, this.props);
+				forwardCustom('onHide')(ev, this.props);
 			} else if (this.props.visible) {
-				forwardCustom('onShow')(null, this.props);
+				forwardCustom('onShow')(ev, this.props);
 			}
 		}
 	};

--- a/packages/ui/Transition/tests/Transition-specs.js
+++ b/packages/ui/Transition/tests/Transition-specs.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 
 import Transition, {TransitionBase} from '../Transition';
 

--- a/packages/ui/Transition/tests/Transition-specs.js
+++ b/packages/ui/Transition/tests/Transition-specs.js
@@ -128,26 +128,6 @@ describe('Transition Specs', () => {
 		expect(actual).toMatchObject(expectedType);
 	});
 
-	test('should fire \'onTransitionEnd\' event with type', () => {
-		const handleTransitionEnd = jest.fn();
-		const ChildNode = (props) => <div {...props}>Body</div>;
-
-		render(
-			<Transition onTransitionEnd={handleTransitionEnd}>
-				<ChildNode />
-			</Transition>
-		);
-
-		fireEvent.transitionEnd(screen.getByText('Body'));
-
-		const expected = 1;
-		const expectedType = {type: 'onTransitionEnd'};
-		const actual = handleTransitionEnd.mock.calls.length && handleTransitionEnd.mock.calls[0][0];
-
-		expect(handleTransitionEnd).toBeCalledTimes(expected);
-		expect(actual).toMatchObject(expectedType);
-	});
-
 	// Tests for prop and className combinations
 	const directionCombination = [
 		['up', 'up'],


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)'
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Event not passed at transition end.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Modify to pass the necessary event at the transition end
- onTransitionEnd : this is not a custom event. So pass the event object as it is.
- onShow, onHide : this is a custom event and Popup(moonstone/sandstone) use the event.currentTarget.
                               So pass the event object with type and currentTarget.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-17780

### Comments
