### PR TITLE
WRQ-11247: Added fontScale prop for large text mode scale values

### DIFF
--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import hoc from '@enact/core/hoc';
 
-import {init, config as riConfig, defineScreenTypes, getResolutionClasses} from './resolution';
+import {init, config as riConfig, defineScreenTypes, getResolutionClasses, updateBaseFontSize, calculateFontSize} from './resolution';
 
 /**
  * Default config for `ResolutionDecorator`.
@@ -118,6 +118,12 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		componentWillUnmount () {
 			if (config.dynamic) window.removeEventListener('resize', this.handleResize);
+		}
+
+		componentDidUpdate (prevProps) {
+			if(prevProps.fontScale !== this.props.fontScale) {
+				updateBaseFontSize(calculateFontSize(null, this.props.fontScale));
+			}
 		}
 
 		handleResize = () => {

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -194,7 +194,7 @@ function getScreenType (rez) {
  * @returns {String}          The calculated pixel size (with unit suffix. Ex: "24px").
  * @public
  */
-function calculateFontSize (type, fontScale) {
+function calculateFontSize (type, fontScale = 1) {
 	const scrObj = getScreenTypeObject(type);
 	const shouldScaleFontSize = (config.intermediateScreenHandling === 'scale') && (config.matchSmallerScreenType ? workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height :
 		workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height);

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -194,18 +194,18 @@ function getScreenType (rez) {
  * @returns {String}          The calculated pixel size (with unit suffix. Ex: "24px").
  * @public
  */
-function calculateFontSize (type) {
+function calculateFontSize (type, fontScale) {
 	const scrObj = getScreenTypeObject(type);
 	const shouldScaleFontSize = (config.intermediateScreenHandling === 'scale') && (config.matchSmallerScreenType ? workspaceBounds.width > scrObj.width && workspaceBounds.height > scrObj.height :
 		workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height);
 	let size;
 
 	if (orientation === 'portrait' && config.orientationHandling === 'scale') {
-		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
+		size = scrObj.height / scrObj.width * (scrObj.pxPerRem * fontScale);
 	} else {
-		size = scrObj.pxPerRem;
+		size = (scrObj.pxPerRem * fontScale);
 		if (orientation === 'landscape' && shouldScaleFontSize) {
-			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
+			size = parseInt(workspaceBounds.height * (scrObj.pxPerRem * fontScale)/ scrObj.height);
 		}
 	}
 	return size + 'px';
@@ -215,7 +215,7 @@ function calculateFontSize (type) {
  * @function
  * @memberof ui/resolution
  * @param {String}    size     A valid CSS measurement to be applied as the base document font size.
- * @private
+ * @public
  * @returns {undefined}
  */
 function updateBaseFontSize (size) {
@@ -494,5 +494,6 @@ export {
 	scaleToRem,
 	selectSrc,
 	unit,
-	unitToPixelFactors
+	unitToPixelFactors,
+	updateBaseFontSize
 };

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -215,7 +215,7 @@ function calculateFontSize (type, fontScale) {
  * @function
  * @memberof ui/resolution
  * @param {String}    size     A valid CSS measurement to be applied as the base document font size.
- * @public
+ * @private
  * @returns {undefined}
  */
 function updateBaseFontSize (size) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a requirement for large text mode for a11y.
I have modified the app (including sampler) to review the screen when large text is applied.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Modified to update the base font size when the fontScale prop changes.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-11247

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim ([myelyn.kim@lge.com](mailto:myelyn.kim@lge.com))