### PR TITLE
WRQ-6229: Add config `scrollTargetOnDescendantsFocus` to container

### DIFF
--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -70,6 +70,7 @@ let GlobalConfig = {
 	partition: false, // use the container bounds for partitioning when leaving
 	rememberSource: false,
 	restrict: 'self-first', // 'self-first', 'self-only', 'none'
+	scrollTargetOnDescendantsFocus: false,    // @private - use the container for the scroll target when its descendants get focused
 	selector: '',           // can be a valid <extSelector> except "@" syntax.
 	selectorDisabled: false,
 	straightMultiplier: 1,
@@ -1101,6 +1102,22 @@ function notifyEnterContainer (direction, previous, previousContainerIds, curren
 	});
 }
 
+/**
+ * Returns a closest container that wrap the element and has scrollTargetOnDescendantsFocus configured
+ *
+ * @param {Node} spotItem Focused element
+ * @param {String[]} containerIds Ids for containers that wrap the spotItem element
+ * @private
+ */
+function getScrollTargetOnDescendantsFocus (spotItem, containerIds = getContainersForNode(spotItem)) {
+	return containerIds.reduceRight((result, containerId) => {
+		if (getContainerConfig(containerId).scrollTargetOnDescendantsFocus) {
+			result = getContainerNode(containerId);
+		}
+		return result;
+	}, spotItem);
+}
+
 export {
 	// Remove
 	getAllContainerIds,
@@ -1127,6 +1144,7 @@ export {
 	getDefaultContainer,
 	getLastContainer,
 	getNavigableContainersForNode,
+	getScrollTargetOnDescendantsFocus,
 	getSpottableDescendants,
 	isContainer,
 	isNavigable,

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -13,6 +13,7 @@ import {
 	getDefaultContainer,
 	getLastContainer,
 	getNavigableContainersForNode,
+	getScrollTargetOnDescendantsFocus,
 	getSpottableDescendants,
 	isContainer,
 	isNavigable,
@@ -142,7 +143,21 @@ const scenarios = {
 			'aria-owns': 's1 n1',
 			children: spottable({id: 's2'})
 		})
-	)
+	),
+	scrollTargetOnDescendantsFocusContainer: container({
+		id: 'scrollTargetContainer',
+		[containerAttribute]: 'scrollTargetContainer',
+		children: join(
+			container({
+				[containerAttribute]: 'child',
+				id: 'spottableDefault',
+				className: 'spottable-default',
+				children: join(
+					spottable({id: 'firstChildSpottable'})
+				)
+			})
+		)
+	})
 };
 
 const setupContainers = () => {
@@ -1252,6 +1267,31 @@ describe('container', () => {
 
 					const expected = [];
 					const actual = getContainerNavigableElements('first-container');
+
+					expect(actual).toEqual(expected);
+				}
+			)
+		);
+	});
+
+	describe('#getScrollTargetOnDescendantsFocus', () => {
+		beforeEach(setupContainers);
+		afterEach(teardownContainers);
+
+		test(
+			'should return a container that has scrollTargetOnDescendantsFocus configured',
+			testScenario(
+				scenarios.scrollTargetOnDescendantsFocusContainer,
+				(root) => {
+					configureContainer('scrollTargetContainer', {
+						scrollTargetOnDescendantsFocus: true
+					});
+					configureContainer('child', {
+						enterTo: 'last-focused'
+					});
+
+					const expected = root.querySelector('#scrollTargetContainer');
+					const actual = getScrollTargetOnDescendantsFocus(root.querySelector('#firstChildSpottable'));
 
 					expect(actual).toEqual(expected);
 				}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The container needs additional config to define whether the container will be the scroll target when its child items get focused. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add private container config scrollTargetOnDescendantsFocus.
Add private method `getScrollTargetOnDescendantsFocus` to find the scroll target container when the element is focused.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6299

### Comments
