### PR TITLE
WRQ-28860: Modified so that related warnings appear only when accessing the webos property of core/platform

### DIFF
--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -150,13 +150,7 @@ const parseUserAgentLegacy = (userAgent) => {
 		}
 	}
 
-	if ('webos' === plat.platformName) {
-		deprecate({
-			name: plat.platformName,
-			message: 'Refer `@enact/webos`\'s `platform` for webOS specific information.',
-			until: '5.0.0'
-		});
-	} else if (!['chrome', 'safari', 'firefox'].includes(plat.platformName)) {
+	if (!['chrome', 'safari', 'firefox'].includes(plat.platformName)) {
 		deprecate({
 			name: plat.platformName,
 			until: '5.0.0'
@@ -334,7 +328,9 @@ const platform = {};
 			if (name === 'touchscreen') {
 				deprecate({name, until: '5.0.0', replacedBy: 'touchScreen'});
 			}
-
+			if (name === 'webos') {
+				deprecate({name, message: 'Refer `@enact/webos`\'s `platform` for webOS specific information.', until: '5.0.0'});
+			}
 			const p = detect();
 			return p[name];
 		}

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -150,13 +150,6 @@ const parseUserAgentLegacy = (userAgent) => {
 		}
 	}
 
-	if (!['chrome', 'safari', 'firefox'].includes(plat.platformName)) {
-		deprecate({
-			name: plat.platformName,
-			until: '5.0.0'
-		});
-	}
-
 	return plat;
 };
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Previously, when accessing the core/platform module, you could see the deprecated warning below.

> DEPRECATED: webos. Will be removed in 5.0.0. Refer `@enact/webos`'s `platform` for webOS specific information..

It would be better to appear this to users accessing webos properties.
Users accessing other properties may not be interested in that information.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The warning has been modified to only be appeared to users accessing platform.webos


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-28860

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
