### PR TITLE
WRO-11530: Update guide for using `bootstrap` 4 and above with enact

### DIFF
--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -37,7 +37,7 @@ For libraries like bootstrap, you can also import the css in your `App.less` fil
 @global-import 'bootstrap/dist/css/bootstrap.css';
 ```
 
-As of `Enact CLI 5.0.0` you can import `.scss` files. This makes it possible to use a package's built-in Sass variables for global style preferences.
+For bootstrap 4 or above, you need to import bootstrap's source Sass files in your `custom.scss`. Make sure you are using Enact CLI 5.0.0 or above.
 
 ```scss
 @import '~bootstrap/scss/bootstrap.scss';

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -37,6 +37,12 @@ For libraries like bootstrap, you can also import the css in your `App.less` fil
 @global-import 'bootstrap/dist/css/bootstrap.css';
 ```
 
+As of `Enact CLI 5.0.0` you can import `.scss` files. This makes it possible to use a package's built-in Sass variables for global style preferences.
+
+```scss
+@import '~bootstrap/scss/bootstrap.scss';
+```
+
 The advantage of this is you get to use Enact's `cli` to develop, test, and build applications.
 If you need to configure Webpack plugin, you can use the [`eject` command](../../developer-tools/cli/ejecting-apps) to copy all the configuration options to the app directory such as the `npm run eject` of the CRA app. After doing that, you don't need `cli` and your application is fully under your control.
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Bootstrap 4 and above uses Sass instead of less so we need to add the recent guide.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add the guide to import `.scss` files in bootstrap
(Guide page: https://enactjs.com/docs/developer-guide/interoperability/#using-third-party-components-inside-of-enact)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11530

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)