### PR TITLE
WRQ-171: Added internal scrolling option to disallow negative offset

### DIFF
--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -550,20 +550,24 @@ class VirtualListBasic extends Component {
 		return index === 0 ? 0 : this.getItemBottomPosition(index - 1) + spacing;
 	};
 
-	getItemPosition = (index, stickTo = 'start', optionalOffset = 0) => {
+	getItemPosition = (index, stickTo = 'start', optionalOffset = 0, disallowNegativeOffset = false) => {
 		const {isPrimaryDirectionVertical, primary, scrollBounds} = this;
 		const maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft;
 		const position = this.getGridPosition(index);
 		let offset = 0;
 
-		if (stickTo === 'start') {
+		if (stickTo === 'start') {         // 'start'
 			offset = optionalOffset;
-		} else if (this.props.itemSizes) {
+		} else if (this.props.itemSizes) { // 'end' for different item sizes
 			offset = primary.clientSize - this.props.itemSizes[index] - optionalOffset;
-		} else if (stickTo === 'center') {
+		} else if (stickTo === 'center') { // 'center'
 			offset = (primary.clientSize / 2) - (primary.gridSize / 2) - optionalOffset;
-		} else {
+		} else {                           // 'end' for same item sizes
 			offset = primary.clientSize - primary.itemSize - optionalOffset;
+		}
+
+		if (disallowNegativeOffset) {
+			offset = Math.max(0, offset);
 		}
 
 		position.primaryPosition = clamp(0, maxPos, position.primaryPosition - offset);

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1296,7 +1296,7 @@ const useScrollBase = (props) => {
 				}
 			} else {
 				if (typeof opt.index === 'number' && typeof scrollContentHandle.current.getItemPosition === 'function') {
-					itemPos = scrollContentHandle.current.getItemPosition(opt.index, opt.stickTo, opt.offset);
+					itemPos = scrollContentHandle.current.getItemPosition(opt.index, opt.stickTo, opt.offset, opt.disallowNegativeOffset);
 				} else if (opt.node instanceof Object) {
 					if (opt.node.nodeType === 1 && typeof scrollContentHandle.current.getNodePosition === 'function') {
 						itemPos = scrollContentHandle.current.getNodePosition(opt.node);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a theme library call `scrollTo` with `optionalOffset` for internal uses, sometimes the finally applied offset could be negative value but it is not desired behavior.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Simply added an option to avoid negative offset.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
No changelog as only internal code is changed without impact for developers.

### Links
[//]: # (Related issues, references)
WRQ-171

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)