### PR TITLE
WRQ-15921: Fix spotlight.disableSelector to set selectorDisabled to false

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight/Spotlight.disableSelector` to properly update the `selectorDisabled` container config
+
 ## [4.9.0-beta.1] - 2024-06-17
 
 No significant changes.
@@ -139,7 +145,7 @@ No significant changes.
 ### Fixed
 
 - `spotlight` to not leave the restrict container after returning from another app
- 
+
 ## [4.5.0-rc.1] - 2022-06-23
 
 No significant changes.
@@ -149,7 +155,7 @@ No significant changes.
 ### Added
 
 - `spotlight` an optional `containerOption.toOuterContainer` parameter to `focus` function to search target recursively to outer container
- 
+
 ## [4.5.0-alpha.2] - 2022-05-09
 
 ### Changed

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -696,7 +696,7 @@ const Spotlight = (function () {
 		 */
 		disableSelector: function (containerId) {
 			if (isContainer(containerId)) {
-				configureContainer(containerId, {selectorDisabled: false});
+				configureContainer(containerId, {selectorDisabled: true});
 				return true;
 			}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`enableSelector` needs to set selectorDisabled to true and `disableSelector` needs to set selectorDisabled to false.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-15921

### Comments
