### PR TITLE
WRQ-3732: Notify focus moving by key from pointer mode internally

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -331,6 +331,17 @@ const Spotlight = (function () {
 		const next = getTargetByDirectionFromPosition(direction, position, containerId);
 
 		if (next) {
+			const currentContainerIds = getContainersForNode(getContainerNode(containerId));
+			const nextContainerIds = getContainersForNode(next);
+
+			notifyLeaveContainer(
+				direction,
+				null,
+				currentContainerIds,
+				next,
+				nextContainerIds
+			);
+
 			setContainerPreviousTarget(
 				containerId,
 				direction,
@@ -338,7 +349,17 @@ const Spotlight = (function () {
 				getContainerLastFocusedElement(containerId)
 			);
 
-			return focusElement(next, getContainersForNode(next));
+			const focused = focusElement(next, getContainersForNode(next));
+
+			notifyEnterContainer(
+				direction,
+				null,
+				currentContainerIds,
+				next,
+				nextContainerIds
+			);
+
+			return focused;
 		}
 
 		return false;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When focus is entering to or leaving from a container by 5-way key input on 5-way mode, Spotlight notify this situation internally so that related features works properly. But there is no notification on pointer mode at the same situation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update internal logic to notify the situation on pointer mode just like on 5-way mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-3732

### Comments
