### PR TITLE
WRP-11806:platform: update regular expression for Edge browser UA string

### DIFF
--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -53,6 +53,7 @@ const platforms = [
 	// Windows Phone 7 - 10
 	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Edge
+	{platform: 'edge', regex: /Chrome\/(\d+)[.\d]+.*Edg(?:e|A|iOS)?\/(\d+)[.\d]+/},
 	{platform: 'edge', regex: /Edg(?:e|A|iOS)?\/(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
@@ -132,6 +133,9 @@ const parseUserAgent = (userAgent) => {
 				if (v >= 7 || v === -1) {
 					plat.chrome = Number(m[1]);
 				}
+			} else if (p.platform === 'edge' && m[2]) {
+				plat.chrome = Number(m[1]);
+				v = Number(m[2]);
 			} else {
 				v = Number(m[1]);
 			}
@@ -143,21 +147,6 @@ const parseUserAgent = (userAgent) => {
 				};
 			}
 			plat.platformName = p.platform;
-
-			if (plat.platformName === 'edge') {
-				const chrome = platforms.filter((item) => {
-					if (item.platform === 'chrome') {
-						return true;
-					}
-				});
-				if (chrome.length > 0) {
-					const chromeRegex = chrome[0].regex;
-					const chromeVersion = chromeRegex.exec(userAgent);
-					if (chromeVersion) {
-						plat['chrome'] = Number(chromeVersion[1]);
-					}
-				}
-			}
 
 			break;
 		}

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -53,7 +53,7 @@ const platforms = [
 	// Windows Phone 7 - 10
 	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Edge
-	{platform: 'edge', regex: /Edg(?:e|A|iOS)?\/(\d+)/},
+	{platform: 'edge', regex: /Edg(?:e|A|iOS)?\/(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4
@@ -143,6 +143,22 @@ const parseUserAgent = (userAgent) => {
 				};
 			}
 			plat.platformName = p.platform;
+
+			if (plat.platformName === 'edge') {
+				const chrome = platforms.filter((item) => {
+					if (item.platform === 'chrome') {
+						return true;
+					}
+				});
+				if (chrome.length > 0) {
+					const chromeRegex = chrome[0].regex;
+					const chromeVersion = chromeRegex.exec(userAgent);
+					if (chromeVersion) {
+						plat['chrome'] = Number(chromeVersion[1]);
+					}
+				}
+			}
+
 			break;
 		}
 	}

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -52,6 +52,8 @@ const webOSVersion = {
 const platforms = [
 	// Windows Phone 7 - 10
 	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
+	// Edge
+	{platform: 'edge', regex: /Edg(?:e|A|iOS)?\/(\d+)/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4
@@ -67,8 +69,6 @@ const platforms = [
 	{platform: 'ie', regex: /MSIE (\d+)/},
 	// IE 11
 	{platform: 'ie', regex: /Trident\/.*; rv:(\d+)/},
-	// Edge
-	{platform: 'edge', regex: /Edge\/(\d+)/},
 	// iOS 3 - 5
 	// Apple likes to make this complicated
 	{platform: 'ios', regex: /iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/},

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -127,14 +127,10 @@ describe('platform', () => {
 
 			expect(actual).toMatchObject(expected);
 
-			expected = {'chrome': 113};
-			actual = parseUserAgent(edge1);
-
+			expected = {chrome: 113};
 			expect(actual).toMatchObject(expected);
 
-			expected = {'edge': 113};
-			actual = parseUserAgent(edge1);
-
+			expected = {edge: 113};
 			expect(actual).toMatchObject(expected);
 		});
 
@@ -144,14 +140,10 @@ describe('platform', () => {
 
 			expect(actual).toMatchObject(expected);
 
-			expected = {'chrome': 113};
-			actual = parseUserAgent(edge2);
-
+			expected = {chrome: 113};
 			expect(actual).toMatchObject(expected);
 
-			expected = {'edge': 113};
-			actual = parseUserAgent(edge2);
-
+			expected = {edge: 113};
 			expect(actual).toMatchObject(expected);
 		});
 
@@ -161,14 +153,10 @@ describe('platform', () => {
 
 			expect(actual).toMatchObject(expected);
 
-			expected = {'chrome': 113};
-			actual = parseUserAgent(edge3);
-
+			expected = {chrome: 113};
 			expect(actual).not.toMatchObject(expected);
 
-			expected = {'edge': 113};
-			actual = parseUserAgent(edge3);
-
+			expected = {edge: 113};
 			expect(actual).toMatchObject(expected);
 		});
 
@@ -178,14 +166,10 @@ describe('platform', () => {
 
 			expect(actual).toMatchObject(expected);
 
-			expected = {'chrome': 113};
-			actual = parseUserAgent(edge4);
-
+			expected = {chrome: 113};
 			expect(actual).toMatchObject(expected);
 
-			expected = {'edge': 40};
-			actual = parseUserAgent(edge4);
-
+			expected = {edge: 40};
 			expect(actual).toMatchObject(expected);
 		});
 	});

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -122,31 +122,71 @@ describe('platform', () => {
 		const edge4 = 'Mozilla/5.0 (Windows Mobile 10; Android 10.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36 Edge/40.15254.603';
 
 		test('should return edge for Edg', () => {
-			const expectd = {platformName: 'edge'};
-			const actual = parseUserAgent(edge1);
+			let expected = {platformName: 'edge'};
+			let actual = parseUserAgent(edge1);
 
-			expect(actual).toMatchObject(expectd);
+			expect(actual).toMatchObject(expected);
+
+			expected = {'chrome': 113};
+			actual = parseUserAgent(edge1);
+
+			expect(actual).toMatchObject(expected);
+
+			expected = {'edge': 113};
+			actual = parseUserAgent(edge1);
+
+			expect(actual).toMatchObject(expected);
 		});
 
 		test('should return edge for EdgA', () => {
-			const expectd = {platformName: 'edge'};
-			const actual = parseUserAgent(edge2);
+			let expected = {platformName: 'edge'};
+			let actual = parseUserAgent(edge2);
 
-			expect(actual).toMatchObject(expectd);
+			expect(actual).toMatchObject(expected);
+
+			expected = {'chrome': 113};
+			actual = parseUserAgent(edge2);
+
+			expect(actual).toMatchObject(expected);
+
+			expected = {'edge': 113};
+			actual = parseUserAgent(edge2);
+
+			expect(actual).toMatchObject(expected);
 		});
 
 		test('should return edge for EdgiOS', () => {
-			const expectd = {platformName: 'edge'};
-			const actual = parseUserAgent(edge3);
+			let expected = {platformName: 'edge'};
+			let actual = parseUserAgent(edge3);
 
-			expect(actual).toMatchObject(expectd);
+			expect(actual).toMatchObject(expected);
+
+			expected = {'chrome': 113};
+			actual = parseUserAgent(edge3);
+
+			expect(actual).not.toMatchObject(expected);
+
+			expected = {'edge': 113};
+			actual = parseUserAgent(edge3);
+
+			expect(actual).toMatchObject(expected);
 		});
 
 		test('should return edge for Edge', () => {
-			const expectd = {platformName: 'edge'};
-			const actual = parseUserAgent(edge4);
+			let expected = {platformName: 'edge'};
+			let actual = parseUserAgent(edge4);
 
-			expect(actual).toMatchObject(expectd);
+			expect(actual).toMatchObject(expected);
+
+			expected = {'chrome': 113};
+			actual = parseUserAgent(edge4);
+
+			expect(actual).toMatchObject(expected);
+
+			expected = {'edge': 40};
+			actual = parseUserAgent(edge4);
+
+			expect(actual).toMatchObject(expected);
 		});
 	});
 

--- a/packages/core/platform/tests/platform-specs.js
+++ b/packages/core/platform/tests/platform-specs.js
@@ -115,6 +115,41 @@ describe('platform', () => {
 		});
 	});
 
+	describe('parseUserAgent for Edge', () => {
+		const edge1 = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.42';
+		const edge2 = 'Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.5672.76 Mobile Safari/537.36 EdgA/113.0.1774.38';
+		const edge3 = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 EdgiOS/113.1774.42 Mobile/15E148 Safari/605.1.15';
+		const edge4 = 'Mozilla/5.0 (Windows Mobile 10; Android 10.0; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36 Edge/40.15254.603';
+
+		test('should return edge for Edg', () => {
+			const expectd = {platformName: 'edge'};
+			const actual = parseUserAgent(edge1);
+
+			expect(actual).toMatchObject(expectd);
+		});
+
+		test('should return edge for EdgA', () => {
+			const expectd = {platformName: 'edge'};
+			const actual = parseUserAgent(edge2);
+
+			expect(actual).toMatchObject(expectd);
+		});
+
+		test('should return edge for EdgiOS', () => {
+			const expectd = {platformName: 'edge'};
+			const actual = parseUserAgent(edge3);
+
+			expect(actual).toMatchObject(expectd);
+		});
+
+		test('should return edge for Edge', () => {
+			const expectd = {platformName: 'edge'};
+			const actual = parseUserAgent(edge4);
+
+			expect(actual).toMatchObject(expectd);
+		});
+	});
+
 	describe('parseUserAgent for User-Agent Reduction', () => {
 		const testVersion = '113';
 		const uaGenerator = (unifiedPlatform, deviceCompatibility = '', majorVersion = testVersion) => (


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The latest Edge platform cannot be detected as our enact/core/platform has an old regex of the Edge platform.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The regular expression for the Edge browsers is updated.

According to the documents
- https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance
- https://www.whatismybrowser.com/guides/the-latest-user-agent/edge.

The identifier token of Edge browsers can be one of the followings.

|          Platform |     UA |
|-------------------|--------|
|           Windows |    Edg |
|             macOS |    Edg |
|           Android |   EdgA |
|               iOS | EdgiOS |
| Windows 10 Mobile |   Edge |
|          Xbox One |   Edge |

The identifier token can be `Edg`, `Edge`, `EdgA`, `EdgiOS`.

In the case of `EdgA` and `Edge`, `Android` is also included in the UA string, so `edge` should be checked before `androidChrome`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11806

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
