### PR TITLE
WRP-10830:spotlight: add unit tests for isStandardFocusable

### DIFF
--- a/packages/spotlight/src/tests/utils-specs.js
+++ b/packages/spotlight/src/tests/utils-specs.js
@@ -9,7 +9,7 @@ import {
 	testScenario
 } from './utils';
 
-const spottable = (props) => {
+const focusable = (props) => {
 	if (!props) {
 		props = {};
 	}
@@ -28,11 +28,11 @@ const spottable = (props) => {
 
 const scenarios = {
 	tabIndexMinusOne: node({id: 'child', tabindex: -1}),
-	spottable: spottable(),
-	button: spottable({tag: 'button'}),
-	buttonWithDisabled: spottable({tag: 'button', valueOnlyAttribute: 'disabled'}),
-	link: spottable({tag: 'a', href: 'www.enactjs.com'}),
-	input: spottable({tag: 'input'})
+	focusable: focusable(),
+	button: focusable({tag: 'button'}),
+	buttonWithDisabled: focusable({tag: 'button', valueOnlyAttribute: 'disabled'}),
+	link: focusable({tag: 'a', href: 'www.enactjs.com'}),
+	input: focusable({tag: 'input'})
 };
 
 describe('utils', () => {
@@ -109,7 +109,7 @@ describe('utils', () => {
 		));
 
 		test('should return false if hidden', testScenario(
-			scenarios.spottable,
+			scenarios.focusable,
 			(root) => {
 				const child = root.querySelector('#child');
 				child.getBoundingClientRect = jest.fn(() => {

--- a/packages/spotlight/src/tests/utils-specs.js
+++ b/packages/spotlight/src/tests/utils-specs.js
@@ -1,7 +1,39 @@
 import {
 	getPointRect,
-	getContainerRect
+	getContainerRect,
+	isStandardFocusable
 } from '../utils';
+
+import {
+	node,
+	testScenario
+} from './utils';
+
+const spottable = (props) => {
+	if (!props) {
+		props = {};
+	}
+
+	let nodeObject = {
+		id: 'child',
+		tabindex: 0
+	};
+
+	Object.keys(props).forEach(key => {
+		nodeObject[key] = props[key];
+	});
+
+	return node(nodeObject);
+};
+
+const scenarios = {
+	tabIndexMinusOne: node({id: 'child', tabindex: -1}),
+	spottable: spottable(),
+	button: spottable({tag: 'button'}),
+	buttonWithDisabled: spottable({tag: 'button', valueOnlyAttribute: 'disabled'}),
+	link: spottable({tag: 'a', href: 'www.enactjs.com'}),
+	input: spottable({tag: 'input'})
+};
 
 describe('utils', () => {
 	describe('#getPointRect', () => {
@@ -52,5 +84,94 @@ describe('utils', () => {
 			};
 			expect(actual).toEqual(expected);
 		});
+	});
+
+	describe('#isStandardFocusable', () => {
+		beforeEach(() => {
+			global.Element.prototype.getBoundingClientRect = jest.fn(() => {
+				return {
+					height: 100,
+					width: 100
+				};
+			});
+		});
+
+		test('should return false if tabIndex < 0', testScenario(
+			scenarios.tabIndexMinusOne,
+			(root) => {
+				const child = root.querySelector('#child');
+
+				const expected = false;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
+
+		test('should return false if hidden', testScenario(
+			scenarios.spottable,
+			(root) => {
+				const child = root.querySelector('#child');
+				child.getBoundingClientRect = jest.fn(() => {
+					return {
+						height: 0,
+						width: 0
+					};
+				});
+
+				const expected = false;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
+
+		test('should return true if button tag', testScenario(
+			scenarios.button,
+			(root) => {
+				const child = root.querySelector('#child');
+
+				const expected = true;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
+
+		test('should return false if button tag with disabled', testScenario(
+			scenarios.buttonWithDisabled,
+			(root) => {
+				const child = root.querySelector('#child');
+
+				const expected = false;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
+
+		test('should return true if A tag with href', testScenario(
+			scenarios.link,
+			(root) => {
+				const child = root.querySelector('#child');
+
+				const expected = true;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
+
+		test('should return true if input tag', testScenario(
+			scenarios.input,
+			(root) => {
+				const child = root.querySelector('#child');
+
+				const expected = true;
+				const actual = isStandardFocusable(child);
+
+				expect(actual).toEqual(expected);
+			}
+		));
 	});
 });

--- a/packages/spotlight/src/tests/utils.js
+++ b/packages/spotlight/src/tests/utils.js
@@ -37,10 +37,15 @@ const coerceProps = (v) => {
 const node = (props) => {
 	let children = '';
 	let attributes = '';
+	let tag = 'div';
 
 	Object.keys(props).forEach(key => {
 		if (key === 'children') {
 			children = props.children;
+		} else if (key === 'tag') {
+			tag = props[key];
+		} else if (key === 'valueOnlyAttribute') {
+			attributes += `${props[key]} `;
 		} else {
 			const value = props[key];
 			if (key === 'className') key = 'class';
@@ -48,7 +53,7 @@ const node = (props) => {
 		}
 	});
 
-	return `<div ${attributes}>${children}</div>`;
+	return `<${tag} ${attributes}>${children}</${tag}>`;
 };
 
 const spottable = (props) => node({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
PR #3127 was for Spotlight to support navigation between standard focusable elements. However, unit tests for the `isStandardFocusable` function, which plays an important role in its support, were not included.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add unit tests for `isStandardFocusable` function. The following items are cases.
- should return false if tabIndex < 0
- should return false if hidden (too small)
- should return true if button tag
- should return false if button tag with disabled
- should return true if A tag with href
- should return true if input tag

Code coverage increased from 57.14% to 77.92%.

Code coverage results

| File     | % Stmts | % Branch | % Funcs | % Lines |
|----------|---------|----------|---------|---------|
| utils.js |   57.14 |    25.6  |   69.23 |   57.14 |
| utils.js |   77.92 |    56.09 |   84.61 |   77.92 |

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Unit tests cover all lines but 196 line of the function. Line 196 is not reachable.

### Links
[//]: # (Related issues, references)
WRP-10830

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
