### PR TITLE
WRR-4289: Converted components styles to SCSS `AnnounceDecorator -> Media`

### DIFF
--- a/packages/ui/BodyText/BodyText.js
+++ b/packages/ui/BodyText/BodyText.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './BodyText.module.less';
+import componentCss from './BodyText.module.scss';
 
 /**
  * A simple, unstyled text block component, without

--- a/packages/ui/BodyText/BodyText.module.scss
+++ b/packages/ui/BodyText/BodyText.module.scss
@@ -1,0 +1,11 @@
+// BodyText.module.scss
+
+.bodyText {
+	text-align: left;
+	margin-block-start: 1em;  // Mimmic the browser's default rules for P tag (in case the component changed)
+	margin-block-end: 1em;    // Mimmic the browser's default rules for P tag (in case the component changed)
+
+	&.centered {
+		text-align: center;
+	}
+}

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -16,7 +16,7 @@ import ComponentOverride from '../ComponentOverride';
 import ForwardRef from '../ForwardRef';
 import Touchable from '../Touchable';
 
-import componentCss from './Button.module.less';
+import componentCss from './Button.module.scss';
 
 /**
  * A basic button component structure without any behaviors applied to it.

--- a/packages/ui/Button/Button.module.scss
+++ b/packages/ui/Button/Button.module.scss
@@ -1,0 +1,57 @@
+// Button.module.scss
+//
+@use "../styles/mixins";
+
+.button {
+	display: inline-block;
+	box-sizing: border-box;
+	position: relative;
+	overflow: visible;
+	white-space: nowrap;
+	width: auto;
+	z-index: 0;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+
+	//**
+	//* Classes to apply to the background of the button, used on a child of button.
+	//* @public
+	//*/
+	.bg {
+		@include mixins.position(0);
+		position: absolute;
+		z-index: -1;
+	}
+
+	//**
+	//* Where the content of the button lives.
+	//* @public
+	//*/
+	.client {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 100%;
+		position: relative;
+	}
+
+	.icon,
+	&.hasIcon,
+	&.large,
+	&.minWidth,
+	&.small,
+	//**
+	//* Classes to apply to the selected state of the button, applied to the base element
+	//* @public
+	//*/
+	&.decoration,
+	&.selected,
+	&.pressed {
+		/* Public Class Names */
+	}
+
+	@include mixins.disabled {
+		cursor: default;
+	}
+}

--- a/packages/ui/Button/Button.module.scss
+++ b/packages/ui/Button/Button.module.scss
@@ -19,8 +19,10 @@
 	//*/
 	.bg {
 		@include mixins.position(0);
-		position: absolute;
-		z-index: -1;
+		& {
+		    position: absolute;
+		    z-index: -1;
+		}
 	}
 
 	//**

--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -11,7 +11,7 @@ import Cancelable from '../Cancelable';
 import {FloatingLayerContext} from './FloatingLayerDecorator';
 import Scrim from './Scrim';
 
-import css from './FloatingLayer.module.less';
+import css from './FloatingLayer.module.scss';
 
 /**
  * A component that creates an entry point to the new render tree.

--- a/packages/ui/FloatingLayer/FloatingLayer.module.scss
+++ b/packages/ui/FloatingLayer/FloatingLayer.module.scss
@@ -1,0 +1,6 @@
+// FloatingLayer.module.scss
+//
+
+.floatingLayer {
+	z-index: 100;
+}

--- a/packages/ui/FloatingLayer/Scrim.js
+++ b/packages/ui/FloatingLayer/Scrim.js
@@ -1,7 +1,7 @@
 import {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import css from './Scrim.module.less';
+import css from './Scrim.module.scss';
 
 const transparentClassName = css.scrim + ' enact-fit ' + css.transparent;
 const translucentClassName = css.scrim + ' enact-fit ' + css.translucent;

--- a/packages/ui/FloatingLayer/Scrim.module.scss
+++ b/packages/ui/FloatingLayer/Scrim.module.scss
@@ -1,0 +1,8 @@
+.scrim {
+	&.transparent { /* Needed to prevent global class being added in the DOM */ }
+
+	&.translucent {
+		pointer-events: auto;
+		background-color: rgba(0, 0, 0, 0.3);
+	}
+}

--- a/packages/ui/FloatingLayer/Scrim.module.scss
+++ b/packages/ui/FloatingLayer/Scrim.module.scss
@@ -1,3 +1,6 @@
+// Scrim.module.scss
+//
+
 .scrim {
 	&.transparent { /* Needed to prevent global class being added in the DOM */ }
 

--- a/packages/ui/Heading/Heading.js
+++ b/packages/ui/Heading/Heading.js
@@ -19,7 +19,7 @@ import compose from 'ramda/src/compose';
 
 import ForwardRef from '../ForwardRef';
 
-import css from './Heading.module.less';
+import css from './Heading.module.scss';
 
 /**
  * A labeled Heading component.

--- a/packages/ui/Heading/Heading.module.scss
+++ b/packages/ui/Heading/Heading.module.scss
@@ -1,0 +1,20 @@
+// Heading.module.scss
+//
+
+.heading {
+	&.title,
+	&.subtitle,
+	&.large,
+	&.medium,
+	&.small,
+	&.tiny,
+	&.titleSpacing,
+	&.subtitleSpacing,
+	&.largeSpacing,
+	&.mediumSpacing,
+	&.smallSpacing,
+	&.tinySpacing,
+	&.noneSpacing {
+		/* Available for export */
+	}
+}

--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -15,7 +15,7 @@ import compose from 'ramda/src/compose';
 import ri from '../resolution';
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './Icon.module.less';
+import componentCss from './Icon.module.scss';
 
 /**
  * Merges consumer styles with the image `src` resolved through the resolution independence module.

--- a/packages/ui/Icon/Icon.module.scss
+++ b/packages/ui/Icon/Icon.module.scss
@@ -1,0 +1,38 @@
+// Icon.module.scss
+//
+@use "../styles/mixins";
+
+.icon {
+	display: inline-block;
+	vertical-align: middle;
+	font-weight: normal;
+	font-style: normal;
+	text-align: center;
+	position: relative;
+
+	@include mixins.font-kerning(none);
+
+	@include mixins.disabled{
+		cursor: default;
+	}
+
+	&.flipBoth {
+		transform: scale(-1);
+	}
+
+	&.flipHorizontal {
+		transform: scaleX(-1);
+	}
+
+	&.flipVertical {
+		transform: scaleY(-1);
+	}
+
+
+	&.dingbat,
+	&.large,
+	&.pressed,
+	&.small {
+		/* Public Class Names */
+	}
+}

--- a/packages/ui/Image/Image.js
+++ b/packages/ui/Image/Image.js
@@ -16,7 +16,7 @@ import warning from 'warning';
 import {selectSrc} from '../resolution';
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './Image.module.less';
+import componentCss from './Image.module.scss';
 
 /**
  * A basic image component designed to display images conditionally based on screen size.

--- a/packages/ui/Image/Image.module.scss
+++ b/packages/ui/Image/Image.module.scss
@@ -1,0 +1,21 @@
+// Image.module.scss
+//
+.image {
+	display: inline-block;
+	background-position: center;
+	background-repeat: no-repeat;
+
+	&.fit {
+		background-size: contain;
+	}
+
+	&.fill {
+		background-size: cover;
+	}
+
+	.img {
+		height: 0;
+		width: 0;
+		visibility: hidden;
+	}
+}

--- a/packages/ui/ImageItem/ImageItem.js
+++ b/packages/ui/ImageItem/ImageItem.js
@@ -17,7 +17,7 @@ import ForwardRef from '../ForwardRef';
 import Image from '../Image';
 import {Cell, Column, Row} from '../Layout';
 
-import componentCss from './ImageItem.module.less';
+import componentCss from './ImageItem.module.scss';
 
 // Adapts ComponentOverride to work within Cell since both use the component prop
 function ImageOverride ({imageComponent, ...rest}) {

--- a/packages/ui/ImageItem/ImageItem.module.scss
+++ b/packages/ui/ImageItem/ImageItem.module.scss
@@ -1,0 +1,29 @@
+// ImageItem.module.scss
+//
+.imageItem {
+	box-sizing: border-box;
+
+	.image {
+		display: block; // leaving this to prevent whitespace between inline-block elements
+		margin: 0;
+	}
+	
+	.caption,
+	&.selected {
+		/* Public Class Names */
+	}
+	
+	&.horizontal {
+		.image {
+			width: 25%;
+			height: 100%;
+		}
+	}
+	
+	&.vertical {
+		.image {
+			width: 100%;
+			height: 100%;
+		}
+	}
+}

--- a/packages/ui/Item/Item.js
+++ b/packages/ui/Item/Item.js
@@ -15,7 +15,7 @@ import compose from 'ramda/src/compose';
 import Touchable from '../Touchable';
 import ForwardRef from '../ForwardRef';
 
-import componentCss from './Item.module.less';
+import componentCss from './Item.module.scss';
 
 /**
  * A basic list item component structure without any behaviors applied to it.

--- a/packages/ui/Item/Item.module.scss
+++ b/packages/ui/Item/Item.module.scss
@@ -1,0 +1,14 @@
+// Item.module.scss
+//
+
+.item {
+	box-sizing: border-box;
+	display: block;
+	align-items: center;
+
+	&.inline {
+		display: inline-block;
+		vertical-align: middle;
+		box-sizing: border-box;
+	}
+}

--- a/packages/ui/LabeledIcon/LabeledIcon.js
+++ b/packages/ui/LabeledIcon/LabeledIcon.js
@@ -18,7 +18,7 @@ import ForwardRef from '../ForwardRef';
 import {CellBase, LayoutBase} from '../Layout';
 import Slottable from '../Slottable';
 
-import componentCss from './LabeledIcon.module.less';
+import componentCss from './LabeledIcon.module.scss';
 
 /**
  * An icon component with a label.

--- a/packages/ui/LabeledIcon/LabeledIcon.module.scss
+++ b/packages/ui/LabeledIcon/LabeledIcon.module.scss
@@ -1,0 +1,45 @@
+// LabeledIcon.module.scss
+//
+@use "../styles/mixins";
+
+.labeledIcon {
+	vertical-align: middle;
+
+	@include mixins.disabled {
+		cursor: default;
+	}
+
+	&.inline {
+		display: inline-flex;
+	}
+
+	&.above,
+	&.below {
+		// ui/Layout defaults to height: 100% which must be suppressed here
+		height: auto;
+	}
+
+	&.above,
+	&.before,
+	&.left,
+	:global(.enact-locale-right-to-left) &.right {
+		.iconCell { order: 2; }
+		.label { order: 1; }
+	}
+	:global(.enact-locale-right-to-left) &.left {
+		.iconCell { order: 1; }
+		.label { order: 2; }
+	}
+
+	&.above,
+	&.after,
+	&.before,
+	&.below,
+	&.left,
+	&.right,
+	.icon,
+	.iconCell,
+	.label {
+		/* Public Class Names */
+	}
+}

--- a/packages/ui/Layout/Cell.js
+++ b/packages/ui/Layout/Cell.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import ForwardRef from '../ForwardRef';
 import ri from '../resolution';
 
-import css from './Layout.module.less';
+import css from './Layout.module.scss';
 
 const toFlexAlign = (align) => (
 	align === 'end' && 'flex-end' ||

--- a/packages/ui/Layout/Layout.js
+++ b/packages/ui/Layout/Layout.js
@@ -131,7 +131,7 @@ import ForwardRef from '../ForwardRef';
 
 import {Cell, CellBase, CellDecorator, toFlexAlign} from './Cell';
 
-import css from './Layout.module.less';
+import css from './Layout.module.scss';
 
 /**
  * A container for `Cell`s.

--- a/packages/ui/Layout/Layout.module.scss
+++ b/packages/ui/Layout/Layout.module.scss
@@ -1,0 +1,92 @@
+// Layout.module.scss
+//
+
+.layout {
+	display: flex;
+	margin: 0;
+	box-sizing: border-box;
+
+	// Children
+	.cell {
+		flex: 1 0;
+		position: relative;  // Allow content to treat cells as positionable spaces
+
+		&.grow {
+			flex: 1 1 100%;
+		}
+
+		&.shrink {
+			flex: 0 0 auto;
+		}
+	}
+
+	// Modes
+	&.horizontal {
+		flex-direction: row;
+
+		> .cell {
+			max-width: var(--cell-size);
+			&.grow {
+				width: 0;
+				&.size {
+					max-width: none;
+					min-width: var(--cell-size);
+				}
+			}
+		}
+	}
+
+	&.vertical {
+		flex-direction: column;
+		height: 100%;
+
+		> .cell {
+			max-height: var(--cell-size);
+			&.grow {
+				height: 0;
+				align-self: normal;
+				&.size {
+					max-height: none;
+					min-height: var(--cell-size);
+				}
+			}
+		}
+	}
+
+	&.inline {
+		display: inline-flex;
+	}
+
+	&.wrap {
+		flex-wrap: wrap;
+	}
+
+	&.nowrap {
+		flex-wrap: nowrap;
+	}
+
+	&.wrapReverse {
+		flex-wrap: wrap-reverse;
+	}
+
+	// Debug lines to help see what's going on
+	:global(.debug.layout) &,
+	:global(.debug.layout) & {
+		outline: 1px dotted teal;
+	}
+
+	.cell {
+		:global(.debug.layout) &,
+		:global(.debug.layout) & {
+			outline: 1px dashed red;
+		}
+	}
+	& .cell {                :global(.debug.layout) & { outline-color: red; }}
+	& & .cell {              :global(.debug.layout) & { outline-color: orange; }}
+	& & & .cell {            :global(.debug.layout) & { outline-color: yellow; }}
+	& & & & .cell {          :global(.debug.layout) & { outline-color: lime; }}
+	& & & & & .cell {        :global(.debug.layout) & { outline-color: cyan; }}
+	& & & & & & .cell {      :global(.debug.layout) & { outline-color: blue; }}
+	& & & & & & & .cell {    :global(.debug.layout) & { outline-color: violet; }}
+	& & & & & & & & .cell {  :global(.debug.layout) & { outline-color: lightslategray; }}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Converted components' styling to SCSS: `BodyText, Button, FloatingLayer, Heading, Icon, Image, ImageItem, Item, LabeledIcon, and Layout`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4289

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com