### PR TITLE
WRP-13532: Fix resolution/getScreenType to set default screen type to the smallest one

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,11 +8,6 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 - `ui/Layout.Cell` prop `grow` to expand its size to the container
 
-### Changed
-
-- `ui/resolution` to select screenType which is smaller than actual screen size
-- `ui/resolution` to calculate the base font size by considering screenType and actual screen size
-
 ### Fixed
 
 - `ui/ViewManager` to set index prop properly when reverseTransition prop is given

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import hoc from '@enact/core/hoc';
 
-import {init, defineScreenTypes, getResolutionClasses} from './resolution';
+import {init, config as riConfig, defineScreenTypes, getResolutionClasses} from './resolution';
 
 /**
  * Default config for `ResolutionDecorator`.
@@ -27,6 +27,29 @@ const defaultConfig = {
 	 * @memberof ui/resolution.ResolutionDecorator.defaultConfig
 	 */
 	dynamic: true,
+
+	/**
+	 *
+	 * Determines how to get the best match screen type of current resolution. When set to `true`, the screen type is the one closest to the screen resolution without going over.
+	 * When set to `false`, the screen type is the one closest to the screen resolution without going below.
+	 *
+	 * @type {Boolean}
+	 * @private
+	 * @memberof ui/resolution.ResolutionDecorator.defaultConfig
+	 */
+	findScreenTypeWithoutGoingOver: false,
+
+	/**
+	 *
+	 * Determines how to calculate font-size. When set to `scale` and the screen is in `landscape` orientation, calculates font-size linearly based on screenTypes.
+	 * When set to `normal`, the font-size will be the pxPerRem value of the best match screen type.
+	 *
+	 * @type {String}
+	 * @default 'normal'
+	 * @private
+	 * @memberof ui/resolution.ResolutionDecorator.defaultConfig
+	 */
+	fontSizeHandling: 'normal',
 
 	/**
 	 * An array of objects containing declarations for screen types to add to the list of known
@@ -76,6 +99,8 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		constructor (props) {
 			super(props);
+			riConfig.fontSizeHandling = config.fontSizeHandling;
+			riConfig.findScreenTypeWithoutGoingOver = config.findScreenTypeWithoutGoingOver;
 			init({measurementNode: (typeof window !== 'undefined' && window)});
 			this.state = {
 				resolutionClasses: ''

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -30,7 +30,8 @@ const defaultConfig = {
 
 	/**
 	 * Determines how to calculate font-size.
-	 * When set to `scale` and the screen is in `landscape` orientation, calculates font-size linearly based on screen resolution.
+	 * When set to `scale` and the screen is in `landscape` orientation,
+	 * calculates font-size linearly based on screen resolution.
 	 * When set to `normal`, the font-size will be the pxPerRem value of the best match screen type.
 	 *
 	 * @type {('normal'|'scale')}
@@ -42,8 +43,10 @@ const defaultConfig = {
 
 	/**
 	 * Determines how to get the best match screen type of current resolution.
-	 * When set to `true`, the matched screen type will be the one that is smaller and the closest to the screen resolution.
-	 * When set to `false`, the matched screen type will be the one that is greater and the closest to the screen resolution.
+	 * When set to `true`, the matched screen type will be the one that is smaller and
+	 * the closest to the screen resolution.
+	 * When set to `false`, the matched screen type will be the one that is greater and
+	 * the closest to the screen resolution.
 	 *
 	 * @type {Boolean}
 	 * @private

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import hoc from '@enact/core/hoc';
 
-import ri from './resolution';
+import {init, config as riConfig, defineScreenTypes, getResolutionClasses} from './resolution.js';
 
 /**
  * Default config for `ResolutionDecorator`.
@@ -29,7 +29,8 @@ const defaultConfig = {
 	dynamic: true,
 
 	/**
-	 * Determines how to calculate font-size. When set to `scale` and the screen is in `landscape` orientation, calculates font-size linearly based on screen resolution.
+	 * Determines how to calculate font-size.
+	 * When set to `scale` and the screen is in `landscape` orientation, calculates font-size linearly based on screen resolution.
 	 * When set to `normal`, the font-size will be the pxPerRem value of the best match screen type.
 	 *
 	 * @type {('normal'|'scale')}
@@ -37,10 +38,11 @@ const defaultConfig = {
 	 * @private
 	 * @memberof ui/resolution.ResolutionDecorator.defaultConfig
 	 */
-	 intermediateScreenHandling: 'normal',
+	intermediateScreenHandling: 'normal',
 
 	/**
-	 * Determines how to get the best match screen type of current resolution. When set to `true`, the matched screen type will be the one that is smaller and the closest to the screen resolution.
+	 * Determines how to get the best match screen type of current resolution.
+	 * When set to `true`, the matched screen type will be the one that is smaller and the closest to the screen resolution.
 	 * When set to `false`, the matched screen type will be the one that is greater and the closest to the screen resolution.
 	 *
 	 * @type {Boolean}
@@ -85,7 +87,7 @@ const defaultConfig = {
  */
 const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	if (config.screenTypes) {
-		ri.defineScreenTypes(config.screenTypes);
+		defineScreenTypes(config.screenTypes);
 	}
 
 	return class extends Component {
@@ -97,9 +99,9 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		constructor (props) {
 			super(props);
-			ri.config.intermediateScreenHandling = config.intermediateScreenHandling;
-			ri.config.matchSmallerScreenType = config.matchSmallerScreenType;
-			ri.init({measurementNode: (typeof window !== 'undefined' && window)});
+			riConfig.intermediateScreenHandling = config.intermediateScreenHandling;
+			riConfig.matchSmallerScreenType = config.matchSmallerScreenType;
+			init({measurementNode: (typeof window !== 'undefined' && window)});
 			this.state = {
 				resolutionClasses: ''
 			};
@@ -131,9 +133,9 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @private
 		 */
 		didClassesChange () {
-			const prevClassNames = ri.getResolutionClasses();
-			ri.init({measurementNode: this.rootNode});
-			const classNames = ri.getResolutionClasses();
+			const prevClassNames = getResolutionClasses();
+			init({measurementNode: this.rootNode});
+			const classNames = getResolutionClasses();
 			if (prevClassNames !== classNames) {
 				return classNames;
 			}
@@ -141,7 +143,7 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		render () {
 			// Check if the classes are different from our previous classes
-			let classes = ri.getResolutionClasses();
+			let classes = getResolutionClasses();
 
 			if (this.props.className) classes += (classes ? ' ' : '') + this.props.className;
 			return <Wrapped {...this.props} className={classes} />;

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import hoc from '@enact/core/hoc';
 
-import {init, config as riConfig, defineScreenTypes, getResolutionClasses} from './resolution.js';
+import {init, config as riConfig, defineScreenTypes, getResolutionClasses} from './resolution';
 
 /**
  * Default config for `ResolutionDecorator`.

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -30,8 +30,8 @@ const unitToPixelFactors = {
 };
 
 const configDefaults = {
-	findScreenTypeWithoutGoingOver: false,
-	fontSizeHandling: 'normal',
+	intermediateScreenHandling: 'normal',
+	matchSmallerScreenType: false,
 	orientationHandling: 'normal'
 };
 
@@ -136,7 +136,7 @@ function getScreenType (rez) {
 	rez = rez || workspaceBounds;
 
 	const types = screenTypes;
-	let bestMatch = config.findScreenTypeWithoutGoingOver ? types[0].name : types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
+	let bestMatch = config.matchSmallerScreenType ? types[0].name : types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
 
 	orientation = 'landscape';
 
@@ -147,7 +147,7 @@ function getScreenType (rez) {
 		rez.height = swap;
 	}
 
-	if (config.findScreenTypeWithoutGoingOver) {
+	if (config.matchSmallerScreenType) {
 		// Loop through resolutions, first->last, smallest->largest
 		for (let i = 0; i <= types.length - 1; i++) {
 			// Does this screenType definition fit inside the current resolution? If so, save it as the current best match.
@@ -196,15 +196,15 @@ function getScreenType (rez) {
  */
 function calculateFontSize (type) {
 	const scrObj = getScreenTypeObject(type);
-	const shouldScaleFontSize = config.findScreenTypeWithoutGoingOver ? workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height :
-		workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height;
+	const shouldScaleFontSize = (config.intermediateScreenHandling === 'scale') && (config.matchSmallerScreenType ? workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height :
+		workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height);
 	let size;
 
 	if (orientation === 'portrait' && config.orientationHandling === 'scale') {
 		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
 	} else {
 		size = scrObj.pxPerRem;
-		if (orientation === 'landscape' && config.fontSizeHandling === 'scale' && shouldScaleFontSize) {
+		if (orientation === 'landscape' && shouldScaleFontSize) {
 			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
 		}
 	}

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -30,6 +30,8 @@ const unitToPixelFactors = {
 };
 
 const configDefaults = {
+	findScreenTypeWithoutGoingOver: false,
+	fontSizeHandling: 'normal',
 	orientationHandling: 'normal'
 };
 
@@ -134,7 +136,7 @@ function getScreenType (rez) {
 	rez = rez || workspaceBounds;
 
 	const types = screenTypes;
-	let bestMatch = types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
+	let bestMatch = config.findScreenTypeWithoutGoingOver ? types[0].name : types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
 
 	orientation = 'landscape';
 
@@ -145,13 +147,24 @@ function getScreenType (rez) {
 		rez.height = swap;
 	}
 
-	// Loop through resolutions, last->first, largest->smallest
-	for (let i = types.length - 1; i >= 0; i--) {
-		// Does the current resolution fit inside this screenType definition? If so, save it as the current best match.
-		if (rez.height <= types[i].height && rez.width <= types[i].width) {
-			bestMatch = types[i].name;
+	if (config.findScreenTypeWithoutGoingOver) {
+		// Loop through resolutions, first->last, smallest->largest
+		for (let i = 0; i <= types.length - 1; i++) {
+			// Does this screenType definition fit inside the current resolution? If so, save it as the current best match.
+			if (rez.height >= types[i].height && rez.width >= types[i].width) {
+				bestMatch = types[i].name;
+			}
+		}
+	} else {
+		// Loop through resolutions, last->first, largest->smallest
+		for (let i = types.length - 1; i >= 0; i--) {
+			// Does the current resolution fit inside this screenType definition? If so, save it as the current best match.
+			if (rez.height <= types[i].height && rez.width <= types[i].width) {
+				bestMatch = types[i].name;
+			}
 		}
 	}
+
 	// Return the name of the closest fitting set of dimensions.
 	return bestMatch;
 }
@@ -183,12 +196,17 @@ function getScreenType (rez) {
  */
 function calculateFontSize (type) {
 	const scrObj = getScreenTypeObject(type);
+	const shouldScaleFontSize = config.findScreenTypeWithoutGoingOver ? workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height :
+		workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height;
 	let size;
 
 	if (orientation === 'portrait' && config.orientationHandling === 'scale') {
 		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
 	} else {
 		size = scrObj.pxPerRem;
+		if (orientation === 'landscape' && config.fontSizeHandling === 'scale' && shouldScaleFontSize) {
+			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
+		}
 	}
 	return size + 'px';
 }

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -134,7 +134,7 @@ function getScreenType (rez) {
 	rez = rez || workspaceBounds;
 
 	const types = screenTypes;
-	let bestMatch = types[0].name; // Blindly set the first screen type, in case no matches are found later.
+	let bestMatch = types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
 
 	orientation = 'landscape';
 
@@ -145,10 +145,10 @@ function getScreenType (rez) {
 		rez.height = swap;
 	}
 
-	// Loop through resolutions, first->last, smallest->largest
-	for (let i = 0; i <= types.length - 1; i++) {
-		// Does this screenType definition fit inside the current resolution? If so, save it as the current best match.
-		if (rez.height >= types[i].height && rez.width >= types[i].width) {
+	// Loop through resolutions, last->first, largest->smallest
+	for (let i = types.length - 1; i >= 0; i--) {
+		// Does the current resolution fit inside this screenType definition? If so, save it as the current best match.
+		if (rez.height <= types[i].height && rez.width <= types[i].width) {
 			bestMatch = types[i].name;
 		}
 	}
@@ -189,9 +189,6 @@ function calculateFontSize (type) {
 		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
 	} else {
 		size = scrObj.pxPerRem;
-		if (workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height ) {
-			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
-		}
 	}
 	return size + 'px';
 }

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -134,7 +134,7 @@ function getScreenType (rez) {
 	rez = rez || workspaceBounds;
 
 	const types = screenTypes;
-	let bestMatch = types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
+	let bestMatch = types[0].name; // Blindly set the first screen type, in case no matches are found later.
 
 	orientation = 'landscape';
 

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -20,6 +20,23 @@ describe('Resolution Specs', () => {
 	const originalWorkspaceBounds = getScreenTypeObject('standard');
 
 	test(
+		'should select the first screen type in the screenTypes array if the screen is smaller than defined screen types',
+		() => {
+			const smallestScreen = {
+				height: 400,
+				width: 600
+			};
+
+			defineScreenTypes(screenTypes);
+
+			const expected = 'vga';
+			const actual = getScreenType(smallestScreen);
+
+			expect(actual).toBe(expected);
+		}
+	);
+
+	test(
 		'should select screen type whose dimensions are smaller than but nearest to the screen',
 		() => {
 			const overHD = {

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -2,8 +2,6 @@ import {
 	calculateFontSize,
 	defineScreenTypes,
 	getScreenType,
-	getScreenTypeObject,
-	init,
 	scale,
 	unit
 } from '../resolution.js';
@@ -17,27 +15,9 @@ describe('Resolution Specs', () => {
 		{name: 'uw-uxga', pxPerRem: 24, width: 2560, height: 1080, aspectRatioName: 'cinema'},
 		{name: 'uhd', pxPerRem: 48, width: 3840, height: 2160, aspectRatioName: 'hdtv'}
 	];
-	const originalWorkspaceBounds = getScreenTypeObject('standard');
 
 	test(
-		'should select the first screen type in the screenTypes array if the screen is smaller than defined screen types',
-		() => {
-			const smallestScreen = {
-				height: 400,
-				width: 600
-			};
-
-			defineScreenTypes(screenTypes);
-
-			const expected = 'vga';
-			const actual = getScreenType(smallestScreen);
-
-			expect(actual).toBe(expected);
-		}
-	);
-
-	test(
-		'should select screen type whose dimensions are smaller than but nearest to the screen',
+		'should select screen type whose dimensions are greater than but nearest to the screen',
 		() => {
 			const overHD = {
 				height: 721,
@@ -46,7 +26,7 @@ describe('Resolution Specs', () => {
 
 			defineScreenTypes(screenTypes);
 
-			const expected = 'hd';
+			const expected = 'fhd';
 			const actual = getScreenType(overHD);
 
 			expect(actual).toBe(expected);
@@ -81,21 +61,7 @@ describe('Resolution Specs', () => {
 		}
 	);
 
-	test(
-		'should calculate the base font size for the given screen type by considering workspaceBounds',
-		() => {
-			init({measurementNode: {clientWidth: '3840', clientHeight: '1600'}});
-
-			const expectedFHD = '35px';
-			const actualFHD = calculateFontSize('fhd');
-
-			expect(actualFHD).toBe(expectedFHD);
-		}
-	);
-
 	test('should scale pixel measurements for the current screen', () => {
-		init({measurementNode: {clientWidth: originalWorkspaceBounds.width, clientHeight: originalWorkspaceBounds.height}});
-
 		const expectedFHD = 24 / 3;
 		const actualFHD = scale(24);
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the screen size is smaller than `hd (1280*720)`, getScreenType(ui/resolution) miscalculates best match screenType and It causes the font-size to be 96px.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix getScreenType to set the default screen type to the smallest one `hd(1280*720)`. In case no matches are found later, the best match screenType would be `hd(1280*720)`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-13532

### Comments