### PR TITLE
WRP-6257: Cell: Add grow prop to expand the size to its container

### DIFF
--- a/packages/sampler/stories/default/Layout.js
+++ b/packages/sampler/stories/default/Layout.js
@@ -21,19 +21,22 @@ export const _Layout = (args) => (
 			orientation={args['orientation']}
 		>
 			<Cell
-				size={args['cell size'] + 'px'}
+				size={args['first cell size'] + 'px'}
 				shrink
 			>
-				<Item>First</Item>
+				<Item>First&#xa0;(shrink)</Item>
 			</Cell>
-			<Cell shrink={args['shrinkable cell']}>
-				<Item>Second</Item>
+			<Cell shrink={args['shrinkable second cell']}>
+				<Item>Second&#xa0;(shrinkable)</Item>
 			</Cell>
-			<Cell>
-				<Item>Third</Item>
+			<Cell
+				grow={args['growable third cell']}
+				size={args['third cell size'] + 'px'}
+			>
+				<Item>Third&#xa0;(growable)</Item>
 			</Cell>
 			<Cell shrink>
-				<Item>Last</Item>
+				<Item>Last&#xa0;(shrink)</Item>
 			</Cell>
 		</Layout>
 	</div>
@@ -41,8 +44,10 @@ export const _Layout = (args) => (
 
 select('align', _Layout, ['start', 'center', 'stretch', 'end'], Layout, 'start');
 select('orientation', _Layout, ['horizontal', 'vertical'], Layout, 'horizontal');
-range('cell size', _Layout, Cell, {min: 0, max: 300, step: 5}, 100);
-boolean('shrinkable cell', _Layout, Cell);
+range('first cell size', _Layout, Cell, {min: 0, max: 300, step: 5}, 100);
+boolean('shrinkable second cell', _Layout, Cell);
+range('third cell size', _Layout, Cell, {min: 0, max: 600, step: 5}, 120);
+boolean('growable third cell', _Layout, Cell);
 
 _Layout.parameters = {
 	info: {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `ui/Layout.Cell` prop `grow` to expand its size to the container
+
 ## [4.6.2] - 2023-03-09
 
 No significant changes.

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -71,6 +71,21 @@ const CellBase = kind({
 		componentRef: EnactPropTypes.ref,
 
 		/**
+		 * Sizes `Cell` to its container.
+		 *
+		 * A `grow`able cell will expand to its maximum size, according to the remaining space of the
+		 * container. This is used when you want to grow the size of this Cell so that it fills the
+		 * container. See the {@link ui/Layout.CellBase.size|size} property for more details.
+		 *
+		 * When combined with {@link ui/Layout.CellBase.shrink|shrink}, `shrink` prop takes precedence over
+		 * `grow` prop and `grow` prop is simply ignored.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		grow: PropTypes.bool,
+
+		/**
 		 * Sizes `Cell` to its contents.
 		 *
 		 * A `shrink`able cell will contract to its minimum size, according to the dimensions of its
@@ -91,10 +106,16 @@ const CellBase = kind({
 		 * When used in conjunction with {@link ui/Layout.Cell#shrink|shrink}, the size will be
 		 * the maximum size, shrinking as necessary, to fit the content.
 		 *
+		 * When used in conjunction with {@link ui/Layout.CellBase.grow|grow}, the size will be the
+		 * minimunm size, growing as necessary, to fit the container.
+		 *
 		 * E.g.
 		 * * `size="400px"` -> cell will be 400px, regardless of the dimensions of your content
 		 * * `size="400px" shrink` -> cell will be 400px if your content is greater than 400px,
 		 *   and will match your contents size if it's smaller
+		 * * `size="400px" grow` -> cell will be 400px if the container has no remaining space.
+		 *   Cell can grow larger than `size` to fill the container if there is remaining space
+		 *   in the container.
 		 *
 		 * This accepts any valid CSS measurement value string. If a numeric value is used, it will
 		 * be treated as a pixel value and converted to a
@@ -118,7 +139,7 @@ const CellBase = kind({
 	},
 
 	computed: {
-		className: ({shrink, size, styler}) => styler.append({shrink, grow: (!shrink && !size)}),
+		className: ({grow, shrink, size, styler}) => styler.append({shrink, grow: !shrink && (grow || !size), size}),
 		style: ({align, shrink, size, style}) => {
 			if (typeof size === 'number') size = ri.unit(ri.scale(size), 'rem');
 
@@ -143,6 +164,7 @@ const CellBase = kind({
 
 	render: ({component: Component, componentRef, ...rest}) => {
 		delete rest.align;
+		delete rest.grow;
 		delete rest.shrink;
 		delete rest.size;
 

--- a/packages/ui/Layout/Layout.module.less
+++ b/packages/ui/Layout/Layout.module.less
@@ -28,6 +28,10 @@
 			max-width: var(--cell-size);
 			&.grow {
 				width: 0;
+				&.size {
+					max-width: none;
+					min-width: var(--cell-size);
+				}
 			}
 		}
 	}
@@ -41,6 +45,10 @@
 			&.grow {
 				height: 0;
 				align-self: normal;
+				&.size {
+					max-height: none;
+					min-height: var(--cell-size);
+				}
 			}
 		}
 	}

--- a/packages/ui/Layout/tests/Layout-specs.js
+++ b/packages/ui/Layout/tests/Layout-specs.js
@@ -91,6 +91,37 @@ describe('Layout Specs', () => {
 		});
 	});
 
+	test ('should apply a class for grow', () => {
+		render(<Cell>Body</Cell>);
+		const cell = screen.getByText('Body');
+
+		const expected = 'grow';
+
+		expect(cell).toHaveClass(expected);
+	});
+
+	test('should apply classes for grow and size and flexBasis styles the size prop value 100px', () => {
+		render(<Layout style={{width: "300px"}}><Cell grow size="100px">Body</Cell></Layout>);
+		const cell = screen.getByText('Body');
+
+		const expectedGrowClass = 'grow';
+		const expectedSizeClass = 'size';
+		const expectedFlexBasis = '100px';
+
+		expect(cell).toHaveClass(expectedGrowClass);
+		expect(cell).toHaveClass(expectedSizeClass);
+		expect(cell).toHaveStyle({'flex-basis': expectedFlexBasis});
+	});
+
+	test('should not be apply a class for grow when using shrink', () => {
+		render(<Cell grow shrink>Body</Cell>);
+		const cell = screen.getByText('Body');
+
+		const notExpected = 'grow';
+
+		expect(cell).not.toHaveClass(notExpected);
+	});
+
 	test('should return a DOM node reference for `componentRef` on `Layout`', () => {
 		const ref = jest.fn();
 		render(<Layout ref={ref} />);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A `grow`able cell will expand to its maximum size according to the remaining space of the container. This is used when you want to grow the size of this cell so that it fills the container.

This PR is reopened (#3128) to fix a screenshot test failing on Item component in sandstone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
add `grow` prop to `Cell` component.

A `grow`able Cell has a declaration of `flex: 1 1 100%` in CSS by default. However, the `flex-basis` property is overridden by the `var(--cell-size)` value passed from JS. And by combining `max-width: none` and `flex-grow: 1` declaration, its size can be increased by the size of its parent container.

Also, by the declaration of `flex: 1 1 100%`, the `flex-shrink` property has a value of `1`, which means that its size can be reduced as much as necessary, but because of `min-width: var(--cell-size)` and `min-height: var(--cell-size)` declaration, it does not decrease below the specified cell size.

`size` CSS class is introduced to distinguish between implict `grow` (`!shrink && !size`) and explicit `grow` used with `size` prop. Explicit `grow` is always used with `size` prop and the `size` CSS class is used for two purposes:
- To invalidate `max-width/height: var(--cell-size)` declaration when `size` prop is used to `max-width/height: none`. It is needed to increase its size by the size of its parent container.
- To declare `min-width/height: var(--cell-size)`. It is needed for its size not to decrease below the specified size.

When combined with `shrink`, `shrink` prop takes precedence over `grow` prop and `grow` prop is simply ignored. When used in conjunction with `size`, the size will be the minimum size, growing as necessary, to fit the container.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Screenshot tests are added to Sandstone ()
Make sure that this change doesn't affect the screenshot test results of other components.

Unit Test Cases
- `grow` CSS class is applied when no props (`shrink`, `size`) are  given
- `grow` and `size` CSS class and `flex-basis` CSS style are applied when `grow` and `size` props are given
- `grow` CSS class is not applied when used with `shrink` prop

Sampler
- The thrid Cell is modified to change the `grow` and `size` props.The part where `grow` is automatically activated is still checkable when `shrink` prop is disabled in the second Cell.
- Clarify the names of each Cell and control to make them easier to distinguish.

### Links
[//]: # (Related issues, references)
WRP-6257
reopened #3128
screenshot test enactjs/sandstone#1427

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
