### PR TITLE
WRQ-6498: Added `lastInputType` module

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ ignore:
     - "packages/i18n/Text"
     - "packages/webos/speech"
     - "packages/webos/keyboard"
+    - "packages/webos/lastInputType"
     - "packages/webos/platform"
     - "packages/webos/pmloglib"
     - "packages/webos/deviceinfo"

--- a/packages/spotlight/src/tests/inputType-specs.js
+++ b/packages/spotlight/src/tests/inputType-specs.js
@@ -2,8 +2,6 @@ import {getInputType, setInputType} from '../inputType';
 
 describe('inputType', () => {
 	test('should have a default input type as \'key\'', () => {
-		setInputType('none');
-
 		const expected = 'key';
 		const actual = getInputType();
 

--- a/packages/spotlight/src/tests/inputType-specs.js
+++ b/packages/spotlight/src/tests/inputType-specs.js
@@ -1,6 +1,24 @@
 import {getInputType, setInputType} from '../inputType';
 
 describe('inputType', () => {
+	test('should have a default input type as \'key\'', () => {
+		setInputType('none');
+
+		const expected = 'key';
+		const actual = getInputType();
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should ignore input type in internal variable when invalid type is set', () => {
+		setInputType('none');
+
+		const expected = 'key';
+		const actual = getInputType();
+
+		expect(actual).toBe(expected);
+	});
+
 	test('should set input type properly in internal variable', () => {
 		setInputType('touch');
 

--- a/packages/webos/lastInputType/lastInputType.js
+++ b/packages/webos/lastInputType/lastInputType.js
@@ -5,8 +5,8 @@
  * @private
  */
 
-import platform from '../platform';
 import LS2Request from '../LS2Request';
+import platform from '../platform';
 
 const requestLastInputType = ({onSuccess, onFailure}) => {
     if (platform.tv) {

--- a/packages/webos/lastInputType/lastInputType.js
+++ b/packages/webos/lastInputType/lastInputType.js
@@ -9,20 +9,20 @@ import LS2Request from '../LS2Request';
 import platform from '../platform';
 
 const requestLastInputType = ({onSuccess, onFailure}) => {
-    if (platform.tv) {
-        return new LS2Request().send({
-            service: 'luna://com.webos.surfacemanager',
-            method: 'getLastInputType',
-            subscribe: true,
-            onSuccess,
-            onFailure
-        });
-    }
+	if (platform.tv) {
+		return new LS2Request().send({
+			service: 'luna://com.webos.surfacemanager',
+			method: 'getLastInputType',
+			subscribe: true,
+			onSuccess,
+			onFailure
+		});
+	}
 
-    return null;
+	return null;
 };
 
 export default requestLastInputType;
 export {
-    requestLastInputType
+	requestLastInputType
 };

--- a/packages/webos/lastInputType/lastInputType.js
+++ b/packages/webos/lastInputType/lastInputType.js
@@ -1,0 +1,28 @@
+/**
+ * Exports a method for calling `surfacemanager` service through LS2Request and returns `lastInputType`
+ *
+ * @module webos/lastInputType
+ * @private
+ */
+
+import platform from '../platform';
+import LS2Request from '../LS2Request';
+
+const requestLastInputType = ({onSuccess, onFailure}) => {
+    if (platform.tv) {
+        return new LS2Request().send({
+            service: 'luna://com.webos.surfacemanager',
+            method: 'getLastInputType',
+            subscribe: true,
+            onSuccess,
+            onFailure
+        });
+    }
+
+    return null;
+};
+
+export default requestLastInputType;
+export {
+    requestLastInputType
+};

--- a/packages/webos/lastInputType/package.json
+++ b/packages/webos/lastInputType/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "lastInputType.js"
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added a new `lastInputType` module under `enact/webos`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Previously this LS2Request was located in `sandstone/ThemeDecorator` and forced apps to access this service without recognizing it.
Changed access permission from `platform.type === 'webos'` to `platform.tv === true`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Added `lastInputType` module to `codecov.yml` since it's a private module

### Links
[//]: # (Related issues, references)
WRQ-6498

### Comments
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com