### PR TITLE
WRP-2655: Fixed MarqueeDecorator to enforce minimum resetDelay when synchronized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `ui/Marquee.MarqueeDecorator` to correctly set minimum reset delay when synchronized
-
 ## [4.5.2] - 2022-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to correctly set minimum reset delay when synchronized
+
 ## [4.5.2] - 2022-08-17
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to restart animation properly when `marqueeDelay` is 0
+
 ## [4.5.2] - 2022-08-17
 
 ### Fixed

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -736,7 +736,10 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			});
 			// synchronized Marquees defer to the controller to restart them
 			if (this.sync) {
-				this.context.complete(this);
+				const resetDelay = this.props.marqueeDelay > 40 ? 0 : 40;
+				this.setTimeout(() => {
+					this.context.complete(this);
+				}, resetDelay, TimerState.RESET_PENDING);
 			} else if (!this.state.animating) {
 				this.startAnimation(delay);
 			}

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -18,6 +18,9 @@ import {MarqueeControllerContext} from './MarqueeController';
 
 import componentCss from './Marquee.module.less';
 
+// The minimum number of milliseconds to wait before resetting the marquee position after it finishes.
+const MINIMUM_MARQUEE_RESET_DELAY = 40;
+
 /**
  * Default configuration parameters for {@link ui/Marquee.MarqueeDecorator}
  *
@@ -736,10 +739,12 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			});
 			// synchronized Marquees defer to the controller to restart them
 			if (this.sync) {
-				const resetDelay = this.props.marqueeDelay > 40 ? 0 : 40;
+				// Even in sync mode, it is necessary to apply a minimum reset delay.
+				// In detail, the timer with 40ms delay needs to be applied only when marqueeDelay is less than 40,
+				// but for consistency, we decided to apply 40ms in all cases.
 				this.setTimeout(() => {
 					this.context.complete(this);
-				}, resetDelay, TimerState.RESET_PENDING);
+				}, MINIMUM_MARQUEE_RESET_DELAY, TimerState.RESET_PENDING);
 			} else if (!this.state.animating) {
 				this.startAnimation(delay);
 			}
@@ -751,7 +756,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		resetAnimation = () => {
-			const delay = Math.max(40, this.props.marqueeResetDelay + this.props.marqueeDelay);
+			const delay = Math.max(MINIMUM_MARQUEE_RESET_DELAY, this.props.marqueeResetDelay + this.props.marqueeDelay);
 			// If we're already timing a start action, don't reset.  Start actions will clear us if
 			// sync.
 			if (this.timerState === TimerState.CLEAR) {

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -462,22 +462,11 @@ describe('MarqueeController', () => {
 		const marquee1 = screen.getByText(ltrArray[0]);
 		const marquee2 = screen.getByText(ltrArray[1]);
 
-		marquee1.getBoundingClientRect = jest.fn(() => {
-			return {
-				width: 50,
-				height: 50,
-				top: 0,
-				left: 0,
-				bottom: 0,
-				right: 0
-			};
-		});
-
 		fireEvent.focus(marquee1);
 
 		act(() => jest.advanceTimersByTime(100));
 
-		expect(marquee1).toHaveStyle({'--ui-marquee-spacing': '25'});
+		expect(marquee1).toHaveStyle({'--ui-marquee-spacing': '50'});
 		expect(marquee2).toHaveStyle({'--ui-marquee-spacing': '50'});
 	});
 
@@ -563,5 +552,42 @@ describe('MarqueeController', () => {
 		fireEvent.mouseLeave(marquee2);
 
 		expect(spy).toHaveBeenCalledTimes(2);
+	});
+	
+	test('should set a minimum value for reset delay when `marqueeDelay` is less than 40', () => {
+		render(
+			<Controller>
+					<Marquee
+						marqueeDelay={0}
+						marqueeOn="render"
+					>
+						{ltrArray[0]}
+					</Marquee>
+			</Controller>
+		);
+
+		const marquee1 = screen.getByText(ltrArray[0]);
+
+		marquee1.getBoundingClientRect = jest.fn(() => {
+			return {
+				width: 50,
+				height: 50,
+				top: 0,
+				left: 0,
+				bottom: 0,
+				right: 0
+			};
+		});
+
+		fireEvent.focus(marquee1);
+		act(() => jest.advanceTimersByTime(10));
+
+		fireEvent.transitionEnd(marquee1);
+
+		act(() => jest.advanceTimersByTime(10));
+		expect(marquee1).toHaveStyle({'transform': 'translateX(0)'});
+
+		act(() => jest.advanceTimersByTime(40));
+		expect(marquee1).toHaveStyle({'transform': 'translateX(-125px)'});
 	});
 });

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -553,16 +553,16 @@ describe('MarqueeController', () => {
 
 		expect(spy).toHaveBeenCalledTimes(2);
 	});
-	
+
 	test('should set a minimum value for reset delay when `marqueeDelay` is less than 40', () => {
 		render(
 			<Controller>
-					<Marquee
-						marqueeDelay={0}
-						marqueeOn="render"
-					>
-						{ltrArray[0]}
-					</Marquee>
+				<Marquee
+					marqueeDelay={0}
+					marqueeOn="render"
+				>
+					{ltrArray[0]}
+				</Marquee>
 			</Controller>
 		);
 

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -462,11 +462,22 @@ describe('MarqueeController', () => {
 		const marquee1 = screen.getByText(ltrArray[0]);
 		const marquee2 = screen.getByText(ltrArray[1]);
 
+		marquee1.getBoundingClientRect = jest.fn(() => {
+			return {
+				width: 50,
+				height: 50,
+				top: 0,
+				left: 0,
+				bottom: 0,
+				right: 0
+			};
+		});
+
 		fireEvent.focus(marquee1);
 
 		act(() => jest.advanceTimersByTime(100));
 
-		expect(marquee1).toHaveStyle({'--ui-marquee-spacing': '50'});
+		expect(marquee1).toHaveStyle({'--ui-marquee-spacing': '25'});
 		expect(marquee2).toHaveStyle({'--ui-marquee-spacing': '50'});
 	});
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using sync mode in `MarqueeDecorator` and set marqueeDelay to be 0, Marquee only works once and stopped.
`MarqueeDecorator` sync mode is set when `MarqueeController` is applied. ([source link](https://github.com/enactjs/enact/blob/develop/packages/ui/Marquee/MarqueeDecorator.js#L368))

In this PR, fixed `MarqueeDecorator` to enforce minimum resetDelay when sync mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If `MarqueeDecorator` is not a sync mode, 40ms is enforced for resetDelay by resetAnimation and restartAnimation functions.
```
resetAnimation = () => {
    const delay = Math.max(40, this.props.marqueeResetDelay + this.props.marqueeDelay);
    this.restartAnimation(delay);
}
```

However, if `MarqueeDecorator` is in sync mode, resetDelay is ignored in restartAnimation function as below. 
```
restartAnimation = (delay) => {
	if (this.sync) {
	    this.context.complete(this);
	} else if (!this.state.animating) {
	    this.startAnimation(delay);
	}
};
```

So I fixed restartAnimation function to force 40ms for resetDelay.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-2655

### Comments
