### PR TITLE
WRO-2087: Replaced `process.env` usage from i18n/Loader and glue

### DIFF
--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -1,4 +1,4 @@
-/* global XMLHttpRequest, ILIB_BASE_PATH, ILIB_RESOURCES_PATH, ILIB_CACHE_ID */
+/* global XMLHttpRequest, ILIB_BASE_PATH, ILIB_RESOURCES_PATH, ILIB_ADDITIONAL_RESOURCES_PATH, ILIB_CACHE_ID */
 
 import {memoize} from '@enact/core/util';
 import Loader from 'ilib/lib/Loader';
@@ -51,7 +51,6 @@ const cachePrefix = 'ENACT-ILIB-';
 const cacheKey = cachePrefix + 'CACHE-ID';
 const cacheID = typeof ILIB_CACHE_ID === 'undefined' ? '$ILIB' : ILIB_CACHE_ID;
 const timeStampKey = 'l10n_timestamp';
-const iLibAdditionalPath = process.env.REACT_APP_ILIB_ADDITIONAL_RESOURCES_PATH;
 
 function EnyoLoader () {
 	this.base = iLibBase;
@@ -302,7 +301,7 @@ EnyoLoader.prototype.loadFiles = function (paths, sync, params, callback, rootPa
 };
 
 EnyoLoader.prototype._handleManifest = function (dirpath, filepath, json) {
-	const isAdditionalPath = typeof iLibAdditionalPath !== 'undefined' ? dirpath.includes(iLibAdditionalPath) : false;
+	const isAdditionalPath = typeof ILIB_ADDITIONAL_RESOURCES_PATH !== 'undefined' ? dirpath.includes(ILIB_ADDITIONAL_RESOURCES_PATH) : false;
 	// star indicates there was no ilibmanifest.json, so always try to load files from
 	// that dir
 	if (json != null) {
@@ -342,7 +341,7 @@ EnyoLoader.prototype._validateManifest = function (cachedManifest, filepath, syn
 					newManifest = json;
 				});
 			}
-			if (newManifest === null && typeof iLibAdditionalPath !== 'undefined' && filepath.includes(iLibAdditionalPath)) {
+			if (newManifest === null && typeof ILIB_ADDITIONAL_RESOURCES_PATH !== 'undefined' && filepath.includes(ILIB_ADDITIONAL_RESOURCES_PATH)) {
 				// If new manifest is null and the filepath has ILIB_ADDITIONAL_RESOURCES_PATH,
 				// meaning we need to clear string cache
 				this._clearStringsCache();

--- a/packages/i18n/src/glue.js
+++ b/packages/i18n/src/glue.js
@@ -1,3 +1,5 @@
+/* global ILIB_ADDITIONAL_RESOURCES_PATH */
+
 /*
  * glue.js - glue code to fit ilib into enyo
  *
@@ -24,11 +26,9 @@ import './dates';
 import Loader from './Loader';
 import {updateLocale} from '../locale';
 
-const ilibAdditionalPath = process.env.REACT_APP_ILIB_ADDITIONAL_RESOURCES_PATH;
-
 ilib.setLoaderCallback(new Loader());
-if (typeof ilibAdditionalPath !== 'undefined') {
-	ilib.getLoader().addPath(ilibAdditionalPath);
+if (typeof ILIB_ADDITIONAL_RESOURCES_PATH !== 'undefined') {
+	ilib.getLoader().addPath(ILIB_ADDITIONAL_RESOURCES_PATH);
 }
 
 if (typeof window === 'object' && typeof window.UILocale !== 'undefined') {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Webpack 5 does no longer include a polyfill for this Node.js variable so it's recommended to add the environment variables to `DefinePlugin`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replaced `process.env` access to embedded environment variables

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This change needs cil, dev-utils prs and change bb file to use new pack option `--ilib-additional-path`.

### Links
[//]: # (Related issues, references)
WRO-2087

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)