### PR TITLE
WRQ-20168: Add support for overriding strings where original resources folder does not have the file

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact i18n module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `i18n` resource loader to override strings where the original strings file does not exist
+
 ## [4.0.14] - 2024-05-14
 
 ### Fixed

--- a/packages/i18n/src/Loader.js
+++ b/packages/i18n/src/Loader.js
@@ -244,21 +244,28 @@ EnyoLoader.prototype.loadFiles = function (paths, sync, params, callback, rootPa
 				};
 
 				const handleAdditionalResourcesPath = (json, err) => {
-					if (found && !err && typeof json === 'object') {
-						// Overwrite the _root/path result
-						Object.assign(ret[ret.length - 1], json);
+					if (!err && typeof json === 'object') {
+						if (found) {
+							// Overwrite the _root/path result
+							Object.assign(ret[ret.length - 1], json);
+						} else {
+							// This case is where the file is only in the additional resources path
+							cache.update = true;
+							ret.push(json);
+							found = true;
+						}
 					}
 				};
 
 				if (this.isAvailable(_root, path)) {
 					getSync(this._pathjoin(_root, path), handler);
+				}
 
-					if (this.addPaths && Array.isArray(this.addPaths) && index === paths.length - 1) {
-						for (let addedRoot of this.addPaths) {
-							for (let i = 0; i <= index; i++) {
-								if (this.isAvailable(addedRoot, paths[i])) {
-									getSync(this._pathjoin(addedRoot, paths[i]), handleAdditionalResourcesPath);
-								}
+				if (this.addPaths && Array.isArray(this.addPaths) && index === paths.length - 1) {
+					for (let addedRoot of this.addPaths) {
+						for (let i = 0; i <= index; i++) {
+							if (this.isAvailable(addedRoot, paths[i])) {
+								getSync(this._pathjoin(addedRoot, paths[i]), handleAdditionalResourcesPath);
 							}
 						}
 					}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some apps need to override strings when the original strings file does not exist

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed to read the resources file from the additional resource's path even if the original file does not exist.
Added the read json object ot the cache array.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Original PR of this patch is https://github.com/enactjs/enact/pull/3072

### Links
[//]: # (Related issues, references)
WRQ-20168


### Comments
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)