### PR TITLE
WRO-12876: Change @extends value format in jsdoc

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -6,7 +6,7 @@ Almost all documentation for Enact is generated directly from the source code or
 
 ## Documentation Overview
 
-In-line documentation uses standard [jsDoc tags](http://usejsdoc.org/) with some additional Enact-specific tags. In-line documentation appears within comment blocks that begin with double asterisks:
+In-line documentation uses standard [jsDoc tags](https://jsdoc.app) with some additional Enact-specific tags. In-line documentation appears within comment blocks that begin with double asterisks:
 
 ```js
 /**
@@ -63,7 +63,7 @@ Below is an example block for a component:
  *
  * @class LabeledIcon
  * @memberof ui/LabeledIcon
- * @extends ui/LabeledIcon.LabeledIconBase
+ * @extends ui/LabeledIcon#LabeledIconBase
  * @mixes ui/LabeledIcon.LabeledIconDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/BodyText/BodyText.js
+++ b/packages/ui/BodyText/BodyText.js
@@ -116,7 +116,7 @@ const BodyTextDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class BodyText
  * @memberof ui/BodyText
- * @extends ui/BodyText.BodyTextBase
+ * @extends ui/BodyText#BodyTextBase
  * @mixes ui/BodyText.BodyTextDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -264,7 +264,7 @@ const ButtonDecorator = compose(
  *
  * @class Button
  * @memberof ui/Button
- * @extends ui/Button.ButtonBase
+ * @extends ui/Button#ButtonBase
  * @mixes ui/Button.ButtonDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -271,7 +271,7 @@ const handleCancel = handle(
  * @class FloatingLayer
  * @memberof ui/FloatingLayer
  * @ui
- * @extends ui/FloatingLayer.FloatingLayerBase
+ * @extends ui/FloatingLayer#FloatingLayerBase
  * @mixes ui/Cancelable.Cancelable
  * @public
  */

--- a/packages/ui/Group/Group.js
+++ b/packages/ui/Group/Group.js
@@ -214,7 +214,7 @@ const GroupDecorator = compose(
  *
  * @class Group
  * @memberof ui/Group
- * @extends ui/Group.GroupBase
+ * @extends ui/Group#GroupBase
  * @mixes ui/Group.GroupDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Heading/Heading.js
+++ b/packages/ui/Heading/Heading.js
@@ -167,7 +167,7 @@ const HeadingDecorator = compose(
  *
  * @class Heading
  * @memberof ui/Heading
- * @extends ui/Heading.HeadingBase
+ * @extends ui/Heading#HeadingBase
  * @mixes ui/Heading.HeadingDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -246,7 +246,7 @@ const IconDecorator = compose(
  * An Icon component.
  *
  * @class Icon
- * @extends ui/Icon.IconBase
+ * @extends ui/Icon#IconBase
  * @mixes ui/Icon.IconDecorator
  * @omit componentRef
  * @memberof ui/Icon

--- a/packages/ui/IconButton/IconButton.js
+++ b/packages/ui/IconButton/IconButton.js
@@ -219,7 +219,7 @@ const IconButtonDecorator = compose(
  * ```
  *
  * @class IconButton
- * @extends ui/IconButton.IconButtonBase
+ * @extends ui/IconButton#IconButtonBase
  * @mixes ui/IconButton.IconButtonDecorator
  * @omit componentRef
  * @memberof ui/IconButton

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -209,7 +209,7 @@ const ImageDecorator = compose(
  *
  * @class Image
  * @memberof ui/Image
- * @extends ui/Image.ImageBase
+ * @extends ui/Image#ImageBase
  * @mixes ui/Image.ImageDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -189,7 +189,7 @@ const ImageItemDecorator = compose(
  *
  * @class ImageItem
  * @memberof ui/ImageItem
- * @extends ui/ImageItem.ImageItemBase
+ * @extends ui/ImageItem#ImageItemBase
  * @mixes ui/ImageItem.ImageItemDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Item/Item.js
+++ b/packages/ui/Item/Item.js
@@ -140,7 +140,7 @@ const ItemDecorator = compose(
  *
  * @class Item
  * @memberof ui/Item
- * @extends ui/Item.ItemBase
+ * @extends ui/Item#ItemBase
  * @mixes ui/Item.ItemDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/LabeledIcon/LabeledIcon.js
+++ b/packages/ui/LabeledIcon/LabeledIcon.js
@@ -265,7 +265,7 @@ const LabeledIconDecorator = compose(
  *
  * @class LabeledIcon
  * @memberof ui/LabeledIcon
- * @extends ui/LabeledIcon.LabeledIconBase
+ * @extends ui/LabeledIcon#LabeledIconBase
  * @mixes ui/LabeledIcon.LabeledIconDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -166,7 +166,7 @@ const CellDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class Cell
  * @memberof ui/Layout
- * @extends ui/Layout.CellBase
+ * @extends ui/Layout#CellBase
  * @mixes ui/Layout.CellDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -336,7 +336,7 @@ const LayoutDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class Layout
  * @memberof ui/Layout
- * @extends ui/Layout.LayoutBase
+ * @extends ui/Layout#LayoutBase
  * @mixes ui/ForwardRef.ForwardRef
  * @omit componentRef
  * @ui
@@ -357,7 +357,7 @@ const Layout = LayoutDecorator(LayoutBase);
  *
  * @class Column
  * @memberof ui/Layout
- * @extends ui/Layout.Layout
+ * @extends ui/Layout#Layout
  * @mixes ui/ForwardRef.ForwardRef
  * @ui
  * @public
@@ -381,7 +381,7 @@ Column.displayName = 'Column';
  *
  * @class Row
  * @memberof ui/Layout
- * @extends ui/Layout.Layout
+ * @extends ui/Layout#Layout
  * @mixes ui/ForwardRef.ForwardRef
  * @ui
  * @public

--- a/packages/ui/Marquee/index.js
+++ b/packages/ui/Marquee/index.js
@@ -23,7 +23,7 @@ import MarqueeDecorator from './MarqueeDecorator';
  * A minimally-styled marquee component.
  *
  * @class Marquee
- * @extends ui/Marquee.MarqueeBase
+ * @extends ui/Marquee#MarqueeBase
  * @memberof ui/Marquee
  * @mixes ui/Marquee.MarqueeDecorator
  * @ui

--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -217,7 +217,7 @@ const ProgressBarDecorator = compose(
  *
  * @class ProgressBar
  * @memberof ui/ProgressBar
- * @extends ui/ProgressBar.ProgressBarBase
+ * @extends ui/ProgressBar#ProgressBarBase
  * @mixes ui/ProgressBar.ProgressBarDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Repeater/Repeater.js
+++ b/packages/ui/Repeater/Repeater.js
@@ -154,7 +154,7 @@ const RepeaterDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class Repeater
  * @memberof ui/Repeater
- * @extends ui/Repeater.RepeaterBase
+ * @extends ui/Repeater#RepeaterBase
  * @mixes ui/Repeater.RepeaterDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Routable/Link.js
+++ b/packages/ui/Routable/Link.js
@@ -170,7 +170,7 @@ const Linkable = hoc({navigate: 'onClick'}, (config, Wrapped) => {
  *
  * @class Link
  * @ui
- * @extends ui/Routable.LinkBase
+ * @extends ui/Routable#LinkBase
  * @mixes ui/Routable.Linkable
  * @memberof ui/Routable
  * @public

--- a/packages/ui/Scrollable/Scrollable.js
+++ b/packages/ui/Scrollable/Scrollable.js
@@ -1389,7 +1389,7 @@ class ScrollableBase extends Component {
  *
  * @class Scrollable
  * @memberof ui/Scrollable
- * @extends ui/Scrollable.ScrollableBase
+ * @extends ui/Scrollable#ScrollableBase
  * @ui
  * @private
  */

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1393,7 +1393,7 @@ class ScrollableBaseNative extends Component {
  *
  * @class ScrollableNative
  * @memberof ui/ScrollableNative
- * @extends ui/Scrollable.ScrollableBaseNative
+ * @extends ui/Scrollable#ScrollableBaseNative
  * @ui
  * @private
  */

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -28,7 +28,7 @@ const nop = () => {};
  *
  * @class Scroller
  * @memberof ui/Scroller
- * @extends ui/Scroller.ScrollerBasic
+ * @extends ui/Scroller#ScrollerBasic
  * @ui
  * @public
  */

--- a/packages/ui/Slider/Slider.js
+++ b/packages/ui/Slider/Slider.js
@@ -343,7 +343,7 @@ const SliderDecorator = compose(
  * A minimally-styled slider component with touch and drag support.
  *
  * @class Slider
- * @extends ui/Slider.SliderBase
+ * @extends ui/Slider#SliderBase
  * @memberof ui/Slider
  * @mixes ui/Slider.SliderDecorator
  * @omit componentRef

--- a/packages/ui/SlotItem/SlotItem.js
+++ b/packages/ui/SlotItem/SlotItem.js
@@ -212,7 +212,7 @@ const SlotItemDecorator = compose(
  *
  * @class SlotItem
  * @memberof ui/SlotItem
- * @extends ui/SlotItem.SlotItemBase
+ * @extends ui/SlotItem#SlotItemBase
  * @mixes ui/SlotItem.SlotItemDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/Spinner/Spinner.js
+++ b/packages/ui/Spinner/Spinner.js
@@ -199,7 +199,7 @@ const SpinnerDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class Spinner
  * @memberof ui/Spinner
- * @extends ui/Spinner.SpinnerBase
+ * @extends ui/Spinner#SpinnerBase
  * @mixes ui/Spinner.SpinnerDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/ToggleIcon/ToggleIcon.js
+++ b/packages/ui/ToggleIcon/ToggleIcon.js
@@ -157,7 +157,7 @@ const ToggleIconDecorator = compose(
  *
  * @class ToggleIcon
  * @memberof ui/ToggleIcon
- * @extends ui/ToggleIcon.ToggleIconBase
+ * @extends ui/ToggleIcon#ToggleIconBase
  * @mixes ui/ToggleIcon.ToggleIconDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/ToggleItem/ToggleItem.js
+++ b/packages/ui/ToggleItem/ToggleItem.js
@@ -295,7 +295,7 @@ const ToggleItemDecorator = compose(
  *
  * @class ToggleItem
  * @memberof ui/ToggleItem
- * @extends ui/ToggleItem.ToggleItemBase
+ * @extends ui/ToggleItem#ToggleItemBase
  * @mixes ui/ToggleItem.ToggleItemDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/ViewManager/ViewManager.js
+++ b/packages/ui/ViewManager/ViewManager.js
@@ -311,7 +311,7 @@ const ViewManagerDecorator = ForwardRef({prop: 'componentRef'});
  *
  * @class ViewManager
  * @memberof ui/ViewManager
- * @extends ui/ViewManager.ViewManagerBase
+ * @extends ui/ViewManager#ViewManagerBase
  * @mixes ui/ViewManager.ViewManagerDecorator
  * @omit componentRef
  * @ui

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -26,7 +26,7 @@ const nop = () => {};
  *
  * @class VirtualList
  * @memberof ui/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
+ * @extends ui/VirtualList#VirtualListBasic
  * @ui
  * @public
  */
@@ -300,7 +300,7 @@ VirtualList.defaultProps = {
  *
  * @class VirtualGridList
  * @memberof ui/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
+ * @extends ui/VirtualList#VirtualListBasic
  * @ui
  * @public
  */


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
@extends tag link is broken.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In gatsby-transformer-documentation plugin source code (https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-documentationjs/src/gatsby-node.js), only the string that comes after dot is explicitly stored as name.
So,  change the jsdoc format for @extends

ex)
@extends ui/BodyText.BodyTextBase
=> @extends ui/BodyText#BodyTextBase

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO- 12868, WRO-12876

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)