### PR TITLE
Implement logic to filter hidden elements

### DIFF
--- a/packages/spotlight/src/core/keymap/index.js
+++ b/packages/spotlight/src/core/keymap/index.js
@@ -1,27 +1,3 @@
-/**
- * Manages a map of names to key codes to simplify event handlers
- *
- * Example:
- * ```
- * import {add, is} from '@enact/core/keymap';
- *
- * add('enter', 13);
- * const isEnter = is('enter');
- *
- * // within event handler
- * if (isEnter(ev.keyCode)) {
- *   // handle enter
- * }
- * ```
- *
- * @module core/keymap
- * @exports add
- * @exports addAll
- * @exports is
- * @exports remove
- * @exports removeAll
- */
-
 // keymap uses a singleton object, map, to manage the keymap. since webpack may make multiple copies
 // of the module available if the import path is different, we ensure a consistent import path for
 // the singleton instance by facading it with this module.

--- a/packages/spotlight/src/core/keymap/keymap.js
+++ b/packages/spotlight/src/core/keymap/keymap.js
@@ -1,54 +1,13 @@
 import curry from 'ramda/src/curry';
 
-/*
- * The singleton map of names to keyCodes. If a name doesn't have any keyCodes mapped to it, it will
- * not exist in this map. If it does, its value will be an array of its keyCodes.
- *
- * @type {Object}
- * @private
- */
 const map = {};
 
-/*
- * Safely converts keymap name to lowercase.
- *
- * @function
- * @param   {String} name  Name for keyCode
- *
- * @returns {String}       Name for keyCode in lowercase
- * @memberof core/keymap
- * @private
- */
 const toLowerCase = (name) => name ? name.toLowerCase() : '';
 
-/*
- * Iterates over `set` and invokes `fn` with the key and value of each item.
- *
- * @function
- * @param   {Function}  fn   Function to invoke
- * @param   {Object}    set  A map of names to keyCodes
- *
- * @returns {undefined}
- * @memberof core/keymap
- * @private
- */
 const forEachObj = curry(function (fn, set) {
 	Object.keys(set).forEach(name => fn(name, set[name]));
 });
 
-/*
- * Invokes `fn` with `name` and `keyCode` for each key code provided.
- *
- * @function
- * @param   {Function}        fn       Function to invoke
- * @param   {String}          name     Name for the key codes
- * @param   {Number|Number[]} keyCode  A key code or array of key codes
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @private
- */
 const oneOrArray = curry(function (fn, name, keyCode) {
 	if (Array.isArray(keyCode)) {
 		keyCode.forEach(fn(name));
@@ -57,18 +16,6 @@ const oneOrArray = curry(function (fn, name, keyCode) {
 	}
 });
 
-/*
- * Adds `keyCode` to `name`.
- *
- * @function
- * @param   {String}    name     Name for the key code
- * @param   {Number}    keyCode  A key code
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @private
- */
 const addOne = curry(function (name, keyCode) {
 	name = toLowerCase(name);
 	if (name in map) {
@@ -81,18 +28,6 @@ const addOne = curry(function (name, keyCode) {
 	}
 });
 
-/*
- * Removes `keyCode` from `name`.
- *
- * @function
- * @param   {String}    name     Name for the key code
- * @param   {Number}    keyCode  A key code
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @private
- */
 const removeOne = curry(function (name, keyCode) {
 	name = toLowerCase(name);
 	if (name in map) {
@@ -106,72 +41,14 @@ const removeOne = curry(function (name, keyCode) {
 	}
 });
 
-/**
- * Registers `keyCode` for `name`.
- *
- * @function add
- * @param   {String}          name     Name for the key code
- * @param   {Number|Number[]} keyCode  A key code or array of key codes
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @public
- */
 const add = oneOrArray(addOne);
 
-/**
- * Registers a set of key codes.
- *
- * @function addAll
- * @param   {Object<String,Number|Number[]>}    set  A map of names to keyCodes
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @public
- */
 const addAll = forEachObj(add);
 
-/**
- * Unregisters `keyCode` from `name`.
- *
- * @function remove
- * @param   {String}          name     Name for the key code
- * @param   {Number|Number[]} keyCode  A key code or array of key codes
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @public
- */
 const remove = oneOrArray(removeOne);
 
-/**
- * Unregisters a set of key codes.
- *
- * @function removeAll
- * @param   {Object}    set  A map of names to keyCodes
- *
- * @returns {undefined}
- * @curried
- * @memberof core/keymap
- * @public
- */
 const removeAll = forEachObj(remove);
 
-/**
- * Determines if `keyCode` is mapped to `name`.
- *
- * @function is
- * @param   {String}    name     Name for the key code
- * @param   {Number}    keyCode  A key code
- *
- * @returns {Boolean}            `true` if `keyCode` is mapped to `name`
- * @curried
- * @memberof core/keymap
- * @public
- */
 const is = curry(function (name, keyCode) {
 	name = toLowerCase(name);
 	return name in map && map[name].indexOf(keyCode) >= 0;

--- a/packages/spotlight/src/core/platform/platform.js
+++ b/packages/spotlight/src/core/platform/platform.js
@@ -1,12 +1,3 @@
-/**
- * Utilities for detecting basic platform capabilities.
- *
- * @module core/platform
- * @exports detect
- * @exports platform
- * @public
- */
-
 import uniq from 'ramda/src/uniq';
 
 const hasGesture = () => {
@@ -148,28 +139,6 @@ const parseUserAgent = (userAgent) => {
 	return plat;
 };
 
-/**
- * @typedef {Object} PlatformDescription
- * @property {Object} [extra] - Additional information about the detected platform
- * @property {Boolean} gesture - `true` if the platform has native double-finger events
- * @property {Boolean} node - `true` only if `window` is `undefined`
- * @property {String} [platformName] - The name of the platform, if detected
- * @property {Boolean} touch - `true` if the platform has native single-finger events
- * @property {Boolean} touchscreen - `true` if the platform has a touch screen
- * @property {Boolean} unknown - `true` for any unknown system
- *
- * @memberof core/platform
- * @public
- */
-
-/**
- * Returns the {@link core/platform.platform} object.
- *
- * @function detect
- * @returns {PlatformDescription}     The {@link core/platform.platform} object
- * @memberof core/platform
- * @public
- */
 const detect = () => {
 	if (_platform) {
 		// if we've already determined the platform, we'll use that determination
@@ -188,13 +157,6 @@ const detect = () => {
 	return (_platform = parseUserAgent(userAgent));
 };
 
-/**
- * Provides basic information about the running platform.
- *
- * @type {PlatformDescription}
- * @memberof core/platform
- * @public
- */
 const platform = {};
 
 [

--- a/packages/spotlight/src/core/snapshot/snapshot.js
+++ b/packages/spotlight/src/core/snapshot/snapshot.js
@@ -1,51 +1,11 @@
-/**
- * Utilities to facilitate integration with v8 snapshot builds
- *
- * @module core/snapshot
- * @exports isWindowReady
- * @exports onWindowReady
- * @exports windowReady
- * @public
- */
-
 import invariant from 'invariant';
 
 const windowCallbacks = [];
 
-/**
- * Determines if the `window` is available
- *
- * @function
- *
- * @returns {Boolean} `true` when `window` is ready
- * @memberof core/snapshot
- * @public
- */
 function isWindowReady () {
 	return typeof window !== 'undefined';
 }
 
-/**
- * Executes a callback, such as registering event handlers, when a valid `window` is available.
- *
- * During normal operation, the callback will be executed immediately. During a pre-rendering pass,
- * the callback is not be executed at all. When using snapshot, the callback is added to a queue
- * and is executed in order once the window is available.
- *
- * *Important Notes*
- * * The callback should not alter the initial HTML state. If it does, it will invalidate the
- * pre-render state and interfere with React rehydration.
- * * The callback should be limited to module-scoped actions and not component instance actions. If
- * the action is tied to a component, it should be invoked from within the component's lifecycle
- * methods.
- *
- * @function
- * @param   {Function}    callback    Function to run when the window is ready
- *
- * @returns {undefined}
- * @memberof core/snapshot
- * @public
- */
 function onWindowReady (callback) {
 	if (isWindowReady()) {
 		callback();
@@ -54,17 +14,6 @@ function onWindowReady (callback) {
 	}
 }
 
-/**
- * Executes all queued window callbacks.
- *
- * Requires that the window be, in fact, available and will throw an `Error` if not.
- *
- * @function
- *
- * @returns {undefined}
- * @memberof core/snapshot
- * @public
- */
 function windowReady () {
 	invariant(
 		isWindowReady(),

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -238,8 +238,10 @@ const Spotlight = (function () {
 		focusEffect.style.top = `${elemRect.y + window.scrollY}px`;
 		focusEffect.style.width = `${elemRect.width}px`;
 		focusEffect.style.height = `${elemRect.height}px`;
+		focusEffect.style.boxShadow = '0 0 0 1px rgba(29, 155, 209, 0.5), 0 0 3px 5px rgba(74, 182, 237, 0.4)';
 
 		// elem.style.outline = 'none';
+
 		elem.focus(focusOptions);
 
 		_duringFocusChange = false;
@@ -522,6 +524,8 @@ const Spotlight = (function () {
 		if (shouldPreventNavigation()) return;
 
 		const {target} = evt;
+
+		focusEffect.style.boxShadow = 'none';
 
 		if (getPointerMode() && hasPointerMoved(evt.clientX, evt.clientY)) {
 			const next = getNavigableTarget(target); // account for child controls

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -173,7 +173,7 @@ function getContainerRect (containerId) {
 }
 
 function isStandardFocusable (element) {
-	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) ) {
+	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) || isElementHidden(element)) {
 		return false;
 	} else if ((!element.parentElement) || (element.tabIndex >= 0)) {
 		return true;
@@ -194,6 +194,15 @@ function isActuallyDisabled (element) {
 
 function isExpresslyInert (element) {
 	return ((element.inert) && (!element.ownerDocument.documentElement.inert));
+}
+
+function isElementHidden (element) {
+	let elemRect = element.getBoundingClientRect();
+	if ((elemRect.width <= 1 && elemRect.height <= 1) || elemRect.x < -3840 || elemRect.y < -2160 || element.getAttribute('hidden')) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 export {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When applying spotlight to the non-enact-app, there are cases where the focus shifts to elements that don't need to visit (hidden element or too small element).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Implement filtering logic that checks element width, height, x, y position, and hidden attributes.
When the mouseover event is triggered, make focusRing to be hidden. Because mouseover event means it needs to move focus.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Using the feature/WRN-14993 and feature/WRN-14994 branches, I created a base branch called the feature/spotlight-for-non-enact-app branch.
I cherry-picked from feature/WRN-14993, and feature/WRN-14994 and cleaned up the code as these were POC branches.

### Links
[//]: # (Related issues, references)
WRP-402

### Comments
