### PR TITLE
WRR-1010: Fixed to recognize the last input type properly

### DIFF
--- a/packages/webos/lastInputType/lastInputType.js
+++ b/packages/webos/lastInputType/lastInputType.js
@@ -6,20 +6,15 @@
  */
 
 import LS2Request from '../LS2Request';
-import platform from '../platform';
 
 const requestLastInputType = ({onSuccess, onFailure}) => {
-	if (platform.tv) {
-		return new LS2Request().send({
-			service: 'luna://com.webos.surfacemanager',
-			method: 'getLastInputType',
-			subscribe: true,
-			onSuccess,
-			onFailure
-		});
-	}
-
-	return null;
+	return new LS2Request().send({
+		service: 'luna://com.webos.surfacemanager',
+		method: 'getLastInputType',
+		subscribe: true,
+		onSuccess,
+		onFailure
+	});
 };
 
 export default requestLastInputType;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The last input type is not recognized properly when `requestLastInputType` is called on some platforms since the function do nothing on unsupported platforms.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs after #3218 that adds `requestLastInputType`. At the moment we added this API, it is unclear that who is in charge of handling unsupported platforms among Enact, theme libraries, and apps.
The `requestLastInputType` function's role is simply to call LS2Request so the usage of this API depends on apps' logic. We'd like to remove platform checking and make this function to call LS2Request always. It means that Enact does not involve checking if the platform is supported. So, theme libraries or apps should check the availability.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
On unsupported platforms, LS2Request API covers warnings so `requestLastInputType` does not need to cover the case.

### Links
[//]: # (Related issues, references)
WRR-1010
enactjs/sandstone#1682
Related: WRQ-6498 / #3218

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)