### PR TITLE
WRR-9866: Fix VirtualListBasic to update its item position when the size of each item is changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/VirtualList` to update its item position when the size of each item is changed
+- `ui/VirtualList` to re-render when the each size of variable sized items changed
 
 ## [4.9.3] - 2024-10-29
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` to update its item position when the size of each item is changed
+
 ## [4.9.3] - 2024-10-29
 
 No significant changes.

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {forward} from '@enact/core/handle';
 import {platform} from '@enact/core/platform';
-import {clamp} from '@enact/core/util';
+import {clamp, shallowEqual} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import equals from 'ramda/src/equals';
 import {createRef, Component} from 'react';
@@ -407,7 +407,7 @@ class VirtualListBasic extends Component {
 			prevProps.overhang !== this.props.overhang ||
 			prevProps.spacing !== this.props.spacing ||
 			!equals(prevProps.itemSize, this.props.itemSize) ||
-			prevProps.itemSizes?.reduce((acc, cur) => acc + cur, 0) !== this.props.itemSizes?.reduce((acc, cur) => acc + cur, 0)
+			!shallowEqual(prevProps.itemSizes, this.props.itemSizes)
 		) {
 			const {x, y} = this.getXY(this.scrollPosition, 0);
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was an issue that VirtualList did not re-calculate the positions of items when items in the VirtualList was changed.

For example, the size(=width) of the item contents is as follows:
contents A = [120, 240, 480]
contents B = [480, 240, 120]

In this case, VirtualList needs to re-calculate the positions of items to render them properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I fixed the code to compare arrays of item sizes instead of the total size of the items.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9866

### Comments
