### PR TITLE
WRO-4003: check parent's container restrict condition when change activate container

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,7 +4,9 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
-- `spotlight` to not leave the restrict container after when returning from another app
+### Fixed
+
+- `spotlight` to not leave the restrict container after returning from another app
  
 ## [4.5.0-rc.1] - 2022-06-23
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+- `spotlight` to not leave the restrict container after when returning from another app
+ 
 ## [4.5.0-rc.1] - 2022-06-23
 
 No significant changes.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -955,7 +955,7 @@ function mayActivateContainer (containerId) {
 	// activated is not inside the restrict container, the next container should not be activated.
 	const currentContainerNode = getContainerNode(currentContainerId);
 	const restrictContainer = getContainersForNode(currentContainerNode).reduceRight((result, outerContainerId) => {
-		return result || (isRestrictedContainer(outerContainerId) ? outerContainerId : null) ;
+		return result || (isRestrictedContainer(outerContainerId) ? outerContainerId : null);
 	}, null);
 
 	return !restrictContainer || containsContainer(restrictContainer, containerId);

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -951,13 +951,14 @@ function containsContainer (outerContainerId, innerContainerId) {
 function mayActivateContainer (containerId) {
 	const currentContainerId = getLastContainer();
 
-	// If the current container is restricted to 'self-only' and if the next container to be
-	// activated is not inside the currently activated container, the next container should not be
-	// activated.
-	return (
-		!isRestrictedContainer(currentContainerId) ||
-		containsContainer(currentContainerId, containerId)
-	);
+	// If the current container or Its outer containers are restricted to 'self-only' and if the next container to be
+	// activated is not inside the restrict container, the next container should not be activated.
+	const currentContainerNode = getContainerNode(currentContainerId);
+	const restrictContainer = getContainersForNode(currentContainerNode).reduceRight((result, outerContainerId) => {
+		return result || (isRestrictedContainer(outerContainerId) ? outerContainerId : null) ;
+	}, null);
+
+	return !restrictContainer || containsContainer(restrictContainer, containerId);
 }
 
 function getDefaultContainer () {

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -951,8 +951,9 @@ function containsContainer (outerContainerId, innerContainerId) {
 function mayActivateContainer (containerId) {
 	const currentContainerId = getLastContainer();
 
-	// If the current container or Its outer containers are restricted to 'self-only' and if the next container to be
-	// activated is not inside the restrict container, the next container should not be activated.
+	// If the current container or its outer containers are restricted to 'self-only' and
+	// if the next container to be activated is not inside the restrict container,
+	// the next container should not be activated.
 	const currentContainerNode = getContainerNode(currentContainerId);
 	const restrictContainer = getContainersForNode(currentContainerNode).reduceRight((result, outerContainerId) => {
 		return result || (isRestrictedContainer(outerContainerId) ? outerContainerId : null);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus can leave the restrict container after when returning from another app.
(Element outside the popup receives focus.)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Cause: 
If the "lastContainer" is `popup container`, focus cannot escape because `popup container` is restrict container. ('self-only')
When button inside popup get focus, spotlight set `lastContainer` to `popup content container`.  `popup content container` is not restrict container.

When pointer leave the popup, spotlight set `lastContainer` to `popup container`.  In that case, there is no problem.
In the reproducible case, the pointer leave event did not occur and another app was opened and closed.
Spotlight try to set `container1`(out of popup) as the new activeContainer because user clicked on the center.
If `lastContainer` is a restrict container, Spotlight does not change activeConatienr to `container1`.
But since `lastContainer` is `popup content container`, activeConatiener is changed to `container1` and the problem is reproduced.

The problem was caused by checking only the `lastContainer` when checking `mayActivateContainer`.

Resolution:
Check parent's container restrict condition when change activate container

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4003

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

