### PR TITLE
WRP-11795: Fix spotlight.focusElement to check cursor visibility

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to show the focus effect when pointer mode is changed to `false` while an app is loading
+
 ## [4.5.2] - 2022-08-17
 
 No significant changes.

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -199,7 +199,7 @@ const Spotlight = (function () {
 			return false;
 		}
 
-		if ((getPointerMode() && !fromPointer)) {
+		if ((getPointerMode() && !fromPointer) && (typeof window !== 'undefined' && (!window.PalmSystem || window.PalmSystem.cursor?.visibility))) {
 			setContainerLastFocusedElement(elem, containerIds);
 			return false;
 		}

--- a/packages/ui/internal/IdProvider/tests/useId-specs.js
+++ b/packages/ui/internal/IdProvider/tests/useId-specs.js
@@ -8,7 +8,7 @@ describe('useId', () => {
 
 	function Base (props) {
 		data.push(props);
-		return <div id={data.id} generateid={data.generateId} />;
+		return <div id={data.id} />;
 	}
 
 	function Component ({key, prefix, onUnmount}) {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As pointerHide event is not delivered to enact, getPointerMode() still true when executing Spotlight.focusElement().

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix focusElement() to check cursor.visibility if it exists.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Fixing lint warning is not directly related to this issue. But for travis test, I fixed lint warnings as below.
I think it also need to be merged to release/4.5.x.develop branch.
#3119 

### Links
[//]: # (Related issues, references)
WRP-11795

### Comments
