### PR TITLE
WRR-9415: Remove styles for legacy IE 5 to 8 from vendor-opacity mixin

### DIFF
--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -153,12 +153,6 @@
 	&:fullscreen { @rule(); }
 }
 
-.vendor-opacity(@opacity) {
-	@opacity-ie: (@opacity * 100);	// Less doesn't like math inside `alpha`
-	opacity: @opacity;
-	filter: alpha(opacity=@opacity-ie);
-}
-
 // Shorthand for positioning code
 .position (@t, @r, @b, @l) {
 	top: @t;

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -149,6 +149,10 @@
 	font-kerning: @val;
 }
 
+.vendor-opacity(@opacity) {
+	opacity: @opacity;
+}
+
 .vendor-fullscreen(@rule) {
 	&:fullscreen { @rule(); }
 }

--- a/packages/ui/styles/mixins.less
+++ b/packages/ui/styles/mixins.less
@@ -149,12 +149,12 @@
 	font-kerning: @val;
 }
 
-.vendor-opacity(@opacity) {
-	opacity: @opacity;
-}
-
 .vendor-fullscreen(@rule) {
 	&:fullscreen { @rule(); }
+}
+
+.vendor-opacity(@opacity) {
+	opacity: @opacity;
 }
 
 // Shorthand for positioning code


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As we stopped supporting Internet Explorer browsers from 5.0.0-alpha.1, we don't need to keep IE related code. `.vendor-opacity()` LESS mixin has code for IE so that I want to remove it. But the mixin function itself is possibly used in apps and I will keep the mixin function even it simply provides the standard opacity CSS attribute.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed IE related code from `.vendor-opacity()` mixin.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9415

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
