### PR TITLE
WRP-24097: Fix margin of marquee text to be zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased] 
+
+### Fixed
+
+- `ui/Marquee` style to avoid letters being cut off
+
 ## [4.7.3] - 2023-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [unreleased] 
-
-### Fixed
-
-- `ui/Marquee` style to avoid letters being cut off
-
 ## [4.7.3] - 2023-08-10
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee` style to avoid letters being cut off
+
 ## [4.7.3] - 2023-08-10
 
 No significant changes.

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -29,6 +29,10 @@
 		transition-timing-function: linear;
 		position: relative;
 
+		& * {
+			margin: 0;
+		}
+
 		&.willAnimate {
 			will-change: opacity;
 			overflow: visible;

--- a/packages/ui/Marquee/Marquee.module.less
+++ b/packages/ui/Marquee/Marquee.module.less
@@ -23,6 +23,7 @@
 		text-overflow: ellipsis;
 		overflow: hidden;
 		width: 100%;
+		margin: 0;
 		white-space: pre !important;
 		transition-property: transform;
 		transition-timing-function: linear;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As the margin of marquee text is not defined, margin text can be cropped by the  `overflow:hidden` prop of `.marquee` class

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix the margin of the marquee text to 0

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-24097

### Comments
