### PR TITLE
WRP-9221:Update .travis.yml to change the CLI downloading method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g enactjs/cli#develop
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+    - pushd ../cli
+    - npm install
+    - npm link
+    - popd
     - npm install -g codecov
     - npm install
     - npm run bootstrap


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a difference between 'npm install gitbranch' and 'git clone gitbranch' -> 'npm install'.
Need to use the git clone method to follow the already tested npm-shrinkwrap.json during travis build.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml to download the cli source code with git clone and then run 'npm install' and 'npm link' in the cli directory. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9221

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)