### PR TITLE
WRQ-6220: Fixed `spotlight` navigation from the focused element clipped by an overflow container

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` navigation from the focused element clipped by an overflow container
+
 ## [4.8.0] - 2024-02-08
 
 No significant changes.

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -20,6 +20,7 @@ import navigate from './navigate';
 import {
 	contains,
 	getContainerRect,
+	getIntersectionRect,
 	getPointRect,
 	getRect,
 	getRects,
@@ -364,7 +365,8 @@ function getTargetByDirectionFromElement (direction, element) {
 		return getTargetBySelector(extSelector);
 	}
 
-	const elementRect = getRect(element);
+	const elementContainerId = getContainersForNode(element).pop();
+	const elementRect = getContainerConfig(elementContainerId)?.overflow ? getIntersectionRect(getContainerNode(elementContainerId), element) : getRect(element);
 
 	const next = getNavigableContainersForNode(element)
 		.reduceRight((result, containerId, index, elementContainerIds) => {

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -14,7 +14,8 @@ import {
 	getLastContainer,
 	getNavigableContainersForNode,
 	isContainer,
-	isNavigable
+	isNavigable,
+	rootContainerId
 } from './container';
 import navigate from './navigate';
 import {
@@ -366,7 +367,12 @@ function getTargetByDirectionFromElement (direction, element) {
 	}
 
 	const elementContainerId = getContainersForNode(element).pop();
-	const elementRect = getContainerConfig(elementContainerId)?.overflow ? getIntersectionRect(getContainerNode(elementContainerId), element) : getRect(element);
+	let elementRect = null;
+	if (elementContainerId !== rootContainerId && getContainerConfig(elementContainerId)?.overflow) {
+		elementRect = getIntersectionRect(getContainerNode(elementContainerId), element);
+	} else {
+		elementRect = getRect(element);
+	}
 
 	const next = getNavigableContainersForNode(element)
 		.reduceRight((result, containerId, index, elementContainerIds) => {

--- a/packages/spotlight/src/tests/utils-specs.js
+++ b/packages/spotlight/src/tests/utils-specs.js
@@ -1,4 +1,6 @@
 import {
+	getIntersectionRect,
+	getRect,
 	getPointRect,
 	getContainerRect,
 	isStandardFocusable
@@ -36,6 +38,81 @@ const scenarios = {
 };
 
 describe('utils', () => {
+	describe('#getIntersectionRect', () => {
+		test('should return the intersection rect between two given rects', () => {
+			const rect1 = {
+				getBoundingClientRect: () => ({
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100
+				})
+			};
+			const rect2 = {
+				getBoundingClientRect: () => ({
+					left: 50,
+					top: 50,
+					width: 100,
+					height: 100
+				})
+			};
+			const expected = {
+				left: 50,
+				top: 50,
+				width: 50,
+				height: 50,
+				right: 100,
+				bottom: 100,
+				center: {
+					x: 75,
+					y: 75,
+					left: 75,
+					right: 75,
+					top: 75,
+					bottom: 75
+				},
+				element: rect2
+			};
+			const actual = getIntersectionRect(rect1, rect2);
+
+			expect(actual).toEqual(expected);
+		});
+	});
+
+	describe('#getRect', () => {
+		test('should return the rect value calculated based on the given element', () => {
+			const element = {
+				getBoundingClientRect: () => ({
+					left: 10,
+					top: 20,
+					width: 100,
+					height: 200
+				})
+			};
+
+			const expected = {
+				left: 10,
+				top: 20,
+				width: 100,
+				height: 200,
+				right: 110,
+				bottom: 220,
+				center: {
+					x: 60,
+					y: 120,
+					left: 60,
+					right: 60,
+					top: 120,
+					bottom: 120
+				},
+				element
+			};
+			const actual = getRect(element);
+
+			expect(actual).toEqual(expected);
+		});
+	});
+
 	describe('#getPointRect', () => {
 		test('should return an rect value calculated based on given position', () => {
 			const expected = {

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -86,6 +86,38 @@ const contains = curry((containerRect, elementRect) => {
 	return testIntersection('contains', containerRect, elementRect);
 });
 
+function getIntersectionRect (container, element) {
+	const {
+		left: L,
+		right: R,
+		top: T,
+		bottom: B
+	} = container.getBoundingClientRect();
+	const {
+		left: l,
+		right: r,
+		top: t,
+		bottom: b
+	} = element.getBoundingClientRect();
+	const intersectionRect = {
+		element,
+		left: Math.max(l, L),
+		right: Math.min(r, R),
+		top: Math.max(t, T),
+		bottom: Math.min(b, B)
+	};
+	intersectionRect.width = intersectionRect.right - intersectionRect.left;
+	intersectionRect.height = intersectionRect.bottom - intersectionRect.top;
+	intersectionRect.center = {
+		x: intersectionRect.left + Math.floor(intersectionRect.width / 2),
+		y: intersectionRect.top + Math.floor(intersectionRect.height / 2)
+	};
+	intersectionRect.center.left = intersectionRect.center.right = intersectionRect.center.x;
+	intersectionRect.center.top = intersectionRect.center.bottom = intersectionRect.center.y;
+
+	return intersectionRect;
+}
+
 function getRect (elem) {
 	const cr = elem.getBoundingClientRect();
 	const rect = {
@@ -209,6 +241,7 @@ function isElementHidden (element) {
 export {
 	contains,
 	getContainerRect,
+	getIntersectionRect,
 	getPointRect,
 	getRect,
 	getRects,

--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -89,22 +89,22 @@ const contains = curry((containerRect, elementRect) => {
 function getIntersectionRect (container, element) {
 	const {
 		left: L,
-		right: R,
 		top: T,
-		bottom: B
+		width: W,
+		height: H
 	} = container.getBoundingClientRect();
 	const {
 		left: l,
-		right: r,
 		top: t,
-		bottom: b
+		width: w,
+		height: h
 	} = element.getBoundingClientRect();
 	const intersectionRect = {
 		element,
 		left: Math.max(l, L),
-		right: Math.min(r, R),
+		right: Math.min(l + w, L + W),
 		top: Math.max(t, T),
-		bottom: Math.min(b, B)
+		bottom: Math.min(t + h, T + H)
 	};
 	intersectionRect.width = intersectionRect.right - intersectionRect.left;
 	intersectionRect.height = intersectionRect.bottom - intersectionRect.top;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight cannot choose the next focus target if the currently focused node is partially visible as clipped by an overflow container. Note that a clipped node within an overflow container can be a navigable target.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated a navigation logic to count only a visible part if the currently focused node is partially visible and its closest container is an overflow container.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6220

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
