### PR TITLE
WRO-608: Replace MarqueeDecorator config `className` to `css`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Added
 
-- `ui/MarqueeDecorator` `locale` type for `forceDirection` prop not to override the direction depending on contents
+- `ui/Marquee.MarqueeDecorator` `locale` type for `forceDirection` prop not to override the direction depending on contents
 
 ### Fixed
 
@@ -54,13 +54,13 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Fixed
 
 - `spotlight/SpotlightRootDecorator` to show focus effect after initial loading
-- `ui/MarqueeDecorator` to restart animation when text changed while focus retained
+- `ui/Marquee.MarqueeDecorator` to restart animation when text changed while focus retained
 
 ## [4.0.8] - 2021-10-21
 
 ### Fixed
 
-`ui/MarqueeDecorator` style to render text properly when starting animation
+`ui/Marquee.MarqueeDecorator` style to render text properly when starting animation
 
 ## [4.0.7] - 2021-09-28
 
@@ -82,7 +82,7 @@ No significant changes.
 
 ### Fixed
 
-- `ui/MarqueeDecorator` to stop marquee properly after hiding pointer when `marqueeOn` is `hover`
+- `ui/Marquee.MarqueeDecorator` to stop marquee properly after hiding pointer when `marqueeOn` is `hover`
 
 ## [4.0.3] - 2021-06-18
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Deprecated
+
+- `ui/MarqueeDecorator` config `className` to be removed in 5.0.0
+
+### Added
+
+- `ui/MarqueeDecorator` config `css` to support customizing the MarqueeBase styles
+
 ## [4.5.0-alpha.1] - 2022-04-15
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,11 +6,11 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Deprecated
 
-- `ui/MarqueeDecorator` config `className` to be removed in 5.0.0
+- `ui/Marquee.MarqueeDecorator` config `className` to be removed in 5.0.0
 
 ### Added
 
-- `ui/MarqueeDecorator` config `css` to support customizing the MarqueeBase styles
+- `ui/Marquee.MarqueeDecorator` config `css` to support customizing the marquee styles
 
 ## [4.5.0-alpha.1] - 2022-04-15
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -26,7 +26,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Added
 
-- `ui/MarqueeDecorator` `locale` type for `forceDirection` prop not to override the direction depending on contents
+- `ui/Marquee.MarqueeDecorator` `locale` type for `forceDirection` prop not to override the direction depending on contents
 
 ### Fixed
 
@@ -52,13 +52,13 @@ No significant changes.
 
 ### Fixed
 
-- `ui/MarqueeDecorator` to restart animation when text changed while focus retained
+- `ui/Marquee.MarqueeDecorator` to restart animation when text changed while focus retained
 
 ## [4.0.8] - 2021-10-21
 
 ### Fixed
 
-- `ui/MarqueeDecorator` style to render text properly when starting animation
+- `ui/Marquee.MarqueeDecorator` style to render text properly when starting animation
 
 ## [4.0.7] - 2021-09-28
 
@@ -76,7 +76,7 @@ No significant changes.
 
 ### Fixed
 
-- `ui/MarqueeDecorator` to stop marquee properly after hiding pointer when `marqueeOn` is `hover`
+- `ui/Marquee.MarqueeDecorator` to stop marquee properly after hiding pointer when `marqueeOn` is `hover`
 
 ## [4.0.3] - 2021-06-18
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -161,13 +161,13 @@ const TimerState = {
 const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {blur, component: MarqueeComponent, enter, focus, invalidateProps, leave, marqueeDirection} = config;
 
-	const configClassName = config.className &&  deprecate(() => config.className, {
+	const configClassName = config.className && deprecate(() => config.className, {
 		name: 'ui/MarqueeDecorator.config.className',
 		replacedBy: 'ui/MarqueeDecorator.config.css',
 		until: '5.0.0'
 	})();
 
-	const css =  (typeof config.css === 'object' &&  config.css) || {marquee: configClassName};
+	const css = (typeof config.css === 'object' &&  config.css) || {marquee: configClassName};
 
 	// Generate functions to forward events to containers
 	const forwardBlur = forward(blur);
@@ -901,7 +901,6 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					<MarqueeComponent
 						alignment={alignment}
 						animating={this.state.animating}
-						className={configClassName}
 						clientRef={this.cacheNode}
 						css={css}
 						distance={this.distance}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -161,13 +161,15 @@ const TimerState = {
 const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {blur, component: MarqueeComponent, enter, focus, invalidateProps, leave, marqueeDirection} = config;
 
-	const configClassName = config.className && deprecate(() => config.className, {
-		name: 'ui/MarqueeDecorator.config.className',
-		replacedBy: 'ui/MarqueeDecorator.config.css',
-		until: '5.0.0'
-	})();
+	if (config.className) {
+		deprecate({
+			name: 'ui/MarqueeDecorator.config.className',
+			replacedBy: 'ui/MarqueeDecorator.config.css',
+			until: '5.0.0'
+		});
+	}
 
-	const css = (typeof config.css === 'object' &&  config.css) || {marquee: configClassName};
+	const css = (typeof config.css === 'object' &&  config.css) || {marquee: config.className};
 
 	// Generate functions to forward events to containers
 	const forwardBlur = forward(blur);


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Receiving the "className" config on MarqueeDecorator is not our standard way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add `ui/MarqueeDecorator` config `css` to support customizing the MarqueeBase styles
- Deprecate `ui/MarqueeDecorator` config `className` to be removed in 5.0.0

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-608

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
