### PR TITLE
WRO-9294: Fix Marquee spacing for bidirectional text

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
+- `ui/Marquee.MarqueeDecorator` to have proper spacing for bidirectional text
 - `ui/Marquee.MarqueeDecorator` to restart animation properly with React 18
 
 ## [4.5.0] - 2022-07-19

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -234,13 +234,12 @@ const MarqueeBase = kind({
 		}
 	},
 
-	render: ({applyOffset, children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, ...rest}) => {
+	render: ({applyOffset, children, clientClassName, clientRef, clientStyle, css, duplicate, onMarqueeComplete, rtl, ...rest}) => {
 		delete rest.alignment;
 		delete rest.animating;
 		delete rest.distance;
 		delete rest.onMarqueeComplete;
 		delete rest.overflow;
-		delete rest.rtl;
 		delete rest.spacing;
 		delete rest.speed;
 		delete rest.willAnimate;
@@ -257,7 +256,9 @@ const MarqueeBase = kind({
 					{duplicate ? (
 						<Fragment>
 							<div className={css.spacing} ref={applyOffset} />
-							{children}
+							<span dir={rtl ? "rtl" : "rtl"}>
+								{children}
+							</span>
 						</Fragment>
 					) : null}
 				</div>

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -256,7 +256,7 @@ const MarqueeBase = kind({
 					{duplicate ? (
 						<Fragment>
 							<div className={css.spacing} ref={applyOffset} />
-							<span dir={rtl ? "rtl" : "rtl"}>
+							<span dir={rtl ? "rtl" : "ltr"}>
 								{children}
 							</span>
 						</Fragment>

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -228,13 +228,13 @@ describe('MarqueeBase', () => {
 
 	test('should duplicate from content when promoted and a non-zero distance', () => {
 		render(
-			<MarqueeBase distance={100} willAnimate>
+			<MarqueeBase data-testid="marquee" distance={100} willAnimate>
 				Text
 			</MarqueeBase>
 		);
-		const marquee = screen.getByText('TextText');
+		const marquee = screen.getByTestId('marquee');
 
-		expect(marquee).toBeInTheDocument();
+		expect(marquee).toHaveTextContent('TextText');
 	});
 
 	test('should not duplicate from content when promoted and a zero distance', () => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Cause : 
Perhaps due to the bidi rule, the div inserted in the middle is repositioned to unexpected position.
![image](https://user-images.githubusercontent.com/34676178/181425910-743bc6f1-afff-41f3-8e7a-3187f5444c51.png)

Resolve: 
Isolate cloned text to avoid reordering by bidi rule. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-9294, WRO-9284

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

