### PR TITLE
WRP-6259:ui:Touchable: add scale payload to pinch event doc

### DIFF
--- a/packages/ui/Touchable/Pinch.js
+++ b/packages/ui/Touchable/Pinch.js
@@ -64,9 +64,9 @@ class Pinch {
 		return 0;
 	};
 
-	updateZoom = (scale) => {
-		const {maxZoom, minZoom} = this.pinchConfig;
-		const newScale = clamp(minZoom, maxZoom, scale);
+	updateScale = (scale) => {
+		const {maxScale, minScale} = this.pinchConfig;
+		const newScale = clamp(minScale, maxScale, scale);
 
 		if (newScale !== this.scale) {
 			this.scale = newScale;
@@ -125,7 +125,7 @@ class Pinch {
 		const scale = (currentDist / this.startDist) * this.startScale;
 
 
-		if (Math.abs(this.previousDist - currentDist) > moveTolerance && this.onPinch && this.updateZoom(scale)) {
+		if (Math.abs(this.previousDist - currentDist) > moveTolerance && this.onPinch && this.updateScale(scale)) {
 			this.onPinch({
 				type: 'onPinch',
 				scale: this.scale,
@@ -158,16 +158,16 @@ class Pinch {
 const defaultPinchConfig = {
 	boxSizing: 'border-box',
 	global: false,
-	maxZoom: 4,
-	minZoom: 0.5,
+	maxScale: 4,
+	minScale: 0.5,
 	moveTolerance: 16
 };
 
 const pinchConfigPropType = PropTypes.shape({
 	boxSizing: PropTypes.string,
 	global: PropTypes.bool,
-	maxZoom: PropTypes.number,
-	minZoom: PropTypes.number,
+	maxScale: PropTypes.number,
+	minScale: PropTypes.number,
 	moveTolerance: PropTypes.number
 });
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -302,7 +302,10 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		 * Event payload includes:
 		 *
 		 * * `type` - Type of event, `'onPinch'`
-		 * * `coords` - the coordinates array of the touch point, relative to the viewport
+		 * * `scale` - The scale factor, calculated from the distance while pinching.
+		 *             The default value is 1.0. The value would be a number between
+		 *             pinchConfig.minScale and pinchConfig.maxScale.
+		 * * `coords` - The coordinates array of the touch point, relative to the viewport
 		 *
 		 * @memberof ui/Touchable.Touchable.prototype
 		 * @type {Function}
@@ -329,7 +332,7 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		  * Event payload includes:
 		  *
 		  * * `type` - Type of event, `'onPinchStart'`
-		  * * `coords` - the coordinates array of the touch point, relative to the viewport
+		  * * `coords` - The coordinates array of the touch point, relative to the viewport
 		  *
 		  * @memberof ui/Touchable.Touchable.prototype
 		  * @type {Function}

--- a/packages/ui/Touchable/config.js
+++ b/packages/ui/Touchable/config.js
@@ -109,8 +109,8 @@ const mergeConfig = (cfg) => {
  *     * `'content-box'` - excludes the padding, border, and margin.
  *   * `global` - When `true`, pinch gestures will continue when leaving the bounds of the component
  *      or blurring the component.
- *   * `maxZoom` - The maximum zoom value. Defaults to `4`.
- *   * `minZoom` - The minimum zoom value. Defaults to `0.5`.
+ *   * `maxScale` - The maximum scale value. Defaults to `4`.
+ *   * `minScale` - The minimum scale value. Defaults to `0.5`.
  *   * `moveTolerance` - The distance difference from the previous distance that the pointer may move
  *     before cancelling the scaling. Defaults to `16`.
  *


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Commit "36e60f5e WRO-4836: Support PinchZoom gesture (#3084)" introduced pinch-zoom functionality and related APIs.
This patch adds and changes the commit partially to make the APIs more precise but leaves the functionality intact.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
1. add 'scale' payload to pinch event docs
2. change names of min/maxZoom to min/maxScale
3. fix the typo of 'the coordinates' to 'The coordinates'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Just only rename 'zoom' to 'scale.' but the code has been changed.

### Links
[//]: # (Related issues, references)
WRP-6259

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
