### PR TITLE
WRQ-153: Add sendLS2Request to use LS2Request with a promise

### DIFF
--- a/packages/webos/LS2Request/LS2Request.js
+++ b/packages/webos/LS2Request/LS2Request.js
@@ -183,3 +183,30 @@ export default class LS2Request {
 		}
 	}
 }
+
+export const sendLS2Request = ({
+	service = '',
+	method = '',
+	parameters = {},
+	onComplete = null,
+	onTimeout = timeoutHandler,
+	subscribe = false,
+	timeout = 0
+}) => {
+	return new Promise((resolve, reject) => {
+		new LS2Request().send({
+			service,
+			method,
+			parameters,
+			onSuccess: resolve,
+			onFailure: result => {
+				failureHandler(result);
+				reject(result);
+			},
+			onComplete,
+			onTimeout,
+			subscribe,
+			timeout
+		});
+	});
+};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
webos/LS2Request provides a class for making LS2 service request.
It would be better to support the developer to request LS2 request with a promise

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`LS2Request.send` is a method to request luna call to a webos app or service.
So `send` method with promise is what developers need.
To provide `LS2Request.send` as a promise, I add a new function: `sendLS2Request`
`sendLS2Request` returns a promise which run `LS2Request.send`.
This promise will be resolved when `send` successes, and will be rejected when `send` fails.
So developers can use their own `onSuccess` and `onFailure` after the promise is resolved or rejected.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
WRQ-153

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)