### PR TITLE
WRP-26268: Rename PalmServiceBridge as WebOSServiceBridge

### DIFF
--- a/docs/redux/redux-async.md
+++ b/docs/redux/redux-async.md
@@ -33,7 +33,7 @@ function incrementAsync() {
 
 ### LS2Request Example
 
-A combination of `redux-thunk` and `LS2Request` allows us to fetch and display data in a React component. `LS2Request` is a wrapper component for `PalmServiceBridge` and is available from `@enact/webos/LS2Request`. The following example shows a simple fetch routine.
+A combination of `redux-thunk` and `LS2Request` allows us to fetch and display data in a React component. `LS2Request` is a wrapper component for `WebOSServiceBridge` and is available from `@enact/webos/LS2Request`. The following example shows a simple fetch routine.
 
 At the root level, we use `<Provider />` to pass store down the component hierarchy.
 

--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -75,17 +75,20 @@ export default class LS2Request {
 		subscribe = false,
 		timeout = 0
 	}) {
+		const WebOSServiceBridge = typeof window === 'object' ? (window.WebOSServiceBridge ?? window.PalmServiceBridge) : null;
+
 		this.cancelled = false;
 
 		if (!onFailure && !onComplete) {
 			onFailure = failureHandler;
 		}
 
-		if (typeof window !== 'object' || !window.PalmServiceBridge) {
+		if (typeof WebOSServiceBridge !== 'function') {
+			const errorText = 'WebOSServiceBridge not found.';
 			/* eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
-			if (onFailure) onFailure({errorCode: -1, errorText: 'PalmServiceBridge not found.', returnValue: false});
-			if (onComplete) onComplete({errorCode: -1, errorText: 'PalmServiceBridge not found.', returnValue: false});
-			console.error('PalmServiceBridge not found.');
+			if (onFailure) onFailure({errorCode: -1, errorText, returnValue: false});
+			if (onComplete) onComplete({errorCode: -1, errorText, returnValue: false});
+			console.error(errorText);
 			return;
 		}
 
@@ -105,7 +108,7 @@ export default class LS2Request {
 		refs[this.ts] = this;
 
 		// eslint-disable-next-line no-undef
-		this.bridge = new PalmServiceBridge();
+		this.bridge = new WebOSServiceBridge();
 		this.bridge.onservicecallback = this.callback.bind(this, onSuccess, onFailure, onComplete);
 		if (timeout) {
 			this.timeoutJob.startAfter(timeout, {onTimeout, timeout});

--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -107,7 +107,6 @@ export default class LS2Request {
 		this.ts = performance.now();
 		refs[this.ts] = this;
 
-		// eslint-disable-next-line no-undef
 		this.bridge = new WebOSServiceBridge();
 		this.bridge.onservicecallback = this.callback.bind(this, onSuccess, onFailure, onComplete);
 		if (timeout) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`PalmServiceBridge` was renamed as `WebOSServiceBridge` in 2018 with an fallback alias for compatibility on legacy webOS.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated docs to use `WebOSServiceBridge`, and updated `LS2Request` module to use `WebOSServiceBridge` with a fallback of `PalmServiceBridge`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-26268

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)