### PR TITLE
WRO-13025: Set default target for Event listeners properly when snapshot build

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/dispatcher`  to set the default target for event listeners properly when built with the snapshot option
+
 ## [4.5.2] - 2022-08-17
 
 No significant changes.

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -36,7 +36,11 @@ const setDefaultTargetById = (id) => {
  * @memberof core/dispatcher
  * @private
  */
-const getDefaultTarget = () => defaultTarget;
+const getDefaultTarget = () => {
+	console.log("getDefaultTarget defaultTarget= ");
+	console.log(defaultTarget);
+	return defaultTarget || (typeof document === 'object' && document);
+};
 
 /*
  * Wraps event callbacks with a try-catch block to prevent unrelated code from blocking.
@@ -91,6 +95,13 @@ const dispatcher = function (ev) {
  * @public
  */
 const on = function (name, fn, target = getDefaultTarget()) {
+	console.log("on. target =");
+	console.log(target);
+	console.log(document);
+	console.log(target === document);
+
+	console.log("===========");
+
 	if (target) {
 		const added = addListener(target, name, fn);
 

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -12,6 +12,7 @@ import curry from 'ramda/src/curry';
 import {getListeners, addListener} from './listeners';
 
 let defaultTarget = typeof document === 'object' && document;
+let rootId;
 
 /*
  * Sets a selector for the default target. If no selector is set, `document` is the default target.
@@ -25,6 +26,7 @@ let defaultTarget = typeof document === 'object' && document;
  */
 const setDefaultTargetById = (id) => {
 	defaultTarget = typeof document === 'object' && document.querySelector('#' + id) || defaultTarget;
+	rootId = id;
 };
 
 /*
@@ -37,9 +39,10 @@ const setDefaultTargetById = (id) => {
  * @private
  */
 const getDefaultTarget = () => {
-	console.log("getDefaultTarget defaultTarget= ");
-	console.log(defaultTarget);
-	return defaultTarget; // || (typeof document === 'object' && document);
+	if (!defaultTarget) {
+		setDefaultTargetById(rootId);
+	}
+	return defaultTarget;
 };
 
 /*

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -98,13 +98,6 @@ const dispatcher = function (ev) {
  * @public
  */
 const on = function (name, fn, target = getDefaultTarget()) {
-	console.log("on. target =");
-	console.log(target);
-	console.log(document);
-	console.log(target === document);
-
-	console.log("===========");
-
 	if (target) {
 		const added = addListener(target, name, fn);
 

--- a/packages/core/dispatcher/dispatcher.js
+++ b/packages/core/dispatcher/dispatcher.js
@@ -39,7 +39,7 @@ const setDefaultTargetById = (id) => {
 const getDefaultTarget = () => {
 	console.log("getDefaultTarget defaultTarget= ");
 	console.log(defaultTarget);
-	return defaultTarget || (typeof document === 'object' && document);
+	return defaultTarget; // || (typeof document === 'object' && document);
 };
 
 /*

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -134,11 +134,7 @@ class FloatingLayerBase extends Component {
 			this.controller = this.context(this.handleNotify.bind(this));
 		}
 
-		console.log("FloatingLayer ComponentDidmout scrimType=" + this.props.scrimType);
-
 		if (this.props.scrimType === 'none' && this.props.open) {
-			console.log("FloatingLayer ComponentDidmout on handleClick");
-
 			on('click', this.handleClick);
 		}
 	}
@@ -160,15 +156,11 @@ class FloatingLayerBase extends Component {
 			forwardCustom('onOpen')(null, this.props);
 		}
 
-		console.log("FloatingLayer componentDidUpdate scrimType=" + this.props.scrimType);
-
 		if (scrimType === 'none') {
 			if (!prevProps.open && open) {
-				console.log("FloatingLayer componentDidUpdate on handleClick1");
-				on('click', this.handleClick);
+				on('click', this.handleClick );
 			} else if (prevProps.open && !open) {
 				off('click', this.handleClick);
-				console.log("FloatingLayer componentDidUpdate on handleClick2");
 			}
 		}
 	}
@@ -203,16 +195,12 @@ class FloatingLayerBase extends Component {
 	}
 
 	handleClose = handle(
-		()=>{console.log("FloatingLayer handleClose1"); return true;},
 		forProp('open', true),
-		()=>{console.log("FloatingLayer handleClose2"); return true;},
 		forwardCustom('onDismiss')
 	).bind(this);
 
 	handleClick = handle(
-		()=>{console.log("FloatingLayer handleClick"); return true;},
 		forProp('noAutoDismiss', false),
-		()=>{console.log("FloatingLayer handleClick"); return true;},
 		forProp('open', true),
 		forwardCustom('onDismiss', () => ({detail: {inputType: 'click'}}))
 	).bind(this);
@@ -254,8 +242,6 @@ class FloatingLayerBase extends Component {
 		delete rest.onDismiss;
 		delete rest.onOpen;
 
-		console.log("FloatingLayer render. scrimType = " + scrimType);
-
 		if (open && this.state.readyToRender) {
 			return ReactDOM.createPortal(
 				<div className={mergedClassName} {...rest}>
@@ -272,9 +258,7 @@ class FloatingLayerBase extends Component {
 
 const handleCancel = handle(
 	// can't use forProp safely since either could be undefined ~= false
-	()=>{console.log("FloatingLayer handleClose"); return true;},
 	(ev, {open, noAutoDismiss, onDismiss}) => open && !noAutoDismiss && onDismiss,
-	()=>{console.log("FloatingLayer handleClose2"); return true;},
 	forwardCustom('onDismiss', () => ({detail: {inputType: 'key'}})),
 	stop
 );

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -195,12 +195,16 @@ class FloatingLayerBase extends Component {
 	}
 
 	handleClose = handle(
+		()=>{console.log("FloatingLayer handleClose1"); return true;},
 		forProp('open', true),
+		()=>{console.log("FloatingLayer handleClose2"); return true;},
 		forwardCustom('onDismiss')
 	).bind(this);
 
 	handleClick = handle(
+		()=>{console.log("FloatingLayer handleClick"); return true;},
 		forProp('noAutoDismiss', false),
+		()=>{console.log("FloatingLayer handleClick"); return true;},
 		forProp('open', true),
 		forwardCustom('onDismiss', () => ({detail: {inputType: 'click'}}))
 	).bind(this);
@@ -258,7 +262,9 @@ class FloatingLayerBase extends Component {
 
 const handleCancel = handle(
 	// can't use forProp safely since either could be undefined ~= false
+	()=>{console.log("FloatingLayer handleClose"); return true;},
 	(ev, {open, noAutoDismiss, onDismiss}) => open && !noAutoDismiss && onDismiss,
+	()=>{console.log("FloatingLayer handleClose2"); return true;},
 	forwardCustom('onDismiss', () => ({detail: {inputType: 'key'}})),
 	stop
 );

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -134,7 +134,11 @@ class FloatingLayerBase extends Component {
 			this.controller = this.context(this.handleNotify.bind(this));
 		}
 
+		console.log("FloatingLayer ComponentDidmout scrimType=" + this.props.scrimType);
+
 		if (this.props.scrimType === 'none' && this.props.open) {
+			console.log("FloatingLayer ComponentDidmout on handleClick");
+
 			on('click', this.handleClick);
 		}
 	}
@@ -156,11 +160,15 @@ class FloatingLayerBase extends Component {
 			forwardCustom('onOpen')(null, this.props);
 		}
 
+		console.log("FloatingLayer componentDidUpdate scrimType=" + this.props.scrimType);
+
 		if (scrimType === 'none') {
 			if (!prevProps.open && open) {
+				console.log("FloatingLayer componentDidUpdate on handleClick1");
 				on('click', this.handleClick);
 			} else if (prevProps.open && !open) {
 				off('click', this.handleClick);
+				console.log("FloatingLayer componentDidUpdate on handleClick2");
 			}
 		}
 	}
@@ -245,6 +253,8 @@ class FloatingLayerBase extends Component {
 		delete rest.onClose;
 		delete rest.onDismiss;
 		delete rest.onOpen;
+
+		console.log("FloatingLayer render. scrimType = " + scrimType);
 
 		if (open && this.state.readyToRender) {
 			return ReactDOM.createPortal(

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -158,7 +158,7 @@ class FloatingLayerBase extends Component {
 
 		if (scrimType === 'none') {
 			if (!prevProps.open && open) {
-				on('click', this.handleClick );
+				on('click', this.handleClick);
 			} else if (prevProps.open && !open) {
 				off('click', this.handleClick);
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ContextualPopup is not dismissed when click ouside aria in Enact browser with Agate

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Cause :
`onClick` event listeners cannot get event, because the `defaultTarget` is `false` when snapshot build.

Resoution:
setDefaultTarget again when defaultTarget is falsy.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There could be other approaches that we fix Agate. 
But this is a more general and safe way to cover all timing and themes.

### Links
[//]: # (Related issues, references)
WRO-13025

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)