### PR TITLE
WRQ-28801: Rollback `handleComplete` function in `useMarqueeController` to not decide whether to start by checking contentFits

### DIFF
--- a/packages/ui/Marquee/useMarqueeController.js
+++ b/packages/ui/Marquee/useMarqueeController.js
@@ -196,7 +196,7 @@ const useMarqueeController = (props) => {
 	 */
 	const handleComplete = useCallback((component) => {
 		const complete = markReady(component);
-		if (complete && !component.contentFits) {
+		if (complete) {
 			markAll(STATE.ready);
 			dispatch('start');
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/enact/pull/3247, I fixed the issue to start animation properly by `marqueeController` when content changed. 
As mentioned in the Additional Consideration section, I added the additional patch in that PR which fix `handleComplete` in `useMarqueeController` becuase it seems that MarqueeDecorator.start function is constantly being called in sync mode even though content that doesn't need to be animate. 
However we found that this patch cause some regression in non-sync mode. So we rollback this additional patch in `useMarqueeController`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Rollback the patch in useMarqueeController.handleComplete.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-28801

### Comments
