### PR TITLE
WRR-24070: Changed function to reset 5WayKeyHold value

### DIFF
--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -977,7 +977,7 @@ const Spotlight = (function () {
 		resetSpotlightAcceleratorAndHoldKey: function () {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
-		},
+		}
 	};
 
 	return exports;

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -974,7 +974,7 @@ const Spotlight = (function () {
 		 *
 		 * @private
 		 */
-		resetSpotlightAcceleratorAndHoldKey: function () {
+		resetKeyHoldState: function () {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
 		}

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -970,13 +970,14 @@ const Spotlight = (function () {
 		focusNextFromPoint: spotNextFromPoint,
 
 		/**
-		 * Resets spotlight accelerator
+		 * Resets spotlight accelerator and 5way key hold value
 		 *
 		 * @private
 		 */
-		resetSpotlightAccelerator: function () {
+		resetSpotlightAcceleratorAndHoldKey: function () {
 			SpotlightAccelerator.reset();
-		}
+			_5WayKeyHold = false;
+		},
 	};
 
 	return exports;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is an issue where Spotlight does not move if there is an InputField and it is not wrapped with the same SpotlightContainerDecorator. this is because the 5WayKeyHold value is not updated when passing spotlight as inputField. This causes the callback to not be called and the spotlight to not move.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to reset 5WayKeyHold by extending the `resetSpotlightAccelerator` function to `resetSpotlightAcceleratorAndHoldKey`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-24070

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)