### PR TITLE
WRP-16065: Scroller: Fixed to pass a ref object to theme libraries instead of a literal object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g enactjs/cli#develop
+    - npm install -g enactjs/cli@5.1.3
     - npm install -g codecov
     - npm install
     - npm run bootstrap --legacy-peer-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g enactjs/cli@5.1.3
+    - npm install -g @enact/cli@5.1.3
     - npm install -g codecov
     - npm install
     - npm run bootstrap --legacy-peer-deps

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -214,74 +214,84 @@ const useScrollBase = (props) => {
 		prevState: {isHorizontalScrollbarVisible, isVerticalScrollbarVisible}
 	});
 
+	/* istanbul ignore next */
+	const themeScrollContainerHandle = useRef({
+		get animator () {
+			return mutableRef.current.animator;
+		},
+		get bounds () {
+			return mutableRef.current.bounds;
+		},
+		get isDragging () {
+			return mutableRef.current.isDragging;
+		},
+		set isDragging (val) {
+			mutableRef.current.isDragging = val;
+		},
+		get isScrollAnimationTargetAccumulated () {
+			return mutableRef.current.isScrollAnimationTargetAccumulated;
+		},
+		set isScrollAnimationTargetAccumulated (val) {
+			mutableRef.current.isScrollAnimationTargetAccumulated = val;
+		},
+		get lastInputType () {
+			return mutableRef.current.lastInputType;
+		},
+		set lastInputType (val) {
+			mutableRef.current.lastInputType = val;
+		},
+		get rtl () {
+			return rtl;
+		},
+		get scrollBounds () {
+			return getScrollBounds();
+		},
+		get scrollHeight () {
+			return mutableRef.current.bounds.scrollHeight;
+		},
+		get scrolling () {
+			return mutableRef.current.scrolling;
+		},
+		get scrollLeft () {
+			return mutableRef.current.scrollLeft;
+		},
+		get scrollToInfo () {
+			return mutableRef.current.scrollToInfo;
+		},
+		get scrollTop () {
+			return mutableRef.current.scrollTop;
+		},
+		get wheelDirection () {
+			return mutableRef.current.wheelDirection;
+		},
+		set wheelDirection (val) {
+			mutableRef.current.wheelDirection = val;
+		}
+	});
+
 	if (mutableRef.current.animator == null) {
 		mutableRef.current.animator = new ScrollAnimator();
 	}
 
 	useLayoutEffect(() => {
+		/* istanbul ignore next */
 		if (setScrollContainerHandle) {
-			setScrollContainerHandle({
-				animator: mutableRef.current.animator,
+			Object.assign(themeScrollContainerHandle.current, {
 				applyOverscrollEffect,
-				bounds: mutableRef.current.bounds,
 				calculateDistanceByWheel,
 				canScrollHorizontally,
 				canScrollVertically,
 				checkAndApplyOverscrollEffect,
 				getScrollBounds,
-				get isDragging () {
-					return mutableRef.current.isDragging;
-				},
-				set isDragging (val) {
-					mutableRef.current.isDragging = val;
-				},
-				get isScrollAnimationTargetAccumulated () {
-					return mutableRef.current.isScrollAnimationTargetAccumulated;
-				},
-				set isScrollAnimationTargetAccumulated (val) {
-					mutableRef.current.isScrollAnimationTargetAccumulated = val;
-				},
-				get lastInputType () {
-					return mutableRef.current.lastInputType;
-				},
-				set lastInputType (val) {
-					mutableRef.current.lastInputType = val;
-				},
-				get rtl () {
-					return rtl;
-				},
-				get scrollBounds () {
-					return getScrollBounds();
-				},
-				get scrollHeight () {
-					return mutableRef.current.bounds.scrollHeight;
-				},
-				get scrolling () {
-					return mutableRef.current.scrolling;
-				},
-				get scrollLeft () {
-					return mutableRef.current.scrollLeft;
-				},
 				scrollTo,
 				scrollToAccumulatedTarget,
-				get scrollToInfo () {
-					return mutableRef.current.scrollToInfo;
-				},
-				get scrollTop () {
-					return mutableRef.current.scrollTop;
-				},
 				setOverscrollStatus,
 				showScrollbarTrack,
 				start,
 				startHidingScrollbarTrack,
-				stop,
-				get wheelDirection () {
-					return mutableRef.current.wheelDirection;
-				},
-				set wheelDirection (val) {
-					mutableRef.current.wheelDirection = val;
-				}
+				stop
 			});
+			setScrollContainerHandle(themeScrollContainerHandle.current);
 		}
 	});
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Theme libraries can assume that a passing object reference is fixed, but `useScrollBase` is passing a literal object that is newly created for each call. And this could cause unexpected behavior of Scroller/VirtualList.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of a literal object, pass a ref object from `useRef`.
(Cherry-pick #3118)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-5951
WRP-16065

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)