### PR TITLE
WRR-30554: Added getPausedInstance method for Spotlight

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+- `spotlight` methods `getPausedInstance` to get the name of the paused instance
+
 ## [5.1.0] - 2025-07-11
 
 No significant changes.

--- a/packages/spotlight/Pause/Pause.js
+++ b/packages/spotlight/Pause/Pause.js
@@ -47,6 +47,10 @@ let paused = false;
 
 // Private, exported methods used by Spotlight to set and query the pause state from its public API
 
+function getPausedInstance () {
+	return paused === false ? null : paused.name;
+}
+
 function pause () {
 	paused = true;
 }
@@ -136,6 +140,7 @@ class Pause {
 export default Pause;
 export {
 	Pause,
+	getPausedInstance,
 	isPaused,
 	pause,
 	resume

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -25,7 +25,7 @@ import last from 'ramda/src/last';
 
 import Accelerator from '../Accelerator';
 import {spottableClass} from '../Spottable';
-import {isPaused, pause, resume} from '../Pause';
+import {getPausedInstance, isPaused, pause, resume} from '../Pause';
 
 import {getInputType} from './inputType';
 import {contains} from './utils';
@@ -879,6 +879,15 @@ const Spotlight = (function () {
 				setLastContainer(containerId || rootContainerId);
 			}
 		},
+
+		/**
+		 * Get the name of the instance.
+		 *
+		 * @function
+		 * @returns {String} the name of the instance.
+		 * @public
+		 */
+		getPausedInstance,
 
 		/**
 		 * Gets the current pointer mode


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Consumer components do not know the Paused Spotlight  instance

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added getPausedInstance method for Spotlight

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-30554

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)