### PR TITLE
WRR-2172: Fixed `VirtualList` to update scroll bounds when the total size of items is changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` to update its scroll bounds when the total size of items is changed
+
 ## [4.9.1] - 2024-09-09
 
 ### Fixed

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -406,7 +406,8 @@ class VirtualListBasic extends Component {
 			prevProps.direction !== this.props.direction ||
 			prevProps.overhang !== this.props.overhang ||
 			prevProps.spacing !== this.props.spacing ||
-			!equals(prevProps.itemSize, this.props.itemSize)
+			!equals(prevProps.itemSize, this.props.itemSize) ||
+			prevProps.itemSizes?.reduce((acc, cur) => acc + cur, 0) !== this.props.itemSizes?.reduce((acc, cur) => acc + cur, 0)
 		) {
 			const {x, y} = this.getXY(this.scrollPosition, 0);
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was an issue where the scroller could not move to the end of the scroller when the content of a VirtualList was changed.
This issue occurs when the content of virtualList is updated between fixed size content and variable size content and its minSize and dataSize is the same.

For example, the size of the item contents is as follows:
contents A = [120, 120, 120]
contents B = [120, 240, 240]
In this case, the condition for recalculating the scroll bounds value is not met in the existing code. Because the minSizes and datasizes of the two content lists are the same.

If the scroll bounds value is not updated, scrollTo will not work because it will assume that maxLeft position of the scroller has already been reached.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In the existing code, we checked whether the minimum size of the item has changed, whether the data size has changed, etc. In this commit, we added a condition to check whether the total size of the items has changed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-2172

### Comments
