### PR TITLE
WRQ-2287: Fix i18n loader to handle exceeded error of localStorage data

### DIFF
--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -52,6 +52,20 @@ const cacheKey = cachePrefix + 'CACHE-ID';
 const cacheID = typeof ILIB_CACHE_ID === 'undefined' ? '$ILIB' : ILIB_CACHE_ID;
 const timeStampKey = 'l10n_timestamp';
 
+function setLocalStorageItem (keyName, keyValue) {
+	const regex = new RegExp(`${cachePrefix}${iLibResources}/([a-z]{2,3}/)+[a-z]+.json`);
+	try {
+		window.localStorage.setItem(keyName, keyValue);
+	} catch {
+		Object.keys(window.localStorage).forEach((key) => {
+			if (regex.test(key) && !key.includes(keyName.slice(0, keyName.lastIndexOf('/')))) {
+				window.localStorage.removeItem(key);
+			}
+		});
+		window.localStorage.setItem(keyName, keyValue);
+	}
+}
+
 function EnyoLoader () {
 	this.base = iLibBase;
 	// TODO: full enyo.platform implementation for improved accuracy
@@ -173,7 +187,7 @@ EnyoLoader.prototype._loadFilesCache = function (_root, paths) {
 EnyoLoader.prototype._storeFilesCache = function (_root, paths, data) {
 	if (typeof window !== 'undefined' && window.localStorage && paths.length > 0) {
 		let target = JSON.stringify(paths);
-		window.localStorage.setItem(cachePrefix + _root + '/' + paths[0], JSON.stringify({target: target, value: data}));
+		setLocalStorageItem(cachePrefix + _root + '/' + paths[0], JSON.stringify({target: target, value: data}));
 	}
 };
 
@@ -200,7 +214,7 @@ EnyoLoader.prototype._validateCache = function () {
 					i--;
 				}
 			}
-			window.localStorage.setItem(cacheKey, cacheID);
+			setLocalStorageItem(cacheKey, cacheID);
 		}
 	}
 	this._cacheValidated = true;
@@ -315,7 +329,7 @@ EnyoLoader.prototype._handleManifest = function (dirpath, filepath, json) {
 	// that dir
 	if (json != null) {
 		if (typeof window !== 'undefined' && window.localStorage) {
-			window.localStorage.setItem(cachePrefix + filepath, JSON.stringify(json));
+			setLocalStorageItem(cachePrefix + filepath, JSON.stringify(json));
 		}
 
 		// Need to clear string cache
@@ -327,7 +341,7 @@ EnyoLoader.prototype._handleManifest = function (dirpath, filepath, json) {
 		// so that we prevent loading everything.
 		this.manifest[dirpath] = [];
 		if (typeof window !== 'undefined' && window.localStorage) {
-			window.localStorage.setItem(cachePrefix + filepath, JSON.stringify({[timeStampKey]: new Date().getTime()}));
+			setLocalStorageItem(cachePrefix + filepath, JSON.stringify({[timeStampKey]: new Date().getTime()}));
 		}
 	} else {
 		this.manifest[dirpath] = '*';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If locale changes are repeated multiple times, QuotaExceededError occurs when saving ilib cache data to localstorage.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add try-catch block to handle exception cases. When QutoaExceededError occurs, filter which cache data to remove and then remove them.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2287

### Comments
