### PR TITLE
WRO-9768: Fix `Marquee` to stop at the proper position when scaled

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee` to stop at the starting point after one cycle when scale is applied
+- `ui/Marquee` to stop at the starting point after one cycle when scaled
 
 ## [4.5.1] - 2022-08-03
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeBase` to stop at the starting point after one cycle when scale is applied
+
 ## [4.5.1] - 2022-08-03
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee.MarqueeBase` to stop at the starting point after one cycle when scale is applied
+- `ui/Marquee` to stop at the starting point after one cycle when scale is applied
 
 ## [4.5.1] - 2022-08-03
 

--- a/packages/ui/Marquee/MarqueeBase.js
+++ b/packages/ui/Marquee/MarqueeBase.js
@@ -174,8 +174,9 @@ const MarqueeBase = kind({
 			new global.IntersectionObserver(function (entries, observer) {
 				const {left, right} = entries[0].boundingClientRect;
 				const {left: rootLeft, right: rootRight} = entries[0].rootBounds;
+				const scale = (root.getBoundingClientRect().width / root.offsetWidth) || 1;
 
-				const textWidth = rtl ? rootRight - right : left - rootLeft;
+				const textWidth = (rtl ? rootRight - right : left - rootLeft) / scale;
 				const offset = distance - (textWidth + spacing);
 
 				node.style.setProperty('--ui-marquee-offset', offset);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After one cycle of Marquee, the text stops over the start line and comes back incase of scaled Item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply the scaled value to the spacing calculation so that it stops at the correct point.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

When an item of size 100 is scaled by 120%,
The marquee component is well calculated the translateX as "120+spacing size" (=distance).
However, in browsers, it translate by 120px * 120%, eventually causing the marquee to pass more than expected.

We can consider the scale value when cacluate the distance value.
In this case, you need to apply the scale value in the `measureWidths` function of `MarqueeDecorator`.
(The code in `MarqueeBase` still needs modifications.)
However, in order to make the modifications as safe as possible,  I have determined that this  `MarqueeDecorator` modification is not essential at this time.

### Links
[//]: # (Related issues, references)
WRO-9768

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
