### PR TITLE
WRP-6258:Layout: add docs for `justify-content` CSS property

### DIFF
--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -179,7 +179,27 @@ const LayoutBase = kind({
 		 * This includes support for `align-parts` which is shorthand for combining `align-items`
 		 * and `justify-content` into a single property, separated by a space, in that order.
 		 * This allows you to specify both the horizontal and vertical alignment in one property,
-		 * separated by a space.
+		 * separated by a space. For example, `align="center space-between"` means
+		 * `align-items: center` and `justify-content: space-between` for each. `justify-content`
+		 * property can be used to align the flex items on the main axis and adjust gaps among the
+		 * flex items. To declare the `justify-content` property only, just add a heading space for
+		 * `align` prop string like `align=" space-between"`. The default value for `align-items`
+		 * is `stretch`. It can be also used for `align` prop like `align="stretch space-between"`.
+		 * All values of `justify-content` are supported, like `start`, `end`, `center`,
+		 * `space-between`, `space-around`, and `space-evenly`.
+		 *
+		 * ```
+		 * <Layout align="center space-around">
+		 *     <Cell>Left Column</Cell>
+		 *     <Cell>Right Column</Cell>
+		 * </Layout>
+		 * ```
+		 * ```
+		 * <Layout align=" space-between">
+		 *     <Cell>Left Column</Cell>
+		 *     <Cell>Right Column</Cell>
+		 * </Layout>
+		 * ```
 		 *
 		 * @type {String}
 		 * @public

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -176,17 +176,17 @@ const LayoutBase = kind({
 		 * `"start"` refers to the top in a horizontal layout, and left in a vertical LTR layout
 		 * `"end"` refers to the bottom in a horizontal layout, and right in a vertical LTR layout
 		 * `"start"` and `"end"` reverse places when in a vertical layout in a RTL locale.
-		 * This includes support for `align-parts` which is shorthand for combining `align-items`
-		 * and `justify-content` into a single property, separated by a space, in that order.
-		 * This allows you to specify both the horizontal and vertical alignment in one property,
-		 * separated by a space. For example, `align="center space-between"` means
-		 * `align-items: center` and `justify-content: space-between` for each. `justify-content`
-		 * property can be used to align the flex items on the main axis and adjust gaps among the
-		 * flex items. To declare the `justify-content` property only, just add a heading space for
-		 * `align` prop string like `align=" space-between"`. The default value for `align-items`
-		 * is `stretch`. It can be also used for `align` prop like `align="stretch space-between"`.
-		 * All values of `justify-content` are supported, like `start`, `end`, `center`,
-		 * `space-between`, `space-around`, and `space-evenly`.
+		 * This includes support shorthand for combining `align-items` and `justify-content` into
+		 * a single property, separated by a space, in that order. This allows you to specify both
+		 * the horizontal and vertical alignment in one property, separated by a space.
+		 * For example, `align="center space-between"` means `align-items: center` and
+		 * `justify-content: space-between` for each. `justify-content` property can be used to
+		 * align the Cells on the main axis and adjust gaps among the Cells. To declare the
+		 * `justify-content` property only, just add a heading space for `align` prop string like
+		 * `align=" space-between"`. The default value for `align-items` is `stretch`. It can be
+		 * also used for `align` prop like `align="stretch space-between"`. All values of
+		 * `justify-content` are supported, like `start`, `end`, `center`, `space-between`,
+		 * `space-around`, and `space-evenly`.
 		 *
 		 * ```
 		 * <Layout align="center space-around">

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -179,6 +179,7 @@ const LayoutBase = kind({
 		 * This includes support shorthand for combining `align-items` and `justify-content` into
 		 * a single property, separated by a space, in that order. This allows you to specify both
 		 * the horizontal and vertical alignment in one property, separated by a space.
+		 *
 		 * For example, `align="center space-between"` means `align-items: center` and
 		 * `justify-content: space-between` for each. `justify-content` property can be used to
 		 * align the Cells on the main axis and adjust gaps among the Cells. To declare the


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We decided to add a prop to support gap . (ex. justify-content: space-between; ), but enact/ui/layout already has `align` prop to apply this. So we need more docs to guide it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
add more docs for `align` prop of `Layout` and for `justify-content` CSS property.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6258

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
