### PR TITLE
WRP-10124: Fixed to apply RTL on a scroller of theme libraries when locale is changed

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -162,6 +162,7 @@ const useScrollBase = (props) => {
 		// status
 		deferScrollTo: true,
 		isScrollAnimationTargetAccumulated: false,
+		rtl,
 
 		// overscroll
 		lastInputType: null,
@@ -241,7 +242,7 @@ const useScrollBase = (props) => {
 			mutableRef.current.lastInputType = val;
 		},
 		get rtl () {
-			return rtl;
+			return mutableRef.current.rtl;
 		},
 		get scrollBounds () {
 			return getScrollBounds();
@@ -271,6 +272,10 @@ const useScrollBase = (props) => {
 
 	if (mutableRef.current.animator == null) {
 		mutableRef.current.animator = new ScrollAnimator();
+	}
+
+	if (mutableRef.current.rtl !== rtl) {
+		mutableRef.current.rtl = rtl;
 	}
 
 	useLayoutEffect(() => {


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A scroller of theme libraries gets wrong RTL status from ui library when locale is changed on run-time.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs since a getter function returns RTL status of a closure variable that is not updated in time. To resolve the issue, I re-write function to return RTL status from mutable object rather than closure.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-10124

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
