### PR TITLE
WRR-12677: Fix node_js to use 'lts/*' and 'node' on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - npm install
     - npm link
     - popd
-    - npm uninstall @enact/ui-test-utils -C packages/i18n
+    - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install
     - npm run bootstrap
     - npm run interlink

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: jammy
 language: node_js
 node_js:
     - lts/*
+    - node
 sudo: false
 before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
@@ -13,6 +14,7 @@ install:
     - npm install
     - npm link
     - popd
+    - npm uninstall @enact/ui-test-utils -C packages/i18n
     - npm install
     - npm run bootstrap
     - npm run interlink


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the travis modified to not install @enact/ui-test-utils, which includes node-canvas, the travis passed even in the latest nodejs environment.
diff: https://github.com/enactjs/sandstone/compare/develop...test/travis-fail
travis result: https://app.travis-ci.com/github/enactjs/sandstone/jobs/628577584

After discussion within the team, we decided not to install this module for stable Travis operation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fix node_js to use 'lts/*' and 'node' on travis
- Remove @enact/ui-test-utils in node_modules

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-12677

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))