### PR TITLE
WRP-9203: Fix to show deprecation message when platform is Windows Phone

### DIFF
--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -147,6 +147,13 @@ const parseUserAgent = (userAgent) => {
 		}
 	}
 
+	if (plat.platformName === 'windowsPhone') {
+		deprecate({
+			name: 'Windows Phone platform',
+			until: '5.0.0'
+		});
+	}
+
 	return plat;
 };
 
@@ -198,11 +205,6 @@ const detect = () => {
  * @public
  */
 const platform = {};
-
-deprecate({
-	name: 'Windows Phone platform',
-	until: '5.0.0'
-});
 
 [
 	'gesture',

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -126,6 +126,8 @@ describe('platform', () => {
 	});
 
 	describe('platform', () => {
+        const windowsPhone = 'Mozilla/5.0 (Windows Phone 8.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4103.84 Mobile Safari/537.36';
+
 		test('should return `true` for `node` if window does not exist', () => {
 			const windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => {});
 
@@ -139,6 +141,13 @@ describe('platform', () => {
 			expect(platform['unknown']).toBe(true);
 			// The second access makes the module to return already detected platform information
 			expect(platform['unknown']).toBe(true);
+		});
+
+        test('should return platformName `windowsPhone`', () => {
+			const expected = {platformName: 'windowsPhone'};
+			const actual = parseUserAgent(windowsPhone);
+
+			expect(actual).toMatchObject(expected);
 		});
 	});
 });

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -104,6 +104,17 @@ describe('platform', () => {
 		});
 	});
 
+	describe('parseUserAgent for Windows Phone', () => {
+		const windowsPhone = 'Mozilla/5.0 (Windows Phone 8.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4103.84 Mobile Safari/537.36';
+
+		test('should return platformName `windowsPhone`', () => {
+			const expected = {platformName: 'windowsPhone'};
+			const actual = parseUserAgent(windowsPhone);
+
+			expect(actual).toMatchObject(expected);
+		});
+	});
+
 	describe('parseUserAgent for User-Agent Reduction', () => {
 		const testVersion = '113';
 		const uaGenerator = (unifiedPlatform, deviceCompatibility = '', majorVersion = testVersion) => (
@@ -126,8 +137,6 @@ describe('platform', () => {
 	});
 
 	describe('platform', () => {
-		const windowsPhone = 'Mozilla/5.0 (Windows Phone 8.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4103.84 Mobile Safari/537.36';
-
 		test('should return `true` for `node` if window does not exist', () => {
 			const windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => {});
 
@@ -141,13 +150,6 @@ describe('platform', () => {
 			expect(platform['unknown']).toBe(true);
 			// The second access makes the module to return already detected platform information
 			expect(platform['unknown']).toBe(true);
-		});
-
-		test('should return platformName `windowsPhone`', () => {
-			const expected = {platformName: 'windowsPhone'};
-			const actual = parseUserAgent(windowsPhone);
-
-			expect(actual).toMatchObject(expected);
 		});
 	});
 });

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -126,7 +126,7 @@ describe('platform', () => {
 	});
 
 	describe('platform', () => {
-        const windowsPhone = 'Mozilla/5.0 (Windows Phone 8.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4103.84 Mobile Safari/537.36';
+		const windowsPhone = 'Mozilla/5.0 (Windows Phone 8.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4103.84 Mobile Safari/537.36';
 
 		test('should return `true` for `node` if window does not exist', () => {
 			const windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => {});
@@ -143,7 +143,7 @@ describe('platform', () => {
 			expect(platform['unknown']).toBe(true);
 		});
 
-        test('should return platformName `windowsPhone`', () => {
+		test('should return platformName `windowsPhone`', () => {
 			const expected = {platformName: 'windowsPhone'};
 			const actual = parseUserAgent(windowsPhone);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There are many modules that access platform.js, so the deprecate message is displayed too often.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix to show deprecation message when platform is Windows Phone

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9203

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)