### PR TITLE
WRQ-164: Remove direction module and use own function

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to not error when unit tests with `direction` module. 
+
 ### Added
 
 - `ui/Layout.Cell` prop `componentCss` to support customizing the component used in `Cell`

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -22,7 +22,7 @@ import componentCss from './Marquee.module.less';
 // The minimum number of milliseconds to wait before resetting the marquee position after it finishes.
 const MINIMUM_MARQUEE_RESET_DELAY = 40;
 
-// This regex pattern is used by the {@link ui/Marquee.MarqueeDecorator.marqueeDirection} config.
+// This regex pattern is used by the {@link ui/Marquee.MarqueeDecorator.defaultConfig.marqueeDirection} config.
 // eslint-disable-next-line no-misleading-character-class
 const rtlPattern = /^[^A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C\uFE00-\uFE6F\uFEFD-\uFFFF]*[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -1,6 +1,5 @@
 /* global ResizeObserver */
 
-import direction from 'direction';
 import {on, off} from '@enact/core/dispatcher';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
@@ -22,6 +21,10 @@ import componentCss from './Marquee.module.less';
 
 // The minimum number of milliseconds to wait before resetting the marquee position after it finishes.
 const MINIMUM_MARQUEE_RESET_DELAY = 40;
+
+// This regex pattern is used by the {@link ui/Marquee.MarqueeDecorator.marqueeDirection} config.
+// eslint-disable-next-line no-misleading-character-class
+const rtlPattern = /^[^A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C\uFE00-\uFE6F\uFEFD-\uFFFF]*[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
 
 /**
  * Default configuration parameters for {@link ui/Marquee.MarqueeDecorator}
@@ -125,7 +128,7 @@ const defaultConfig = {
 	 * @kind member
 	 * @memberof ui/Marquee.MarqueeDecorator.defaultConfig
 	 */
-	marqueeDirection: (str) => direction(str) === 'rtl' ? 'rtl' : 'ltr'
+	marqueeDirection: (str) => rtlPattern.test(str) ? 'rtl' : 'ltr'
 };
 
 /*

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -22,9 +22,29 @@ import componentCss from './Marquee.module.less';
 // The minimum number of milliseconds to wait before resetting the marquee position after it finishes.
 const MINIMUM_MARQUEE_RESET_DELAY = 40;
 
-// This regex pattern is used by the {@link ui/Marquee.MarqueeDecorator.defaultConfig.marqueeDirection} config.
+/*
+ * This regex pattern is used by the {@link ui/Marquee.MarqueeDecorator.defaultConfig.marqueeDirection} config.
+ *
+ * rtlRange
+ * \u0591-\u07FF: RTL Languages(Hebrew, Arabic, ...)
+ * \uFB1D-\uFDFD\uFE70-\uFEFC: Hebrew Presentation Forms, Arabic Presentation Forms
+ *
+ * ltrRange
+ * A-Za-z: Alphabet
+ * \u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8: Latin
+ * \u0300-\u0590\u0800-\u1FFF: Other LTR Languages(Greek, Coptic, ...)
+ * \u200E: Left-To-Right Mark
+ * \u2C00-\uFB1C\uFE00-\uFE6F\uFEFD-\uFFFF: Other LTR Languages2(Glagolitic, Latin Extended-C, ...)
+ *
+ * @private
+ */
+const rtlRange = '\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC';
+const ltrRange =
+  'A-Za-z\u00C0-\u00D6\u00D8-\u00F6' +
+  '\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C' +
+  '\uFE00-\uFE6F\uFEFD-\uFFFF';
 // eslint-disable-next-line no-misleading-character-class
-const rtlPattern = /^[^A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C\uFE00-\uFE6F\uFEFD-\uFFFF]*[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
+const rtlPattern = new RegExp('^[^' + ltrRange + ']*[' + rtlRange + ']');
 
 /**
  * Default configuration parameters for {@link ui/Marquee.MarqueeDecorator}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@enact/core": "^4.8.0",
     "classnames": "^2.5.1",
-    "direction": "^1.0.4",
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When checking WRP-21845, the below issue has been occurred while updating direction  ^1.0.4  →  ^2.0.1
(details: check WRQ-164)
The API we use in the `direction` module is simple, so we only need to import the parts we need.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove direction module and use own function

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
History of why `direction` is used: https://github.com/enactjs/enact/pull/1378#issuecomment-368181264

### Links
[//]: # (Related issues, references)
WRQ-164

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)