### PR TITLE
WRP-11048: Move storybook-related modules from devDependencies to dependencies

### DIFF
--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -15,22 +15,19 @@
     "@enact/core": "^4.7.1",
     "@enact/i18n": "^4.7.1",
     "@enact/spotlight": "^4.7.1",
+    "@enact/storybook-utils": "^5.0.4",
     "@enact/ui": "^4.7.1",
     "@enact/webos": "^4.7.1",
-    "classnames": "^2.3.2",
-    "ilib": "^14.17.0",
-    "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@enact/storybook-utils": "^5.0.4",
     "@storybook/addons": "^6.5.16",
     "@storybook/builder-webpack5": "^6.5.16",
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/react": "^6.5.16",
     "@storybook/theming": "^6.5.16",
     "babel-loader": "^8.2.5",
-    "core-js": "^3.30.1"
+    "classnames": "^2.3.2",
+    "ilib": "^14.17.0",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When you initialize a storybook, the module related to the storybook is automatically installed in devDependencies.
(https://storybook.js.org/docs/react/get-started/install , in simply, $ npx storybook@latest init)

There was no reason to be managed as devDependencies even if you checked related documents or developer sites, and it is right to move to dependencies because the sampler directory itself aims to create samplers through storybooks.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move storybook-related modules from devDependencies to dependencies

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Removed the `core-js` module.
The `core-js` module is not needed. I cannot find any code usage and the sampler works fine without this module.


### Links
[//]: # (Related issues, references)
WRP-11048

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)