### PR TITLE
WRP-10827: Fixed `forwardCustom` and `forwardCustomWithPrevent` to bind adapters properly

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `core/handle.forwardCustom` and `core/handle.forwardCustomWithPrevent` to bind an adapter function properly
+
 ## [4.5.3] - 2023-04-06
 
 No significant changes.
+
 ## [4.7.0] - 2023-04-25
 
 ### Deprecated

--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -730,10 +730,10 @@ const adaptEvent = handle.adaptEvent = curry(function (adapter, handler) {
  * @memberof core/handle
  * @public
  */
-const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
-	adaptEvent(
-		(ev, ...args) => {
-			let customEventPayload = adapter ? adapter(ev, ...args) : null;
+const forwardCustom = handle.forwardCustom = function (name, adapter) {
+	return named(adaptEvent(
+		function (ev, ...args) {
+			let customEventPayload = adapter ? adapter.call(this, ev, ...args) : null;
 
 			// Handle either no adapter or a non-object return from the adapter
 			if (!customEventPayload || typeof customEventPayload !== 'object') {
@@ -751,8 +751,8 @@ const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
 			return customEventPayload;
 		},
 		forward(name)
-	)
-).named('forwardCustom');
+	), 'forwardCustom');
+};
 
 /**
  * Creates a handler that will forward the event to a function at `name` on `props` with capability
@@ -795,12 +795,12 @@ const forwardCustom = handle.forwardCustom = (name, adapter) => handle(
  * @memberof core/handle
  * @private
  */
-const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, adapter) => {
-	return (ev, ...args) => {
+const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = function (name, adapter) {
+	return named(function (ev, ...args) {
 		let prevented = false;
 
-		const adapterWithPrevent = () => {
-			let customEventPayload = adapter ? adapter(ev, ...args) : null;
+		function adapterWithPrevent () {
+			let customEventPayload = adapter ? adapter.call(this, ev, ...args) : null;
 			let existingPreventDefault = null;
 
 			// Handle either no adapter or a non-object return from the adapter
@@ -822,11 +822,11 @@ const forwardCustomWithPrevent = handle.forwardCustomWithPrevent = named((name, 
 			};
 
 			return customEventPayload;
-		};
+		}
 
-		return forwardCustom(name, adapterWithPrevent)(ev, ...args) && !prevented;
-	};
-}, 'forwardCustomWithPrevent');
+		return forwardCustom.call(this, name, adapterWithPrevent.bind(this))(ev, ...args) && !prevented;
+	}, 'forwardCustomWithPrevent');
+};
 
 /**
  * Accepts a handler and returns the logical complement of the value returned from the handler.

--- a/packages/core/handle/tests/handle-specs.js
+++ b/packages/core/handle/tests/handle-specs.js
@@ -1,3 +1,7 @@
+import PropTypes from 'prop-types';
+import {Component} from 'react';
+import {render} from '@testing-library/react';
+
 import {
 	adaptEvent,
 	call,
@@ -567,6 +571,90 @@ describe('handle', () => {
 
 			expect(actual).toEqual(expected);
 		});
+
+		test('should support bound adapter function', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+			const obj = {
+				data: expected,
+				adapter: function () {
+					return {
+						value: this?.data
+					};
+				}
+			};
+			const forwarderFn = forwardCustom('onCustomEvent', obj.adapter).bind(obj);
+			forwarderFn(null, {onCustomEvent: handler}, null);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
+		});
+
+		test('should support bound adapter function by call', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+			const obj = {
+				data: expected,
+				adapter: function () {
+					return {
+						value: this?.data
+					};
+				}
+			};
+
+			const forwarderFn = forwardCustom('onCustomEvent', call('adapter')).bind(obj);
+			forwarderFn(null, {onCustomEvent: handler}, null);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
+		});
+
+		test('should support bound adapter function by handle', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+
+			class TestComponent extends Component {
+				static propTypes = {
+					onCustomEvent: PropTypes.func
+				};
+
+				constructor (props) {
+					super(props);
+
+					this.data = expected;
+					handle(
+						forwardCustom('onCustomEvent', call('adapter'))
+					).bindAs(this, 'handleCustomEvent');
+				}
+
+				componentDidMount () {
+					this.handleCustomEvent(null, this.props, this.context);
+				}
+
+				adapter () {
+					return {
+						value: this?.data
+					};
+				}
+
+				render () {
+					return <div />;
+				}
+			}
+			render(<TestComponent onCustomEvent={handler} />);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
+		});
 	});
 
 	describe('#forwardCustomWithPrevent', () => {
@@ -645,6 +733,90 @@ describe('handle', () => {
 			const actual = adapter.mock.calls[0];
 
 			expect(actual).toEqual(expected);
+		});
+
+		test('should support bound adapter function', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+			const obj = {
+				data: expected,
+				adapter: function () {
+					return {
+						value: this?.data
+					};
+				}
+			};
+			const forwarderFn = forwardCustomWithPrevent('onCustomEvent', obj.adapter).bind(obj);
+			forwarderFn(null, {onCustomEvent: handler}, null);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
+		});
+
+		test('should support bound adapter function by call', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+			const obj = {
+				data: expected,
+				adapter: function () {
+					return {
+						value: this?.data
+					};
+				}
+			};
+
+			const forwarderFn = forwardCustomWithPrevent('onCustomEvent', call('adapter')).bind(obj);
+			forwarderFn(null, {onCustomEvent: handler}, null);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
+		});
+
+		test('should support bound adapter function by handle', () => {
+			const handler = jest.fn();
+			const expected = 'ok';
+
+			class TestComponent extends Component {
+				static propTypes = {
+					onCustomEvent: PropTypes.func
+				};
+
+				constructor (props) {
+					super(props);
+
+					this.data = expected;
+					handle(
+						forwardCustomWithPrevent('onCustomEvent', call('adapter'))
+					).bindAs(this, 'handleCustomEvent');
+				}
+
+				componentDidMount () {
+					this.handleCustomEvent(null, this.props, this.context);
+				}
+
+				adapter () {
+					return {
+						value: this?.data
+					};
+				}
+
+				render () {
+					return <div />;
+				}
+			}
+			render(<TestComponent onCustomEvent={handler} />);
+
+			const actual = handler.mock.calls[0][0];
+
+			expect(actual).toEqual(expect.objectContaining({
+				value: expected
+			}));
 		});
 
 		test('should call the next handler when `preventDefault` from provided props hasn\'t been called', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`core/handle/forwardCustom` and `core/handle/forwardCustomWithPrevent` do not bind given _adapter_ functions to `this` that is bound by native `bind` function or `bindAs` utility function from `core/handle/handle`. So, `core/handle/call` does not working as an adapter function.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated `core/handle/forwardCustom` and `core/handle/forwardCustomWithPrevent` to bind `this` to adapters properly.
Unit test cases are added also.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-10827

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
