### PR TITLE
WRP-6259:ui/Touchable: make pinch-zoom related events/prop APIs private

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Removed
+
+- `ui/Touchable` events `onPinch`, `onPinchStart`, `onPinchEnd` and prop `pinchConfig`.
+
 ### Added
 
 - `ui/Touchable` events `onPinch`, `onPinchStart`, and `onPinchEnd` to support pinch zoom gesture

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -92,8 +92,7 @@ const defaultConfig = {
 /**
  * A higher-order component that provides a consistent set of pointer events -- `onDown`, `onUp`,
  * and `onTap` -- across mouse and touch interfaces along with support for common gestures including
- * `onFlick`, `onDragStart`, `onDrag`, `onDragEnd`, `onHoldStart`, `onHold`, `onHoldEnd`,
- * `onPinchStart`, `onPinch`, and `onPinchEnd`.
+ * `onFlick`, `onDragStart`, `onDrag`, `onDragEnd`, `onHoldStart`, `onHold`, and `onHoldEnd`.
  * Note: This HoC passes a number of props to the wrapped component that should be passed to the
  * main DOM node or consumed by the wrapped component.
  *
@@ -306,7 +305,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		 *
 		 * @memberof ui/Touchable.Touchable.prototype
 		 * @type {Function}
-		 * @public
+		 * @private
 		 */
 		onPinch: PropTypes.func,
 
@@ -319,7 +318,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		  *
 		  * @memberof ui/Touchable.Touchable.prototype
 		  * @type {Function}
-		  * @public
+		  * @private
 		  */
 		onPinchEnd: PropTypes.func,
 
@@ -333,7 +332,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		  *
 		  * @memberof ui/Touchable.Touchable.prototype
 		  * @type {Function}
-		  * @public
+		  * @private
 		  */
 		onPinchStart: PropTypes.func,
 
@@ -361,7 +360,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		 * @see {@link ui/Touchable.configure}
 		 * @memberof ui/Touchable.Touchable.prototype
 		 * @type {Object}
-		 * @public
+		 * @private
 		 */
 		pinchConfig: pinchConfigPropType
 	};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Commit "36e60f5e WRO-4836: Support PinchZoom gesture (#3084)" introduced pinch-zoom functionality and related APIs.
This PR reverts the commit partially to make the APIs hidden and private but leaves the functionality intact.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This PR reverts the commit partially to make the APIs hidden and private but leaves the functionality intact.
- onPinch, onPinchEnd, onPinchStarts, and pinchConfig.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6259
partially reverses WRO-4836, #3084

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>