### PR TITLE
WRQ-1033: Fix i18n loader to traverse additional resources later while loading resources

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n` resource loader to prioritize strings from additional resources files 
+
 ## [4.7.6] - 2023-09-20
 
 No significant changes.

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -260,10 +260,12 @@ EnyoLoader.prototype.loadFiles = function (paths, sync, params, callback, rootPa
 					getSync(this._pathjoin(_root, path), handler);
 				}
 
-				if (this.addPaths && Array.isArray(this.addPaths)) {
+				if (this.addPaths && Array.isArray(this.addPaths) && index === paths.length - 1) {
 					for (let addedRoot of this.addPaths) {
-						if (this.isAvailable(addedRoot, path)) {
-							getSync(this._pathjoin(addedRoot, path), handleAdditionalResourcesPath);
+						for (let i = 0; i <= index; i++) {
+							if (this.isAvailable(addedRoot, paths[i])) {
+								getSync(this._pathjoin(addedRoot, paths[i]), handleAdditionalResourcesPath);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For example, when the es-ES folder of original resources and the es folder of additional resources have the same key, the app wants key-value from the es folder of additional resources instead of the es-ES of original resources. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix i18n loader to traverse additional resources from the root later to override strings while loading resources files

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-1033

### Comments
