### PR TITLE
WRQ-2906 : Change the variable name to prevent export error when 'enact transpile'

### DIFF
--- a/packages/ui/Routable/Routable.js
+++ b/packages/ui/Routable/Routable.js
@@ -17,7 +17,7 @@ import warning from 'warning';
 import {Link, Linkable} from './Link';
 import Route from './Route';
 import Router from './Router';
-import {propTypes, toSegments, RouteContext, resolve} from './util';
+import {RoutablePropTypes, toSegments, RouteContext, resolve} from './util';
 
 /**
  * Default config for {@link ui/Routable.Routable|Routable}.
@@ -69,7 +69,7 @@ const Routable = hoc(defaultConfig, (config, Wrapped) => {
 			 * @required
 			 * @public
 			 */
-			path: propTypes.path.isRequired,
+			path: RoutablePropTypes.path.isRequired,
 
 			/**
 			 * Called when navigating.

--- a/packages/ui/Routable/Router.js
+++ b/packages/ui/Routable/Router.js
@@ -5,7 +5,7 @@ import warning from 'warning';
 
 import ForwardRef from '../ForwardRef';
 
-import {propTypes, stringifyRoutes, toSegments} from './util';
+import {RoutablePropTypes, stringifyRoutes, toSegments} from './util';
 
 /**
  * A Router component for use with {@link ui/ViewManager.ViewManager|ViewManager}
@@ -33,7 +33,7 @@ const RouterBase = class extends ReactComponent {
 		 * @required
 		 * @public
 		 */
-		path: propTypes.path.isRequired,
+		path: RoutablePropTypes.path.isRequired,
 
 		/**
 		 * The component wrapping the rendered path.

--- a/packages/ui/Routable/util.js
+++ b/packages/ui/Routable/util.js
@@ -64,7 +64,7 @@ const resolve = (base = '/', path) => {
 	return `/${base.concat(path).join('/')}`;
 };
 
-const propTypes = {
+const RoutablePropTypes = {
 	path: PropTypes.oneOfType([
 		PropTypes.arrayOf(PropTypes.string),	// array of path segments
 		PropTypes.string						// URI-style path
@@ -72,7 +72,7 @@ const propTypes = {
 };
 
 export {
-	propTypes,
+	RoutablePropTypes,
 	resolve,
 	stringifyRoutes,
 	toSegments,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In babel version 7.23 or higher, an error occurs when exporting `propTypes` in `ui/Routable/util.js` when `enact transpile`.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change variable name from `propTypes` to `RoutablePropTypes`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2906

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)