### PR TITLE
WRQ-7108: Remove unnecessary vendor prefixes

### DIFF
--- a/packages/spotlight/src/utils.js
+++ b/packages/spotlight/src/utils.js
@@ -9,11 +9,6 @@ let elementMatchesSelector = function (selector) {
 };
 if (typeof window === 'object') {
 	elementMatchesSelector = window.Element.prototype.matches ||
-		window.Element.prototype.matchesSelector ||
-		window.Element.prototype.mozMatchesSelector ||
-		window.Element.prototype.webkitMatchesSelector ||
-		window.Element.prototype.msMatchesSelector ||
-		window.Element.prototype.oMatchesSelector ||
 		elementMatchesSelector;
 }
 

--- a/packages/ui/Scrollable/ScrollThumb.module.less
+++ b/packages/ui/Scrollable/ScrollThumb.module.less
@@ -12,7 +12,6 @@
 	opacity: 0;
 	flex: auto;
 
-	-webkit-transition: opacity 100ms linear;
 	transition: opacity 100ms linear;
 
 	will-change: transform, top, left, right;

--- a/packages/ui/Scrollable/Scrollable.module.less
+++ b/packages/ui/Scrollable/Scrollable.module.less
@@ -35,8 +35,4 @@
 		overflow: hidden;
 		flex: 1 1 100%;
 	}
-
-	.contentNative {
-		-webkit-overflow-scrolling: touch;
-	}
 }

--- a/packages/ui/Scrollable/ScrollableNative.js
+++ b/packages/ui/Scrollable/ScrollableNative.js
@@ -1328,7 +1328,7 @@ class ScrollableBaseNative extends Component {
 			{className, containerRenderer, noScrollByDrag, rtl, style, ...rest} = this.props,
 			{isHorizontalScrollbarVisible, isVerticalScrollbarVisible} = this.state,
 			scrollableClasses = classNames(css.scrollable, className),
-			contentClasses = classNames(css.content, css.contentNative),
+			contentClasses = classNames(css.content),
 			childWrapper = noScrollByDrag ? 'div' : TouchableDiv,
 			childWrapperProps = {
 				className: contentClasses,

--- a/packages/ui/Scrollable/Scrollbar.module.less
+++ b/packages/ui/Scrollable/Scrollbar.module.less
@@ -7,10 +7,7 @@
 	flex: none;
 
 	transform: translateZ(0);
-	-webkit-transform: translateZ(0);
 	transition: opacity 0.1s linear;
-	-moz-transition: opacity 0.1s linear;
-	-webkit-transition: opacity 0.1s linear;
 
 	&.vertical {
 		flex-direction: column;
@@ -25,7 +22,7 @@
 	}
 
 	&.corner {
-		-webkit-padding-end: 3px;
+		padding-inline-end: 3px;
 	}
 
 	/* ScrollThumb */

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -25,7 +25,7 @@
 
 	// Touch interaction
 	.enact-no-touch-action {
-		-ms-touch-action: none;
+		touch-action: none;
 	}
 
 	.enact-untouchable {
@@ -39,17 +39,11 @@
 	// Selection
 	.enact-unselectable {
 		cursor: default;
-		-ms-user-select: none;
-		-webkit-user-select: none;
-		-moz-user-select: -moz-none;
 		user-select: none;
 	}
 
 	.enact-selectable {
 		cursor: auto;
-		-ms-user-select: element;
-		-webkit-user-select: text;
-		-moz-user-select: text;
 		user-select: text;
 	}
 

--- a/packages/ui/styles/core.less
+++ b/packages/ui/styles/core.less
@@ -39,11 +39,13 @@
 	// Selection
 	.enact-unselectable {
 		cursor: default;
+		-webkit-user-select: none;
 		user-select: none;
 	}
 
 	.enact-selectable {
 		cursor: auto;
+		-webkit-user-select: text;
 		user-select: text;
 	}
 

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -14,9 +14,6 @@
 }
 
 .enact-composite() {
-	-webkit-transform: translateZ(0);
-	-ms-transform: translateZ(0);
-	-o-transform: translateZ(0);
 	transform: translateZ(0);
 	will-change: transform;
 }
@@ -103,11 +100,11 @@
 //  */
 .remove-margin-on-edge-children() {
 	> :first-child {
-		-webkit-margin-start: 0;
+		margin-inline-start: 0;
 	}
 
 	> :last-child {
-		-webkit-margin-end: 0;
+		margin-inline-end: 0;
 	}
 }
 
@@ -117,11 +114,11 @@
 //  */
 .remove-padding-on-edge-children() {
 	> :first-child {
-		-webkit-padding-start: 0;
+		padding-inline-start: 0;
 	}
 
 	> :last-child {
-		-webkit-padding-end: 0;
+		padding-inline-end: 0;
 	}
 }
 
@@ -142,26 +139,17 @@
 }
 
 .input-placeholder(@rule) {
-	&::-webkit-input-placeholder {
-		@rule();
-	}
-	&::-moz-placeholder {
+	&::placeholder {
 		@rule();
 	}
 }
 
 // Assign font-kerning rules in a non-proprietary way. Default value being "normal", to enable kerning.
 .font-kerning(@val: normal) {
-	-webkit-font-kerning: @val;
 	font-kerning: @val;
 }
 
-// Provide a set of rules to assign to each vendor-prefixed pseudo selector
 .vendor-fullscreen(@rule) {
-	&:-webkit-full-screen { @rule(); }
-	&:-moz-full-screen { @rule(); }
-	&:-ms-fullscreen { @rule(); }
-	&:-o-full-screen { @rule(); }
 	&:fullscreen { @rule(); }
 }
 
@@ -211,7 +199,6 @@
 
 .border-box() {
 	box-sizing: border-box;
-	-moz-box-sizing: border-box;
 }
 
 // Helpful debugging way to understand how LESS variables are being interpreted

--- a/packages/ui/useScroll/Scrollbar.module.less
+++ b/packages/ui/useScroll/Scrollbar.module.less
@@ -9,10 +9,7 @@
 	flex: none;
 
 	transform: translateZ(0);
-	-webkit-transform: translateZ(0);
 	transition: opacity 0.1s linear;
-	-moz-transition: opacity 0.1s linear;
-	-webkit-transition: opacity 0.1s linear;
 
 	&.vertical {
 		flex-direction: column;
@@ -27,7 +24,7 @@
 	}
 
 	&.corner {
-		-webkit-padding-end: 3px;
+		padding-inline-end: 3px;
 	}
 
 	/* ScrollbarTrack */

--- a/packages/ui/useScroll/ScrollbarTrack.module.less
+++ b/packages/ui/useScroll/ScrollbarTrack.module.less
@@ -14,7 +14,6 @@
 	opacity: 0;
 	flex: auto;
 
-	-webkit-transition: opacity 100ms linear;
 	transition: opacity 100ms linear;
 
 	will-change: transform, top, left, right;

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1518,7 +1518,7 @@ const useScrollBase = (props) => {
 	});
 
 	assignProperties('scrollContentWrapperProps', {
-		className: scrollMode === 'translate' ? [css.scrollContentWrapper] : [css.scrollContentWrapper, css.scrollContentWrapperNative], // scrollMode 'native'
+		className: [css.scrollContentWrapper],
 		...(!noScrollByDrag && {
 			flickConfig,
 			onDrag: onDrag,

--- a/packages/ui/useScroll/useScroll.module.less
+++ b/packages/ui/useScroll/useScroll.module.less
@@ -37,8 +37,4 @@
 		overflow: hidden;
 		flex: 1 1 100%;
 	}
-
-	.scrollContentWrapperNative {
-		-webkit-overflow-scrolling: touch;
-	}
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Enact has CSS vendor prefixes. Most of them are not required anymore.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Considering browser versions we support, I removed unnecessary vendor prefixes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7108

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)