### PR TITLE
WRO-3625: Add `usePublicClassNames`

### DIFF
--- a/packages/core/usePublicClassNames/package.json
+++ b/packages/core/usePublicClassNames/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "usePublicClassNames.js"
+}

--- a/packages/core/usePublicClassNames/tests/usePublicClassNames-specs.js
+++ b/packages/core/usePublicClassNames/tests/usePublicClassNames-specs.js
@@ -1,0 +1,50 @@
+import {renderHook} from '@testing-library/react';
+
+import usePublicClassNames from '../usePublicClassNames';
+
+describe('usePublicClassNames', () => {
+	const componentCss = {
+		test: 'test-class',
+		a: 'a-class',
+		b: 'b-class'
+	};
+	const customCss = {
+		test: 'test-class-custom',
+		a: 'a-class-custom',
+		b: 'b-class-custom',
+		myClass: 'my-class'
+	};
+
+	test('should return `componentCss` if `customCss` is undefined', () => {
+		const testComponentCss = {test: 'test-class'};
+		const {result} = renderHook(() => usePublicClassNames({componentCss: testComponentCss, customCss: null, publicClassNames: true}));
+
+		expect(result.current).toEqual(testComponentCss);
+	});
+
+	test('should return a merged css has all keys from `componentCss` and merged values when `publicClassNames` is true', () => {
+		const {result} = renderHook(() => usePublicClassNames({componentCss, customCss, publicClassNames: true}));
+
+		const expected = {
+			test: 'test-class test-class-custom',
+			a: 'a-class a-class-custom',
+			b: 'b-class b-class-custom'
+		};
+
+		expect(result.current.test).toBe(expected.test);
+		expect(result.current.a).toBe(expected.a);
+		expect(result.current.b).toBe(expected.b);
+	});
+
+	test('should return a merged css has all keys from `componentCss` and merged values when `publicClassNames` is an array of strings', () => {
+		const {result} = renderHook(() => usePublicClassNames({componentCss, customCss, publicClassNames: ['a', 'b']}));
+
+		const expected = {
+			a: 'a-class a-class-custom',
+			b: 'b-class b-class-custom'
+		};
+
+		expect(result.current.a).toBe(expected.a);
+		expect(result.current.b).toBe(expected.b);
+	});
+});

--- a/packages/core/usePublicClassNames/usePublicClassNames.js
+++ b/packages/core/usePublicClassNames/usePublicClassNames.js
@@ -1,0 +1,37 @@
+import {mergeClassNameMaps} from '../util';
+
+/**
+ * A hook for supporting `publicClassNames` to functional components.
+ * It returns merged CSS of given two CSS objects according to `publicClassNames` option.
+ *
+ * @param   {Object.<string, string>}    [componentCss]     The CSS of the component
+ * @param   {Object.<string, string>}    [customCss]        The supplied collection of CSS class names to the
+ *                                                          corresponding internal elements and states of the component
+ * @param   {Boolean|String|String[]}    [publicClassNames] The keys of public class names of the component
+ *                                                          If this value is `true`, all of the keys from the component
+ *                                                          CSS will become public class names.
+ * @returns {Object}                                        A merged CSS
+ * @private
+ */
+function usePublicClassNames ({componentCss, customCss, publicClassNames}) {
+	let allowedClassNames = publicClassNames;
+	let mergedCss = componentCss;
+
+	if (componentCss && allowedClassNames === true) {
+		allowedClassNames = Object.keys(componentCss);
+	} else if (typeof allowedClassNames === 'string') {
+		allowedClassNames = allowedClassNames.split(/\s+/);
+	}
+
+	// if the config includes a css map, merge them together now
+	if (componentCss && allowedClassNames && customCss) {
+		mergedCss = mergeClassNameMaps(componentCss, customCss, allowedClassNames);
+	}
+
+	return mergedCss;
+}
+
+export default usePublicClassNames;
+export {
+	usePublicClassNames
+};


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As we develop with functional components, we needed to use the public class name feature of `kind` in functional components.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a hook that supports public class name features for functional components

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3625

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)