### PR TITLE
WRR-4290: Convert components styling to SCSS: ProgressBar -> VirtualList

### DIFF
--- a/packages/ui/ProgressBar/ProgressBar.js
+++ b/packages/ui/ProgressBar/ProgressBar.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import {validateRange} from '../internal/validators';
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './ProgressBar.module.less';
+import componentCss from './ProgressBar.module.scss';
 
 const progressToProportion = (value) => clamp(0, 1, value);
 const calcBarStyle = (prop, anchor, value = anchor, startProp, endProp) => {

--- a/packages/ui/ProgressBar/ProgressBar.module.scss
+++ b/packages/ui/ProgressBar/ProgressBar.module.scss
@@ -1,0 +1,117 @@
+// ProgressBar.module.scss
+//
+
+@mixin radial-bar-styles {
+	height: 100%;
+	width: 100%;
+	border-radius: 50%;
+	border-style: solid;
+	box-sizing: border-box;
+}
+
+.progressBar {
+	--ui-progressbar-proportion-start: 0;
+	--ui-progressbar-proportion-start-background: 0;
+	--ui-progressbar-proportion-end: 0;
+	--ui-progressbar-proportion-end-background: 0;
+
+	position: relative;
+	direction: ltr;
+
+	.bar,
+	.fill,
+	.load {
+		position: absolute;
+	}
+
+	&.vertical {
+		display: inline-block;
+
+		.bar,
+		.fill,
+		.load {
+			height: 100%;
+			width: 100%;
+			bottom: 0;
+		}
+
+		.fill {
+			bottom: calc(var(--ui-progressbar-proportion-start) * 100%);
+			height: calc(var(--ui-progressbar-proportion-end) * 100%);
+		}
+
+		.load {
+			bottom: calc(var(--ui-progressbar-proportion-start-background) * 100%);
+			height: calc(var(--ui-progressbar-proportion-end-background) * 100%);
+		}
+	}
+
+	&.horizontal {
+		.bar,
+		.fill,
+		.load {
+			height: 100%;
+		}
+
+		.bar {
+			width: 100%;
+		}
+
+		.fill {
+			left: calc(var(--ui-progressbar-proportion-start) * 100%);
+			width: calc(var(--ui-progressbar-proportion-end) * 100%);
+		}
+
+		.load {
+			left: calc(var(--ui-progressbar-proportion-start-background) * 100%);
+			width: calc(var(--ui-progressbar-proportion-end-background) * 100%);
+		}
+	}
+
+	&.radial {
+		.bar {
+			@include radial-bar-styles;
+		}
+
+		.fill,
+		.load {
+			clip-path: inset(0 0 0 50%);  // Render these as half their width, clipping the left side
+
+			&::before,
+			&::after {
+				@include radial-bar-styles;
+
+				& {
+					position: absolute;
+					content: "";
+				}
+			}
+
+			&::before {
+				clip-path: inset(0 0 0 50%);  // Clip off the left half
+				display: none;
+			}
+
+			&::after {
+				clip-path: inset(0 50% 0 0);  // Clip off the right half
+			}
+		}
+
+		.fill::after {
+			transform: rotate(calc(var(--ui-progressbar-proportion-end) * 360deg));
+		}
+
+		.load::after {
+			transform: rotate(calc(var(--ui-progressbar-proportion-end-background) * 360deg));
+		}
+
+		&.fillOverHalf .fill,
+		&.loadOverHalf .load {
+			clip-path: initial;
+
+			&::before {
+				display: block;  // Enable the right-half of the progress circle
+			}
+		}
+	}
+}

--- a/packages/ui/Scroller/Scroller.module.scss
+++ b/packages/ui/Scroller/Scroller.module.scss
@@ -1,0 +1,14 @@
+// Scroller.module.scss
+//
+.scroller {
+	/* hide native scrollbar */
+	scrollbar-width: none;
+
+	will-change: transform;
+
+	/* hide native scrollbar */
+	/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import {Component} from 'react';
 
-import css from './Scroller.module.less';
+import css from './Scroller.module.scss';
 
 /**
  * An unstyled base scroller component.

--- a/packages/ui/Slider/PositionDecorator.js
+++ b/packages/ui/Slider/PositionDecorator.js
@@ -7,7 +7,7 @@ import {validateRangeOnce, validateSteppedOnce} from '../internal/validators';
 
 import {calcProportion} from './utils';
 
-import css from './Slider.module.less';
+import css from './Slider.module.scss';
 
 const validateRange = validateRangeOnce((props) => props, {'component': 'PositionDecorator'});
 const validateStepValue = validateSteppedOnce((props) => props, {'component': 'PositionDecorator'});

--- a/packages/ui/Slider/Slider.js
+++ b/packages/ui/Slider/Slider.js
@@ -21,7 +21,7 @@ import Touchable from '../Touchable';
 import Knob from './Knob';
 import PositionDecorator from './PositionDecorator';
 
-import componentCss from './Slider.module.less';
+import componentCss from './Slider.module.scss';
 
 import {calcProportion} from './utils';
 

--- a/packages/ui/Slider/Slider.module.scss
+++ b/packages/ui/Slider/Slider.module.scss
@@ -1,0 +1,20 @@
+.slider {
+	// The "end" referenced below refers to the current "max value" of the proportion. This is a
+	// forward-looking variable name to support a potential second knob at the "min value".
+	--ui-slider-proportion-end-knob: 0;
+
+	position: relative;
+	direction: ltr;
+
+	.knob {
+		top: 50%;
+		left: 50%;
+	}
+
+	&.horizontal,
+	&.pressed,
+	&.noFill,
+	&.vertical {
+		/* CSS Override */
+	}
+}

--- a/packages/ui/Slider/Slider.module.scss
+++ b/packages/ui/Slider/Slider.module.scss
@@ -1,3 +1,5 @@
+// Slider.modules.scss
+//
 .slider {
 	// The "end" referenced below refers to the current "max value" of the proportion. This is a
 	// forward-looking variable name to support a potential second knob at the "min value".

--- a/packages/ui/Spinner/Spinner.js
+++ b/packages/ui/Spinner/Spinner.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import FloatingLayer from '../FloatingLayer';
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './Spinner.module.less';
+import componentCss from './Spinner.module.scss';
 
 /**
  * A minimally styled component that controls `Spinner` positioning and interaction states, without

--- a/packages/ui/Spinner/Spinner.module.scss
+++ b/packages/ui/Spinner/Spinner.module.scss
@@ -1,0 +1,52 @@
+// Spinner.module.scss
+//
+@use "../styles/mixins";
+
+.spinner {
+	position: relative;
+	display: inline-block;
+
+	// centered
+	&.centered {
+		left: 50%;
+		position: absolute;
+		top: 50%;
+		transform: translateX(-50%) translateY(-50%);
+	}
+
+	&.running {
+		/* Available for theming */
+	}
+
+	:global(.enact-locale-right-to-left) & {
+		// centered
+		&.centered {
+			left: initial;
+			right: 50%;
+			transform: translateX(50%) translateY(-50%);
+		}
+	}
+}
+
+.spinnerContainer {
+	.scrim {
+		/* Available for theming */
+	}
+
+	// When `blockClickOn='container'` && `centered={false}`, there is a container div that should have
+	// `display: inline-block;` to match SpinnerBase's .spinner
+	display: inline-block;
+
+	// When `blockClickOn='container'` && `centered`, the container div should have 'display:block' for
+	// the spinner to be centered in the container correctly.
+	&.centered {
+		display: block;
+	}
+
+	// Scrim will fill up to the first ancestor element with absolute or relative position.
+	// Parent needs to have absolute or relative position for scrim to block as expected.
+	.blockClickOn {
+		position: absolute;
+		@include mixins.position(0);
+	}
+}

--- a/packages/ui/Spinner/Spinner.module.scss
+++ b/packages/ui/Spinner/Spinner.module.scss
@@ -35,7 +35,9 @@
 
 	// When `blockClickOn='container'` && `centered={false}`, there is a container div that should have
 	// `display: inline-block;` to match SpinnerBase's .spinner
-	display: inline-block;
+	& {
+		display: inline-block;
+	}
 
 	// When `blockClickOn='container'` && `centered`, the container div should have 'display:block' for
 	// the spinner to be centered in the container correctly.

--- a/packages/ui/ToggleIcon/ToggleIcon.js
+++ b/packages/ui/ToggleIcon/ToggleIcon.js
@@ -20,7 +20,7 @@ import ForwardRef from '../ForwardRef';
 import Toggleable from '../Toggleable';
 import Touchable from '../Touchable';
 
-import componentCss from './ToggleIcon.module.less';
+import componentCss from './ToggleIcon.module.scss';
 
 /**
  * Represents a Boolean state, and can accept any icon to toggle.

--- a/packages/ui/ToggleIcon/ToggleIcon.module.scss
+++ b/packages/ui/ToggleIcon/ToggleIcon.module.scss
@@ -1,0 +1,14 @@
+// ToggleIcon.module.scss
+//
+
+.toggleIcon {
+	display: inline-block;
+
+	.icon {
+		vertical-align: top;
+	}
+
+	&.selected {
+		/* Available for customization */
+	}
+}

--- a/packages/ui/Transition/Transition.js
+++ b/packages/ui/Transition/Transition.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
 
 import {ResizeContext} from '../Resizable';
 
-import componentCss from './Transition.module.less';
+import componentCss from './Transition.module.scss';
 
 const formatter = (duration) => (typeof duration === 'number' ? duration + 'ms' : duration);
 /**

--- a/packages/ui/Transition/Transition.module.scss
+++ b/packages/ui/Transition/Transition.module.scss
@@ -1,0 +1,177 @@
+// Transition.module.scss
+//
+.transition {
+	.inner {
+		overflow: hidden;
+	}
+
+	&.slide {
+		overflow: hidden;
+
+		.inner {
+			transition-property: transform;
+			will-change: transform;
+		}
+	}
+
+	&.fade .inner {
+		transition-property: opacity;
+		will-change: opacity;
+	}
+
+	&.shown {
+		&.slide .inner {
+			transform: translate3d(0, 0, 0);
+		}
+
+		&.clip {
+			&.right,
+			&.left {
+				max-width: 100%;
+			}
+		}
+
+		&.fade .inner {
+			opacity: 1;
+		}
+	}
+
+	&.hidden {
+		&.slide {
+			&.up .inner {
+				transform: translateY(-100%);
+			}
+
+			&.right .inner {
+				transform: translateX(100%);
+			}
+
+			&.down .inner {
+				transform: translateY(100%);
+			}
+
+			&.left .inner {
+				transform: translateX(-100%);
+			}
+		}
+
+		&.clip {
+			&.up,
+			&.down {
+				height: 0;
+			}
+
+			&.right,
+			&.left {
+				max-width: 0;
+			}
+		}
+
+		&.fade .inner {
+			opacity: 0;
+		}
+	}
+
+	&.clip {
+		position: relative;
+
+		&.up,
+		&.down {
+			transition-property: height;
+			will-change: height;
+		}
+
+		&.right,
+		&.left {
+			transition-property: max-width;
+			will-change: max-width;
+
+			.inner {
+				position: relative;
+			}
+		}
+
+		&.up .inner {
+			top: 0;
+		}
+
+		&.down {
+			.inner {
+				transition-property: transform;
+				will-change: transform;
+			}
+
+			&.shown .inner {
+				transform: translate(0, 0);
+			}
+		}
+
+		&.right {
+			.inner {
+				right: 0;
+			}
+
+			&.hidden .inner {
+				transform: translateX(-100%);
+			}
+		}
+
+		&.down {
+			&.hidden .inner {
+				transform: translateY(-100%);
+			}
+		}
+	}
+
+	// Durations
+	&.short,
+	&.short .inner {
+		transition-duration: 250ms;
+	}
+
+	&.medium,
+	&.medium .inner {
+		transition-duration: 500ms;
+	}
+
+	&.long,
+	&.long .inner {
+		transition-duration: 1s;
+	}
+
+	// Timing Functions
+	&.ease,
+	&.ease .inner {
+		transition-timing-function: ease;
+	}
+
+	&.ease-in,
+	&.ease-in .inner {
+		transition-timing-function: ease-in;
+	}
+
+	&.ease-out,
+	&.ease-out .inner {
+		transition-timing-function: ease-out;
+	}
+
+	&.ease-in-out,
+	&.ease-in-out .inner {
+		transition-timing-function: ease-in-out;
+	}
+
+	&.ease-in-quart,
+	&.ease-in-quart .inner {
+		transition-timing-function: cubic-bezier(0.895, 0.030, 0.685, 0.220);
+	}
+
+	&.ease-out-quart,
+	&.ease-out-quart .inner {
+		transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
+	}
+
+	&.linear,
+	&.linear .inner {
+		transition-timing-function: linear;
+	}
+}

--- a/packages/ui/VirtualList/VirtualList.module.scss
+++ b/packages/ui/VirtualList/VirtualList.module.scss
@@ -1,0 +1,44 @@
+// VirtualList.module.scss
+//
+.virtualList {
+	position: relative;
+	height: 100%;
+	width: 100%;
+	overflow: hidden;
+	/* hide native scrollbar */
+	scrollbar-width: none;
+
+	.content {
+		will-change: transform;
+	}
+}
+
+.vertical {
+	&.native {
+		overflow-y: scroll;
+	}
+
+	.listItem {
+		width: 100%;
+	}
+}
+
+.horizontal {
+	&.native {
+		overflow-x: scroll;
+	}
+
+	.listItem {
+		height: 100%;
+	}
+}
+
+.listItem {
+	position: absolute;
+	will-change: transform;
+}
+
+/* NOTE: Needs to be revisited whether it can be replaced with scrollbar-width */
+.virtualList::-webkit-scrollbar {
+	display: none;
+}

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import equals from 'ramda/src/equals';
 import {createRef, Component} from 'react';
 
-import css from './VirtualList.module.less';
+import css from './VirtualList.module.scss';
 
 const nop = () => {};
 

--- a/packages/ui/useScroll/Scrollbar.js
+++ b/packages/ui/useScroll/Scrollbar.js
@@ -7,7 +7,7 @@ import ri from '../resolution';
 
 import ScrollbarTrack from './ScrollbarTrack';
 
-import componentCss from './Scrollbar.module.less';
+import componentCss from './Scrollbar.module.scss';
 
 const scrollbarTrackHidingDelay = 900; // 900ms + 100ms(fade out duration) = 1000ms.
 

--- a/packages/ui/useScroll/Scrollbar.module.scss
+++ b/packages/ui/useScroll/Scrollbar.module.scss
@@ -1,0 +1,34 @@
+// Scrollbar.module.scss
+//
+.scrollbar {
+	background: inherit;
+	display: flex;
+	border-color: transparent;
+	visibility: visible;
+	opacity: 1;
+	flex: none;
+
+	transform: translateZ(0);
+	transition: opacity 0.1s linear;
+
+	&.vertical {
+		flex-direction: column;
+	}
+
+	&.horizontal {
+		:global(.enact-locale-right-to-left) & {
+			// Flip the entire bar horizontally in RTL mode, and force it to remain in LTR.
+			direction: ltr;
+			transform: scaleX(-1);
+		}
+	}
+
+	&.corner {
+		padding-inline-end: 3px;
+	}
+
+	/* ScrollbarTrack */
+	.scrollbarTrackShown {
+		opacity: 1;
+	}
+}

--- a/packages/ui/useScroll/ScrollbarTrack.js
+++ b/packages/ui/useScroll/ScrollbarTrack.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import {forwardRef, memo} from 'react';
 
-import css from './ScrollbarTrack.module.less';
+import css from './ScrollbarTrack.module.scss';
 
 /**
  * An unstyled scroll track without any behavior.

--- a/packages/ui/useScroll/ScrollbarTrack.module.scss
+++ b/packages/ui/useScroll/ScrollbarTrack.module.scss
@@ -1,0 +1,46 @@
+// ScrollbarTrack.module.scss
+//
+.scrollbarTrack {
+	/* Set these to reasonable default values */
+	--scrollbar-thumb-size-ratio: 1;
+	--scrollbar-thumb-progress-ratio: 0;
+	--scrollbar-thumb-size: calc(100% * var(--scrollbar-thumb-size-ratio));
+	--scrollbar-thumb-progress: calc(((1 - var(--scrollbar-thumb-size-ratio)) * var(--scrollbar-thumb-progress-ratio)) * 100%);
+
+	position: relative;
+	width: 3px;
+	height: 3px;
+	margin: auto;
+	opacity: 0;
+	flex: auto;
+
+	transition: opacity 100ms linear;
+
+	will-change: transform, top, left, right;
+
+	&::before {
+		background: fade-out(#666, 0.25);
+		display: block;
+		position: absolute;
+		content: "";
+		width: 100%;
+		height: 100%;
+		will-change: transform, top, left, right;
+	}
+
+	&.vertical {
+		&::before {
+			height: var(--scrollbar-thumb-size);
+			top: var(--scrollbar-thumb-progress);
+		}
+	}
+
+	&:not(.vertical) {
+		&::before {
+			width: var(--scrollbar-thumb-size);
+			left: var(--scrollbar-thumb-progress);
+			top: 50%;
+			transform: translateY(-50%);
+		}
+	}
+}

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -29,7 +29,7 @@ import ScrollAnimator from './ScrollAnimator';
 import utilDOM from './utilDOM';
 import utilEvent from './utilEvent';
 
-import css from './useScroll.module.less';
+import css from './useScroll.module.scss';
 
 const
 	constants = {

--- a/packages/ui/useScroll/useScroll.module.scss
+++ b/packages/ui/useScroll/useScroll.module.scss
@@ -1,17 +1,19 @@
 // useScroll.module.scss
 //
-.scrollFill {
+@mixin scrollFill {
 	position: relative;
 	width: 100%;
 	height: 100%;
 }
 
 .scroll {
-	.scrollFill;
+	@include scrollFill;
 
-	display: flex;
-	box-sizing: border-box;
-	flex-direction: column;
+	& {
+		display: flex;
+		box-sizing: border-box;
+		flex-direction: column;
+	}
 
 	&[data-container-muted="true"]::before {
 		position: absolute;

--- a/packages/ui/useScroll/useScroll.module.scss
+++ b/packages/ui/useScroll/useScroll.module.scss
@@ -1,0 +1,40 @@
+// useScroll.module.scss
+//
+.scrollFill {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}
+
+.scroll {
+	.scrollFill;
+
+	display: flex;
+	box-sizing: border-box;
+	flex-direction: column;
+
+	&[data-container-muted="true"]::before {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		content: '';
+		z-index: 10;
+	}
+
+	.scrollInnerContainer {
+		display: flex;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		flex: auto;
+	}
+
+	.scrollContentWrapper {
+		background: inherit;
+		position: relative;
+		overflow: hidden;
+		flex: 1 1 100%;
+	}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Converted components' styling to SCSS: ProgressBar, Scroller, Slider, Spinner, Transition, useScroll and VirtualList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-4290

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com