### PR TITLE
WRO-11514: Add Repository/Hompage address to enact packages at npmjs.com

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,12 @@
   "name": "@enact/core",
   "version": "4.5.2",
   "description": "Enact is an open source JavaScript framework containing everything you need to create a fast, scalable mobile or web application.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enactjs/enact.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/enactjs/enact/tree/master/packages/core#readme", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/enactjs/enact.git",
     "directory": "packages/core"
   },
-  "homepage": "https://github.com/enactjs/enact/tree/master/packages/core#readme", 
+  "homepage": "https://enactjs.com", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -3,6 +3,12 @@
   "main": "./src/index.js",
   "version": "4.5.2",
   "description": "Internationalization support for Enact using iLib",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enactjs/enact.git",
+    "directory": "packages/i18n"
+  },
+  "homepage": "https://github.com/enactjs/enact/tree/master/packages/i18n#readme", 
   "scripts": {
     "clean": "enact clean",
     "lint": "enact lint --strict",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/enactjs/enact.git",
     "directory": "packages/i18n"
   },
-  "homepage": "https://github.com/enactjs/enact/tree/master/packages/i18n#readme", 
+  "homepage": "https://enactjs.com", 
   "scripts": {
     "clean": "enact clean",
     "lint": "enact lint --strict",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/enactjs/enact.git",
     "directory": "packages/spotlight"
   },
-  "homepage": "https://github.com/enactjs/enact/tree/master/packages/spotlight#readme", 
+  "homepage": "https://enactjs.com", 
   "main": "src/spotlight.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -2,6 +2,12 @@
   "name": "@enact/spotlight",
   "version": "4.5.2",
   "description": "A focus management library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enactjs/enact.git",
+    "directory": "packages/spotlight"
+  },
+  "homepage": "https://github.com/enactjs/enact/tree/master/packages/spotlight#readme", 
   "main": "src/spotlight.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/enactjs/enact.git",
     "directory": "packages/ui"
   },
-  "homepage": "https://github.com/enactjs/enact/tree/master/packages/ui#readme", 
+  "homepage": "https://enactjs.com", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,12 @@
   "name": "@enact/ui",
   "version": "4.5.2",
   "description": "A collection of simplified unstyled cross-platform UI components for Enact",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enactjs/enact.git",
+    "directory": "packages/ui"
+  },
+  "homepage": "https://github.com/enactjs/enact/tree/master/packages/ui#readme", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/enactjs/enact.git",
     "directory": "packages/webos"
   },
-  "homepage": "https://github.com/enactjs/enact/tree/master/packages/webos#readme", 
+  "homepage": "https://enactjs.com", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -2,6 +2,12 @@
   "name": "@enact/webos",
   "version": "4.5.2",
   "description": "webOS support library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/enactjs/enact.git",
+    "directory": "packages/webos"
+  },
+  "homepage": "https://github.com/enactjs/enact/tree/master/packages/webos#readme", 
   "main": "index.js",
   "scripts": {
     "clean": "enact clean",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is no homepage and repository information in the enact packages page of npmjs.com

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add 'homepage' and 'repository' field to package.json according to the guide of https://docs.npmjs.com/cli/v8/configuring-npm/package-json

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11514

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)