### PR TITLE
WRR-23385: Remove unused eslint-disable directive 'enact/prop-types'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enact",
-  "version": "5.0.0-alpha.4",
+  "version": "5.0.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enact",
-      "version": "5.0.0-alpha.4",
+      "version": "5.0.0-alpha.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@enact/docs-utils": "^0.4.11",

--- a/packages/sampler/stories/default/ViewManager.js
+++ b/packages/sampler/stories/default/ViewManager.js
@@ -59,7 +59,6 @@ const ViewManagerLayout = (props) => {
 		setSelected(ev.selected);
 	}, [setSelected]);
 
-	// eslint-disable-next-line enact/prop-types
 	const {args, selectedEnd, selectedStart, ...rest} = props;
 	const endRange = [selected, selected + 1, selected + 2];
 	const startRange = [selected, selected - 1, selected - 2];

--- a/packages/sampler/stories/default/VirtualGridList.js
+++ b/packages/sampler/stories/default/VirtualGridList.js
@@ -19,7 +19,6 @@ const
 	shouldAddLongContent = ({index, modIndex}) => (
 		index % modIndex === 0 ? ` ${longContent}` : ''
 	),
-	// eslint-disable-next-line enact/prop-types
 	uiRenderItem = ({index, ...rest}) => {
 		const {text, source} = items[index];
 

--- a/packages/sampler/stories/default/VirtualList.js
+++ b/packages/sampler/stories/default/VirtualList.js
@@ -12,7 +12,7 @@ const
 	},
 	items = [],
 	defaultDataSize = 1000,
-	// eslint-disable-next-line enact/prop-types, enact/display-name
+	// eslint-disable-next-line enact/display-name
 	uiRenderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {
 			borderBottom: ri.unit(3, 'rem') + ' solid #202328',

--- a/packages/ui/Button/Button.js
+++ b/packages/ui/Button/Button.js
@@ -211,8 +211,6 @@ const ButtonBase = kind({
 			// configured to handle.
 			if (typeof iconComponent !== 'string') {
 				props.size = size;
-				// the following inadvertently triggers a linting rule
-				// eslint-disable-next-line enact/prop-types
 				props.flip = iconFlip;
 			}
 

--- a/packages/ui/Group/GroupItem.js
+++ b/packages/ui/Group/GroupItem.js
@@ -47,9 +47,6 @@ const pickGroupItemProps = (props) => ({
  */
 const GroupItemBase = kind({
 	name: 'GroupItem',
-	// TODO: Add propTypes
-	/* eslint-disable enact/prop-types */
-
 	handlers: {
 		handleSelect: (ev, props) => {
 			const {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://ko.react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis
PropTypes were deprecated in April 2017 (v15.5.0).
However, the enact/prop-types rule still exists, so removing PropType causes a linting error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused eslint-disable directive 'enact/prop-types'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-23385

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)