### PR TITLE
WRQ-9619: Fixed the scrollbar on Firefox browser

### DIFF
--- a/packages/ui/Scroller/Scroller.module.less
+++ b/packages/ui/Scroller/Scroller.module.less
@@ -6,7 +6,8 @@
 
 	will-change: transform;
 
-	/* hide native scrollbar - to be removed after chrome version 121 */
+	/* hide native scrollbar */
+	/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
 	&::-webkit-scrollbar {
 		display: none;
 	}

--- a/packages/ui/Scroller/Scroller.module.less
+++ b/packages/ui/Scroller/Scroller.module.less
@@ -1,9 +1,12 @@
 // Scroller.module.less
 //
 .scroller {
+	/* hide native scrollbar */
+	scrollbar-width: none;
+
 	will-change: transform;
 
-	/* hide native scrollbar */
+	/* hide native scrollbar - to be removed after chrome version 121 */
 	&::-webkit-scrollbar {
 		display: none;
 	}

--- a/packages/ui/Scroller/UiScroller.module.less
+++ b/packages/ui/Scroller/UiScroller.module.less
@@ -5,8 +5,9 @@
 	scrollbar-width: none;
 
 	will-change: transform;
-
-	/* hide native scrollbar - to be removed after chrome version 121 */
+	
+	/* hide native scrollbar */
+	/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
 	&::-webkit-scrollbar {
 		display: none;
 	}

--- a/packages/ui/Scroller/UiScroller.module.less
+++ b/packages/ui/Scroller/UiScroller.module.less
@@ -1,9 +1,12 @@
 // UiScroller.module.less
 //
 .scroller {
+	/* hide native scrollbar */
+	scrollbar-width: none;
+
 	will-change: transform;
 
-	/* hide native scrollbar */
+	/* hide native scrollbar - to be removed after chrome version 121 */
 	&::-webkit-scrollbar {
 		display: none;
 	}

--- a/packages/ui/VirtualList/UiVirtualList.module.less
+++ b/packages/ui/VirtualList/UiVirtualList.module.less
@@ -28,7 +28,7 @@
 	}
 }
 
-/* to be removed after chrome version 121 */
+/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
 .virtualList::-webkit-scrollbar {
 	display: none;
 }

--- a/packages/ui/VirtualList/UiVirtualList.module.less
+++ b/packages/ui/VirtualList/UiVirtualList.module.less
@@ -26,6 +26,12 @@
 	}
 }
 
+.virtualList {
+	/* hide native scrollbar */
+	scrollbar-width: none;
+}
+
+/* to be removed after chrome version 121 */
 .virtualList::-webkit-scrollbar {
 	display: none;
 }

--- a/packages/ui/VirtualList/UiVirtualList.module.less
+++ b/packages/ui/VirtualList/UiVirtualList.module.less
@@ -5,6 +5,8 @@
 	height: 100%;
 	width: 100%;
 	overflow: hidden;
+	/* hide native scrollbar */
+	scrollbar-width: none;
 
 	&.vertical {
 		overflow-y: scroll;
@@ -24,11 +26,6 @@
 	.content {
 		will-change: transform;
 	}
-}
-
-.virtualList {
-	/* hide native scrollbar */
-	scrollbar-width: none;
 }
 
 /* to be removed after chrome version 121 */

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -5,6 +5,8 @@
 	height: 100%;
 	width: 100%;
 	overflow: hidden;
+	/* hide native scrollbar */
+	scrollbar-width: none;
 
 	.content {
 		will-change: transform;
@@ -32,11 +34,6 @@
 .listItem {
 	position: absolute;
 	will-change: transform;
-}
-
-.virtualList {
-	/* hide native scrollbar */
-	scrollbar-width: none;
 }
 
 /* to be removed after chrome version 121 */

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -36,7 +36,7 @@
 	will-change: transform;
 }
 
-/* to be removed after chrome version 121 */
+/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
 .virtualList::-webkit-scrollbar {
 	display: none;
 }

--- a/packages/ui/VirtualList/VirtualList.module.less
+++ b/packages/ui/VirtualList/VirtualList.module.less
@@ -34,6 +34,12 @@
 	will-change: transform;
 }
 
+.virtualList {
+	/* hide native scrollbar */
+	scrollbar-width: none;
+}
+
+/* to be removed after chrome version 121 */
 .virtualList::-webkit-scrollbar {
 	display: none;
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller and VirtualList had 2 kinds of scrollbars in the Firefox browser.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Only the Sandstone scrollbar appears in the Firefox browser.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-9619

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac [ion.andrusciac@lgepartner.com](mailto:ion.andrusciac@lgepartner.com)