### PR TITLE
WRR-22638: Added reset method to spotlight to reseting an instance of Spotlight Accelerator

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -967,7 +967,16 @@ const Spotlight = (function () {
 		 * @param {Object} position `x` and `y` coordinates for the pointer
 		 * @private
 		 */
-		focusNextFromPoint: spotNextFromPoint
+		focusNextFromPoint: spotNextFromPoint,
+
+		/**
+		 * Resets spotlight accelerate
+		 *
+		 * @private
+		 */
+		resetSpotlightAccelerate: function () {
+			SpotlightAccelerator.reset();
+		}
 	};
 
 	return exports;

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -974,7 +974,7 @@ const Spotlight = (function () {
 		 *
 		 * @private
 		 */
-		resetSpotlightAccelerate: function () {
+		resetSpotlightAccelerator: function () {
 			SpotlightAccelerator.reset();
 		}
 	};

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -970,7 +970,7 @@ const Spotlight = (function () {
 		focusNextFromPoint: spotNextFromPoint,
 
 		/**
-		 * Resets spotlight accelerate
+		 * Resets spotlight accelerator
 		 *
 		 * @private
 		 */


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is an issue where the instance value of `SpotlightAccelerator` is not updated when passing spotlight as `inputField`. This causes the callback to not be called and the spotlight to not move.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added it as a private function so that reset can be called from onKeyDown of `InputFieldSpotlightDecorator`.



### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-22638

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)