### PR TITLE
WRO-6848: Provide `stopPropagation` and `preventDefault` for custom events

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,11 @@ The following is a curated list of changes in the Enact core module, newest chan
 ## [4.5.0-rc.1] - 2022-06-23
 
 No significant changes.
+## [unreleased]
+
+### Changed
+
+- `core/handle.forwardCustom` handler to include `preventDefault` and `stopPropagation` methods in the forwarded event payload
 
 ## [4.5.0-beta.1] - 2022-05-31
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
-## [4.5.0-rc.1] - 2022-06-23
-
-No significant changes.
 ## [unreleased]
 
 ### Changed
 
 - `core/handle.forwardCustom` handler to include `preventDefault` and `stopPropagation` methods in the forwarded event payload
+
+## [4.5.0-rc.1] - 2022-06-23
+
+No significant changes.
 
 ## [4.5.0-beta.1] - 2022-05-31
 

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -436,7 +436,7 @@ const preventDefault = handle.preventDefault = callOnEvent('preventDefault');
  * @param    {Object}    ev     Event payload
  * @param    {Object}    props  Props object
  *
- * @returns  {Boolean}          Returns `true` if default action is prevented
+ * @returns  {Boolean}          Returns `false` if default action is prevented
  * @curried
  * @memberof core/handle
  * @private
@@ -732,21 +732,104 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
  */
 const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
 	adaptEvent(
-		(...args) => {
-			let ev = adapter ? adapter(...args) : null;
+		(ev, ...args) => {
+			let customEventPayload = adapter ? adapter(ev, ...args) : null;
 
 			// Handle either no adapter or a non-object return from the adapter
-			if (!ev || typeof ev !== 'object') {
-				ev = {};
+			if (!customEventPayload || typeof customEventPayload !== 'object') {
+				customEventPayload = {};
 			}
 
-			ev.type = name;
+			customEventPayload.type = name;
+			if (typeof customEventPayload.preventDefault !== 'function' && typeof ev?.preventDefault === 'function') {
+				customEventPayload.preventDefault = ev.preventDefault.bind(ev);
+			}
+			if (typeof customEventPayload.stopPropagation !== 'function' && typeof ev?.stopPropagation === 'function') {
+				customEventPayload.stopPropagation = ev.stopPropagation.bind(ev);
+			}
 
-			return ev;
+			return customEventPayload;
 		},
 		forward(name)
 	)
 ).named('forwardCustom');
+
+/**
+ * Creates a handler that will forward the event to a function at `name` on `props` with capability
+ * to prevent default behavior. If the specified prop is `undefined` or is not a function, it is
+ * ignored. Returns `false` when `event.preventDefault()` has been called in a handler.
+ *
+ * If `adapter` is not specified, a new event payload will be generated with a `type` member with
+ * the `name` of the custom event. If `adapter` is specified, the `type` member is added to the
+ * value returned by `adapter`.
+ *
+ * The `adapter` function receives the same arguments as any handler. The value returned from
+ * `adapter` is passed as the first argument to `handler` with the remaining arguments kept the
+ * same. This is often useful to generate a custom event payload before forwarding on to a callback.
+ *
+ * Example:
+ * ```
+ * import {forwardCustomWithPrevent, handle} from '@enact/core/handle';
+ *
+ * // calls the onChange callback with the event: {type: 'onChange'}
+ * const forwardChangePreventDefault = handle(
+ *   forwardCustomWithPrevent('onChange'),
+ *   (ev) => console.log('default action', ev)
+ * );
+ *
+ * // calls the onChange callback with the event: {type: 'onChange', index}
+ * const forwardChangeWithIndexPreventDefault = handle(
+ *   forwardCustomWithPrevent('onChange', (ev, {index}) => ({index})),
+ *   (ev) => console.log('default action', ev)
+ * );
+ * ```
+ *
+ * @method   forwardCustomWithPrevent
+ * @param    {String}        name      Name of method on the `props`
+ * @param    {EventAdapter}  [adapter] Function to adapt the event payload
+ *
+ * @returns  {HandlerFunction}         Returns an [event handler]{@link core/handle.EventHandler}
+ *                                     (suitable for passing to handle or used directly within
+ *                                     `handlers` in [kind]{@link core/kind}) that will forward the
+ *                                     custom event and will return `false` if default action is prevented
+ * @memberof core/handle
+ * @private
+ */
+const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, adapter) => {
+	let prevented = false;
+
+	const adapterWithPrevent = (ev, ...args) => {
+		let customEventPayload = adapter ? adapter(ev, ...args) : null;
+		let preventDefaultFromAdapter = null;
+
+		// Handle either no adapter or a non-object return from the adapter
+		if (!customEventPayload || typeof customEventPayload !== 'object') {
+			customEventPayload = {};
+		}
+
+		if (typeof customEventPayload.preventDefault === 'function') {
+			preventDefaultFromAdapter = customEventPayload.preventDefault;
+		} else if (typeof ev.preventDefault === 'function') {
+			preventDefaultFromAdapter = ev.preventDefault.bind(ev);
+		}
+
+		customEventPayload.preventDefault = () => {
+			prevented = true;
+			if (typeof preventDefaultFromAdapter === 'function') {
+				preventDefaultFromAdapter();
+			}
+		};
+
+		return customEventPayload;
+	};
+
+	return (
+		handle(
+			forwardCustom(name, adapterWithPrevent),
+			() => (!prevented)
+		)
+	);
+}, 'forwardCustomWithPrevent');
 
 /**
  * Accepts a handler and returns the logical complement of the value returned from the handler.
@@ -782,6 +865,7 @@ export {
 	callOnEvent,
 	forward,
 	forwardCustom,
+	forwardCustomWithPrevent,
 	forwardWithPrevent,
 	forEventProp,
 	forKey,

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -757,7 +757,7 @@ const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
 /**
  * Creates a handler that will forward the event to a function at `name` on `props` with capability
  * to prevent default behavior. If the specified prop is `undefined` or is not a function, it is
- * ignored. Returns `false` when `event.preventDefault()` has been called in a handler.
+ * ignored. The created handler returns `false` when `event.preventDefault()` has been called in a handler.
  *
  * If `adapter` is not specified, a new event payload will be generated with a `type` member with
  * the `name` of the custom event. If `adapter` is specified, the `type` member is added to the
@@ -800,7 +800,7 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
 
 	const adapterWithPrevent = (ev, ...args) => {
 		let customEventPayload = adapter ? adapter(ev, ...args) : null;
-		let preventDefaultFromAdapter = null;
+		let existingPreventDefault = null;
 
 		// Handle either no adapter or a non-object return from the adapter
 		if (!customEventPayload || typeof customEventPayload !== 'object') {
@@ -808,15 +808,15 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
 		}
 
 		if (typeof customEventPayload.preventDefault === 'function') {
-			preventDefaultFromAdapter = customEventPayload.preventDefault;
+			existingPreventDefault = customEventPayload.preventDefault;
 		} else if (typeof ev.preventDefault === 'function') {
-			preventDefaultFromAdapter = ev.preventDefault.bind(ev);
+			existingPreventDefault = ev.preventDefault.bind(ev);
 		}
 
 		customEventPayload.preventDefault = () => {
 			prevented = true;
-			if (typeof preventDefaultFromAdapter === 'function') {
-				preventDefaultFromAdapter();
+			if (typeof existingPreventDefault === 'function') {
+				existingPreventDefault();
 			}
 		};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`focusCustom` method of `handle` module does not include `stopPropagation` in the event payload that it dispatches, so there is no way to stop propagation of the event in Enact apps when they use `focusCustom`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This PR changes `forwardCustom` to include `stopPropagation` and `preventDefault` of the original event in a forwarded event payload.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The original issue is only about `stopPropagation` but `preventDefault` is also commonly called by apps. So two methods are supported.
DOM `Event` interface has [two more methods](https://developer.mozilla.org/en-US/docs/Web/API/Event#methods) -`composedPath` and `stopImmediatePropagation`- but they are not a member of React synthetic event interface and actually not so meaningful in React apps. So those methods are not included.

### Links
[//]: # (Related issues, references)
WRO-6848
enactjs/enact#2982
enactjs/sandstone#1120
enactjs/sandstone#1136

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
