### PR TITLE
WRP-7784: Fix resolution getScreenType and calculateFontSize to support undefined screenType layout

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,6 +8,11 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Layout.Cell` prop `grow` to expand its size to the container
 
+### Fixed
+
+- `ui/resolution` to select screenType which is smaller than actual screen size
+- `ui/resolution` to calculate the base font size by considering screenType and actual screen size
+
 ## [4.6.2] - 2023-03-09
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,10 +8,13 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Layout.Cell` prop `grow` to expand its size to the container
 
-### Fixed
+### Changed
 
 - `ui/resolution` to select screenType which is smaller than actual screen size
 - `ui/resolution` to calculate the base font size by considering screenType and actual screen size
+
+### Fixed
+
 - `ui/ViewManager` to set index prop properly when reverseTransition prop is given
 
 ## [4.6.2] - 2023-03-09

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -145,10 +145,10 @@ function getScreenType (rez) {
 		rez.height = swap;
 	}
 
-	// Loop through resolutions, last->first, largest->smallest
-	for (let i = types.length - 1; i >= 0; i--) {
-		// Does the current resolution fit inside this screenType definition? If so, save it as the current best match.
-		if (rez.height <= types[i].height && rez.width <= types[i].width) {
+	// Loop through resolutions, first->last, smallest->largest
+	for (let i = 0; i <= types.length - 1; i++) {
+		// Does this screenType definition fit inside the current resolution? If so, save it as the current best match.
+		if (rez.height >= types[i].height && rez.width >= types[i].width) {
 			bestMatch = types[i].name;
 		}
 	}

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -189,6 +189,9 @@ function calculateFontSize (type) {
 		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
 	} else {
 		size = scrObj.pxPerRem;
+		if (workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height ) {
+			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
+		}
 	}
 	return size + 'px';
 }

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -2,6 +2,8 @@ import {
 	calculateFontSize,
 	defineScreenTypes,
 	getScreenType,
+	getScreenTypeObject,
+	init,
 	scale,
 	unit
 } from '../resolution.js';
@@ -15,6 +17,7 @@ describe('Resolution Specs', () => {
 		{name: 'uw-uxga', pxPerRem: 24, width: 2560, height: 1080, aspectRatioName: 'cinema'},
 		{name: 'uhd', pxPerRem: 48, width: 3840, height: 2160, aspectRatioName: 'hdtv'}
 	];
+	const originalWorkspaceBounds = getScreenTypeObject('standard');
 
 	test(
 		'should select screen type whose dimensions are smaller than but nearest to the screen',
@@ -61,7 +64,21 @@ describe('Resolution Specs', () => {
 		}
 	);
 
+	test(
+		'should calculate the base font size for the given screen type by considering workspaceBounds',
+		() => {
+			init({measurementNode: {clientWidth: '3840', clientHeight: '1600'}});
+
+			const expectedFHD = '35px';
+			const actualFHD = calculateFontSize('fhd');
+
+			expect(actualFHD).toBe(expectedFHD);
+		}
+	);
+
 	test('should scale pixel measurements for the current screen', () => {
+		init({measurementNode: {clientWidth: originalWorkspaceBounds.width, clientHeight: originalWorkspaceBounds.height}});
+
 		const expectedFHD = 24 / 3;
 		const actualFHD = scale(24);
 

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -17,7 +17,7 @@ describe('Resolution Specs', () => {
 	];
 
 	test(
-		'should select screen type whose dimensions are greater than but nearest to the screen',
+		'should select screen type whose dimensions are smaller than but nearest to the screen',
 		() => {
 			const overHD = {
 				height: 721,
@@ -26,7 +26,7 @@ describe('Resolution Specs', () => {
 
 			defineScreenTypes(screenTypes);
 
-			const expected = 'fhd';
+			const expected = 'hd';
 			const actual = getScreenType(overHD);
 
 			expect(actual).toBe(expected);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong ([juwon.jeong@lge.com](mailto:juwon.jeong@lge.com))

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When an undefined screen type layout is given, resolution calculates a base font size larger than it should be given.
Therefore, there are cases where apps are cropped from the layout. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix getScreenType to select a screen type whose dimensions are smaller than but nearest to the screen.
Fix calculateFontSize to calculate the base font size for the given screen type by considering workspace bounds to support undefined screen type layout. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-7784

### Comments
