### PR TITLE
WRO-13490: Modify jsdocs comments for @link tag

### DIFF
--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -850,7 +850,7 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
  *
  * @returns  {HandlerFunction}           Returns an {@link core/handle.HandlerFunction|event handler}
  *										 (suitable for passing to handle) that returns the complement of the
- *                                       return value of `handler`
+ *										 return value of `handler`
  * @curried
  * @memberof core/handle
  * @public

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -849,8 +849,8 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
  * @param    {HandlerFunction}  handler  Handler to complement
  *
  * @returns  {HandlerFunction}           Returns an {@link core/handle.HandlerFunction|event handler}
- *										 (suitable for passing to handle) that returns the complement of the
- *										 return value of `handler`
+ *                                       (suitable for passing to handle) that returns the complement of the
+ *                                       return value of `handler`
  * @curried
  * @memberof core/handle
  * @public

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -686,7 +686,7 @@ const call = function (method) {
  * @param    {EventAdapter}     adapter  Function to adapt the event payload
  * @param    {HandlerFunction}  handler  Handler to call with the handler function
  *
- * @returns  {HandlerFunction}           Returns an [event handler]{@link core/handle.HandlerFunction} (suitable for passing to handle) that returns the result of `handler`
+ * @returns  {HandlerFunction}           Returns an {@link core/handle.HandlerFunction|event handler} (suitable for passing to handle) that returns the result of `handler`
  * @curried
  * @memberof core/handle
  * @public
@@ -723,9 +723,9 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
  * @param    {String}        name      Name of method on the `props`
  * @param    {EventAdapter}  [adapter] Function to adapt the event payload
  *
- * @returns  {HandlerFunction}         Returns an [event handler]{@link core/handle.EventHandler}
+ * @returns  {HandlerFunction}         Returns an {@link core/handle.EventHandler|event handler}
  *                                     (suitable for passing to handle or used directly within
- *                                     `handlers` in [kind]{@link core/kind}) that will forward the
+ *                                     `handlers` in {@link core/kind|kind}) that will forward the
  *                                     custom event.
  * @memberof core/handle
  * @public
@@ -788,9 +788,9 @@ const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
  * @param    {String}        name      Name of method on the `props`
  * @param    {EventAdapter}  [adapter] Function to adapt the event payload
  *
- * @returns  {HandlerFunction}         Returns an [event handler]{@link core/handle.EventHandler}
+ * @returns  {HandlerFunction}         Returns an {@link core/handle.EventHandler|event handler}
  *                                     (suitable for passing to handle or used directly within
- *                                     `handlers` in [kind]{@link core/kind}) that will forward the
+ *                                     `handlers` in {@link core/kind|kind}) that will forward the
  *                                     custom event and will return `false` if default action is prevented
  * @memberof core/handle
  * @private
@@ -848,9 +848,8 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
  * @method   not
  * @param    {HandlerFunction}  handler  Handler to complement
  *
- * @returns  {HandlerFunction}           Returns an [event
- *                                       handler]{@link core/handle.HandlerFunction} (suitable for
- *                                       passing to handle) that returns the complement of the
+ * @returns  {HandlerFunction}           Returns an {@link core/handle.HandlerFunction|event handler}
+ *										 (suitable for passing to handle) that returns the complement of the
  *                                       return value of `handler`
  * @curried
  * @memberof core/handle

--- a/packages/i18n/util/util.js
+++ b/packages/i18n/util/util.js
@@ -12,7 +12,7 @@ import '../src/glue';
 import {toLowerCase, toUpperCase} from '../src/case';
 
 /*
- * This regex pattern is used by the [isRtlText()]{@link i18n/utils.isRtlText} function.
+ * This regex pattern is used by the {@link i18n/utils.isRtlText|isRtlText()} function.
  *
  * Arabic: \u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFE
  * Hebrew: \u0590-\u05FF\uFB1D-\uFB4F
@@ -22,11 +22,11 @@ import {toLowerCase, toUpperCase} from '../src/case';
 const rtlPattern = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFE\u0590-\u05FF\uFB1D-\uFB4F]/;
 
 /**
- * Takes content `str` and determines whether or not it is [RTL]{@link /docs/developer-guide/glossary/#rtl}.
+ * Takes content `str` and determines whether or not it is {@link /docs/developer-guide/glossary/#rtl|RTL}.
  *
  * @function
  * @memberof i18n/util
- * @param {String} str - A string to check the [RTL]{@link /docs/developer-guide/glossary/#rtl}-ness of.
+ * @param {String} str - A string to check the {@link /docs/developer-guide/glossary/#rtl|RTL}-ness of.
  * @returns {Boolean} `true` if `str` should be RTL; `false` if not.
  * @public
  */

--- a/packages/spotlight/Pause/Pause.js
+++ b/packages/spotlight/Pause/Pause.js
@@ -3,8 +3,8 @@
  * another consumer's pause.
  *
  * When multiple components attempt to pause and resume spotlight at overlapping times using
- * [Spotlight.pause()]{@link spotlight.Spotlight.pause} and
- * [Spotlight.resume()]{@link spotlight.Spotlight.resume}, one component might resume spotlight when
+ * {@link spotlight.Spotlight.pause|Spotlight.pause()} and
+ * {@link spotlight.Spotlight.resume|Spotlight.resume()}, one component might resume spotlight when
  * another expected it to still be paused.
  *
  * `Pause` helps to address this by setting a "soft lock" on the pause which informs other instances
@@ -12,8 +12,8 @@
  * by the instance that locked it. Subsequent calls to `pause` and `resume` on another instance of
  * `Pause` have no effect.
  *
- * *Note:* The top-level [Spotlight.pause()]{@link spotlight.Spotlight.pause} and
- * [Spotlight.resume()]{@link spotlight.Spotlight.resume} do not respect the pause locks and act as
+ * *Note:* The top-level {@link spotlight.Spotlight.pause|Spotlight.pause()} and
+ * {@link spotlight.Spotlight.resume|Spotlight.resume()} do not respect the pause locks and act as
  * a user-space escape hatch.
  *
  * ```

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -248,7 +248,7 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		spotlightId: PropTypes.string,
 
 		/*
-		 * Called with a reference to [component]{@link spotlight/Spottable.Spottable#component}
+		 * Called with a reference to {@link spotlight/Spottable.Spottable#component|component}
 		 *
 		 * @type {Object|Function}
 		 * @private

--- a/packages/ui/BodyText/BodyText.js
+++ b/packages/ui/BodyText/BodyText.js
@@ -15,7 +15,7 @@ import componentCss from './BodyText.module.less';
 
 /**
  * A simple, unstyled text block component, without
- * [BodyTextDecorator](ui/BodyText.BodyTextDecorator) applied.
+ * {@link ui/BodyText.BodyTextDecorator|BodyTextDecorator} applied.
  *
  * @class BodyTextBase
  * @memberof ui/BodyText

--- a/packages/ui/BodyText/BodyText.js
+++ b/packages/ui/BodyText/BodyText.js
@@ -30,7 +30,7 @@ const BodyTextBase = kind({
 		 * Centers the contents.
 		 *
 		 * Applies the `centered` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @default false

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -105,10 +105,10 @@ const ButtonBase = kind({
 		icon: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
 
 		/**
-		 * The component used to render the [icon]{@link ui/Button.ButtonBase.icon}.
+		 * The component used to render the {@link ui/Button.ButtonBase.icon|icon}.
 		 *
 		 * This component will receive the `icon` class to customize its styling.
-		 * If [icon]{@link ui/Button.ButtonBase.icon} is not assigned or is false, this component
+		 * If {@link ui/Button.ButtonBase.icon|icon} is not assigned or is false, this component
 		 * will not be rendered.
 		 *
 		 * If this is a component rather than an HTML element string, this component will also
@@ -133,7 +133,7 @@ const ButtonBase = kind({
 		 * Enforces a minimum width for the component.
 		 *
 		 * Applies the `minWidth` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @default true
@@ -145,7 +145,7 @@ const ButtonBase = kind({
 		 * Indicates the component is depressed.
 		 *
 		 * Applies the `pressed` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -157,7 +157,7 @@ const ButtonBase = kind({
 		 * Indicates the component is selected.
 		 *
 		 * Applies the `selected` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -169,7 +169,7 @@ const ButtonBase = kind({
 		 * The size of the button.
 		 *
 		 * Applies the CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {String}
 		 * @public
@@ -247,7 +247,7 @@ const ButtonBase = kind({
 });
 
 /**
- * A higher-order component that adds touch support to a [ButtonBase]{@link ui/Button.ButtonBase}.
+ * A higher-order component that adds touch support to a {@link ui/Button.ButtonBase|ButtonBase}.
  *
  * @hoc
  * @memberof ui/Button

--- a/packages/ui/GridListImageItem/GridListImageItem.js
+++ b/packages/ui/GridListImageItem/GridListImageItem.js
@@ -83,7 +83,7 @@ const GridListImageItem = kind({
 		imageComponent: EnactPropTypes.component,
 
 		/**
-		 * Placeholder image used while [source]{@link ui/GridListImageItem.GridListImageItem#source}
+		 * Placeholder image used while {@link ui/GridListImageItem.GridListImageItem#source|source}
 		 * is loaded.
 		 *
 		 * @type {String}

--- a/packages/ui/Group/Group.js
+++ b/packages/ui/Group/Group.js
@@ -193,7 +193,7 @@ const GroupBase = kind({
 });
 
 /**
- * A higher-order component that adds behavior to [Group]{@link ui/Group.GroupBase}.
+ * A higher-order component that adds behavior to {@link ui/Group.GroupBase|Group}.
  *
  * @hoc
  * @memberof ui/Group

--- a/packages/ui/Group/GroupItem.js
+++ b/packages/ui/Group/GroupItem.js
@@ -10,7 +10,7 @@ import kind from '@enact/core/kind';
 import {isSelected, select as selectItem} from '../internal/selection';
 
 /**
- * Pick the `GroupItem`-specific props into a [private]{@link /developer-guide/glossary/#private} `itemProps` key to be extracted by
+ * Pick the `GroupItem`-specific props into a {@link /developer-guide/glossary/#private|private} `itemProps` key to be extracted by
  * `GroupItem` before passing the remaining on to the repeated `childComponent`
  *
  * @function

--- a/packages/ui/Heading/Heading.js
+++ b/packages/ui/Heading/Heading.js
@@ -151,7 +151,7 @@ const HeadingBase = kind({
 });
 
 /**
- * A higher-order component that adds behavior to [Heading]{@link ui/Heading.HeadingBase}.
+ * A higher-order component that adds behavior to {@link ui/Heading.HeadingBase|Heading}.
  *
  * @hoc
  * @memberof ui/Heading

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -68,7 +68,7 @@ const IconBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link ui/Icon.IconBase.iconList},
+		 * * A string that represents an icon from the {@link ui/Icon.IconBase.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution}).
@@ -96,8 +96,8 @@ const IconBase = kind({
 		 * The following classes are supported:
 		 *
 		 * * `icon` - The root component class
-		 * * `dingbat` - Applied when the value of [`icon`]{@link ui/Icon.IconBase.icon} is not
-		 *   found in [iconList]{@link ui/Icon.IconBase.iconList}
+		 * * `dingbat` - Applied when the value of {@link ui/Icon.IconBase.icon|icon} is not
+		 *   found in {@link ui/Icon.IconBase.iconList|iconList}
 		 * * `large` - Applied when `size` prop is `'large'`
 		 * * `pressed` - Applied when `pressed` prop is `true`
 		 * * `small` - Applied when `size` prop is `'small'`
@@ -142,7 +142,7 @@ const IconBase = kind({
 		 * The size of the button.
 		 *
 		 * Applies the CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {String}
 		 * @public
@@ -231,7 +231,7 @@ const IconBase = kind({
 });
 
 /**
- * A higher-order component that adds behavior to [Icon]{@link ui/Icon.IconBase}.
+ * A higher-order component that adds behavior to {@link ui/Icon.IconBase|Icon}.
  *
  * @hoc
  * @memberof ui/Icon

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -1,8 +1,8 @@
 /**
- * An [Icon]{@link ui/Icon.Icon} that acts like a [Button]{@link ui/Button.Button}.
+ * An {@link ui/Icon.Icon|Icon} that acts like a {@link ui/Button.Button|Button}.
  *
  * You may specify an image or a font-based icon by setting the `children` to either the path
- * to the image or a string from an [iconList]{@link ui/Icon.Icon.iconList}. This is unstyled,
+ * to the image or a string from an {@link ui/Icon.Icon.iconList|iconList}. This is unstyled,
  * but can easily be extended and customized by a theme or application.
  *
  * @module ui/IconButton
@@ -46,7 +46,7 @@ const IconButtonBase = kind({
 		buttonComponent: EnactPropTypes.componentOverride.isRequired,
 
 		/**
-		 * The component used to render the [icon]{@link ui/IconButton.IconButtonBase.icon}.
+		 * The component used to render the {@link ui/IconButton.IconButtonBase.icon|icon}.
 		 *
 		 * This component will receive the `flip` and `size` property set on the `IconButton` as well as the
 		 * `icon` class to customize its styling.
@@ -86,7 +86,7 @@ const IconButtonBase = kind({
 		 * The following classes are supported:
 		 *
 		 * * `iconButton` - The root component class
-		 * * `icon` - The [icon component]{@link ui/IconButton.IconButtonBase.iconComponent} class
+		 * * `icon` - The {@link ui/IconButton.IconButtonBase.iconComponent|icon component} class
 		 * * `large` - Applied when `size` prop is `'large'`
 		 * * `small` - Applied when `size` prop is `'small'`
 		 * * `pressed` - Applied when `pressed` prop is `true`
@@ -100,7 +100,7 @@ const IconButtonBase = kind({
 		 * Disables IconButton.
 		 *
 		 * When `true`, the button is shown as disabled and does not generate
-		 * `onClick` [events]{@link /docs/developer-guide/glossary/#event}.
+		 * `onClick` {@link /docs/developer-guide/glossary/#event|events}.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -148,7 +148,7 @@ const IconButtonBase = kind({
 		 * The size of the button.
 		 *
 		 * Applies the CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {String}
 		 * @public
@@ -195,7 +195,7 @@ const IconButtonBase = kind({
 });
 
 /**
- * A higher-order component that adds universal button behaviors to an [IconButtonBase]{@link ui/IconButton.IconButtonBase}.
+ * A higher-order component that adds universal button behaviors to an {@link ui/IconButton.IconButtonBase|IconButtonBase}.
  *
  * @hoc
  * @memberof ui/IconButton

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -193,7 +193,7 @@ const ImageBase = kind({
 });
 
 /**
- * A higher-order component that adds behaviors to an [ImageBase]{@link ui/Image.ImageBase}.
+ * A higher-order component that adds behaviors to an {@link ui/Image.ImageBase|ImageBase}.
  *
  * @hoc
  * @memberof ui/Image

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -173,7 +173,7 @@ const ImageItemBase = kind({
 
 /**
  * A higher-order component that adds behaviors to an
- * [ImageItemBase]{@link ui/ImageItem.ImageItemBase}.
+ * {@link ui/ImageItem.ImageItemBase|ImageItemBase}.
  *
  * @hoc
  * @memberof ui/ImageItem

--- a/packages/ui/Item/Item.js
+++ b/packages/ui/Item/Item.js
@@ -50,7 +50,7 @@ const ItemBase = kind({
 		component: EnactPropTypes.renderable,
 
 		/**
-		 * Called with a reference to [component]{@link ui/Item.ItemBase#component}
+		 * Called with a reference to {@link ui/Item.ItemBase#component|component}
 		 *
 		 * @type {Object|Function}
 		 * @private

--- a/packages/ui/LabeledIcon/LabeledIcon.js
+++ b/packages/ui/LabeledIcon/LabeledIcon.js
@@ -122,7 +122,7 @@ const LabeledIconBase = kind({
 		 * Enables this component to be used in an "inline" context.
 		 *
 		 * This is useful for when you have several of these components in a row and are not using a
-		 * [Layout]{@link ui/Layout} or flex-box configuration.
+		 * {@link ui/Layout|Layout} or flex-box configuration.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -153,7 +153,7 @@ const LabeledIconBase = kind({
 		 * The size of the icon.
 		 *
 		 * Applies the CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {String}
 		 * @public
@@ -241,7 +241,7 @@ const LabeledIconBase = kind({
 });
 
 /**
- * A higher-order component that adds [slot]{@link ui/Slottable.Slottable} support to [LabeledIconBase]{@link ui/LabeledIcon.LabeledIconBase}
+ * A higher-order component that adds {@link ui/Slottable.Slottable|slot} support to {@link ui/LabeledIcon.LabeledIconBase|LabeledIconBase}
  *
  * @hoc
  * @memberof ui/LabeledIcon

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -15,7 +15,7 @@ const toFlexAlign = (align) => (
 
 /**
  * A stateless component that provides a space for your content in a
- * [Layout]{@link ui/Layout.Layout}, without [CellDecorator](ui/Layout.CellDecorator) applied.
+ * {@link ui/Layout.Layout|Layout}, without [CellDecorator](ui/Layout.CellDecorator) applied.
  *
  * @class CellBase
  * @memberof ui/Layout
@@ -42,7 +42,7 @@ const CellBase = kind({
 		align: PropTypes.string,
 
 		/**
-		 * Any valid [Node]{@link /docs/developer-guide/glossary/#node} that should be positioned in this `Cell`.
+		 * Any valid {@link /docs/developer-guide/glossary/#node|Node} that should be positioned in this `Cell`.
 		 *
 		 * @type {Any}
 		 * @public
@@ -76,7 +76,7 @@ const CellBase = kind({
 		 * A `shrink`able cell will contract to its minimum size, according to the dimensions of its
 		 * contents. This is used when you want the size of this Cell's content to influence the
 		 * dimensions of this cell. `shrink` will not allow the contents of the Layout to be pushed
-		 * beyond its boundaries (overflowing). See the [size]{@link ui/Layout.Cell#size} property
+		 * beyond its boundaries (overflowing). See the {@link ui/Layout.Cell#size|size} property
 		 * for more details.
 		 *
 		 * @type {Boolean}
@@ -88,7 +88,7 @@ const CellBase = kind({
 		/**
 		 * Sets the desired size of the Cell using any valid CSS measurement value.
 		 *
-		 * When used in conjunction with [shrink]{@link ui/Layout.Cell#shrink}, the size will be
+		 * When used in conjunction with {@link ui/Layout.Cell#shrink|shrink}, the size will be
 		 * the maximum size, shrinking as necessary, to fit the content.
 		 *
 		 * E.g.
@@ -98,8 +98,8 @@ const CellBase = kind({
 		 *
 		 * This accepts any valid CSS measurement value string. If a numeric value is used, it will
 		 * be treated as a pixel value and converted to a
-		 * [relative unit]{@link ui/resolution.unit} based on the rules of
-		 * [resolution independence]{@link ui/resolution}.
+		 * {@link ui/resolution.unit|relative unit} based on the rules of
+		 * {@link ui/resolution|resolution independence}.
 		 *
 		 * @type {String|Number}
 		 * @public
@@ -162,7 +162,7 @@ const CellDecorator = ForwardRef({prop: 'componentRef'});
 
 /**
  * A stateless component that provides a space for your content in a
- * [Layout]{@link ui/Layout.Layout}.
+ * {@link ui/Layout.Layout|Layout}.
  *
  * @class Cell
  * @memberof ui/Layout

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -6,8 +6,8 @@
  * which were largely abandoned for their drawbacks, ignoring their strengths. A `Layout` is simply
  * a container for `Cell`, the only "legal" child. Conversely, `Cell` may only be used in a
  * `Layout`. Cells in a Layout can either be positioned next to each other (horizontally) or
- * above/below each other (vertically) in what we refer to as a [Row]{@link ui/Layout.Row} or
- * [Column]{@link ui/Layout.Column}, respectively.
+ * above/below each other (vertically) in what we refer to as a {@link ui/Layout.Row|Row} or
+ * {@link ui/Layout.Column|Column}, respectively.
  *
  * The `Row` and `Column` layout presets describe the direction of layout for their children. This
  * can sometimes cause confusion. A `Row` of children naturally forms a _layout_ whose children can
@@ -136,9 +136,9 @@ import css from './Layout.module.less';
 /**
  * A container for `Cell`s.
  *
- * A stateless component that acts as a containing area for [Cells]{@link ui/Layout.Cell} to be
+ * A stateless component that acts as a containing area for {@link ui/Layout.Cell|Cells} to be
  * positioned in a row or a column (horizontally or vertically, respectively. It supports an
- * [orientation]{@link ui/Layout.Layout#orientation} property for laying-out its contents
+ * {@link ui/Layout.Layout#orientation|orientation} property for laying-out its contents
  * (`Cells`) in an organized, readable way.
  *
  * Example:
@@ -170,7 +170,7 @@ const LayoutBase = kind({
 		/**
 		 * The alignment of children.
 		 *
-		 * Aligns the children [Cells]{@link ui/Layout.Cell} vertically in the case of a horizontal
+		 * Aligns the children {@link ui/Layout.Cell|Cells} vertically in the case of a horizontal
 		 * layout or horizontally in the case of a vertical layout. `"start"`, `"center"` and
 		 * `"end"` are the most commonly used, although all values of `align-items` are supported.
 		 * `"start"` refers to the top in a horizontal layout, and left in a vertical LTR layout
@@ -187,7 +187,7 @@ const LayoutBase = kind({
 		align: PropTypes.string,
 
 		/**
-		 * Only [Cell]{@link ui/Layout.Cell} components are supported as children.
+		 * Only {@link ui/Layout.Cell|Cell} components are supported as children.
 		 *
 		 * @type {Cell|Cell[]}
 		 * @public
@@ -226,7 +226,7 @@ const LayoutBase = kind({
 		inline: PropTypes.bool,
 
 		/**
-		 * The orientation of the `Layout`, i.e. how the children [Cells]{@link ui/Layout.Cell} are
+		 * The orientation of the `Layout`, i.e. how the children {@link ui/Layout.Cell|Cells} are
 		 * positioned on the screen. Must be either `'horizontal'` or `'vertical'`.
 		 *
 		 * @type {String}
@@ -312,9 +312,9 @@ const LayoutDecorator = ForwardRef({prop: 'componentRef'});
 /**
  * A container for `Cell`s.
  *
- * A stateless component that acts as a containing area for [Cells]{@link ui/Layout.Cell} to be
+ * A stateless component that acts as a containing area for {@link ui/Layout.Cell|Cells} to be
  * positioned in a row or a column (horizontally or vertically, respectively. It supports an
- * [orientation]{@link ui/Layout.Layout#orientation} property for laying-out its contents
+ * {@link ui/Layout.Layout#orientation|orientation} property for laying-out its contents
  * (`Cells`) in an organized, readable way.
  *
  * Example:
@@ -346,7 +346,7 @@ const Layout = LayoutDecorator(LayoutBase);
 
 /**
  * Shorthand for `<Layout orientation="vertical">`, which positions its
- * [Cells]{@link ui/Layout.Cell} vertically.
+ * {@link ui/Layout.Cell|Cells} vertically.
  * ```
  * ┌────┐
  * ├────┤
@@ -372,7 +372,7 @@ Column.displayName = 'Column';
 
 /**
  * Shorthand for `<Layout orientation="horizontal">`, which positions its
- * [Cells]{@link ui/Layout.Cell} horizontally.
+ * {@link ui/Layout.Cell|Cells} horizontally.
  * ```
  * ┌─┬─┬─┬─┐
  * │ │ │ │ │

--- a/packages/ui/Placeholder/index.js
+++ b/packages/ui/Placeholder/index.js
@@ -2,7 +2,7 @@
  * Exports the {@link ui/Placeholder.PlaceholderControllerDecorator} and
  * {@link ui/Placeholder.PlaceholderDecorator} higher-order components.
  *
- * The default export is [PlaceholderDecorator]{@link ui/Placeholder.PlaceholderDecorator}.
+ * The default export is {@link ui/Placeholder.PlaceholderDecorator|PlaceholderDecorator}.
  *
  * @module ui/Placeholder
  * @exports PlaceholderControllerDecorator

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -201,7 +201,7 @@ const ProgressBarBase = kind({
 
 /**
  * A higher-order component that adds behavior to
- * [ProgressBar]{@link ui/ProgressBar.ProgressBarBase}.
+ * {@link ui/ProgressBar.ProgressBarBase|ProgressBar}.
  *
  * @hoc
  * @memberof ui/ProgressBar

--- a/packages/ui/Resizable/Resizable.js
+++ b/packages/ui/Resizable/Resizable.js
@@ -55,13 +55,13 @@ const defaultConfig = {
  * A higher-order component that notifies a container that the wrapped component has been resized.
  *
  * It may be useful in cases where a component may need to update itself as a result of its children
- * changing in size, such as a [Scroller]{@link ui/Scroller}.
+ * changing in size, such as a {@link ui/Scroller|Scroller}.
  *
  * Containers must provide an `invalidateBounds` method via React's context in order for `Resizable`
  * instances to notify it of resize.
  *
  * The wrapped component must respond to the configured
- * [resize]{@link ui/Resizable.Resizable.defaultConfig.resize} event.
+ * {@link ui/Resizable.Resizable.defaultConfig.resize|resize} event.
  *
  * @class Resizable
  * @memberof ui/Resizable

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -59,10 +59,10 @@ const LinkBase = kind({
 });
 
 /**
- * A higher-order component adds support to a component to handle `navigate` from [`Routable`]{@link ui/Routable.Routable}.
+ * A higher-order component adds support to a component to handle `navigate` from {@link ui/Routable.Routable|Routable}.
  * It has configuration placed in the first argument to define which event will be used to navigate.
  * `onClick` event is used by default. Thus, if you don't configure it, the component should forward `onClick` event
- * to make [`Routable`]{@link ui/Routable.Routable} know when navigation is triggered.
+ * to make {@link ui/Routable.Routable|Routable} know when navigation is triggered.
  *
  * Example:
  * ```
@@ -131,7 +131,7 @@ const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
 });
 
 /**
- * A component that is used to make a link to navigate among [`Route`]{@link ui/Routable.Route} components.
+ * A component that is used to make a link to navigate among {@link ui/Routable.Route|Route} components.
  *
  * In the following example, `Sample` would render `Main` with two Links for `About` and `FAQ`.
  * If `About` is clicked, the content of `About` would be displayed under `Main`.

--- a/packages/ui/Routable/Routable.js
+++ b/packages/ui/Routable/Routable.js
@@ -20,7 +20,7 @@ import Router from './Router';
 import {propTypes, toSegments, RouteContext, resolve} from './util';
 
 /**
- * Default config for [`Routable`]{@link ui/Routable.Routable}.
+ * Default config for {@link ui/Routable.Routable|Routable}.
  *
  * @memberof ui/Routable.Routable
  * @hocconfig
@@ -29,7 +29,7 @@ const defaultConfig = {
 	/**
 	 * The event to listen to for path changes.
 	 *
-	 * This defines the actual name of the [navigate]{@link ui/Routable.Routable#navigate}
+	 * This defines the actual name of the {@link ui/Routable.Routable#navigate|navigate}
 	 * property.
 	 *
 	 * @type {String}

--- a/packages/ui/Routable/Router.js
+++ b/packages/ui/Routable/Router.js
@@ -8,7 +8,7 @@ import ForwardRef from '../ForwardRef';
 import {propTypes, stringifyRoutes, toSegments} from './util';
 
 /**
- * A Router component for use with [`ViewManager`]{@link ui/ViewManager.ViewManager}
+ * A Router component for use with {@link ui/ViewManager.ViewManager|ViewManager}
  *
  * @class Router
  * @memberof ui/Routable
@@ -45,7 +45,7 @@ const RouterBase = class extends ReactComponent {
 		component: EnactPropTypes.renderable,
 
 		/**
-		 * Called with a reference to [component]{@link ui/Routable.Router#component}.
+		 * Called with a reference to {@link ui/Routable.Router#component|component}.
 		 *
 		 * @type {Object|Function}
 		 * @private

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -154,7 +154,7 @@ class ScrollableBase extends Component {
 		/**
 		 * Direction of the list or the scroller.
 		 *
-		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
+		 * `'both'` could be only used for {@link ui/Scroller.Scroller|Scroller}.
 		 *
 		 * Valid values are:
 		 * * `'both'`,

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -140,7 +140,7 @@ class ScrollableBaseNative extends Component {
 		/**
 		 * Direction of the list or the scroller.
 		 *
-		 * `'both'` could be only used for[Scroller]{@link ui/Scroller.Scroller}.
+		 * `'both'` could be only used for {@link ui/Scroller.Scroller|Scroller}.
 		 *
 		 * Valid values are:
 		 * * `'both'`,

--- a/packages/ui/Scrollable/Scrollbar.js
+++ b/packages/ui/Scrollable/Scrollbar.js
@@ -28,7 +28,7 @@ const setCSSVariable = (element, variable, value) => {
 };
 
 /**
- * An unstyled base component for a scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
+ * An unstyled base component for a scroll bar. It is used in {@link ui/Scrollable.Scrollable|Scrollable}.
  *
  * @class ScrollbarBase
  * @memberof ui/Scrollable
@@ -192,7 +192,7 @@ class ScrollbarBase extends PureComponent {
 }
 
 /**
- * An unstyled scroll bar. It is used in [Scrollable]{@link ui/Scrollable.Scrollable}.
+ * An unstyled scroll bar. It is used in {@link ui/Scrollable.Scrollable|Scrollable}.
  *
  * @class Scrollbar
  * @memberof ui/Scrollable

--- a/packages/ui/Slider/Slider.js
+++ b/packages/ui/Slider/Slider.js
@@ -134,7 +134,7 @@ const SliderBase = kind({
 		 * The maximum value of the slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link ui/Slider.SliderBase.step}.
+		 * {@link ui/Slider.SliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 100
@@ -146,7 +146,7 @@ const SliderBase = kind({
 		 * The minimum value of the slider.
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link ui/Slider.SliderBase.step}.
+		 * {@link ui/Slider.SliderBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @default 0
@@ -324,7 +324,7 @@ const SliderBase = kind({
 });
 
 /**
- * Adds touch and drag support to a [SliderBase]{@link ui/Slider.SliderBase}.
+ * Adds touch and drag support to a {@link ui/Slider.SliderBase|SliderBase}.
  *
  * @hoc
  * @memberof ui/Slider

--- a/packages/ui/SlotItem/SlotItem.js
+++ b/packages/ui/SlotItem/SlotItem.js
@@ -36,7 +36,7 @@ const SlotItemBase = kind({
 		 * The type of component to use to render the item.
 		 *
 		 * This component will receive the `inline` prop and any additional unhandled props provided
-		 * to `SlotItem`. A derivative of [Item]{@link ui/Item.Item} is recommended.
+		 * to `SlotItem`. A derivative of {@link ui/Item.Item|Item} is recommended.
 		 *
 		 * @type {Component}
 		 * @required
@@ -181,7 +181,7 @@ const SlotItemBase = kind({
 });
 
 /**
- * A ui-specific higher-order component (HOC) with slot behaviors to apply to [SlotItem]{@link ui/SlotItem.SlotItemBase}.
+ * A ui-specific higher-order component (HOC) with slot behaviors to apply to {@link ui/SlotItem.SlotItemBase|SlotItem}.
  *
  * @class SlotItemDecorator
  * @memberof ui/SlotItem

--- a/packages/ui/Slottable/Slottable.js
+++ b/packages/ui/Slottable/Slottable.js
@@ -1,7 +1,7 @@
 /**
  * Provides a higher-order component that render child components into pre-designated slots.
  *
- * See [SlotItem]{@link ui/SlotItem.SlotItemDecorator} for the use of `Slottable`.
+ * See {@link ui/SlotItem.SlotItemDecorator|SlotItem} for the use of `Slottable`.
  *
  * @module ui/Slottable
  * @exports Slottable

--- a/packages/ui/Spinner/Spinner.js
+++ b/packages/ui/Spinner/Spinner.js
@@ -6,7 +6,7 @@
  * screen, and hooks into the interaction blocking code and scrim management.
  *
  * The theme using this component must supply a `component` element which follows the requirements
- * listed by the [component]{@link ui/Spinner.Spinner.component} prop documentation.
+ * listed by the {@link ui/Spinner.Spinner.component|component} prop documentation.
  *
  * @module ui/Spinner
  * @exports Spinner
@@ -61,7 +61,7 @@ const SpinnerBase = kind({
 		 * * 'container' blocks up to the nearest ancestor with absolute or relative positioning
 		 *
 		 * When `blockClickOn` is either `'screen'` or `'container'`, a translucent scrim can be added
-		 * by setting [scrim]{@link ui/Spinner.Spinner#scrim} prop to `true`.
+		 * by setting {@link ui/Spinner.Spinner#scrim|scrim} prop to `true`.
 		 *
 		 * @type {String|null}
 		 * @public

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -3,7 +3,7 @@
  *
  * This is not intended to be used directly, but should be extended by a component that will
  * customize this component's appearance by supplying an
- * [iconComponent prop]{@link ui/ToggleItem.ToggleItemBase#iconComponent}.
+ * {@link ui/ToggleItem.ToggleItemBase#iconComponent|iconComponent prop}.
  *
  * @module ui/ToggleItem
  * @exports ToggleItem
@@ -88,7 +88,7 @@ const ToggleItemBase = kind({
 		 *
 		 * This receives the `css` prop for theme extension and therefore must be a custom
 		 * component and not a simple HTML DOM node. Recommended component or themed
-		 * derivative: [SlotItem]{@link ui/SlotItem.SlotItem}
+		 * derivative: {@link ui/SlotItem.SlotItem|SlotItem}
 		 *
 		 * @type {Component}
 		 * @required
@@ -101,7 +101,7 @@ const ToggleItemBase = kind({
 		 *
 		 * This component receives the `selected` prop and value,
 		 * and must therefore respond to it in some way. It is recommended to use
-		 * [ToggleIcon]{@link ui/ToggleIcon} for this.
+		 * {@link ui/ToggleIcon|ToggleIcon} for this.
 		 *
 		 * @type {Component|Element}
 		 * @required
@@ -145,7 +145,7 @@ const ToggleItemBase = kind({
 		/**
 		 * An optional prop that lets you override the icon of the `iconComponent` component.
 		 *
-		 * This accepts any string that the [Icon]{@link ui/Icon.Icon} component supports, provided
+		 * This accepts any string that the {@link ui/Icon.Icon|Icon} component supports, provided
 		 * the recommendations of `iconComponent` are followed.
 		 *
 		 * @type {String|Object}

--- a/packages/ui/ViewManager/TransitionGroup.js
+++ b/packages/ui/ViewManager/TransitionGroup.js
@@ -94,7 +94,7 @@ class TransitionGroup extends Component {
 		component: EnactPropTypes.renderable,
 
 		/**
-		 * Called with a reference to [component]{@link ui/ViewManager.TransitionGroup#component}
+		 * Called with a reference to {@link ui/ViewManager.TransitionGroup#component|component}
 		 *
 		 * @type {Object|Function}
 		 * @private

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -26,7 +26,7 @@ import {wrapWithView} from './View';
 
 /**
  * The base `ViewManager` component, without
- * [ViewManagerDecorator]{@link ui/ViewManager.ViewManagerDecorator} applied.
+ * {@link ui/ViewManager.ViewManagerDecorator|ViewManagerDecorator} applied.
  *
  * @class ViewManagerBase
  * @memberof ui/ViewManager

--- a/packages/ui/VirtualList/UiVirtualListBase.js
+++ b/packages/ui/VirtualList/UiVirtualListBase.js
@@ -82,7 +82,7 @@ const VirtualListBaseFactory = (type) => {
 
 			/**
 			 * Callback method of scrollTo.
-			 * Normally, [Scrollable]{@link ui/Scrollable.Scrollable} should set this value.
+			 * Normally, {@link ui/Scrollable.Scrollable|Scrollable} should set this value.
 			 *
 			 * @type {Function}
 			 * @private
@@ -1163,7 +1163,7 @@ const VirtualListBaseFactory = (type) => {
 
 /**
  * A basic base component for
- * [VirtualList]{@link ui/VirtualList.VirtualList} and [VirtualGridList]{@link ui/VirtualList.VirtualGridList}.
+ * {@link ui/VirtualList.VirtualList|VirtualList} and {@link ui/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @class VirtualListBase
  * @memberof ui/VirtualList
@@ -1175,7 +1175,7 @@ VirtualListBase.displayName = 'ui:VirtualListBase';
 
 /**
  * A basic base component for
- * [VirtualListNative]{@link ui/VirtualList.VirtualListNative} and [VirtualGridListNative]{@link ui/VirtualList.VirtualGridListNative}.
+ * {@link ui/VirtualList.VirtualListNative|VirtualListNative} and {@link ui/VirtualList.VirtualGridListNative|VirtualGridListNative}.
  *
  * @class VirtualListBaseNative
  * @memberof ui/VirtualList

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -13,7 +13,7 @@ const nop = () => {};
 
 /**
  * The shape for the grid list item size
- * in a list for [VirtualGridList]{@link ui/VirtualList.VirtualGridList}.
+ * in a list for {@link ui/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @typedef {Object} gridListItemSizeShape
  * @memberof ui/VirtualList
@@ -28,7 +28,7 @@ const gridListItemSizeShape = PropTypes.shape({
 
 /**
  * The shape for the list different item size
- * in a list for [VirtualList]{@link ui/VirtualList.VirtualList}.
+ * in a list for {@link ui/VirtualList.VirtualList|VirtualList}.
  *
  * @typedef {Object} itemSizesShape
  * @memberof ui/VirtualList
@@ -43,7 +43,7 @@ const itemSizesShape = PropTypes.shape({
 
 /**
  * A basic base component for
- * [VirtualList]{@link ui/VirtualList.VirtualList} and [VirtualGridList]{@link ui/VirtualList.VirtualGridList}.
+ * {@link ui/VirtualList.VirtualList|VirtualList} and {@link ui/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @class VirtualListBasic
  * @memberof ui/VirtualList


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara [adrian.cocoara@lgepartner.com](mailto:adrian.cocoara@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`documentation` module from `docs-utils` has updated to version 14.0.0. In order for the links to be rendered correctly, they have been changed as:
[BodyText]{@link ui/BodyText.BodyText}
=> {@link ui/BodyText.BodyText|BodyText}

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13490

### Comments
