### PR TITLE
WRO-7190: Fix timing issue when rerende VL by resizing

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` and `ui/VirtualList` to rerender property when `clientSize` is changed
+
 ## [4.5.0-rc.1] - 2022-06-23
 
 No significant changes.

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -403,7 +403,7 @@ const useScrollBase = (props) => {
 		};
 	}, [direction, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, rtl, scrollMode, spotlightContainerDisabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const
 			{hasDataSizeChanged} = scrollContentHandle.current,
 			{prevState, resizeRegistry, scrollToInfo} = mutableRef.current;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Item list is disappear after the `VirtualList size is changed".

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This problem is because the virtualList's `firstIndex` state is not updated properly.

Complex to explain, this is a timing issue.
After resizing VL, VL tried to sets a new `firstIndex`.
The problem is that immediately after this, another rerender is occured by the App.

In between, the `didScroll` event handler is called.
In this `didScroll`, It `setState` the previous `firstIndex`, and as a result, the `firstIndex` state is not updated properly.

Even if rerender occurs by the app, the state value should be updated by VL normally.
Due to the asynchronous handling of `useEffect` this was not guaranteed.
**In order to prevent of invoking `didScroll` in the middle, it should be handled synchronously by using `useLayoutEffect` instead of `useEffect`.**

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7190

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)