### PR TITLE
WRO-3415: Provides event payload info for input type

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/FloatingLayer` to add `detail` property containing `inputType` in `onDismiss` event payload
+
 ## [4.5.0-alpha.2] - 2022-05-09
 
 ### Deprecated

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -69,6 +69,11 @@ class FloatingLayerBase extends Component {
 		 * by `FloatingLayerDecorator`. When cancel key is pressed, the function will only invoke if
 		 * `noAutoDismiss` is set to `false`.
 		 *
+		 * When pressing `ESC` key, event payload carries `detail` property containing `inputType`
+		 * value of `'key'`.
+		 * When clicking outside the boundary of the popup, event payload carries `detail` property
+		 * containing `inputType` value of `'click'`.
+		 *
 		 * @type {Function}
 		 * @public
 		 */
@@ -196,7 +201,7 @@ class FloatingLayerBase extends Component {
 	handleClick = handle(
 		forProp('noAutoDismiss', false),
 		forProp('open', true),
-		forwardCustom('onDismiss')
+		forwardCustom('onDismiss', () => ({detail: {inputType: 'click'}}))
 	).bind(this);
 
 	handleScroll = (ev) => {
@@ -253,7 +258,7 @@ class FloatingLayerBase extends Component {
 const handleCancel = handle(
 	// can't use forProp safely since either could be undefined ~= false
 	(ev, {open, noAutoDismiss, onDismiss}) => open && !noAutoDismiss && onDismiss,
-	forwardCustom('onDismiss'),
+	forwardCustom('onDismiss', () => ({detail: {inputType: 'key'}})),
 	stop
 );
 

--- a/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
+++ b/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
@@ -69,7 +69,7 @@ describe('FloatingLayer Specs', () => {
 		expect(actual).toMatchObject(expectedType);
 	});
 
-	test('should fire onDimiss event with type when FloatingLayer is closed', () => {
+	test('should fire onDimiss event with type and detail info when FloatingLayer is closed', () => {
 		const handleDismiss = jest.fn();
 
 		render(
@@ -80,7 +80,7 @@ describe('FloatingLayer Specs', () => {
 
 		fireEvent.keyUp(screen.getByText('Hi'), {keyCode: 27});
 
-		const expectedType = {type: 'onDismiss'};
+		const expectedType = {type: 'onDismiss', detail: {inputType: 'key'}};
 		const actual = handleDismiss.mock.calls.length && handleDismiss.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expectedType);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
App developers want to know which user input invokes `onDismiss` event from `FloatingLayer` to provide different actions based on the input type.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `detail` property that contains `inputType` value: its value is `'key'` for `ESC` key, and `'click'` for clicking outside a floating layer.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3415

### Comments

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)