### PR TITLE
WRO-8481: Fixed `MarqueeDecorator` to restart animation properly with React 18

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to restart animation properly when applied to item related components
+
 ## [4.5.0] - 2022-07-19
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee.MarqueeDecorator` to restart animation properly when applied to item related components
+- `ui/Marquee.MarqueeDecorator` to restart animation properly with React 18
 
 ## [4.5.0] - 2022-07-19
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -7,6 +7,7 @@ import {is} from '@enact/core/keymap';
 import {Job, shallowEqual} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {PureComponent} from 'react';
+import {flushSync} from 'react-dom';
 import warning from 'warning';
 
 import {scale} from '../resolution';
@@ -728,8 +729,10 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		restartAnimation = (delay) => {
-			this.setState({
-				animating: false
+			flushSync(() => {
+				this.setState({
+					animating: false
+				});
 			});
 			// synchronized Marquees defer to the controller to restart them
 			if (this.sync) {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When marquee applied to item related components, marquee cannot restart animation after completes its marquee once.

When marquee completes its marquee once, restartAnimation() func in marqueeDecorator called to set animating state to be false and then called start() func. As react batchs its state, animating state is true when start() executed and it caused animation to be stopped.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use flushSync in marqueeDecorator to synchronously update animating state to be false.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-8481

### Comments
