### PR TITLE
WRQ-24303: Fix `marqueeDecorator` and `marqueeController` to start animation properly when content changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/Marquee.MarqueeDecorator` to start animation properly when synchronized by MarqueeController and text changed
+- `ui/Marquee.MarqueeDecorator` to start animation properly when synchronized by `ui/Marquee.MarqueeController` and text changed
 
 ## [4.9.0-beta.1] - 2024-06-17
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Marquee.MarqueeDecorator` to start animation properly when synchronized by MarqueeController and text changed
+
 ## [4.9.0-beta.1] - 2024-06-17
 
 No significant changes.

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -710,8 +710,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns	{undefined}
 		 */
 		restart = () => {
-			this.restartAnimation()
-		}
+			this.restartAnimation();
+		};
 
 		/*
 		 * Starts marquee animation with synchronization, if not already animating and a timer is

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -374,6 +374,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.context && this.context.register) {
 				this.sync = true;
 				this.context.register(this, {
+					restartAnimation: this.restartAnimation,
 					start: this.start,
 					stop: this.stop
 				});
@@ -412,7 +413,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				);
 
 				this.invalidateMetrics();
-				this.cancelAnimation();
+				this.cancelAnimation(forceRestartMarquee);
 				if (forceRestartMarquee && marqueeOn === 'focus') {
 					this.resetAnimation();
 				}
@@ -795,9 +796,9 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 *
 		 * @returns {undefined}
 		 */
-		cancelAnimation = () => {
+		cancelAnimation = (retryStartingAnimation = false) => {
 			if (this.sync) {
-				this.context.cancel(this);
+				this.context.cancel(retryStartingAnimation);
 				return;
 			}
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -374,7 +374,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.context && this.context.register) {
 				this.sync = true;
 				this.context.register(this, {
-					restartAnimation: this.restartAnimation,
+					restart: this.restart,
 					start: this.start,
 					stop: this.stop
 				});
@@ -705,6 +705,15 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		/*
+		 * Restarts the animation
+		 *
+		 * @returns	{undefined}
+		 */
+		restart = () => {
+			this.restartAnimation()
+		}
+
+		/*
 		 * Starts marquee animation with synchronization, if not already animating and a timer is
 		 * not already active to start.
 		 *
@@ -748,7 +757,7 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		 *
 		 * @returns {undefined}
 		 */
-		restartAnimation = (delay) => {
+		restartAnimation = (delay = MINIMUM_MARQUEE_RESET_DELAY) => {
 			flushSync(() => {
 				this.setState({
 					animating: false

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -428,14 +428,8 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
-
-			const delay = this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay;
-			if (forceRestartMarquee) {
-				window.setTimeout(() => {
-					this.tryStartingAnimation(delay);
-				}, 100);
-			} else if (this.shouldStartMarquee()) {
-				this.tryStartingAnimation(delay);
+			if (forceRestartMarquee || this.shouldStartMarquee()) {
+				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
 			}
 		}
 

--- a/packages/ui/Marquee/MarqueeDecorator.js
+++ b/packages/ui/Marquee/MarqueeDecorator.js
@@ -428,8 +428,14 @@ const MarqueeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			this.validateTextDirection();
-			if (forceRestartMarquee || this.shouldStartMarquee()) {
-				this.tryStartingAnimation(this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay);
+
+			const delay = this.props.marqueeOn === 'render' ? this.props.marqueeOnRenderDelay : this.props.marqueeDelay;
+			if (forceRestartMarquee) {
+				window.setTimeout(() => {
+					this.tryStartingAnimation(delay);
+				}, 100);
+			} else if (this.shouldStartMarquee()) {
+				this.tryStartingAnimation(delay);
 			}
 		}
 

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -609,4 +609,24 @@ describe('MarqueeController', () => {
 		act(() => jest.advanceTimersByTime(40));
 		expect(marquee1).toHaveStyle({'transform': 'translateX(-125px)'});
 	});
+
+	test('should force restart marquee after delay when the text content changes after initial render', () => {
+		const originalSetTimeout = window.setTimeout;
+
+		const observe = jest.fn();
+		window.setTimeout = observe;
+
+		const {rerender} = render(
+			<Controller>
+				<Marquee marqueeOn="render">{ltrText}</Marquee>
+			</Controller>);
+
+		rerender(
+			<Controller>
+				<Marquee marqueeOn="render">{ltrArray[0]}</Marquee>
+			</Controller>
+		);
+		expect(observe).toHaveBeenCalledTimes(3);
+		window.setTimeout = originalSetTimeout;
+	});
 });

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -610,23 +610,4 @@ describe('MarqueeController', () => {
 		expect(marquee1).toHaveStyle({'transform': 'translateX(-125px)'});
 	});
 
-	test('should force restart marquee after delay when the text content changes after initial render', () => {
-		const originalSetTimeout = window.setTimeout;
-
-		const observe = jest.fn();
-		window.setTimeout = observe;
-
-		const {rerender} = render(
-			<Controller>
-				<Marquee marqueeOn="render">{ltrText}</Marquee>
-			</Controller>);
-
-		rerender(
-			<Controller>
-				<Marquee marqueeOn="render">{ltrArray[0]}</Marquee>
-			</Controller>
-		);
-		expect(observe).toHaveBeenCalledTimes(3);
-		window.setTimeout = originalSetTimeout;
-	});
 });

--- a/packages/ui/Marquee/tests/Marquee-specs.js
+++ b/packages/ui/Marquee/tests/Marquee-specs.js
@@ -609,5 +609,4 @@ describe('MarqueeController', () => {
 		act(() => jest.advanceTimersByTime(40));
 		expect(marquee1).toHaveStyle({'transform': 'translateX(-125px)'});
 	});
-
 });

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -193,7 +193,7 @@ const useMarqueeController = (props) => {
 	 */
 	const handleComplete = useCallback((component) => {
 		const complete = markReady(component);
-		if (complete) {
+		if (complete && !component.contentFits) {
 			markAll(STATE.ready);
 			dispatch('start');
 		}

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -109,7 +109,7 @@ const useMarqueeController = (props) => {
 		markAll(STATE.inactive);
 		dispatch('stop');
 		if (retryStartingAnimation) {
-			dispatch('restartAnimation');
+			dispatch('restart');
 		}
 	}, [dispatch, markAll]);
 

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -24,7 +24,7 @@ const useMarqueeController = (props) => {
 	 * Invokes the `action` handler for each synchronized component except the invoking
 	 * `component`.
 	 *
-	 * @param	{String}	action		`'start'` or `'stop'`
+	 * @param	{String}	action		`'start'`, `'stop'`, or `'restartAnimation'`
 	 * @param	{Object}	component	A previously registered component
 	 *
 	 * @returns	{undefined}
@@ -116,11 +116,11 @@ const useMarqueeController = (props) => {
 	const cancelJob = useMemo(() => new Job((retryStartingAnimation = false) => doCancel(retryStartingAnimation), 30), [doCancel]);
 
 	/*
-	 * Registers `component` with a set of handlers for `start` and `stop`.
+	 * Registers `component` with a set of handlers for `start`, `stop`, and `restartAnimation`.
 	 *
 	 * @param	{Object}	component	A component, typically a React component instance, on
 	 *									which handlers will be dispatched.
-	 * @param	{Object}	handlers	An object containing `start` and `stop` functions
+	 * @param	{Object}	handlers	An object containing `start`, `stop`, and `restartAnimation` functions
 	 *
 	 * @returns {undefined}
 	 */
@@ -177,7 +177,7 @@ const useMarqueeController = (props) => {
 	/*
 	 * Handler for the `cancel` context function
 	 *
-	 * @param	{Boolean}	retryStartingAnimation	If true, restartAnimation after cancelJob completes
+	 * @param	{Boolean}	retryStartingAnimation	If true, `restartAnimation` called after `cancelJob` completes
 	 *
 	 * @returns	{undefined}
 	 */

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -24,7 +24,7 @@ const useMarqueeController = (props) => {
 	 * Invokes the `action` handler for each synchronized component except the invoking
 	 * `component`.
 	 *
-	 * @param	{String}	action		`'start'`, `'stop'`, or `'restartAnimation'`
+	 * @param	{String}	action		`'start'`, `'stop'`, or `'restart'`
 	 * @param	{Object}	component	A previously registered component
 	 *
 	 * @returns	{undefined}
@@ -116,11 +116,11 @@ const useMarqueeController = (props) => {
 	const cancelJob = useMemo(() => new Job((retryStartingAnimation = false) => doCancel(retryStartingAnimation), 30), [doCancel]);
 
 	/*
-	 * Registers `component` with a set of handlers for `start`, `stop`, and `restartAnimation`.
+	 * Registers `component` with a set of handlers for `start`, `stop`, and `restart`.
 	 *
 	 * @param	{Object}	component	A component, typically a React component instance, on
 	 *									which handlers will be dispatched.
-	 * @param	{Object}	handlers	An object containing `start`, `stop`, and `restartAnimation` functions
+	 * @param	{Object}	handlers	An object containing `start`, `stop`, and `restart` functions
 	 *
 	 * @returns {undefined}
 	 */
@@ -177,7 +177,7 @@ const useMarqueeController = (props) => {
 	/*
 	 * Handler for the `cancel` context function
 	 *
-	 * @param	{Boolean}	retryStartingAnimation	If true, `restartAnimation` called after `cancelJob` completes
+	 * @param	{Boolean}	retryStartingAnimation	If true, `restart` called after `cancelJob` completes
 	 *
 	 * @returns	{undefined}
 	 */

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -102,15 +102,18 @@ const useMarqueeController = (props) => {
 		}, false);
 	}, []);
 
-	const doCancel = useCallback(() => {
+	const doCancel = useCallback((retryStartingAnimation) => {
 		if (mutableRef.current.isHovered || mutableRef.current.isFocused) {
 			return;
 		}
 		markAll(STATE.inactive);
 		dispatch('stop');
+		if (retryStartingAnimation) {
+			dispatch('restartAnimation');
+		}
 	}, [dispatch, markAll]);
 
-	const cancelJob = useMemo(() => new Job(() => doCancel(), 30), [doCancel]);
+	const cancelJob = useMemo(() => new Job((retryStartingAnimation = false) => doCancel(retryStartingAnimation), 30), [doCancel]);
 
 	/*
 	 * Registers `component` with a set of handlers for `start` and `stop`.
@@ -178,9 +181,9 @@ const useMarqueeController = (props) => {
 	 *
 	 * @returns	{undefined}
 	 */
-	const handleCancel = useCallback(() => {
+	const handleCancel = useCallback((retryStartingAnimation) => {
 		if (anyRunning()) {
-			cancelJob.start();
+			cancelJob.start(retryStartingAnimation);
 		}
 	}, [anyRunning, cancelJob]);
 

--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -164,7 +164,7 @@ const useMarqueeController = (props) => {
 	 *
 	 * @param	{Object}	component	A previously registered component
 	 *
-	 * @returns	{undefined}f
+	 * @returns	{undefined}
 	 */
 	const handleStart = useCallback((component) => {
 		cancelJob.stop();
@@ -177,7 +177,7 @@ const useMarqueeController = (props) => {
 	/*
 	 * Handler for the `cancel` context function
 	 *
-	 * @param	{Object}	component	A previously registered component
+	 * @param	{Boolean}	retryStartingAnimation	If true, restartAnimation after cancelJob completes
 	 *
 	 * @returns	{undefined}
 	 */


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When <Marquee> is wrapped with MarqueeController to be synchronized and marqueeOn props is 'render' and the content changes, MarqueeDecorator cannot start the marquee animation. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`MarqueeDecorator.componentDidUpdate()` called when content changed. 
As children is changed, `this.invalidateMetrics()`, `this.cancelAnimation()` are called and `forceRestartMarquee` variable set to true in `componentDidUpdate` function,

`this.tryStartingAnimation()` function is called because `forceRestartMarquee` is true.
However, In `tryStartingAnimation()`, it returns without calling `startAnimation()` function becuase `this.timerState` is 1(=TimerState.START_PENDING). 
`this.timerState` is set to 1 in `MarqueeDecorator.start()` function which is called before `componentDidUpdate`. 

So I added `retryStartingAnimation` flag in `MarqueeDecorator.cancelAnimation()` to check whether we need to restartAnimation after cancelJob completes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In additional, I think handleComplete in useMarqueeController needs to be fixed too.
When <Marquee> is wrapped with a MarqueeController, I found that the MarqueeDecorator.start function is constantly being called, even though content is short that doesn't need to be animate.


### Links
[//]: # (Related issues, references)
WRQ-24303

### Comments
