### PR TITLE
WRO-13139: Sampler: Remove controls from Docs tab

### DIFF
--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -6,7 +6,6 @@ import {themes} from '@storybook/theming';
 
 import Environment from '../src/Environment';
 
-
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
 	'local':                                                             '',

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -43,7 +43,7 @@ export const parameters = {
 	docs: {
 		container: DocsContainer,
 		inlineStories: false,
-		iframeHeight: ri.scaleToRem(900),
+		iframeHeight: ri.scaleToRem(300),
 		page: () => (
 			<>
 				<Title />

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -1,10 +1,11 @@
 import {configureActions} from '@enact/storybook-utils/addons/actions';
 import {getBooleanType, getObjectType} from '@enact/storybook-utils/addons/controls';
 import {DocsContainer, Primary, Title} from '@enact/storybook-utils/addons/docs';
+import ri from '@enact/ui/resolution';
 import {themes} from '@storybook/theming';
 
 import Environment from '../src/Environment';
-import ri from "../../ui/resolution";
+
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -1,9 +1,10 @@
 import {configureActions} from '@enact/storybook-utils/addons/actions';
 import {getBooleanType, getObjectType} from '@enact/storybook-utils/addons/controls';
-import {DocsPage, DocsContainer} from '@enact/storybook-utils/addons/docs';
+import {DocsContainer, Primary, Title} from '@enact/storybook-utils/addons/docs';
 import {themes} from '@storybook/theming';
 
 import Environment from '../src/Environment';
+import ri from "../../ui/resolution";
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
@@ -41,7 +42,14 @@ configureActions();
 export const parameters = {
 	docs: {
 		container: DocsContainer,
-		page: DocsPage,
+		inlineStories: false,
+		iframeHeight: ri.scaleToRem(300),
+		page: () => (
+			<>
+				<Title />
+				<Primary />
+			</>
+		),
 		theme: themes.light
 	},
 	options: {

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -43,7 +43,7 @@ export const parameters = {
 	docs: {
 		container: DocsContainer,
 		inlineStories: false,
-		iframeHeight: ri.scaleToRem(300),
+		iframeHeight: ri.scaleToRem(900),
 		page: () => (
 			<>
 				<Title />

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -37,12 +37,11 @@ const backgrounds = {
 };
 
 configureActions();
+
 export const parameters = {
 	docs: {
 		container: DocsContainer,
 		page: DocsPage,
-		iframeHeight: 360,
-		inlineStories: false,
 		theme: themes.light
 	},
 	options: {
@@ -51,6 +50,7 @@ export const parameters = {
 		}
 	}
 };
+
 export const globalTypes = {
 	'locale': getObjectType('locale', 'en-US', locales),
 	'background': getObjectType('background', 'default', backgrounds),
@@ -58,4 +58,5 @@ export const globalTypes = {
 	'debug layout': getBooleanType('debug layout'),
 	'debug spotlight': getBooleanType('debug spotlight')
 };
+
 export const decorators = [Environment];

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@enact/storybook-utils": "^5.0.0",
+    "@enact/storybook-utils": "^5.0.1",
     "@storybook/addons": "^6.5.12",
     "@storybook/builder-webpack5": "^6.5.12",
     "@storybook/manager-webpack5": "^6.5.12",

--- a/packages/sampler/src/Environment/Environment.js
+++ b/packages/sampler/src/Environment/Environment.js
@@ -38,6 +38,7 @@ const StorybookDecorator = (story, config) => {
 
 	const {globals} = config;
 
+	const height = config.viewMode === "docs" ? {height: '360px'} : {};
 	const hasText = config.parameters && config.parameters.info && config.parameters.info.text;
 
 	// NOTE: The properties of globals are only defined by string type.
@@ -46,23 +47,26 @@ const StorybookDecorator = (story, config) => {
 		layout: JSON.parse(globals['debug layout']),
 		spotlight: JSON.parse(globals['debug spotlight'])
 	};
+
 	if (Object.keys(classes).length > 0) {
 		classes.debug = true;
 	}
 
 	return (
-		<PanelsBase
-			className={classnames(classes)}
-			title={`${config.kind}`.replace(/\//g, ' ').trim()}
-			description={hasText ? config.parameters.info.text : null}
-			locale={globals.locale}
-			style={{
-				'--env-background': globals.background === 'default' ? '' : globals.background
-			}}
-			{...config.panelsProps}
-		>
-			{sample}
-		</PanelsBase>
+		<div style={height}>
+			<PanelsBase
+				className={classnames(classes)}
+				title={`${config.kind}`.replace(/\//g, ' ').trim()}
+				description={hasText ? config.parameters.info.text : null}
+				locale={globals.locale}
+				style={{
+					'--env-background': globals.background === 'default' ? '' : globals.background
+				}}
+				{...config.panelsProps}
+			>
+				{sample}
+			</PanelsBase>
+		</div>
 	);
 };
 

--- a/packages/sampler/src/Environment/Environment.js
+++ b/packages/sampler/src/Environment/Environment.js
@@ -38,7 +38,6 @@ const StorybookDecorator = (story, config) => {
 
 	const {globals} = config;
 
-	const height = config.viewMode === "docs" ? {height: '360px'} : {};
 	const hasText = config.parameters && config.parameters.info && config.parameters.info.text;
 
 	// NOTE: The properties of globals are only defined by string type.
@@ -53,20 +52,18 @@ const StorybookDecorator = (story, config) => {
 	}
 
 	return (
-		<div style={height}>
-			<PanelsBase
-				className={classnames(classes)}
-				title={`${config.kind}`.replace(/\//g, ' ').trim()}
-				description={hasText ? config.parameters.info.text : null}
-				locale={globals.locale}
-				style={{
-					'--env-background': globals.background === 'default' ? '' : globals.background
-				}}
-				{...config.panelsProps}
-			>
-				{sample}
-			</PanelsBase>
-		</div>
+		<PanelsBase
+			className={classnames(classes)}
+			title={`${config.kind}`.replace(/\//g, ' ').trim()}
+			description={hasText ? config.parameters.info.text : null}
+			locale={globals.locale}
+			style={{
+				'--env-background': globals.background === 'default' ? '' : globals.background
+			}}
+			{...config.panelsProps}
+		>
+			{sample}
+		</PanelsBase>
 	);
 };
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In packages/sampler storybook, if controls are changed from Docs tab, it doesn't update the component preview.

### Resolution
Setting "inlineStories" to true causes bugs, so we agreed to keep inlineStories false and set a height to the iFrame. Also, controls were removed from the docs page.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13139


### Comments
