### PR TITLE
WRQ-2421: Fix MarqueeDecorator to re-render marquee when its size changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to re-render when its size changed
+
 ## [4.7.7] - 2023-11-09
 
 No significant changes.

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -1,3 +1,5 @@
+/* global ResizeObserver */
+
 import direction from 'direction';
 import {on, off} from '@enact/core/dispatcher';
 import {forward} from '@enact/core/handle';
@@ -365,6 +367,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.distance = null;
 			this.contentFits = null;
 			this.resizeRegistry = null;
+			this.resizeObserver = null;
 		}
 
 		componentDidMount () {
@@ -377,6 +380,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
+
+			if (typeof ResizeObserver === 'function' && this.node) {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.handleResize();
+				});
+				this.resizeObserver.observe(this.node);
+			}
+
 			if (this.props.marqueeOn === 'render') {
 				this.startAnimation(this.props.marqueeOnRenderDelay);
 			}
@@ -432,6 +443,11 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (this.resizeRegistry) {
 				this.resizeRegistry.unregister(this.handleResize);
+			}
+
+			if (this.resizeObserver) {
+				this.resizeObserver.disconnect();
+				this.resizeObserver = null;
 			}
 
 			off('keydown', this.handlePointerHide, document);

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -38,6 +38,18 @@ beforeEach(() => {
 			return observe;
 		}
 	};
+
+	global.ResizeObserver = class ResizeObserver {
+		constructor () {}
+
+		disconnect () {
+			return null;
+		}
+
+		observe () {
+			return observe;
+		}
+	};
 });
 
 afterEach(() => {

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -250,6 +250,21 @@ describe('Marquee', () => {
 
 		expect(spy).toHaveBeenCalled();
 	});
+
+	test('should creates and observes with ResizeObserver', () => {
+		const observe = jest.fn();
+		global.ResizeObserver = jest.fn(() => ({
+			observe,
+			disconnect: jest.fn()
+		}));
+
+		render(<Marquee>{ltrText}</Marquee>);
+
+		act(() => jest.advanceTimersByTime(100));
+
+		expect(global.ResizeObserver).toHaveBeenCalled();
+		expect(observe).toHaveBeenCalled();
+	});
 });
 
 describe('MarqueeBase', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When Marquee size is changed dynamically(for example, changing the screen size or rotating the screen) it is not re-rendered, so the text will not be able to start marquee animation and may be truncated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `ResizeObserver` to make Marquee re-render when its size is changed. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2421

### Comments
