### PR TITLE
Add isStandardFocusableMode private globalConfig 

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -599,7 +599,7 @@ const isNavigable = (node, containerId, verify) => {
 	}
 
 	const config = getContainerConfig(containerId);
-	if (verify && config && config.selector && !isContainer(node) && !(matchSelector(config.selector, node) || (GlobalConfig.isStandardFocusableMode && isStandardFocusable(node)))) {
+	if (verify && config && config.selector && !isContainer(node) && !matchSelector(config.selector, node) && !(GlobalConfig.isStandardFocusableMode && isStandardFocusable(node))) {
 		return false;
 	}
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -90,9 +90,8 @@ let GlobalConfig = {
  * @private
  */
 const querySelector = (node, includeSelector, excludeSelector) => {
-	let include = new Set(node.querySelectorAll(includeSelector));
 	const focusables = GlobalConfig.isStandardFocusableMode ? Array.prototype.filter.call(node.getElementsByTagName('*'), isStandardFocusable) : [];
-	include = new Set([...include, ...focusables]);
+	const include = new Set([...node.querySelectorAll(includeSelector), ...focusables]);
 
 	const exclude = node.querySelectorAll(excludeSelector);
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -12,7 +12,7 @@ import {coerceArray} from '@enact/core/util';
 import intersection from 'ramda/src/intersection';
 import last from 'ramda/src/last';
 
-import {contains, matchSelector, getContainerRect, getRect, intersects} from './utils';
+import {contains, matchSelector, getContainerRect, getRect, intersects, isStandardFocusable} from './utils';
 
 const containerAttribute = 'data-spotlight-id';
 const containerConfigs   = new Map();
@@ -89,7 +89,10 @@ let GlobalConfig = {
  * @private
  */
 const querySelector = (node, includeSelector, excludeSelector) => {
-	const include = new Set(node.querySelectorAll(includeSelector));
+	let include = new Set(node.querySelectorAll(includeSelector));
+	const focusables = Array.prototype.filter.call(node.getElementsByTagName('*'), isStandardFocusable);
+	include = new Set([...include, ...focusables]);
+
 	const exclude = node.querySelectorAll(excludeSelector);
 
 	for (let i = 0; i < exclude.length; i++) {
@@ -595,7 +598,7 @@ const isNavigable = (node, containerId, verify) => {
 	}
 
 	const config = getContainerConfig(containerId);
-	if (verify && config && config.selector && !isContainer(node) && !matchSelector(config.selector, node)) {
+	if (verify && config && config.selector && !isContainer(node) && !(matchSelector(config.selector, node) || isStandardFocusable(node))) {
 		return false;
 	}
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -46,6 +46,7 @@ let GlobalConfig = {
 	continue5WayHold: false,
 	defaultElement: '',     // <extSelector> except "@" syntax.
 	enterTo: '',            // '', 'last-focused', 'default-element'
+	isStandardFocusableMode: false,     // @private - set to true to focus standard focusable element
 	lastFocusedElement: null,
 	lastFocusedKey: null,
 	lastFocusedPersist: (node, all) => {
@@ -90,7 +91,7 @@ let GlobalConfig = {
  */
 const querySelector = (node, includeSelector, excludeSelector) => {
 	let include = new Set(node.querySelectorAll(includeSelector));
-	const focusables = Array.prototype.filter.call(node.getElementsByTagName('*'), isStandardFocusable);
+	const focusables = GlobalConfig.isStandardFocusableMode ? Array.prototype.filter.call(node.getElementsByTagName('*'), isStandardFocusable) : [];
 	include = new Set([...include, ...focusables]);
 
 	const exclude = node.querySelectorAll(excludeSelector);
@@ -598,7 +599,7 @@ const isNavigable = (node, containerId, verify) => {
 	}
 
 	const config = getContainerConfig(containerId);
-	if (verify && config && config.selector && !isContainer(node) && !(matchSelector(config.selector, node) || isStandardFocusable(node))) {
+	if (verify && config && config.selector && !isContainer(node) && !(matchSelector(config.selector, node) || (GlobalConfig.isStandardFocusableMode && isStandardFocusable(node)))) {
 		return false;
 	}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -233,6 +233,7 @@ const Spotlight = (function () {
 
 		elem.focus(focusOptions);
 
+		/* istanbul ignore next */
 		if (_focusRingElement) {
 			const elemRect = elem.getBoundingClientRect();
 
@@ -579,9 +580,12 @@ const Spotlight = (function () {
 				// by default, pointer mode is off but the platform's current state will override that
 				setPointerMode(false);
 				setPlatformPointerMode();
+
+				/* istanbul ignore next */
 				if (getContainerConfig('spotlightRootDecorator')?.isStandardFocusableMode) {
 					_focusRingElement = document.querySelector('#spotlightFocusRing');
 				}
+
 				_initialized = true;
 			}
 		},

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -231,15 +231,15 @@ const Spotlight = (function () {
 			_duringFocusChange = false;
 			return true;
 		}
+
+		elem.focus(focusOptions);
+
 		const elemRect = elem.getBoundingClientRect();
 
 		focusEffect.style.left = `${elemRect.x + window.scrollX}px`;
 		focusEffect.style.top = `${elemRect.y + window.scrollY}px`;
 		focusEffect.style.width = `${elemRect.width}px`;
 		focusEffect.style.height = `${elemRect.height}px`;
-
-		// elem.style.outline = 'none';
-		elem.focus(focusOptions);
 
 		_duringFocusChange = false;
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -949,7 +949,20 @@ const Spotlight = (function () {
 		 */
 		focusNextFromPoint: spotNextFromPoint
 	};
+	window.addEventListener('load', () => {
+		if (typeof window === 'object' && !_initialized) {
+			Spotlight.initialize({
+				selector: '.' + spottableClass,
+				restrict: 'none'
+			});
 
+			Spotlight.set(rootContainerId, {
+				overflow: true
+			});
+
+			Spotlight.focus();
+		}
+	});
 	return exports;
 
 })();

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -89,6 +89,8 @@ const isLeft = is('left');
 const isRight = is('right');
 const isUp = is('up');
 
+let focusEffect = document.createElement('div');
+
 /**
  * Translates keyCodes into 5-way direction descriptions (e.g. `'down'`)
  *
@@ -229,7 +231,14 @@ const Spotlight = (function () {
 			_duringFocusChange = false;
 			return true;
 		}
+		const elemRect = elem.getBoundingClientRect();
 
+		focusEffect.style.left = `${elemRect.x + window.scrollX}px`;
+		focusEffect.style.top = `${elemRect.y + window.scrollY}px`;
+		focusEffect.style.width = `${elemRect.width}px`;
+		focusEffect.style.height = `${elemRect.height}px`;
+
+		// elem.style.outline = 'none';
 		elem.focus(focusOptions);
 
 		_duringFocusChange = false;
@@ -951,6 +960,15 @@ const Spotlight = (function () {
 	};
 	window.addEventListener('load', () => {
 		if (typeof window === 'object' && !_initialized) {
+			document.body.appendChild(focusEffect);
+
+			focusEffect.style.position = 'absolute';
+			focusEffect.style.boxShadow = '0 0 0 1px rgba(29, 155, 209, 0.5), 0 0 3px 5px rgba(74, 182, 237, 0.4)';
+			focusEffect.style.borderRadius = '4px';
+			focusEffect.style.transition = 'top 0.2s ease-in-out, left 0.2s ease-in-out';
+			focusEffect.style.willChange = 'top, left';
+			focusEffect.style.zIndex = 10001;
+			focusEffect.style.pointerEvents = 'none';
 			Spotlight.initialize({
 				selector: '.' + spottableClass,
 				restrict: 'none'

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -963,12 +963,13 @@ const Spotlight = (function () {
 			document.body.appendChild(focusEffect);
 
 			focusEffect.style.position = 'absolute';
-			focusEffect.style.boxShadow = '0 0 0 1px rgba(29, 155, 209, 0.5), 0 0 3px 5px rgba(74, 182, 237, 0.4)';
+			focusEffect.style.boxShadow = '0 0 0 2px white, 0 0 0 4px #997EF9, 0 0 10px 7px rgb(140, 108, 255, 0.4)';
 			focusEffect.style.borderRadius = '4px';
 			focusEffect.style.transition = 'top 0.2s ease-in-out, left 0.2s ease-in-out';
 			focusEffect.style.willChange = 'top, left';
 			focusEffect.style.zIndex = 10001;
 			focusEffect.style.pointerEvents = 'none';
+
 			Spotlight.initialize({
 				selector: '.' + spottableClass,
 				restrict: 'none'

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -89,8 +89,6 @@ const isLeft = is('left');
 const isRight = is('right');
 const isUp = is('up');
 
-let focusEffect = document.createElement('div');
-
 /**
  * Translates keyCodes into 5-way direction descriptions (e.g. `'down'`)
  *
@@ -138,6 +136,7 @@ const Spotlight = (function () {
 	*/
 	let _initialized = false;
 	let _duringFocusChange = false;
+	let _focusRingElement = null;
 
 	/*
 	 * Whether a 5-way directional key is being held.
@@ -234,12 +233,14 @@ const Spotlight = (function () {
 
 		elem.focus(focusOptions);
 
-		const elemRect = elem.getBoundingClientRect();
+		if (_focusRingElement) {
+			const elemRect = elem.getBoundingClientRect();
 
-		focusEffect.style.left = `${elemRect.x + window.scrollX}px`;
-		focusEffect.style.top = `${elemRect.y + window.scrollY}px`;
-		focusEffect.style.width = `${elemRect.width}px`;
-		focusEffect.style.height = `${elemRect.height}px`;
+			_focusRingElement.style.left = `${elemRect.x + window.scrollX}px`;
+			_focusRingElement.style.top = `${elemRect.y + window.scrollY}px`;
+			_focusRingElement.style.width = `${elemRect.width}px`;
+			_focusRingElement.style.height = `${elemRect.height}px`;
+		}
 
 		_duringFocusChange = false;
 
@@ -578,6 +579,9 @@ const Spotlight = (function () {
 				// by default, pointer mode is off but the platform's current state will override that
 				setPointerMode(false);
 				setPlatformPointerMode();
+				if (getContainerConfig('spotlightRootDecorator')?.isStandardFocusableMode) {
+					_focusRingElement = document.querySelector('#spotlightFocusRing');
+				}
 				_initialized = true;
 			}
 		},
@@ -958,30 +962,7 @@ const Spotlight = (function () {
 		 */
 		focusNextFromPoint: spotNextFromPoint
 	};
-	window.addEventListener('load', () => {
-		if (typeof window === 'object' && !_initialized) {
-			document.body.appendChild(focusEffect);
 
-			focusEffect.style.position = 'absolute';
-			focusEffect.style.boxShadow = '0 0 0 2px white, 0 0 0 4px #997EF9, 0 0 10px 7px rgb(140, 108, 255, 0.4)';
-			focusEffect.style.borderRadius = '4px';
-			focusEffect.style.transition = 'top 0.2s ease-in-out, left 0.2s ease-in-out';
-			focusEffect.style.willChange = 'top, left';
-			focusEffect.style.zIndex = 10001;
-			focusEffect.style.pointerEvents = 'none';
-
-			Spotlight.initialize({
-				selector: '.' + spottableClass,
-				restrict: 'none'
-			});
-
-			Spotlight.set(rootContainerId, {
-				overflow: true
-			});
-
-			Spotlight.focus();
-		}
-	});
 	return exports;
 
 })();

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -172,32 +172,33 @@ function getContainerRect (containerId) {
 	return getRect(containerNode);
 }
 
+// For details see: https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
 function isStandardFocusable (element) {
-	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) || isElementHidden(element)) {
+	if (element.tabIndex < 0) {
+		// If the tabIndex value is negative, it is not focusable
 		return false;
-	} else if ((!element.parentElement) || (element.tabIndex >= 0)) {
+	} else if (isElementHidden(element)) {
+		return false;
+	} else if (['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'OPTGROUP', 'OPTION', 'FIELDSET'].includes(element.tagName) && element.disabled) {
+		// If the element is actually disabled, it is not focusable
+		return false;
+	} else if (element.tagName ==='A' && element.getAttribute('href') !== null) {
+		// Anchor element that has an href attribute is focusable
 		return true;
-	}
-}
-
-function isAtagWithoutHref (element) {
-	return (element.tagName === 'A' && element.getAttribute('href') === null && element.getAttribute('tabIndex') === null);
-}
-
-function isActuallyDisabled (element) {
-	if (['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'OPTGROUP', 'OPTION', 'FIELDSET'].includes(element.tagName)) {
-		return (element.disabled);
+	} else if (element.tagName ==='INPUT' && element.type !== 'hidden') {
+		// Input element whose type attribute is not hidden is focusable
+		return true;
+	} else if (element.tabIndex >= 0 || !element.parentElement) {
+		// If the tabIndex value is more than 0, it is focusable
+		// If element is document or iframe, it is focusable
+		return true;
 	} else {
 		return false;
 	}
 }
 
-function isExpresslyInert (element) {
-	return ((element.inert) && (!element.ownerDocument.documentElement.inert));
-}
-
 function isElementHidden (element) {
-	let elemRect = element.getBoundingClientRect();
+	const elemRect = element.getBoundingClientRect();
 	if ((elemRect.width <= 1 && elemRect.height <= 1) || elemRect.x < -3840 || elemRect.y < -2160 || element.getAttribute('hidden')) {
 		return true;
 	} else {

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -182,10 +182,10 @@ function isStandardFocusable (element) {
 	} else if (['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'OPTGROUP', 'OPTION', 'FIELDSET'].includes(element.tagName) && element.disabled) {
 		// If the element is actually disabled, it is not focusable
 		return false;
-	} else if (element.tagName ==='A' && element.getAttribute('href') !== null) {
+	} else if (element.tagName === 'A' && element.getAttribute('href') !== null) {
 		// Anchor element that has an href attribute is focusable
 		return true;
-	} else if (element.tagName ==='INPUT' && element.type !== 'hidden') {
+	} else if (element.tagName === 'INPUT' && element.type !== 'hidden') {
 		// Input element whose type attribute is not hidden is focusable
 		return true;
 	} else if (element.tabIndex >= 0 || !element.parentElement) {

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -173,7 +173,7 @@ function getContainerRect (containerId) {
 }
 
 function isStandardFocusable (element) {
-	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) ) {
+	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) || isElementHidden(element)) {
 		return false;
 	} else if ((!element.parentElement) || (element.tabIndex >= 0)) {
 		return true;
@@ -194,6 +194,15 @@ function isActuallyDisabled (element) {
 
 function isExpresslyInert (element) {
 	return ((element.inert) && (!element.ownerDocument.documentElement.inert));
+}
+
+function isElementHidden (element) {
+	let elemRect = element.getBoundingClientRect();
+	if ((elemRect.width <= 1 && elemRect.height <= 1) || elemRect.x < -3840 || elemRect.y < -2160 || element.getAttribute('hidden')) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 export {

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -172,6 +172,30 @@ function getContainerRect (containerId) {
 	return getRect(containerNode);
 }
 
+function isStandardFocusable (element) {
+	if ((element.tabIndex < 0) || isAtagWithoutHref(element) || isActuallyDisabled(element) || isExpresslyInert(element) ) {
+		return false;
+	} else if ((!element.parentElement) || (element.tabIndex >= 0)) {
+		return true;
+	}
+}
+
+function isAtagWithoutHref (element) {
+	return (element.tagName === 'A' && element.getAttribute('href') === null && element.getAttribute('tabIndex') === null);
+}
+
+function isActuallyDisabled (element) {
+	if (['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'OPTGROUP', 'OPTION', 'FIELDSET'].includes(element.tagName)) {
+		return (element.disabled);
+	} else {
+		return false;
+	}
+}
+
+function isExpresslyInert (element) {
+	return ((element.inert) && (!element.ownerDocument.documentElement.inert));
+}
+
 export {
 	contains,
 	getContainerRect,
@@ -179,6 +203,7 @@ export {
 	getRect,
 	getRects,
 	intersects,
+	isStandardFocusable,
 	matchSelector,
 	parseSelector
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight needs to navigate standard focusable element when isStandardFocusableMode is set true.
If focusRingElement exists, when the spotlight focuses a certain element, focusRingElement needs to move.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Implement spotlight logic to determine if the element is standard focusable element.
Add `isStandardFocusMode` config in GlobalConfig(https://github.com/enactjs/enact/blob/master/packages/spotlight/src/container.js#L43).
`isStandardFocusMode` config can be set with spotlight.initialize function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
isStandardFocusMode config is the private config.

### Links
[//]: # (Related issues, references)
WRP-10235

### Comments
