### PR TITLE
WRO-4551:Update the node version of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-    - "14"
+    - lts/*
+    - 18
+    - 14  
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
+    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: node_js
 node_js:
     - lts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
+    # - node
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
     - lts/*
     - 18
-    - 14  
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ sudo: false
 cache:
   directories:
     - $(npm config get cache)
+before_install:
+    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: focal 
 language: node_js
 node_js:
     - lts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
     - npm install
-    - npm run bootstrap
+    - npm run bootstrap --legacy-peer-deps
 script:
     - echo -e "\x1b\x5b35;1m*** Starting tests...\x1b\x5b0m"
     - npm test -- -- -- --runInBand --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - 18
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
-    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Requires travis test on multiple node versions including lts

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml so that it can be tested on multiple node versions (lts(16), node(18))
- ubuntu 20 is required for node 18 ( https://docs.travis-ci.com/user/reference/focal/)

Currently, @enact/storybook-utils is not updated, so an error occurs in node 18
So node18 test will be reflected after storybook-utils is updated

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4551

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO ([sj.ro@lge.com](mailto:sj.ro@lge.com))