### PR TITLE
WRP-11025: Remove 'window phone' from @enact/core/platform

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Removed
 
-- Window phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
+- Windows phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
 
 ## [4.6.2] - 2023-03-09
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- Window phone from `platforms` in `core/platform` which means the list of platforms supprorted by Enact
+
 ## [4.6.2] - 2023-03-09
 
 No significant changes.
@@ -14,7 +20,7 @@ No significant changes.
 
 ### Fixed
 
-- `core/dispatcher`  to set the default target for event listeners properly when built with the snapshot option
+- `core/dispatcher` to set the default target for event listeners properly when built with the snapshot option
 
 ## [4.0.12] - 2022-09-16
 

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -48,8 +48,6 @@ const webOSVersion = {
 };
 
 const platforms = [
-	// Windows Phone 7 - 10
-	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Microsoft ended support for windows mobile on December 10, 2019
So there is no need to keep windows phone on the list of platforms that enact recognizes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove 'windows phone' from packages/core/platform/platform.js


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11025

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)