### PR TITLE
WRR-24215: Remove the old postcss module usage in docs

### DIFF
--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -31,13 +31,7 @@ const App = kind({
 });
 ```
 
-For libraries like bootstrap, you can also import the css in your `App.less` file.
-
-```css
-@global-import 'bootstrap/dist/css/bootstrap.css';
-```
-
-For bootstrap 4 or above, you need to import bootstrap's source Sass files in your `custom.scss`. Make sure you are using Enact CLI 5.0.0 or above.
+For libraries like bootstrap, you can also import bootstrap's source Sass files in your `custom.scss`.
 
 ```scss
 @import '~bootstrap/scss/bootstrap.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enact",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enact",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-alpha.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@enact/docs-utils": "^0.4.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enact",
-  "version": "5.0.0-alpha.5",
+  "version": "5.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enact",
-      "version": "5.0.0-alpha.5",
+      "version": "5.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@enact/docs-utils": "^0.4.11",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Remove the old postcss module usage in docs

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the old postcss module usage in docs

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-24215

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)