### PR TITLE
WRQ-2288: Implement large screen mode

### DIFF
--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import hoc from '@enact/core/hoc';
 
 import {
-	init, 
+	init,
 	calculateFontSize,
 	config as riConfig,
 	defineScreenTypes,

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -508,5 +508,6 @@ export {
 	unit,
 	unitToPixelFactors,
 	updateBaseFontSize,
-	updateScreenScale
+	updateScreenScale,
+	updateWorkspaceBounds
 };

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -1,6 +1,7 @@
 let baseScreen,
 	orientation,
 	riRatio,
+	screenScale = 1,
 	screenType,
 	workspaceBounds = {
 		width: (typeof window === 'object') ? window.innerWidth : 1920,
@@ -201,11 +202,11 @@ function calculateFontSize (type) {
 	let size;
 
 	if (orientation === 'portrait' && config.orientationHandling === 'scale') {
-		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
+		size = scrObj.height / (scrObj.width * scrObj.pxPerRem * screenScale);
 	} else {
-		size = scrObj.pxPerRem;
+		size = scrObj.pxPerRem * screenScale;
 		if (orientation === 'landscape' && shouldScaleFontSize) {
-			size = parseInt(workspaceBounds.height * scrObj.pxPerRem / scrObj.height);
+			size = parseInt(workspaceBounds.height * scrObj.pxPerRem * screenScale / scrObj.height);
 		}
 	}
 	return size + 'px';
@@ -222,6 +223,17 @@ function updateBaseFontSize (size) {
 	if (typeof window === 'object') {
 		document.documentElement.style.fontSize = size;
 	}
+}
+
+/**
+ * @function
+ * @memberof ui/resolution
+ * @param {Number}    screenScaleValue     A value that adjusts the screen scaling.
+ * @returns {undefined}
+ * @private
+ */
+function updateScreenScale (screenScaleValue) {
+	screenScale = screenScaleValue;
 }
 
 /**
@@ -332,7 +344,7 @@ function getAspectRatioName (type) {
  * @public
  */
 function scale (px) {
-	return (riRatio || getRiRatio()) * px;
+	return (riRatio || getRiRatio()) * px * screenScale;
 }
 
 /**
@@ -366,7 +378,7 @@ function unit (pixels, toUnit) {
 	if (typeof pixels === 'string' && pixels.substr(-2) === 'px') pixels = parseInt(pixels.substr(0, pixels.length - 2));
 	if (typeof pixels !== 'number') return;
 
-	return (pixels / unitToPixelFactors[toUnit]) + '' + toUnit;
+	return (pixels / (screenScale * unitToPixelFactors[toUnit])) + '' + toUnit;
 }
 
 /**
@@ -494,5 +506,7 @@ export {
 	scaleToRem,
 	selectSrc,
 	unit,
-	unitToPixelFactors
+	unitToPixelFactors,
+	updateBaseFontSize,
+	updateScreenScale
 };

--- a/packages/ui/resolution/tests/ResolutionDecorator-specs.js
+++ b/packages/ui/resolution/tests/ResolutionDecorator-specs.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 
+import {updateBaseFontSize, calculateFontSize} from '../resolution';
 import ResolutionDecorator from '../ResolutionDecorator';
 
 describe('ResolutionDecorator Specs', () => {
@@ -26,6 +27,23 @@ describe('ResolutionDecorator Specs', () => {
 		const div = screen.getByTestId('component');
 
 		expect(div).toHaveClass('enact-res-mhd');
+	});
+
+	test('should change the base font size when screenScale prop changed', () => {
+		const before = 1;
+
+		const Component = ResolutionDecorator('div');
+		const {rerender} = render(<Component data-testid="component" screenScale={before} />);
+		const after = 2;
+		rerender(
+			<Component data-testid="component" screenScale={after} />
+		);
+
+		updateBaseFontSize(calculateFontSize());
+		const value = document.documentElement.style.fontSize;
+		const expected = '72px';
+
+		expect(value).toBe(expected);
 	});
 
 	test.skip('should update the resolution when the screen is resized', function () {

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -3,8 +3,10 @@ import {
 	config,
 	defineScreenTypes,
 	getScreenType,
+	getScreenTypeObject,
 	scale,
-	unit
+	unit,
+	updateWorkspaceBounds
 } from '../resolution.js';
 
 describe('Resolution Specs', () => {
@@ -270,6 +272,41 @@ describe('Resolution Specs', () => {
 
 		expect(actualFHD).toBe(expectedFHD);
 		expect(actualHD).toBe(expectedHD);
+	});
+
+	test('should calculate font size when orientation is landscape and shouldScaleFontSize value is true', () => {
+		config.intermediateScreenHandling = 'scale';
+		config.matchSmallerScreenType = true;
+
+		window.innerWidth = 1920;
+		window.innerHeight = 1080;
+
+		// update workspaceBounds
+		updateWorkspaceBounds(window);
+		// update orientation
+		getScreenType();
+		const size = calculateFontSize();
+		const expected = '18px';
+
+		expect(size).toBe(expected);
+
+		// clear window inner size
+		window.innerWidth = 640;
+		window.innerHeight = 480;
+	});
+
+	test('should calculate font size when orientation is portrait and config.orientationHandling is scale', () => {
+		config.orientationHandling = 'scale';
+		const fhdPortrait = {width: 1080, height: 1920};
+		getScreenType(fhdPortrait);
+
+		const size = calculateFontSize();
+		const scrObj = getScreenTypeObject();
+		const screenScale = 1;
+		const expected = scrObj.height / (scrObj.width * scrObj.pxPerRem * screenScale) + 'px';
+
+		expect(size).toBe(expected);
+
 	});
 
 	// NOTE: Currently tough to test selectSrc because it relies on a global variable for screenType


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a requirement for large screen mode(before large text) for a11y.
Since the purpose is to increase the screen magnification, the name large screen mode was used.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When you pass the screenScale prop to resolutionDecorator, the base font size is calculated using that value.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2288

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)