### PR TITLE
Revert "WRP-6257: Cell: Add `grow` prop to expand the size to its container"

### DIFF
--- a/packages/sampler/stories/default/Layout.js
+++ b/packages/sampler/stories/default/Layout.js
@@ -21,22 +21,19 @@ export const _Layout = (args) => (
 			orientation={args['orientation']}
 		>
 			<Cell
-				size={args['first cell size'] + 'px'}
+				size={args['cell size'] + 'px'}
 				shrink
 			>
-				<Item>First&#xa0;(shrink)</Item>
+				<Item>First</Item>
 			</Cell>
-			<Cell shrink={args['shrinkable second cell']}>
-				<Item>Second&#xa0;(shrinkable)</Item>
+			<Cell shrink={args['shrinkable cell']}>
+				<Item>Second</Item>
 			</Cell>
-			<Cell
-				grow={args['growable third cell']}
-				size={args['third cell size'] + 'px'}
-			>
-				<Item>Third&#xa0;(growable)</Item>
+			<Cell>
+				<Item>Third</Item>
 			</Cell>
 			<Cell shrink>
-				<Item>Last&#xa0;(shrink)</Item>
+				<Item>Last</Item>
 			</Cell>
 		</Layout>
 	</div>
@@ -44,10 +41,8 @@ export const _Layout = (args) => (
 
 select('align', _Layout, ['start', 'center', 'stretch', 'end'], Layout, 'start');
 select('orientation', _Layout, ['horizontal', 'vertical'], Layout, 'horizontal');
-range('first cell size', _Layout, Cell, {min: 0, max: 300, step: 5}, 100);
-boolean('shrinkable second cell', _Layout, Cell);
-range('third cell size', _Layout, Cell, {min: 0, max: 600, step: 5}, 120);
-boolean('growable third cell', _Layout, Cell);
+range('cell size', _Layout, Cell, {min: 0, max: 300, step: 5}, 100);
+boolean('shrinkable cell', _Layout, Cell);
 
 _Layout.parameters = {
 	info: {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [unreleased]
-
-### Added
-
-- `ui/Layout.Cell` prop `grow` to expand its size to the container
-
 ## [4.6.2] - 2023-03-09
 
 No significant changes.

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -71,21 +71,6 @@ const CellBase = kind({
 		componentRef: EnactPropTypes.ref,
 
 		/**
-		 * Sizes `Cell` to its container.
-		 *
-		 * A `grow`able cell will expand to its maximum size, according to the remaining space of the
-		 * container. This is used when you want to grow the size of this Cell so that it fills the
-		 * container. See the {@link ui/Layout.CellBase.size|size} property for more details.
-		 *
-		 * When combined with {@link ui/Layout.CellBase.shrink|shrink}, `shrink` prop takes precedence over
-		 * `grow` prop and `grow` prop is simply ignored.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		grow: PropTypes.bool,
-
-		/**
 		 * Sizes `Cell` to its contents.
 		 *
 		 * A `shrink`able cell will contract to its minimum size, according to the dimensions of its
@@ -106,16 +91,10 @@ const CellBase = kind({
 		 * When used in conjunction with {@link ui/Layout.Cell#shrink|shrink}, the size will be
 		 * the maximum size, shrinking as necessary, to fit the content.
 		 *
-		 * When used in conjunction with {@link ui/Layout.CellBase.grow|grow}, the size will be the
-		 * minimunm size, growing as necessary, to fit the container.
-		 *
 		 * E.g.
 		 * * `size="400px"` -> cell will be 400px, regardless of the dimensions of your content
 		 * * `size="400px" shrink` -> cell will be 400px if your content is greater than 400px,
 		 *   and will match your contents size if it's smaller
-		 * * `size="400px" grow` -> cell will be 400px if the container has no remaining space.
-		 *   Cell can grow larger than `size` to fill the container if there is remaining space
-		 *   in the container.
 		 *
 		 * This accepts any valid CSS measurement value string. If a numeric value is used, it will
 		 * be treated as a pixel value and converted to a
@@ -139,7 +118,7 @@ const CellBase = kind({
 	},
 
 	computed: {
-		className: ({grow, shrink, size, styler}) => styler.append({shrink, grow: !shrink && (grow || !size)}),
+		className: ({shrink, size, styler}) => styler.append({shrink, grow: (!shrink && !size)}),
 		style: ({align, shrink, size, style}) => {
 			if (typeof size === 'number') size = ri.unit(ri.scale(size), 'rem');
 
@@ -164,7 +143,6 @@ const CellBase = kind({
 
 	render: ({component: Component, componentRef, ...rest}) => {
 		delete rest.align;
-		delete rest.grow;
 		delete rest.shrink;
 		delete rest.size;
 

--- a/packages/ui/Layout/Layout.module.less
+++ b/packages/ui/Layout/Layout.module.less
@@ -28,8 +28,6 @@
 			max-width: var(--cell-size);
 			&.grow {
 				width: 0;
-				max-width: none;
-				min-width: var(--cell-size);
 			}
 		}
 	}
@@ -43,8 +41,6 @@
 			&.grow {
 				height: 0;
 				align-self: normal;
-				max-height: none;
-				min-height: var(--cell-size);
 			}
 		}
 	}

--- a/packages/ui/Layout/tests/Layout-specs.js
+++ b/packages/ui/Layout/tests/Layout-specs.js
@@ -91,35 +91,6 @@ describe('Layout Specs', () => {
 		});
 	});
 
-	test ('should apply a class for grow', () => {
-		render(<Cell>Body</Cell>);
-		const cell = screen.getByText('Body');
-
-		const expected = 'grow';
-
-		expect(cell).toHaveClass(expected);
-	});
-
-	test('should apply a class for grow and flexBasis styles the size prop value 100px', () => {
-		render(<Layout style={{width: "300px"}}><Cell grow size="100px">Body</Cell></Layout>);
-		const cell = screen.getByText('Body');
-
-		const expectedClass = 'grow';
-		const expectedFlexBasis = '100px';
-
-		expect(cell).toHaveClass(expectedClass);
-		expect(cell).toHaveStyle({'flex-basis': expectedFlexBasis});
-	});
-
-	test('should not be apply a class for grow when using shrink', () => {
-		render(<Cell grow shrink>Body</Cell>);
-		const cell = screen.getByText('Body');
-
-		const notExpected = 'grow';
-
-		expect(cell).not.toHaveClass(notExpected);
-	});
-
 	test('should return a DOM node reference for `componentRef` on `Layout`', () => {
 		const ref = jest.fn();
 		render(<Layout ref={ref} />);


### PR DESCRIPTION
Reverts enactjs/enact#3128 

This PR affects centered prop of theme library components

Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)
