### PR TITLE
WRR-21724: Delete flip prop from rest to prevent it from being passed to the DOM element

### DIFF
--- a/packages/ui/Icon/Icon.js
+++ b/packages/ui/Icon/Icon.js
@@ -215,6 +215,7 @@ const IconBase = kind({
 	},
 
 	render: ({componentRef, iconProps, ...rest}) => {
+		delete rest.flip;
 		delete rest.iconList;
 		delete rest.pressed;
 		delete rest.size;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Delete flip prop from rest to prevent it from being passed to the DOM element

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delete flip prop from rest to prevent it from being passed to the DOM element

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-21724

### Comments
