### PR TITLE
WRQ-28000: Fix `VoiceControlDecorator` and `PlaceholderControllerDecorator` not to remount its children when it rerenders

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee.MarqueeDecorator` to start animation properly when synchronized by `ui/Marquee.MarqueeController` and text changed
+- `ui/Placeholder.PlaceholderControllerDecorator` to not remount its children when it rendered
 
 ## [4.9.0-beta.1] - 2024-06-17
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee.MarqueeDecorator` to start animation properly when synchronized by `ui/Marquee.MarqueeController` and text changed
-- `ui/Placeholder.PlaceholderControllerDecorator` to not remount its children when it rendered
+- `ui/Placeholder.PlaceholderControllerDecorator` to not remount its children when it rerenders
 
 ## [4.9.0-beta.1] - 2024-06-17
 

--- a/packages/ui/Placeholder/PlaceholderControllerDecorator.js
+++ b/packages/ui/Placeholder/PlaceholderControllerDecorator.js
@@ -61,6 +61,7 @@ const PlaceholderContext = createContext();
  */
 const PlaceholderControllerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {bounds, notify, thresholdFactor} = config;
+	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'PlaceholderControllerDecorator';
@@ -140,7 +141,6 @@ const PlaceholderControllerDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		render () {
 			const props = Object.assign({}, this.props);
-			const WrappedWithRef = WithRef(Wrapped);
 
 			if (notify) props[notify] = this.handleNotify;
 

--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact webos module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `webos/speech.VoiceControlDecorator` to not remount its children when it rendered
+
 ## [4.9.0-beta.1] - 2024-06-17
 
 No significant changes.

--- a/packages/webos/CHANGELOG.md
+++ b/packages/webos/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact webos module, newest cha
 
 ### Fixed
 
-- `webos/speech.VoiceControlDecorator` to not remount its children when it rendered
+- `webos/speech.VoiceControlDecorator` to not remount its children when it rerenders
 
 ## [4.9.0-beta.1] - 2024-06-17
 

--- a/packages/webos/speech/VoiceControlDecorator.js
+++ b/packages/webos/speech/VoiceControlDecorator.js
@@ -55,6 +55,8 @@ import {WithRef} from '@enact/core/internal/WithRef';
  * @public
  */
 const VoiceControlDecorator = hoc((config, Wrapped) => {
+	const WithRefComponent = WithRef(Wrapped);
+
 	return class extends Component {
 		static displayName = 'VoiceControlDecorator';
 
@@ -91,7 +93,6 @@ const VoiceControlDecorator = hoc((config, Wrapped) => {
 		render () {
 			const props = {...this.props};
 			delete props.onVoice;
-			const WithRefComponent = WithRef(Wrapped);
 
 			return (
 				<WithRefComponent {...props} outermostRef={this.nodeRef} referrerName="VoiceControlDecorator" />


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `VoiceControlDecorator` wrapped video player component in the app, video player component remounted continuously.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In the previous logic, every time `VoiceControlDecorator` render, the children of the `VoiceControlDecorator` are unmounted and then remounted. 
It means that `Video` and `Media` components are re-mounted continuously. 
To fix this issue, we modify `VoiceControlDecorator` and `PlaceholderControllerDecorator` to not use HOCs in the render method.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-28000

### Comments
