### PR TITLE
Update 'update-copyright-years.yml' to change triggering date to Jan 4 for copyright update

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -2,7 +2,7 @@ name: Update copyright year(s) in license file
 
 on:
   schedule:
-    - cron: "00 7 12 1 *"
+    - cron: "0 7 1 1 *"
 
 jobs:
   run:

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -2,7 +2,7 @@ name: Update copyright year(s) in license file
 
 on:
   schedule:
-    - cron: "0 7 1 1 *"
+    - cron: "0 0 4 1 *"
 
 jobs:
   run:


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update GitHub Actions 'update-copyright-years' to make a PR automatically for copyright year update. The updated triggering date will be Jan 4.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
