### PR TITLE
WRP-6139: fix broken link on enactjs.com i18n docs page

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `docs/index.md` broken link to i18n sample app repository
+
 ## [4.6.0] - 2022-12-05
 
 No significant changes.

--- a/packages/i18n/docs/index.md
+++ b/packages/i18n/docs/index.md
@@ -137,4 +137,4 @@ iLib provides the locale-specific features of i18n. If you wish to learn about s
 
 ## Sample
 
-A sample i18n app is available [here](https://github.com/enactjs/samples/tree/master/pattern-locale-switching).
+A sample i18n app is available [here](https://github.com/enactjs/samples/tree/master/sandstone/pattern-locale-switching).


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix broken link to a sample i18n app (github repo) on i18n docs

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change the broken link to a valid URL ([pattern-locale-switching](https://github.com/enactjs/samples/tree/master/sandstone/pattern-locale-switching))

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6139

### Comments
Developer Guide on enactjs.com has "i18n (Internationalization)" page and the page has "Sample" part having a broken link to a sample i18n app github repository. "sandstone/" is missing in the URL path.
    
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
