### PR TITLE
WRP-539: Update handle docs to remove bindAs example

### DIFF
--- a/packages/core/handle/handle.js
+++ b/packages/core/handle/handle.js
@@ -28,8 +28,7 @@
  * `props` and `context`. This allows you to write consistent event handlers for components created
  * either with `kind()` or ES6 classes without worrying about from where the props are sourced.
  *
- * Handlers can either be bound directly using the native `bind()` method or using the `bindAs()`
- * utility method that is appended to the handler.
+ * Handlers can be bound directly using the native `bind()` method.
  *
  * Example:
  * ```
@@ -42,12 +41,7 @@
  *     super();
  *
  *     // logEnter will be bound to `this` and set as this.handleKeyDown
- *     //
- *     // Equivalent to the following with the advantage of set the function name to be displayed in
- *     // development tool call stacks
- *     //
- *     //   this.handleKeyDown = logEnter.bind(this)
- *     logEnter.bindAs(this, 'handleKeyDown');
+ *     this.handleKeyDown = logEnter.bind(this);
  *   }
  *
  *   render () {
@@ -153,6 +147,7 @@ const named = (fn, name) => {
 	return fn;
 };
 
+// Setting the function name to be displayed in development tool call stacks rather than `anonymous`
 const bindAs = (fn, obj, name) => {
 	const namedFunction = name ? named(fn, name) : fn;
 	const bound = namedFunction.bind(obj);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`bindAs` utility is for internal use only and is not exported but docs example uses.
It could cause confusion for readers.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed `bindAs` usage from the example and added some inline comments for internal developers about the handle.bindAs purpose.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I still don't know if we need to export `bindAs` function to the public. This function is definitely useful.
If we decide to make it public, we shall add docs, example.

### Links
[//]: # (Related issues, references)
WRP-539
https://github.com/enactjs/enact/pull/1652

### Comments

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>