### PR TITLE
WRQ-2421: Fix MarqueeDecorator to re-render marquee when its size changed (enact 4.5)

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,36 +2,13 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
-## [4.5.5] - 2023-11-08
 ## [unreleased]
 
 ### Fixed
 
 - `ui/Marquee.MarqueeDecorator` to re-render when its size changed
 
-## [4.7.7] - 2023-11-09
-
-No significant changes.
-
-## [4.7.6] - 2023-09-20
-
-No significant changes.
-
-## [4.7.5] - 2023-09-12
-
-No significant changes.
-
-## [4.7.4] - 2023-08-31
-
-### Fixed
-
-- `ui/Marquee` style to avoid letters being cut off
-
-## [4.7.3] - 2023-08-10
-
-No significant changes.
-
-## [4.7.2] - 2023-07-14
+## [4.5.5] - 2023-11-08
 
 No significant changes.
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,35 @@
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
 ## [4.5.5] - 2023-11-08
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to re-render when its size changed
+
+## [4.7.7] - 2023-11-09
+
+No significant changes.
+
+## [4.7.6] - 2023-09-20
+
+No significant changes.
+
+## [4.7.5] - 2023-09-12
+
+No significant changes.
+
+## [4.7.4] - 2023-08-31
+
+### Fixed
+
+- `ui/Marquee` style to avoid letters being cut off
+
+## [4.7.3] - 2023-08-10
+
+No significant changes.
+
+## [4.7.2] - 2023-07-14
 
 No significant changes.
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -1,3 +1,5 @@
+/* global ResizeObserver */
+
 import direction from 'direction';
 import {on, off} from '@enact/core/dispatcher';
 import {forward} from '@enact/core/handle';
@@ -362,6 +364,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.distance = null;
 			this.contentFits = null;
 			this.resizeRegistry = null;
+			this.resizeObserver = null;
 		}
 
 		componentDidMount () {
@@ -374,6 +377,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
+
+			if (typeof ResizeObserver === 'function' && this.node) {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.handleResize();
+				});
+				this.resizeObserver.observe(this.node);
+			}
+
 			if (this.props.marqueeOn === 'render') {
 				this.startAnimation(this.props.marqueeOnRenderDelay);
 			}
@@ -429,6 +440,11 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (this.resizeRegistry) {
 				this.resizeRegistry.unregister(this.handleResize);
+			}
+
+			if (this.resizeObserver) {
+				this.resizeObserver.disconnect();
+				this.resizeObserver = null;
 			}
 
 			off('keydown', this.handlePointerHide, document);

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -38,18 +38,6 @@ beforeEach(() => {
 			return observe;
 		}
 	};
-
-	global.ResizeObserver = class ResizeObserver {
-		constructor () {}
-
-		disconnect () {
-			return null;
-		}
-
-		observe () {
-			return observe;
-		}
-	};
 });
 
 afterEach(() => {
@@ -252,6 +240,8 @@ describe('Marquee', () => {
 	});
 
 	test('should creates and observes with ResizeObserver', () => {
+		const originalResizeObserver = global.ResizeObserver;
+
 		const observe = jest.fn();
 		global.ResizeObserver = jest.fn(() => ({
 			observe,
@@ -264,6 +254,8 @@ describe('Marquee', () => {
 
 		expect(global.ResizeObserver).toHaveBeenCalled();
 		expect(observe).toHaveBeenCalled();
+
+		global.ResizeObserver = originalResizeObserver;
 	});
 });
 

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -38,6 +38,18 @@ beforeEach(() => {
 			return observe;
 		}
 	};
+
+	global.ResizeObserver = class ResizeObserver {
+		constructor () {}
+
+		disconnect () {
+			return null;
+		}
+
+		observe () {
+			return observe;
+		}
+	};
 });
 
 afterEach(() => {
@@ -237,6 +249,21 @@ describe('Marquee', () => {
 		fireEvent.mouseLeave(marquee);
 
 		expect(spy).toHaveBeenCalled();
+	});
+
+	test('should creates and observes with ResizeObserver', () => {
+		const observe = jest.fn();
+		global.ResizeObserver = jest.fn(() => ({
+			observe,
+			disconnect: jest.fn()
+		}));
+
+		render(<Marquee>{ltrText}</Marquee>);
+
+		act(() => jest.advanceTimersByTime(100));
+
+		expect(global.ResizeObserver).toHaveBeenCalled();
+		expect(observe).toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When Marquee size is changed dynamically(for example, changing the screen size or rotating the screen) it is not re-rendered, so the text will not be able to start marquee animation and may be truncated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Cherry-pick #3183 to add `ResizeObserver` to make Marquee re-render when its size is changed

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2421

### Comments
