### PR TITLE
WRO-737: Replaced ReactDOM.findDomNode with refs

### DIFF
--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -1,6 +1,5 @@
 import useClass from '@enact/core/useClass';
 import {useLayoutEffect, useRef} from 'react';
-import ReactDOM from 'react-dom';
 
 import {SpottableCore, spottableClass} from './SpottableCore';
 
@@ -75,8 +74,7 @@ const useSpottable = ({spotRef, emulateMouse, selectionKeys = [ENTER_KEY, REMOTE
 	hook.setPropsAndContext({selectionKeys, spotlightDisabled, ...props}, context.current);
 
 	useLayoutEffect(() => {
-		// eslint-disable-next-line react/no-find-dom-node
-		hook.load(ReactDOM.findDOMNode(spotRef || null));
+		hook.load(spotRef || null);
 
 		return () => {
 			hook.unload();

--- a/packages/ui/useScroll/Scrollbar.js
+++ b/packages/ui/useScroll/Scrollbar.js
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import {Job} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {memo, useEffect, useRef} from 'react';
-import ReactDOM from 'react-dom';
 
 import ri from '../resolution';
 
@@ -13,16 +12,14 @@ import componentCss from './Scrollbar.module.less';
 const scrollbarTrackHidingDelay = 900; // 900ms + 100ms(fade out duration) = 1000ms.
 
 const addClass = (element, className) => {
-	const node = ReactDOM.findDOMNode(element); // eslint-disable-line react/no-find-dom-node
-	if (node) {
-		node.classList.add(className);
+	if (element) {
+		element.classList.add(className);
 	}
 };
 
 const removeClass = (element, className) => {
-	const node = ReactDOM.findDOMNode(element); // eslint-disable-line react/no-find-dom-node
-	if (node) {
-		node.classList.remove(className);
+	if (element) {
+		element.classList.remove(className);
 	}
 };
 
@@ -35,7 +32,7 @@ const removeClass = (element, className) => {
  * @param {String} value - CSS Variable value.
  */
 const setCSSVariable = (element, variable, value) => {
-	ReactDOM.findDOMNode(element).style.setProperty(variable, value); // eslint-disable-line react/no-find-dom-node
+	element.style.setProperty(variable, value);
 };
 
 /**


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
React.findDomNode is deprecated in Strict mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replaced React.findDomNode in enact components with React.createRef().
Note:
ui/ViewManager/View - cannot replace without adding a new DOM node
ui/resolution/ResolutionDecorator - cannot replace without adding a new DOM node
spotlight/Spottable/Spottable.js - cannot replace without adding a new DOM node
webos/speech/VoiceControlDecorator.js - cannot replace without adding a new DOM node
ui/Scrollable - package is only for Moonstone. It is marked as deprecated in WRO-4903

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-737

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)