### PR TITLE
WRN-18494: Remove unnecessary wrapper node on FloatingLayer

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [4.1.4] - 2022-03-24
+## [unreleased]
+
+### Fixed
+
+- `ui/FloatingLayer` to display popup that open later always shown on top of previous popups
 
 ### Removed
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/FloatingLayer` to display popup that open later always shown on top of previous popups
+- `ui/FloatingLayer` to stack popups always in the order in which they were opened
 
 ## [4.1.4] - 2022-03-24
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/FloatingLayer` to display popup that open later always shown on top of previous popups
 
+## [4.1.4] - 2022-03-24
+
 ### Removed
 
 - `ui/Scroller` and `ui/VirtualList` prop `data-webos-voice-focused`, `data-webos-voice-disabled`, and `data-webos-voice-group-label`

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -104,7 +104,7 @@ class FloatingLayerBase extends Component {
 	static contextType = FloatingLayerContext;
 
 	static defaultProps = {
-		floatLayerClassName: 'enact-fit enact-clip enact-untouchable',
+		floatLayerClassName: 'enact-fit enact-clip enact-untouchable enact-z-index',
 		floatLayerId: 'floatLayer',
 		noAutoDismiss: false,
 		open: false,
@@ -227,10 +227,8 @@ class FloatingLayerBase extends Component {
 
 	render () {
 		const {children, className, floatLayerClassName, open, scrimType, ...rest} = this.props;
-
 		const mergedClassName = classNames(floatLayerClassName, className);
 
-		delete rest.floatLayerClassName;
 		delete rest.floatLayerId;
 		delete rest.noAutoDismiss;
 		delete rest.onClose;
@@ -239,7 +237,7 @@ class FloatingLayerBase extends Component {
 
 		if (open && this.state.readyToRender) {
 			return ReactDOM.createPortal(
-				<div className={mergedClassName} style={{zIndex: 100}} {...rest}>
+				<div className={mergedClassName} {...rest}>
 					{scrimType !== 'none' ? <Scrim type={scrimType} onClick={this.handleClick} /> : null}
 					{cloneElement(children, {onClick: this.stopPropagation})}
 				</div>,

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -11,6 +11,8 @@ import Cancelable from '../Cancelable';
 import {FloatingLayerContext} from './FloatingLayerDecorator';
 import Scrim from './Scrim';
 
+import css from './FloatingLayer.module.less';
+
 /**
  * A component that creates an entry point to the new render tree.
  *
@@ -29,7 +31,7 @@ class FloatingLayerBase extends Component {
 		 * CSS classes for FloatingLayer.
 		 *
 		 * @type {String}
-		 * @default 'enact-fit enact-clip enact-untouchable enact-z-index'
+		 * @default 'enact-fit enact-clip enact-untouchable'
 		 * @public
 		 */
 		floatLayerClassName: PropTypes.string,
@@ -104,7 +106,7 @@ class FloatingLayerBase extends Component {
 	static contextType = FloatingLayerContext;
 
 	static defaultProps = {
-		floatLayerClassName: 'enact-fit enact-clip enact-untouchable enact-z-index',
+		floatLayerClassName: 'enact-fit enact-clip enact-untouchable',
 		floatLayerId: 'floatLayer',
 		noAutoDismiss: false,
 		open: false,
@@ -227,7 +229,7 @@ class FloatingLayerBase extends Component {
 
 	render () {
 		const {children, className, floatLayerClassName, open, scrimType, ...rest} = this.props;
-		const mergedClassName = classNames(floatLayerClassName, className);
+		const mergedClassName = classNames(floatLayerClassName, css.floatingLayer, className);
 
 		delete rest.floatLayerId;
 		delete rest.noAutoDismiss;

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -223,7 +223,6 @@ class FloatingLayerBase extends Component {
 
 		on('scroll', this.handleScroll, this.floatingLayer);
 
-		// render children when this.node is inserted in the DOM tree.
 		this.setState({readyToRender: true});
 	}
 

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -29,7 +29,7 @@ class FloatingLayerBase extends Component {
 		 * CSS classes for FloatingLayer.
 		 *
 		 * @type {String}
-		 * @default 'enact-fit enact-clip enact-untouchable'
+		 * @default 'enact-fit enact-clip enact-untouchable enact-z-index'
 		 * @public
 		 */
 		floatLayerClassName: PropTypes.string,

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -1,5 +1,6 @@
 import {on, off} from '@enact/core/dispatcher';
 import {forwardCustom, forProp, handle, oneOf, stop, forEventProp, call} from '@enact/core/handle';
+import classNames from 'classnames';
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
 import {cloneElement, Component} from 'react';
@@ -114,7 +115,7 @@ class FloatingLayerBase extends Component {
 		super(props);
 		this.node = null;
 		this.state = {
-			nodeRendered: false
+			readyToRender: false
 		};
 	}
 
@@ -136,11 +137,11 @@ class FloatingLayerBase extends Component {
 		if (prevProps.open && !open) {
 			// when open changes to false, forward close
 			forwardCustom('onClose')(null, this.props);
-		} else if (!prevProps.open && open && !this.state.nodeRendered) {
+		} else if (!prevProps.open && open && !this.state.readyToRender) {
 			// when open changes to true and node hasn't rendered, render it
-			this.renderNode();
-		} else if (this.state.nodeRendered &&
-			(!prevState.nodeRendered || (prevState.nodeRendered && open && !prevProps.open))
+			this.readyToRender();
+		} else if (this.state.readyToRender &&
+			(!prevState.readyToRender || (prevState.readyToRender && open && !prevProps.open))
 		) {
 			// when node has been rendered and either it was just rendered in this update cycle or
 			// the open prop changed in this cycle, forward open
@@ -157,9 +158,8 @@ class FloatingLayerBase extends Component {
 	}
 
 	componentWillUnmount () {
-		if (this.node && this.floatingLayer) {
-			this.floatingLayer.removeChild(this.node);
-			this.node = null;
+		if (this.floatingLayer) {
+			off('scroll', this.handleScroll, this.floatingLayer);
 			this.floatingLayer = null;
 		}
 
@@ -181,8 +181,8 @@ class FloatingLayerBase extends Component {
 
 		// the first time we have a valid floating layer container and this instance is set to open,
 		// we need to render the layer.
-		if (isNewLayer && this.props.open && !this.state.nodeRendered) {
-			this.renderNode();
+		if (isNewLayer && this.props.open && !this.state.readyToRender) {
+			this.readyToRender();
 		}
 	}
 
@@ -211,29 +211,24 @@ class FloatingLayerBase extends Component {
 		}
 	};
 
-	renderNode () {
-		const {floatLayerClassName} = this.props;
-
-		if (this.node) return;
+	readyToRender () {
+		if (this.state.readyToRender) return;
 
 		invariant(
 			this.floatingLayer,
 			'FloatingLayer cannot be used outside the subtree of a FloatingLayerDecorator'
 		);
 
-		this.node = document.createElement('div');
-		this.node.className = floatLayerClassName;
-		this.node.style.zIndex = 100;
-
-		this.floatingLayer.appendChild(this.node);
-		on('scroll', this.handleScroll, this.node);
+		on('scroll', this.handleScroll, this.floatingLayer);
 
 		// render children when this.node is inserted in the DOM tree.
-		this.setState({nodeRendered: true});
+		this.setState({readyToRender: true});
 	}
 
 	render () {
-		const {children, open, scrimType, ...rest} = this.props;
+		const {children, className, floatLayerClassName, open, scrimType, ...rest} = this.props;
+
+		const mergedClassName = classNames(floatLayerClassName, className);
 
 		delete rest.floatLayerClassName;
 		delete rest.floatLayerId;
@@ -242,13 +237,13 @@ class FloatingLayerBase extends Component {
 		delete rest.onDismiss;
 		delete rest.onOpen;
 
-		if (open && this.state.nodeRendered) {
+		if (open && this.state.readyToRender) {
 			return ReactDOM.createPortal(
-				<div {...rest}>
+				<div className={mergedClassName} style={{zIndex: 100}} {...rest}>
 					{scrimType !== 'none' ? <Scrim type={scrimType} onClick={this.handleClick} /> : null}
 					{cloneElement(children, {onClick: this.stopPropagation})}
 				</div>,
-				this.node
+				this.floatingLayer
 			);
 		}
 

--- a/packages/ui/FloatingLayer/FloatingLayer.module.less
+++ b/packages/ui/FloatingLayer/FloatingLayer.module.less
@@ -1,0 +1,6 @@
+// FloatingLayer.module.less
+//
+
+.floatingLayer {
+	z-index: 100;
+}

--- a/packages/ui/Spinner/tests/Spinner-specs.js
+++ b/packages/ui/Spinner/tests/Spinner-specs.js
@@ -52,6 +52,6 @@ describe('Spinner Specs', () => {
 		const spinner = screen.getByTestId('spinner');
 
 		expect(spinner).toBeInTheDocument();
-		expect(spinner.parentElement.parentElement.parentElement.id).toBe('floatLayer');
+		expect(spinner.parentElement.parentElement.id).toBe('floatLayer');
 	});
 });

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -36,6 +36,10 @@
 		}
 	}
 
+	.enact-z-index {
+		z-index: 100;
+	}
+
 	// Selection
 	.enact-unselectable {
 		cursor: default;

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -36,10 +36,6 @@
 		}
 	}
 
-	.enact-z-index {
-		z-index: 100;
-	}
-
 	// Selection
 	.enact-unselectable {
 		cursor: default;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When two floatinglayers are displayed, there is a bug that a popup which open later shown on down of other popup .
Because `FloatingLayer `reuses nodes , If you reopen a previously opened Popup, it may open below other popups.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I removed unnecessary wrapper node that is reused on FloatingLayer

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I wanted to remove the `state.nodeRendered` also, but I failed. There was much bug when I remove the variable
In the case of a popup that is start with open, re-rendering is required after the ref of this.floatingLayer is bound.

### Links
[//]: # (Related issues, references)
WRN-18494

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)