### PR TITLE
WRR-5235: Converted remaining Enact mixins to SCSS

### DIFF
--- a/packages/spotlight/styles/mixins.scss
+++ b/packages/spotlight/styles/mixins.scss
@@ -38,3 +38,16 @@
 		}
 	}
 }
+
+// Muted elements
+@mixin muted($target: '') {
+	@if ($target == parent) {
+		[data-spotlight-container-muted="true"] {
+			@content;
+		}
+	} @else {
+		&[data-spotlight-container-muted="true"] {
+			@content;
+		}
+	}
+}

--- a/packages/ui/styles/mixins.scss
+++ b/packages/ui/styles/mixins.scss
@@ -279,6 +279,9 @@
 		islist: type-of($value) == list;
 		isbool: type-of($value) == bool;
 		isnull: type-of($value) == null;
+		ispixel: type-of($value) == number and unit($value) == "px";
+		isem: type-of($value) == number and unit($value) == "em";
+		ispercentage: type-of($value) == number and unit($value) == "%";
 	}
 }
 

--- a/packages/ui/styles/mixins.scss
+++ b/packages/ui/styles/mixins.scss
@@ -20,9 +20,11 @@
 // Disabled elements
 @mixin disabled($parent: false) {
 	$selector: "";
+
 	@if $parent == false {
 		$selector: "&";
 	}
+
 	@if content-exists() {
 		#{$selector}[disabled] {
 			@content;
@@ -30,12 +32,9 @@
 	}
 }
 
-// Assign font-kerning rules in a non-proprietary way. Default value being "normal", to enable kerning.
-@mixin font-kerning($val: normal) {
-	& {
-		-webkit-font-kerning: $val;
-		font-kerning: $val;
-	}
+@mixin enact-composite {
+	transform: translateZ(0);
+	will-change: transform;
 }
 
 // Applies RTL-compatible start and end position to a selector
@@ -171,11 +170,70 @@
 	}
 }
 
+// NOTE: Until we are able to automatically remove these JSDoc-style comments, they should remain SCSS-commented
+// /**
+//  * Removes the margin from the appropriate side of the child components that touch the edges of the
+//  * component this is applied to. This respects both LTR and RTL modes.
+//  */
+@mixin remove-margin-on-edge-children {
+	> :first-child {
+		margin-inline-start: 0;
+	}
+
+	> :last-child {
+		margin-inline-end: 0;
+	}
+}
+
+// /**
+//  * Removes the padding from the appropriate side of the child components that touch the edges of the
+//  * component this is applied to. This respects both LTR and RTL modes.
+//  */
+@mixin remove-padding-on-edge-children {
+	> :first-child {
+		padding-inline-start: 0;
+	}
+
+	> :last-child {
+		padding-inline-end: 0;
+	}
+}
+
+@mixin full-screen-video-player {
+	position: static !important;
+	display: block !important;
+	margin: 0;
+}
+
+@mixin hide-full-screen-ancestor {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+
 @mixin input-placeholder {
 	&::-webkit-input-placeholder {
 		@content;
 	}
+
 	&::-moz-placeholder {
+		@content;
+	}
+}
+
+// Assign font-kerning rules in a non-proprietary way. Default value being "normal", to enable kerning.
+@mixin font-kerning($val: normal) {
+	& {
+		-webkit-font-kerning: $val;
+		font-kerning: $val;
+	}
+}
+
+@mixin vendor-fullscreen {
+	&:fullscreen {
 		@content;
 	}
 }
@@ -206,7 +264,7 @@
 	}
 }
 
-@mixin border-box() {
+@mixin border-box {
 	box-sizing: border-box;
 	-moz-box-sizing: border-box;
 }

--- a/packages/ui/styles/mixins.scss
+++ b/packages/ui/styles/mixins.scss
@@ -269,6 +269,19 @@
 	-moz-box-sizing: border-box;
 }
 
+// Helpful debugging way to understand how SCSS variables are being interpreted
+@mixin debugScssTypes($value) {
+	:global(.debugScssTypes) {
+		value: $value;
+		isnumber: type-of($value) == number;
+		isstring: type-of($value) == string;
+		iscolor: type-of($value) == color;
+		islist: type-of($value) == list;
+		isbool: type-of($value) == bool;
+		isnull: type-of($value) == null;
+	}
+}
+
 //
 // Mixin classes supporting advanced text
 //

--- a/packages/ui/styles/utils.scss
+++ b/packages/ui/styles/utils.scss
@@ -1,0 +1,44 @@
+//
+// Computational mixins that return values
+//
+
+// Normalizes a list of values, using the logic from padding and margin short-hand, and expands it up
+// to the full long-hand representation, giving a consistent list length to extract from.
+// Supports 1, 2, 3, or 4 values in a space separated list.
+// Always returns a list of 4.
+// normalize-shorthand(11px 21px 31px 41px)  -->  11px 21px 31px 41px
+// normalize-shorthand(11px 21px 31px)       -->  11px 21px 31px 21px
+// normalize-shorthand(11px 21px)            -->  11px 21px 11px 21px
+// normalize-shorthand(11px)                 -->  11px 11px 11px 11px
+//
+@function normalize-shorthand($trbl) {
+	@if ((length($trbl) >= 1) and (length($trbl) <= 4)) {
+		@return
+				nth($trbl, 1)
+				nth($trbl, if((length($trbl) >= 2), 2, 1))
+				nth($trbl, if((length($trbl) >= 3), 3, 1))
+				nth($trbl, if((length($trbl) >= 4), 4, if((length($trbl) >= 2), 2, 1)));
+	}
+}
+
+// Extracts one or all short-hand values out of a list (See `normalize-shorthand`), returning all
+// values or a requested value.
+// padding-left: extract(11px 21px 31px 41px, left)  -->  41px
+// padding-left: extract(11px 21px 31px, left)       -->  21px
+// padding-left: extract(11px 21px, left)        m   -->  21px
+// padding-left: extract(11px, left)                 -->  11px
+// padding: extract(11px 21px 31px 41px)             -->  11px 21px 31px 41px
+//
+@function extract($trbl, $position) {
+	@if ($position == top or $position == 1) {
+		@return nth(normalize-shorthand($trbl), 1);
+	} @else if ($position == right or $position == 2) {
+		@return nth(normalize-shorthand($trbl), 2);
+	} @else if ($position == bottom or $position == 3) {
+		@return nth(normalize-shorthand($trbl), 3);
+	} @else if ($position == left or $position == 4) {
+		@return nth(normalize-shorthand($trbl), 4);
+	} @else {
+		@return normalize-shorthand($trbl);
+	}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Converted mixins to SCSS: `enact-composite`, `remove-margin-on-edge-children`, `remove-padding-on-edge-children`, `full-screen-video-player`, `hide-full-screen-ancestor` and `vendor-fullscreen`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-5235

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com