### PR TITLE
WRR-6697: Fix node_js to use lts version only on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: jammy
 language: node_js
 node_js:
     - lts/*
-    - "22"
 sudo: false
 before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
npm intall not working on node v23 because of node-canvas
https://github.com/enactjs/sandstone/pull/1723/checks?check_run_id=31623413345

So we decided to change the node version to lts/*

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix node_js to use lts version only on travis

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-6697

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)