### PR TITLE
Update preventScroll option in focus and focusElement

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+
+### Changed
+- Added preventScroll parameter to `focusElement` for enhanced scroll control.
+- Extended `focus` in `spotlight/Spotlight` with a containerOption parameter that includes preventScroll.
+
 ## [4.7.5] - 2023-09-12
 
 No significant changes.

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -197,7 +197,7 @@ const Spotlight = (function () {
 		}
 	}
 
-	function focusElement (elem, containerIds, fromPointer) {
+	function focusElement (elem, containerIds, fromPointer, preventScroll = false) {
 		if (!elem) {
 			return false;
 		}
@@ -214,7 +214,8 @@ const Spotlight = (function () {
 			return true;
 		}
 
-		const focusOptions = isWithinOverflowContainer(elem, containerIds) ? {preventScroll: true} : null;
+		const shouldPreventScroll = isWithinOverflowContainer(elem, containerIds) || preventScroll;
+		const focusOptions = shouldPreventScroll ? { preventScroll: true } : null;
 
 		let silentFocus = function () {
 			elem.focus(focusOptions);
@@ -750,12 +751,13 @@ const Spotlight = (function () {
 		 * @param {String|Node} [elem] The spotlight ID or selector for either a spottable
 		 *  component or a spotlight container, or spottable node. If not supplied, the default
 		 *  container will be focused.
-		 * @param {Object} [containerOption] The object including `enterTo` and `toOuterContainer`.
+		 * @param {Object} [containerOption] The object including `enterTo`, `toOuterContainer`, and `preventScroll`.
 		 *  It works when the first parameter `elem` is either a spotlight container ID or a spotlight container node.
 		 * @param {('last-focused'|'default-element'|'topmost')} [containerOption.enterTo] Specifies preferred
 		 *  `enterTo` configuration.
 		 * @param {Boolean} [containerOption.toOuterContainer] If the proper target is not found, search one
 		 *  recursively to outer container.
+		 * @param {Boolean} [containerOption.preventScroll] Prevents automatic scrolling when focusing the element.
 		 * @returns {Boolean} `true` if focus successful, `false` if not.
 		 * @public
 		 */
@@ -785,7 +787,7 @@ const Spotlight = (function () {
 			const nextContainerIds = getContainersForNode(target);
 			const nextContainerId = last(nextContainerIds);
 			if (isNavigable(target, nextContainerId, true)) {
-				const focused = focusElement(target, nextContainerIds);
+				const focused = focusElement(target, nextContainerIds, false, containerOption.preventScroll);
 
 				if (!focused && wasContainerId) {
 					setLastContainer(elem);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Nakjun Hwang <wns450@gmail.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Improved scrolling behavior by adding a preventScroll parameter to the focusElement and extending focus in spotlight/Spotlight to include containerOption with preventScroll.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- The code works as intended, enabling more precise control over the scrolling behavior when focusing elements. This change was implemented to enhance the user navigation experience.
- The preventScroll parameter was introduced because, when using spotlight.focus, the forced scrolling behavior caused discomfort in the user experience. Consequently, this change was implemented to improve the user experience by granting greater control over preventScroll in enact.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

Separate PRs for focusElement and spotlight.focus
Considering splitting this PR into two: one for focusElement and another for spotlight.focus. This would allow for more focused review and testing of each feature.

### Links
[//]: # (Related issues, references)
[Focus with and without scrolling](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focus_with_and_without_scrolling)

### Comments

To avoid affecting existing code:

A 4th argument was introduced in focusElement specifically for the preventScroll parameter.
For spotlight.focus, preventScroll was added to the existing containerOption.

Extensibility
The preventScroll parameter is designed for integration into other methods using focusElement.