### PR TITLE
WRQ-19328: Fix React 18.3 warnings in enact

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,9 +36,9 @@
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-is": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-is": "^18.3.1",
     "warning": "^4.0.3"
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -51,8 +51,8 @@
     "@enact/core": "^4.9.0-alpha.1",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "xhr": "^2.6.0"
   },
   "peerDependencies": {

--- a/packages/sampler/package.json
+++ b/packages/sampler/package.json
@@ -28,7 +28,7 @@
     "classnames": "^2.5.1",
     "ilib": "14.19.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
+++ b/packages/spotlight/SpotlightContainerDecorator/SpotlightContainerDecorator.js
@@ -180,7 +180,7 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 	// eslint-disable-next-line no-shadow
 	function SpotlightContainerDecorator (props) {
-		const {spotlightDisabled, spotlightId, spotlightMuted, spotlightRestrict, ...rest} = props;
+		const {spotlightDisabled = false, spotlightId, spotlightMuted = false, spotlightRestrict = 'self-first', ...rest} = props;
 
 		const spotlightContainer = useSpotlightContainer({
 			id: spotlightId,
@@ -248,12 +248,6 @@ const SpotlightContainerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @public
 		 */
 		spotlightRestrict: PropTypes.oneOf(['none', 'self-first', 'self-only'])
-	};
-
-	SpotlightContainerDecorator.defaultProps = {
-		spotlightDisabled: false,
-		spotlightMuted: false,
-		spotlightRestrict: 'self-first'
 	};
 
 	// Wrapping with a React.Component to maintain ref support

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -29,8 +29,8 @@
     "classnames": "^2.5.1",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "warning": "^4.0.3"
   }
 }

--- a/packages/ui/Repeater/Repeater.js
+++ b/packages/ui/Repeater/Repeater.js
@@ -124,7 +124,8 @@ const RepeaterBase = kind({
 				}
 				if (indexProp) props[indexProp] = index;
 
-				return <Component {...props} />;
+				const {key, ...rest} = {...props};
+				return <Component key={key} {...rest} />;
 			});
 		}
 	},

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -32,8 +32,36 @@ const nop = () => {};
  * @ui
  * @public
  */
-const Scroller = (props) => {
+const Scroller = ({
+	cbScrollTo = nop,
+	direction = 'both',
+	horizontalScrollbar = 'auto',
+	noScrollByDrag = false,
+	noScrollByWheel = false,
+	onScroll = nop,
+	onScrollStart = nop,
+	onScrollStop = nop,
+	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
+	scrollMode = 'translate',
+	verticalScrollbar = 'auto',
+	...rest
+}) => {
 	// Hooks
+
+	const props = {
+		cbScrollTo,
+		direction,
+		horizontalScrollbar,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {drag, pageKey, wheel},
+		scrollMode,
+		verticalScrollbar,
+		...rest
+	};
 
 	const {
 		scrollContentHandle,
@@ -257,23 +285,6 @@ Scroller.propTypes = /** @lends ui/Scroller.Scroller.prototype */ {
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
 };
 
-Scroller.defaultProps = {
-	cbScrollTo: nop,
-	direction: 'both',
-	horizontalScrollbar: 'auto',
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		drag: false,
-		pageKey: false,
-		wheel: false
-	},
-	scrollMode: 'translate',
-	verticalScrollbar: 'auto'
-};
 
 export default Scroller;
 export {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -32,36 +32,28 @@ const nop = () => {};
  * @ui
  * @public
  */
-const Scroller = ({
-	cbScrollTo = nop,
-	direction = 'both',
-	horizontalScrollbar = 'auto',
-	noScrollByDrag = false,
-	noScrollByWheel = false,
-	onScroll = nop,
-	onScrollStart = nop,
-	onScrollStop = nop,
-	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
-	scrollMode = 'translate',
-	verticalScrollbar = 'auto',
-	...rest
-}) => {
+const scrollerDefaultProps = {
+	cbScrollTo: nop,
+	direction: 'both',
+	horizontalScrollbar: 'auto',
+	noScrollByDrag: false,
+	noScrollByWheel: false,
+	onScroll: nop,
+	onScrollStart: nop,
+	onScrollStop: nop,
+	overscrollEffectOn: {
+		drag: false,
+		pageKey: false,
+		wheel: false
+	},
+	scrollMode: 'translate',
+	verticalScrollbar: 'auto'
+};
+
+const Scroller = (props) => {
 	// Hooks
 
-	const props = {
-		cbScrollTo,
-		direction,
-		horizontalScrollbar,
-		noScrollByDrag,
-		noScrollByWheel,
-		onScroll,
-		onScrollStart,
-		onScrollStop,
-		overscrollEffectOn: {drag, pageKey, wheel},
-		scrollMode,
-		verticalScrollbar,
-		...rest
-	};
+	const scrollerProps = Object.assign({}, scrollerDefaultProps, props);
 
 	const {
 		scrollContentHandle,
@@ -76,7 +68,7 @@ const Scroller = ({
 		scrollContentProps,
 		verticalScrollbarProps,
 		horizontalScrollbarProps
-	} = useScroll(props);
+	} = useScroll(scrollerProps);
 
 	// Return
 

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -277,6 +277,7 @@ Scroller.propTypes = /** @lends ui/Scroller.Scroller.prototype */ {
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
 };
 
+Scroller.defaultPropValues = scrollerDefaultProps;
 
 export default Scroller;
 export {

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -18,20 +18,6 @@ import ScrollerBase from './UiScrollerBase';
 
 const nop = () => {};
 
-/**
- * An unstyled scroller.
- *
- * Example:
- * ```
- * <Scroller>Scroll me.</Scroller>
- * ```
- *
- * @class Scroller
- * @memberof ui/Scroller
- * @extends ui/Scroller.ScrollerBasic
- * @ui
- * @public
- */
 const scrollerDefaultProps = {
 	cbScrollTo: nop,
 	direction: 'both',
@@ -50,6 +36,20 @@ const scrollerDefaultProps = {
 	verticalScrollbar: 'auto'
 };
 
+/**
+ * An unstyled scroller.
+ *
+ * Example:
+ * ```
+ * <Scroller>Scroll me.</Scroller>
+ * ```
+ *
+ * @class Scroller
+ * @memberof ui/Scroller
+ * @extends ui/Scroller.ScrollerBasic
+ * @ui
+ * @public
+ */
 const Scroller = (props) => {
 	// Hooks
 

--- a/packages/ui/Slottable/tests/Slottable-specs.js
+++ b/packages/ui/Slottable/tests/Slottable-specs.js
@@ -240,17 +240,13 @@ describe('Slottable Specs', () => {
 	});
 
 	test('should allow downstream component to have default value for unset slot', () => {
-		function ComponentBase ({a}) {
+		function ComponentBase ({a = 'Default A'}) {
 			return (
 				<div data-testid="slottable">
 					{a}
 				</div>
 			);
 		}
-
-		ComponentBase.defaultProps = {
-			a: 'Default A'
-		};
 
 		const Component = Slottable({slots: ['a']}, ComponentBase);
 

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -152,13 +152,14 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		)
 	};
 
-	function Toggleable (props) {
+	function Toggleable ({disabled = false, ...rest}) {
+		const props = {disabled, ...rest};
 		const updated = {...props};
 		const propSelected = props[prop];
 
 		const hook = useToggle({
 			defaultSelected: props[defaultPropKey],
-			disabled: props.disabled,
+			disabled: disabled,
 			onToggle: (ev) => forwardCustom(toggle, adapter)(ev, props),
 			prop,
 
@@ -251,10 +252,6 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 		 * @public
 		 */
 		[toggle]: PropTypes.func
-	};
-
-	Toggleable.defaultProps = {
-		disabled: false
 	};
 
 	return Toggleable;

--- a/packages/ui/Toggleable/Toggleable.js
+++ b/packages/ui/Toggleable/Toggleable.js
@@ -159,7 +159,7 @@ const ToggleableHOC = hoc(defaultConfig, (config, Wrapped) => {
 
 		const hook = useToggle({
 			defaultSelected: props[defaultPropKey],
-			disabled: disabled,
+			disabled,
 			onToggle: (ev) => forwardCustom(toggle, adapter)(ev, props),
 			prop,
 

--- a/packages/ui/Touchable/Touchable.js
+++ b/packages/ui/Touchable/Touchable.js
@@ -109,7 +109,8 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 
 	// eslint-disable-next-line no-shadow
 	const Touchable = forwardRef((props, ref) => {
-		const {configForHook, propsForWrapped} = selectProps(props);
+		const {disabled = false, noResume = false, ...rest} = props;
+		const {configForHook, propsForWrapped} = selectProps({disabled, noResume, ...rest});
 		const hook = useTouch({getActive: !!activeProp, ...configForHook});
 
 		Object.assign(propsForWrapped, hook.handlers);
@@ -367,11 +368,6 @@ const Touchable = hoc(defaultConfig, (config, Wrapped) => {
 		 * @public
 		 */
 		pinchConfig: pinchConfigPropType
-	};
-
-	Touchable.defaultProps = {
-		disabled: false,
-		noResume: false
 	};
 
 	Touchable.displayName = 'Touchable';

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -30,8 +30,38 @@ const nop = () => {};
  * @ui
  * @public
  */
-const VirtualList = (props) => {
+const VirtualList = ({
+	cbScrollTo = nop,
+	direction = 'vertical',
+	horizontalScrollbar = 'auto',
+	noScrollByDrag = false,
+	noScrollByWheel = false,
+	onScroll = nop,
+	onScrollStart = nop,
+	onScrollStop = nop,
+	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
+	role = 'list',
+	scrollMode = 'translate',
+	verticalScrollbar = 'auto',
+	...rest
+}) => {
 	// Hooks
+
+	const props = {
+		cbScrollTo,
+		direction,
+		horizontalScrollbar,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {drag, pageKey, wheel},
+		role,
+		scrollMode,
+		verticalScrollbar,
+		...rest
+	};
 
 	const {
 		scrollContentHandle,
@@ -276,25 +306,6 @@ VirtualList.propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
 };
 
-VirtualList.defaultProps = {
-	cbScrollTo: nop,
-	direction: 'vertical',
-	horizontalScrollbar: 'auto',
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		drag: false,
-		pageKey: false,
-		wheel: false
-	},
-	role: 'list',
-	scrollMode: 'translate',
-	verticalScrollbar: 'auto'
-};
-
 /**
  * An unstyled scrollable virtual grid list component with touch support.
  *
@@ -304,7 +315,37 @@ VirtualList.defaultProps = {
  * @ui
  * @public
  */
-const VirtualGridList = (props) => {
+const VirtualGridList = ({
+	cbScrollTo = nop,
+	direction = 'vertical',
+	horizontalScrollbar = 'auto',
+	noScrollByDrag = false,
+	noScrollByWheel = false,
+	onScroll = nop,
+	onScrollStart = nop,
+	onScrollStop = nop,
+	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
+	role = 'list',
+	scrollMode = 'translate',
+	verticalScrollbar = 'auto',
+	...rest
+}) => {
+	const props = {
+		cbScrollTo,
+		direction,
+		horizontalScrollbar,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {drag, pageKey, wheel},
+		role,
+		scrollMode,
+		verticalScrollbar,
+		...rest
+	};
+
 	const {
 		scrollContentHandle,
 		scrollContentWrapper: ScrollContentWrapper,
@@ -544,25 +585,6 @@ VirtualGridList.propTypes = /** @lends ui/VirtualList.VirtualGridList.prototype 
 	 * @public
 	 */
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
-};
-
-VirtualGridList.defaultProps = {
-	cbScrollTo: nop,
-	direction: 'vertical',
-	horizontalScrollbar: 'auto',
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		drag: false,
-		pageKey: false,
-		wheel: false
-	},
-	role: 'list',
-	scrollMode: 'translate',
-	verticalScrollbar: 'auto'
 };
 
 export default VirtualList;

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -21,15 +21,6 @@ import {gridListItemSizeShape, itemSizesShape, VirtualListBasic} from './Virtual
 
 const nop = () => {};
 
-/**
- * An unstyled scrollable virtual list component with touch support.
- *
- * @class VirtualList
- * @memberof ui/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
- * @ui
- * @public
- */
 const virtualListDefaultProps = {
 	cbScrollTo: nop,
 	direction: 'vertical',
@@ -49,6 +40,15 @@ const virtualListDefaultProps = {
 	verticalScrollbar: 'auto'
 };
 
+/**
+ * An unstyled scrollable virtual list component with touch support.
+ *
+ * @class VirtualList
+ * @memberof ui/VirtualList
+ * @extends ui/VirtualList.VirtualListBasic
+ * @ui
+ * @public
+ */
 const VirtualList = (props) => {
 	// Hooks
 
@@ -299,15 +299,6 @@ VirtualList.propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
 
 VirtualList.defaultPropValues = virtualListDefaultProps;
 
-/**
- * An unstyled scrollable virtual grid list component with touch support.
- *
- * @class VirtualGridList
- * @memberof ui/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
- * @ui
- * @public
- */
 const virtualGridListDefaultProps = {
 	cbScrollTo: nop,
 	direction: 'vertical',
@@ -327,6 +318,15 @@ const virtualGridListDefaultProps = {
 	verticalScrollbar: 'auto'
 };
 
+/**
+ * An unstyled scrollable virtual grid list component with touch support.
+ *
+ * @class VirtualGridList
+ * @memberof ui/VirtualList
+ * @extends ui/VirtualList.VirtualListBasic
+ * @ui
+ * @public
+ */
 const VirtualGridList = (props) => {
 	const virtualGridListProps = Object.assign({}, virtualGridListDefaultProps, props);
 

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -30,38 +30,29 @@ const nop = () => {};
  * @ui
  * @public
  */
-const VirtualList = ({
-	cbScrollTo = nop,
-	direction = 'vertical',
-	horizontalScrollbar = 'auto',
-	noScrollByDrag = false,
-	noScrollByWheel = false,
-	onScroll = nop,
-	onScrollStart = nop,
-	onScrollStop = nop,
-	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
-	role = 'list',
-	scrollMode = 'translate',
-	verticalScrollbar = 'auto',
-	...rest
-}) => {
+const virtualListDefaultProps = {
+	cbScrollTo: nop,
+	direction: 'vertical',
+	horizontalScrollbar: 'auto',
+	noScrollByDrag: false,
+	noScrollByWheel: false,
+	onScroll: nop,
+	onScrollStart: nop,
+	onScrollStop: nop,
+	overscrollEffectOn: {
+		drag: false,
+		pageKey: false,
+		wheel: false
+	},
+	role: 'list',
+	scrollMode: 'translate',
+	verticalScrollbar: 'auto'
+};
+
+const VirtualList = (props) => {
 	// Hooks
 
-	const props = {
-		cbScrollTo,
-		direction,
-		horizontalScrollbar,
-		noScrollByDrag,
-		noScrollByWheel,
-		onScroll,
-		onScrollStart,
-		onScrollStop,
-		overscrollEffectOn: {drag, pageKey, wheel},
-		role,
-		scrollMode,
-		verticalScrollbar,
-		...rest
-	};
+	const virtualListProps = Object.assign({}, virtualListDefaultProps, props);
 
 	const {
 		scrollContentHandle,
@@ -76,7 +67,7 @@ const VirtualList = ({
 		scrollContentProps,
 		verticalScrollbarProps,
 		horizontalScrollbarProps
-	} = useScroll(props);
+	} = useScroll(virtualListProps);
 
 	// Render
 
@@ -315,36 +306,27 @@ VirtualList.propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
  * @ui
  * @public
  */
-const VirtualGridList = ({
-	cbScrollTo = nop,
-	direction = 'vertical',
-	horizontalScrollbar = 'auto',
-	noScrollByDrag = false,
-	noScrollByWheel = false,
-	onScroll = nop,
-	onScrollStart = nop,
-	onScrollStop = nop,
-	overscrollEffectOn: {drag = false, pageKey = false, wheel = false} = {},
-	role = 'list',
-	scrollMode = 'translate',
-	verticalScrollbar = 'auto',
-	...rest
-}) => {
-	const props = {
-		cbScrollTo,
-		direction,
-		horizontalScrollbar,
-		noScrollByDrag,
-		noScrollByWheel,
-		onScroll,
-		onScrollStart,
-		onScrollStop,
-		overscrollEffectOn: {drag, pageKey, wheel},
-		role,
-		scrollMode,
-		verticalScrollbar,
-		...rest
-	};
+const virtualGridListDefaultProps = {
+	cbScrollTo: nop,
+	direction: 'vertical',
+	horizontalScrollbar: 'auto',
+	noScrollByDrag: false,
+	noScrollByWheel: false,
+	onScroll: nop,
+	onScrollStart: nop,
+	onScrollStop: nop,
+	overscrollEffectOn: {
+		drag: false,
+		pageKey: false,
+		wheel: false
+	},
+	role: 'list',
+	scrollMode: 'translate',
+	verticalScrollbar: 'auto'
+};
+
+const VirtualGridList = (props) => {
+	const virtualGridListProps = Object.assign({}, virtualGridListDefaultProps, props);
 
 	const {
 		scrollContentHandle,
@@ -359,7 +341,7 @@ const VirtualGridList = ({
 		scrollContentProps,
 		verticalScrollbarProps,
 		horizontalScrollbarProps
-	} = useScroll(props);
+	} = useScroll(virtualGridListProps);
 
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -297,6 +297,8 @@ VirtualList.propTypes = /** @lends ui/VirtualList.VirtualList.prototype */ {
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
 };
 
+VirtualList.defaultPropValues = virtualListDefaultProps;
+
 /**
  * An unstyled scrollable virtual grid list component with touch support.
  *
@@ -568,6 +570,8 @@ VirtualGridList.propTypes = /** @lends ui/VirtualList.VirtualGridList.prototype 
 	 */
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden'])
 };
+
+VirtualGridList.defaultPropValues = virtualGridListDefaultProps;
 
 export default VirtualList;
 export {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,9 +38,9 @@
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-is": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-is": "^18.3.1",
     "warning": "^4.0.3"
   }
 }

--- a/packages/ui/useScroll/Scrollbar.js
+++ b/packages/ui/useScroll/Scrollbar.js
@@ -125,7 +125,8 @@ const useScrollbar = (props) => {
  * @ui
  * @private
  */
-const Scrollbar = memo((props) => {
+const Scrollbar = memo(({corner = false, css = componentCss, minThumbSize = 18, vertical = true, ...rest}) => {
+	const props = {corner, css, minThumbSize, vertical, ...rest};
 	const {
 		restProps,
 		scrollbarProps,
@@ -195,13 +196,6 @@ Scrollbar.propTypes = /** @lends ui/useScroll.Scrollbar.prototype */ {
 	 * @public
 	 */
 	vertical: PropTypes.bool
-};
-
-Scrollbar.defaultProps = {
-	corner: false,
-	css: componentCss,
-	minThumbSize: 18,
-	vertical: true
 };
 
 export default Scrollbar;

--- a/packages/ui/useScroll/ScrollbarTrack.js
+++ b/packages/ui/useScroll/ScrollbarTrack.js
@@ -14,7 +14,7 @@ import css from './ScrollbarTrack.module.less';
  */
 const ScrollbarTrack = forwardRef((props, ref) => {
 	const
-		{vertical, ...rest} = props,
+		{vertical = true, ...rest} = props,
 		className = classNames(css.scrollbarTrack, vertical ? css.vertical : null);
 
 	return <div {...rest} className={className} ref={ref} />;
@@ -29,10 +29,6 @@ ScrollbarTrack.propTypes = /** @lends ui/useScroll.ScrollbarTrack.prototype */ {
 	 * @public
 	 */
 	vertical: PropTypes.bool
-};
-
-ScrollbarTrack.defaultProps = {
-	vertical: true
 };
 
 const MemoizedScrollbarTrack = memo(ScrollbarTrack);

--- a/packages/webos/package.json
+++ b/packages/webos/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@enact/core": "^4.9.0-alpha.1",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In React 19, defaultProps in function components will be removed.
In React 18.3, There are warnings for key spreading


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove defaultProps for function components and replaced them with ES6 default parameters.
Pass key directly to JSX without using spread

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-19328

### Comments
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)
