### PR TITLE
WRP-19306: Fixed `VirtualList` to work properly when both `minSize` in `itemSize` and `clientSize` are given

### DIFF
--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -292,17 +292,10 @@ class VirtualListBasic extends Component {
 	};
 
 	constructor (props) {
-		let nextState = null;
-
 		super(props);
 
 		this.contentRef = createRef();
 		this.itemContainerRefs = [];
-
-		if (props.clientSize) {
-			this.calculateMetrics(props);
-			nextState = this.getStatesAndUpdateBounds(props);
-		}
 
 		this.state = {
 			firstIndex: 0,
@@ -310,9 +303,13 @@ class VirtualListBasic extends Component {
 			prevChildProps: null,
 			prevFirstIndex: 0,
 			updateFrom: 0,
-			updateTo: 0,
-			...nextState
+			updateTo: 0
 		};
+
+		if (props.clientSize) {
+			this.calculateMetrics(props);
+			Object.assign(this.state, this.getStatesAndUpdateBounds(props));
+		}
 	}
 
 	static getDerivedStateFromProps (props, state) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If both `minSize` in `itemSize` prop and `clientSize` are specified, `VirtualList` does not work properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed uninitialized internal state in the given condition.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-19306
WRP-4365

### Comments
