### PR TITLE
WRP-9203: Add deprecated notification before removing 'window phone' from @enact/core/platform

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,9 +4,9 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ## [unreleased]
 
-### Removed
+### Deprecated
 
-- Windows phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
+- Windows phone from `platforms` in `core/platform` to be removed in 5.0.0
 
 ## [4.6.2] - 2023-03-09
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Removed
 
-- Window phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
+- Windows phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
 
 ## [4.6.2] - 2023-03-09
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Deprecated
 
-- Windows phone from `platforms` in `core/platform` to be removed in 5.0.0
+- `windowsPhone` element in `core/platform.platforms` to be removed in 5.0.0
 
 ## [4.6.2] - 2023-03-09
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- Window phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
+
 ## [4.6.2] - 2023-03-09
 
 No significant changes.
@@ -14,7 +20,7 @@ No significant changes.
 
 ### Fixed
 
-- `core/dispatcher`  to set the default target for event listeners properly when built with the snapshot option
+- `core/dispatcher` to set the default target for event listeners properly when built with the snapshot option
 
 ## [4.0.12] - 2022-09-16
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Deprecated
 
-- `windowsPhone` element in `core/platform.platforms` to be removed in 5.0.0
+- `windowsPhone` platform in `core/platform.platforms` to be removed in 5.0.0
 
 ## [4.6.2] - 2023-03-09
 

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -9,6 +9,8 @@
 
 import uniq from 'ramda/src/uniq';
 
+import deprecate from '../internal/deprecate';
+
 const hasGesture = () => {
 	return Boolean(
 		('ongesturestart' in window) ||
@@ -196,6 +198,11 @@ const detect = () => {
  * @public
  */
 const platform = {};
+
+deprecate({
+	name: 'Windows Phone platform',
+	until: '5.0.0'
+});
 
 [
 	'gesture',

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -48,6 +48,8 @@ const webOSVersion = {
 };
 
 const platforms = [
+	// Windows Phone 7 - 10
+	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -48,8 +48,6 @@ const webOSVersion = {
 };
 
 const platforms = [
-	// Windows Phone 7 - 10
-	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Microsoft ended support for windows mobile on December 10, 2019
So there is no need to keep windows phone on the list of platforms that enact recognizes.
Deprecated notice required before the removal.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update a change log to add deprecated notice for deleting Windows phone from platform list.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9203

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)