### PR TITLE
WRR-12807: Fixed `VirtualList` to not abnormally scroll when `dataSize` and `itemSizes` changed

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` to not abnoramlly scroll when `dataSize` and `itemSizes` changed
+
 ## [4.9.4] - 2024-11-19
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/VirtualList` to not abnoramlly scroll when `dataSize` and `itemSizes` changed
+- `ui/VirtualList` to not abnormally scroll when `dataSize` and `itemSizes` changed
 
 ## [4.9.4] - 2024-11-19
 

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -407,7 +407,7 @@ class VirtualListBasic extends Component {
 			prevProps.overhang !== this.props.overhang ||
 			prevProps.spacing !== this.props.spacing ||
 			!equals(prevProps.itemSize, this.props.itemSize) ||
-			!shallowEqual(prevProps.itemSizes, this.props.itemSizes)
+			(!this.hasDataSizeChanged && !shallowEqual(prevProps.itemSizes, this.props.itemSizes))
 		) {
 			const {x, y} = this.getXY(this.scrollPosition, 0);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `dataSize` of `VirtualList` changed when the item sizes are variable(e.g. removing an item), the scroll position goes to 0.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When we resolve other issues, we added a condition to recalculate metrics from https://github.com/enactjs/enact/pull/3275 and https://github.com/enactjs/enact/pull/3293.
In this case, it should not recalculate metrics when `dataSize` also changed.
So I added a condition that sees the `dataSize`. For previous issues, there is no change of `dataSize` so it should be fine. I've verified the related test cases from sandstone qa-sampler.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-12807

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)