### PR TITLE
WRO-745: Clean up Spotlight document

### DIFF
--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -110,7 +110,7 @@ const defaultConfig = {
 	 * navigable element. Specifying 'self-only' indicates that elements in other containers
 	 * cannot be navigated to by using 5-way navigation - however, elements in other containers
 	 * can still receive focus by calling `Spotlight.focus(elem)` explicitly. Specifying 'none'
-	 * indicates there should be no restrictions when 5-way navigating the container.
+	 * indicates there is no restrictions when 5-way navigating the container.
 	 *
 	 * @type {String}
 	 * @default 'self-first'
@@ -211,7 +211,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		/**
 		 * Whether or not the container is in muted mode.
 		 * When in muted mode, Spottable controls within the container can still gain focus,
-		 * however their `:focus` CSS styles will not be applied, giving them the appearance of not
+		 * but their `:focus` CSS styles will not be applied, giving them the appearance of not
 		 * having focus.
 		 *
 		 * @type {Boolean}
@@ -227,7 +227,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * navigable element. Specifying 'self-only' indicates that elements in other containers
 		 * cannot be navigated to by using 5-way navigation - however, elements in other containers
 		 * can still receive focus by calling `Spotlight.focus(elem)` explicitly. Specifying 'none'
-		 * indicates there should be no restrictions when 5-way navigating the container.
+		 * indicates there is no restrictions when 5-way navigating the container.
 		 *
 		 * @type {String}
 		 * @default 'self-first'

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -228,7 +228,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * navigable element. Specifying 'self-only' indicates that elements in other containers
 		 * cannot be navigated to by using 5-way navigation - however, elements in other containers
 		 * can still receive focus by calling `Spotlight.focus(elem)` explicitly. Specifying 'none'
-		 * indicates there is no restrictions when 5-way navigating the container.
+		 * indicates there should be no restrictions when 5-way navigating the container.
 		 *
 		 * @type {String}
 		 * @default 'self-first'

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -61,8 +61,10 @@ const defaultConfig = {
 
 	/**
 	 * The selector for the default spottable element within the container.
+	 * When an array of selectors is provided, the first selector that successfully matches a
+	 * node is used.
 	 *
-	 * @type {String}
+	 * @type {String|String[]}
 	 * @default '.spottable-default'
 	 * @memberof spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator.defaultConfig
 	 * @public
@@ -99,7 +101,21 @@ const defaultConfig = {
 	 * @memberof spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator.defaultConfig
 	 * @public
 	 */
-	preserveId: false
+	preserveId: false,
+
+	/**
+	 * Restricts or prioritizes navigation when focus attempts to leave the container. It
+	 * can be either 'none', 'self-first', or 'self-only'. Specifying 'self-first' indicates that
+	 * elements within the container will have a higher likelihood to be chosen as the next
+	 * navigable element. Specifying 'self-only' indicates that elements in other containers
+	 * cannot be navigated to by using 5-way navigation - however, elements in other containers
+	 * can still receive focus by calling `Spotlight.focus(elem)` explicitly. Specifying 'none'
+	 * indicates there should be no restrictions when 5-way navigating the container.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	restrict: PropTypes.oneOf(['none', 'self-first', 'self-only'])
 };
 
 /**
@@ -182,6 +198,8 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * Used to identify this component within the Spotlight system.
 		 *
 		 * If the value is `null`, an id will be generated.
+		 * To keep the container information for restoring focus, it is required to specify
+		 * a unique identifier.
 		 *
 		 * @type {String}
 		 * @public
@@ -190,6 +208,9 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		/**
 		 * Whether or not the container is in muted mode.
+		 * When in muted mode, Spottable controls within the container can still gain focus,
+		 * however their `:focus` CSS styles will not be applied, giving them the appearance of not
+		 * having focus.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -113,6 +113,8 @@ const defaultConfig = {
 	 * indicates there should be no restrictions when 5-way navigating the container.
 	 *
 	 * @type {String}
+	 * @default 'self-first'
+	 * @memberof spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator.defaultConfig
 	 * @public
 	 */
 	restrict: PropTypes.oneOf(['none', 'self-first', 'self-only'])
@@ -228,6 +230,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * indicates there should be no restrictions when 5-way navigating the container.
 		 *
 		 * @type {String}
+		 * @default 'self-first'
 		 * @public
 		 */
 		spotlightRestrict: PropTypes.oneOf(['none', 'self-first', 'self-only'])

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -110,7 +110,7 @@ const defaultConfig = {
 	 * navigable element. Specifying 'self-only' indicates that elements in other containers
 	 * cannot be navigated to by using 5-way navigation - however, elements in other containers
 	 * can still receive focus by calling `Spotlight.focus(elem)` explicitly. Specifying 'none'
-	 * indicates there is no restrictions when 5-way navigating the container.
+	 * indicates there should be no restrictions when 5-way navigating the container.
 	 *
 	 * @type {String}
 	 * @default 'self-first'
@@ -210,9 +210,10 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		/**
 		 * Whether or not the container is in muted mode.
-		 * When in muted mode, Spottable controls within the container can still gain focus,
-		 * but their `:focus` CSS styles will not be applied, giving them the appearance of not
-		 * having focus.
+		 *
+		 * In muted mode, `:focus` CSS styles will not be applied to the
+		 * Spottable controls giving them the appearance of not having focus
+		 * while they still have focus.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -290,7 +290,7 @@ provided, the first selector that successfully matches a node is used.
 + Default: `''`
 
 If the focus originates from another container, you can define which element in
-this container receives focus first. 
+this container receives focus first.
 
 `preserveId`
 + Type: [boolean]

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -215,12 +215,12 @@ matches `selector`. This method has no effect if Spotlight is paused.
 Moves focus in the specified direction of `selector`. If `selector` is not specified,
 Spotlight will move in the given direction of the currently spotted control.
 
-## HOC Configuration And Properties
+## HOC Configuration Parameters And Properties
 
-##### Spotlight HOC Configuration
+##### Spotlight HOC Configuration Parameters
 
-Configuration in the form of an object can be passed as an initial argument to a HOC when creating a
-Spotlight control. In these cases, the HOC configuration should remain static and unchanged in the
+Configuration parameters in the form of an object can be passed as an initial argument to a HOC when creating a
+Spotlight control. In these cases, the HOC configuration parameters should remain static and unchanged in the
 life-cycle of the control.
 
 ```js
@@ -246,9 +246,9 @@ const App = kind({
 
 ### Spottable
 
-For more details and full list of `Spottable` api, see [spotlight/Spottable/](../../modules/spotlight/Spottable/).
+For more details and full list of `Spottable` API, see [spotlight/Spottable](../../modules/spotlight/Spottable).
 
-##### Configuration
+##### Configuration Parameters
 
 `emulateMouse`
 + Type: [boolean]
@@ -273,9 +273,9 @@ A callback function to override default spotlight behavior when exiting the spot
 
 ### Container
 
-For more details and full list of `Container` api, see [spotlight/SpotlightContainerDecorator](../../modules/spotlight/SpotlightContainerDecorator/).
+For more details and full list of `Container` API, see [spotlight/SpotlightContainerDecorator](../../modules/spotlight/SpotlightContainerDecorator).
 
-##### Configuration
+##### Configuration Parameters
 
 `defaultElement`
 + Type: [string|string[]]
@@ -291,6 +291,26 @@ provided, the first selector that successfully matches a node is used.
 
 If the focus originates from another container, you can define which element in
 this container receives focus first. 
+
+`preserveId`
++ Type: [boolean]
++ Default: `false`
+
+Whether the container will preserve the id when it unmounts.
+
+#### Configuration Properties
+
+`containerId`
++ Type: [string]
+
+Specifies the container id. If the value is `null`, an id will be generated.
+
+`spotlightRestrict`
++ Type: [string]
++ Values: [`'none'`, `'self-first'`, or `'self-only'`]
++ Default: `'none'`
+
+Restricts or prioritizes focus to the controls in the current container.
 
 ```js
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -215,12 +215,12 @@ matches `selector`. This method has no effect if Spotlight is paused.
 Moves focus in the specified direction of `selector`. If `selector` is not specified,
 Spotlight will move in the given direction of the currently spotted control.
 
-## HOC Parameters And Properties
+## HOC Configuration And Properties
 
-##### Spotlight HOC Parameters
+##### Spotlight HOC Configuration
 
-Parameters in the form of an object can be passed as an initial argument to a HOC when creating a
-Spotlight control. In these cases, the HOC parameter should remain static and unchanged in the
+Configuration in the form of an object can be passed as an initial argument to a HOC when creating a
+Spotlight control. In these cases, the HOC configuration should remain static and unchanged in the
 life-cycle of the control.
 
 ```js
@@ -246,7 +246,9 @@ const App = kind({
 
 ### Spottable
 
-##### Parameters
+For more details and full list of `Spottable` api, see [spotlight/Spottable/](../../modules/spotlight/Spottable/).
+
+##### Configuration
 
 `emulateMouse`
 + Type: [boolean]
@@ -269,14 +271,11 @@ May be added to temporarily make a control not spottable.
 
 A callback function to override default spotlight behavior when exiting the spottable control.
 
-`onSpotlightDisappear`
-+ Type: [function]
-
-A callback function to be called when the component is removed while retaining focus.
-
 ### Container
 
-##### Parameters
+For more details and full list of `Container` api, see [spotlight/SpotlightContainerDecorator](../../modules/spotlight/SpotlightContainerDecorator/).
+
+##### Configuration
 
 `defaultElement`
 + Type: [string|string[]]
@@ -291,43 +290,7 @@ provided, the first selector that successfully matches a node is used.
 + Default: `''`
 
 If the focus originates from another container, you can define which element in
-this container receives focus first.
-
-`preserveId`
-+ Type: [boolean]
-+ Default: `false`
-
-Whether the container will preserve the id when it unmounts.
-
-#### Properties
-
-`containerId`
-+ Type: [string]
-
-Specifies the container id. If the value is `null`, an id will be generated.
-
-`spotlightDisabled`
-+ Type: [boolean]
-+ Default: `false`
-
-When `true`, controls in the container cannot be navigated.
-
-`spotlightMuted`
-+ Type: [boolean]
-+ Default: `false`
-
-Whether or not the container is in muted mode. When in muted mode, Spottable controls within the container
-can still gain focus, however their `:focus` CSS styles will not be applied, giving them the appearance
-of not having focus. Muting a container is generally done to temporarily disable CSS changes and
-default `onFocus` and `onBlur` events without removing focus from the container itself - which would
-happen if you disabled the container using `spotlightDisabled`.
-
-`spotlightRestrict`
-+ Type: [string]
-+ Values: [`'none'`, `'self-first'`, or `'self-only'`]
-+ Default: `'none'`
-
-Restricts or prioritizes focus to the controls in the current container.
+this container receives focus first. 
 
 ```js
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -298,7 +298,7 @@ this container receives focus first.
 
 Whether the container will preserve the id when it unmounts.
 
-#### Configuration Properties
+#### Properties
 
 `containerId`
 + Type: [string]


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is duplicated api description on `Spotlight`/index.md files.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Leave only the APIs that are mainly used and remove others.
- Add link for full api list
- Merge some docs in `SpotlightContainerDecorator.js` (There was nothing to merge in the `Spottable` docs.)
- In the md document, the term "Parameters" is used, but in the api documents and code, the term "Configuration" is used. So, I modified it to use "Configuration Parameters."

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`restrict` is not an officially provided `config`, but it is used for initial setting in many places. (even in the Spotlight example)
So I thought `restrict` should be added to the `SpotlightContainerDecorator` docs

### Links
[//]: # (Related issues, references)
WRO-745

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
