### PR TITLE
WRQ-179: Fix default value of `enteroTo` in GlobalConfig to null

### DIFF
--- a/packages/spotlight/SpotlightRootDecorator/tests/SpotlightRootDecorator-specs.js
+++ b/packages/spotlight/SpotlightRootDecorator/tests/SpotlightRootDecorator-specs.js
@@ -7,6 +7,10 @@ import {
 	getInputType
 } from '../SpotlightRootDecorator';
 
+import {
+	getContainerConfig
+} from '../../src/container';
+
 describe('SpotlightRootDecorator', () => {
 	const AppBase = (props) => (
 		<div id="root" data-testid="root" {...props} >
@@ -38,6 +42,18 @@ describe('SpotlightRootDecorator', () => {
 
 		const expected = 'touch';
 		const actual = getInputType();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should set spotlightRootDecorator container enterTo config to `null` by default', () => {
+		const App = SpotlightRootDecorator(AppBase);
+
+		render(<App />);
+
+		const containerConfig = getContainerConfig('spotlightRootDecorator');
+		const expected = null;
+		const actual = containerConfig.enterTo;
 
 		expect(actual).toBe(expected);
 	});

--- a/packages/spotlight/docs/index.md
+++ b/packages/spotlight/docs/index.md
@@ -286,8 +286,8 @@ provided, the first selector that successfully matches a node is used.
 
 `enterTo`
 + Type: [string]
-+ Values: [`''`, `'last-focused'`, or `'default-element'`]
-+ Default: `''`
++ Values: [`null`, `'last-focused'`, or `'default-element'`]
++ Default: `null`
 
 If the focus originates from another container, you can define which element in
 this container receives focus first.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -45,7 +45,7 @@ let GlobalConfig = {
 	active: true,
 	continue5WayHold: false,
 	defaultElement: '',     // <extSelector> except "@" syntax.
-	enterTo: '',            // '', 'last-focused', 'default-element'
+	enterTo: null,            // null, 'last-focused', 'default-element'
 	isStandardFocusableMode: false,     // @private - set to true to focus standard focusable element
 	lastFocusedElement: null,
 	lastFocusedKey: null,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`enterTo` default value is defined in `SpotlightContainerDecorator.js` and `container.js`. 

However, in SpotlightContainerDecorator.js, we set the default value of enterTo to `null`, and in container.js, we set the default value of enterTo to `''`.

We fix container.js to set the default value of enterTo to `null`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix GlobalConfig in container.js.
Fix spotlight docs where explaining enterTo container config.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-179

### Comments
