### PR TITLE
WRQ-31515: Fixed Scroller, VirtualList, and VirtualGridList to set prop value to default when undefined is passed for the prop value

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `core/util` function `setDefaultProps` to set props to default values when props are missing or `undefined`
+
 ## [4.9.0] - 2024-07-17
 
 No significant changes.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact core module, newest chan
 
 ### Added
 
-- `core/util` function `setDefaultProps` to set props to default values when props are missing or `undefined`
+- `core/util` function `setDefaultProps` to set props that are missing or `undefined` to default values
 
 ## [4.9.0] - 2024-07-17
 

--- a/packages/core/util/tests/util-specs.js
+++ b/packages/core/util/tests/util-specs.js
@@ -1,6 +1,6 @@
 import {forwardRef, memo, lazy} from 'react';
 
-import {cap, clamp, coerceArray, coerceFunction, extractAriaProps, isRenderable, memoize, mergeClassNameMaps, mapAndFilterChildren, shallowEqual} from '../util';
+import {cap, clamp, coerceArray, coerceFunction, extractAriaProps, isRenderable, memoize, mergeClassNameMaps, mapAndFilterChildren, setDefaultProps, shallowEqual} from '../util';
 
 describe('util', () => {
 	describe('cap', () => {
@@ -250,6 +250,32 @@ describe('util', () => {
 				0 // index
 			];
 			const actual = spy.mock.calls[0];
+
+			expect(expected).toEqual(actual);
+		});
+	});
+
+	describe('setDefaultProps', () => {
+		const props = {
+			// eslint-disable-next-line no-undefined
+			direction: undefined,
+			index: 0,
+			size: 'small'
+		};
+		const defaultProps = {
+			direction: 'below',
+			selected: true,
+			size: 'large'
+		};
+
+		test('should set props to default values when props are missing or `undefined`', () => {
+			const expected = {
+				direction: 'below',
+				index: 0,
+				selected: true,
+				size: 'small'
+			};
+			const actual = setDefaultProps(props, defaultProps);
 
 			expect(expected).toEqual(actual);
 		});

--- a/packages/core/util/tests/util-specs.js
+++ b/packages/core/util/tests/util-specs.js
@@ -268,7 +268,7 @@ describe('util', () => {
 			size: 'large'
 		};
 
-		test('should set props to default values when props are missing or `undefined`', () => {
+		test('should set props that are missing or `undefined` to default values', () => {
 			const expected = {
 				direction: 'below',
 				index: 0,

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -267,7 +267,7 @@ const mapAndFilterChildren = (children, callback, filter) => {
 };
 
 /**
- * Set props to default values when props are missing or `undefined`
+ * Sets props that are missing or `undefined` to default values
  *
  * @function
  * @param {Obejct}        props           Props object

--- a/packages/core/util/util.js
+++ b/packages/core/util/util.js
@@ -267,6 +267,30 @@ const mapAndFilterChildren = (children, callback, filter) => {
 };
 
 /**
+ * Set props to default values when props are missing or `undefined`
+ *
+ * @function
+ * @param {Obejct}        props           Props object
+ * @param {Obejct}        defaultProps    Default value object
+ *
+ * @returns {Object}                      Props with default values
+ * @memberof core/util
+ * @public
+ */
+const setDefaultProps = (props, defaultProps = {}) => {
+	const result = Object.assign({}, props);
+
+	for (const prop in defaultProps) {
+		// eslint-disable-next-line no-undefined
+		if (props[prop] === undefined) {
+			result[prop] = defaultProps[prop];
+		}
+	}
+
+	return result;
+};
+
+/**
  * Performs shallow comparison for given objects.
  *
  * @function
@@ -317,5 +341,6 @@ export {
 	mergeClassNameMaps,
 	perfNow,
 	mapAndFilterChildren,
+	setDefaultProps,
 	shallowEqual
 };

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee.MarqueeController` to start animation properly when `marqueeOnFocus` is set to `true` and text changed
-- `ui/Scroller`, `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` to set prop value to default when `undefined` is passed for the prop value
+- `ui/Scroller` and `ui/VirtualList` to have default prop when `undefined` prop is passed
 
 ## [4.9.0] - 2024-07-17
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 ### Fixed
 
 - `ui/Marquee.MarqueeController` to start animation properly when `marqueeOnFocus` is set to `true` and text changed
+- `ui/Scroller`, `ui/VirtualList.VirtualList` and `ui/VirtualList.VirtualGridList` to set prop value to default when `undefined` is passed for the prop value
 
 ## [4.9.0] - 2024-07-17
 

--- a/packages/ui/Scroller/Scroller.js
+++ b/packages/ui/Scroller/Scroller.js
@@ -6,6 +6,7 @@
  * @exports ScrollerBasic
  */
 
+import {setDefaultProps} from '@enact/core/util';
 import PropTypes from 'prop-types';
 
 import {ResizeContext} from '../Resizable';
@@ -51,7 +52,7 @@ const scrollerDefaultProps = {
 const Scroller = (props) => {
 	// Hooks
 
-	const scrollerProps = Object.assign({}, scrollerDefaultProps, props);
+	const scrollerProps = setDefaultProps(props, scrollerDefaultProps);
 
 	const {
 		scrollContentHandle,

--- a/packages/ui/VirtualList/VirtualList.js
+++ b/packages/ui/VirtualList/VirtualList.js
@@ -9,6 +9,7 @@
  * @exports VirtualListBasic
  */
 
+import {setDefaultProps} from '@enact/core/util';
 import PropTypes from 'prop-types';
 
 import {ResizeContext} from '../Resizable';
@@ -50,7 +51,7 @@ const virtualListDefaultProps = {
 const VirtualList = (props) => {
 	// Hooks
 
-	const virtualListProps = Object.assign({}, virtualListDefaultProps, props);
+	const virtualListProps = setDefaultProps(props, virtualListDefaultProps);
 
 	const {
 		scrollContentHandle,
@@ -326,7 +327,7 @@ const virtualGridListDefaultProps = {
  * @public
  */
 const VirtualGridList = (props) => {
-	const virtualGridListProps = Object.assign({}, virtualGridListDefaultProps, props);
+	const virtualGridListProps = setDefaultProps(props, virtualGridListDefaultProps);
 
 	const {
 		scrollContentHandle,


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/enact/pull/3238, we removed defaultProps and implemented this feature manually.
After this implementation, if undefined is passed for a prop value, the prop value remains undefined.
However, defaultProps(https://legacy.reactjs.org/docs/typechecking-with-proptypes.html#default-prop-values) sets prop value to default value when undefined value is passed for the prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `setDefaultProps` util function
Fix `Scroller`, `VirtualList` and `VirtualGridList` to set prop value to default value when undefined is passed for the prop value


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I checked React's defaultProps for falsy values(null, undefined, false, NaN, 0, -0, "") and found that it sets the prop value to its default value only when undefined is passed.

And it seems that React's defaultProps only checked `undefined`.
- https://react.dev/reference/react/Component#static-defaultprops
- https://github.com/facebook/react/pull/28733/files/41b4a691b2ccf01a224a4e7c6e4f8e979a125876#diff-dbd72a473871eeddbe00ceed54a59bff33e6324ffdea15cb4ee3abbdad988cfbR348

### Links
[//]: # (Related issues, references)
WRQ-31515

### Comments
