### PR TITLE
WRO-2712: Use fakeTimers for unit test

### DIFF
--- a/packages/core/util/tests/Job-specs.js
+++ b/packages/core/util/tests/Job-specs.js
@@ -1,10 +1,19 @@
+import {act} from '@testing-library/react';
+
 import Job from '../Job';
 
 describe('Job', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+	afterEach(() => {
+		jest.useRealTimers();
+	});
 	describe('#start', () => {
 		test('should start job', done => {
 			const j = new Job(done, 10);
 			j.start();
+			jest.runAllTimers();
 		});
 
 		test('should pass args to fn', done => {
@@ -19,6 +28,7 @@ describe('Job', () => {
 
 			const j = new Job(fn, 10);
 			j.start(value);
+			jest.runAllTimers();
 		});
 	});
 
@@ -33,9 +43,9 @@ describe('Job', () => {
 			j.start();
 			j.stop();
 
-			window.setTimeout(function () {
-				if (!ran) done();
-			}, 30);
+			act(() => jest.advanceTimersByTime(30));
+
+			if (!ran) done();
 		});
 	});
 
@@ -47,22 +57,22 @@ describe('Job', () => {
 			}, 20);
 
 			j.throttle();
-			window.setTimeout(function () {
-				j.throttle();
-			}, 5);
-			window.setTimeout(function () {
-				j.throttle();
-			}, 15);
-			window.setTimeout(function () {
-				j.throttle();
-			}, 25);
-			window.setTimeout(function () {
-				if (number === 2) {
-					done();
-				} else {
-					done(new Error('too many or too few calls' + number));
-				}
-			}, 30);
+
+			act(() => jest.advanceTimersByTime(5));
+			j.throttle();
+
+			act(() => jest.advanceTimersByTime(10));
+			j.throttle();
+
+			act(() => jest.advanceTimersByTime(10));
+			j.throttle();
+
+			act(() => jest.advanceTimersByTime(5));
+			if (number === 2) {
+				done();
+			} else {
+				done(new Error('too many or too few calls' + number));
+			}
 		});
 
 		test('should pass args to fn', done => {
@@ -102,6 +112,7 @@ describe('Job', () => {
 		test('should start job', done => {
 			const j = new Job(done, 10);
 			j.idle();
+			jest.runAllTimers();
 		});
 
 		test('should pass args to fn', done => {
@@ -116,6 +127,7 @@ describe('Job', () => {
 
 			const j = new Job(fn, 10);
 			j.idle(value);
+			jest.runAllTimers();
 		});
 
 		test('should clear an existing job id before starting job', done => {
@@ -129,6 +141,7 @@ describe('Job', () => {
 			const j = new Job(fn);
 			j.idle('first');
 			j.idle('second');
+			jest.runAllTimers();
 		});
 	});
 
@@ -163,7 +176,9 @@ describe('Job', () => {
 				done(new Error('Job ran for rejected promise'));
 			});
 			j.promise(Promise.reject(true)).catch(() => {});
-			setTimeout(done, 10);
+
+			act(() => jest.advanceTimersByTime(10));
+			done();
 		});
 
 		test('should not start job when stopped before promise resolves', done => {
@@ -171,8 +186,12 @@ describe('Job', () => {
 				done(new Error('Job ran for stopped promise'));
 			});
 			j.promise(new Promise(resolve => setTimeout(resolve, 20)));
-			setTimeout(() => j.stop(), 10);
-			setTimeout(done, 30);
+
+			act(() => jest.advanceTimersByTime(10));
+			j.stop();
+
+			act(() => jest.advanceTimersByTime(20));
+			done();
 		});
 
 		test('should not start job when another is started', done => {

--- a/packages/ui/Touchable/tests/Touchable-specs.js
+++ b/packages/ui/Touchable/tests/Touchable-specs.js
@@ -4,6 +4,13 @@ import {configure, getConfig, resetDefaultConfig} from '../config';
 import Touchable from '../Touchable';
 
 describe('Touchable', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	let data;
 
 	const DivComponent = ({children = 'Toggle', id, onClick, onMouseDown, onMouseLeave, onMouseUp, onTouchStart, onTouchEnd, ...props}) => {
@@ -55,10 +62,10 @@ describe('Touchable', () => {
 			fireEvent.mouseDown(component, ev);
 			rerender(<Component holdConfig={holdConfig} onHold={handler} onHoldStart={() => {}} />);
 
-			setTimeout(() => {
-				expect(handler).toHaveBeenCalled();
-				done();
-			}, 20);
+			jest.runOnlyPendingTimers();
+
+			expect(handler).toHaveBeenCalled();
+			done();
 		});
 
 		test('should update state configurations onHoldStart events', (done) => {
@@ -78,10 +85,10 @@ describe('Touchable', () => {
 			fireEvent.mouseDown(component, ev);
 			rerender(<Component holdConfig={holdConfig} onHold={() => {}} onHoldStart={handler} />);
 
-			setTimeout(() => {
-				expect(handler).toHaveBeenCalled();
-				done();
-			}, 20);
+			jest.runOnlyPendingTimers();
+
+			expect(handler).toHaveBeenCalled();
+			done();
 		});
 
 		test('should update state configurations onHoldEnd events', (done) => {
@@ -101,11 +108,11 @@ describe('Touchable', () => {
 			fireEvent.mouseDown(component, ev);
 			rerender(<Component holdConfig={holdConfig} onHold={() => {}} onHoldEnd={handler} />);
 
-			setTimeout(() => {
-				fireEvent.mouseUp(component, ev);
-				expect(handler).toHaveBeenCalled();
-				done();
-			}, 30);
+			jest.runOnlyPendingTimers();
+
+			fireEvent.mouseUp(component, ev);
+			expect(handler).toHaveBeenCalled();
+			done();
 		});
 
 		test('should merge configurations', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In some cases, when the code uses timers (setTimeout, setInterval, clearTimeout, clearInterval), the tests may become unpredictable, slow and flaky.
In fact, an unpredictable error occurs when performing unit tests on travis of this repository.
To solve this problem, most testing frameworks provide an option to replace the real timer in the test with a fake timer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use fake timers in all unit test cases that require timers.
(https://testing-library.com/docs/using-fake-timers)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-2712

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)