### PR TITLE
WRR-30001: Migrate test code to apply Jest 30

### DIFF
--- a/packages/spotlight/Spottable/tests/Spottable-specs.js
+++ b/packages/spotlight/Spottable/tests/Spottable-specs.js
@@ -48,7 +48,7 @@ describe('Spottable', () => {
 		const expected = 1;
 
 		expect(spy).toHaveBeenCalledTimes(expected);
-		expect(spy).toBeCalledWith({type: 'onSpotlightDisappear'});
+		expect(spy).toHaveBeenCalledWith({type: 'onSpotlightDisappear'});
 	});
 
 	describe('shouldComponentUpdate', () => {

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -75,7 +75,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(root.querySelector('[data-spotlight-id="s1"]'));
 				Spotlight.focus('s1');
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -87,7 +87,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(root.querySelector('[data-spotlight-id="first-container"] > .spottable'));
 				Spotlight.focus('first-container');
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -98,7 +98,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(n);
 				Spotlight.focus(n);
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -111,7 +111,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(n.querySelector('.spottable'));
 				Spotlight.focus(n);
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -122,7 +122,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(n);
 				Spotlight.focus('[data-spotlight-id="s1"]');
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -135,7 +135,7 @@ describe('Spotlight', () => {
 				const fn = mockFocus(n.querySelector('.spottable'));
 				Spotlight.focus('[data-spotlight-id="first-container"]');
 
-				expect(fn).toBeCalled();
+				expect(fn).toHaveBeenCalled();
 			}
 		));
 
@@ -174,12 +174,12 @@ describe('Spotlight', () => {
 		test('should register event listener of several event types', () => {
 			Spotlight.initialize();
 
-			expect(window.addEventListener).toBeCalledWith('blur', expect.any(Function));
-			expect(window.addEventListener).toBeCalledWith('focus', expect.any(Function));
-			expect(window.addEventListener).toBeCalledWith('keydown', expect.any(Function));
-			expect(window.addEventListener).toBeCalledWith('keyup', expect.any(Function));
-			expect(window.addEventListener).toBeCalledWith('mouseover', expect.any(Function));
-			expect(window.addEventListener).toBeCalledWith('mousemove', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('blur', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('keyup', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('mouseover', expect.any(Function));
+			expect(window.addEventListener).toHaveBeenCalledWith('mousemove', expect.any(Function));
 		});
 	});
 
@@ -194,12 +194,12 @@ describe('Spotlight', () => {
 		test('should remove event listener of several event types', () => {
 			Spotlight.terminate();
 
-			expect(window.removeEventListener).toBeCalledWith('blur', expect.any(Function));
-			expect(window.removeEventListener).toBeCalledWith('focus', expect.any(Function));
-			expect(window.removeEventListener).toBeCalledWith('keydown', expect.any(Function));
-			expect(window.removeEventListener).toBeCalledWith('keyup', expect.any(Function));
-			expect(window.removeEventListener).toBeCalledWith('mouseover', expect.any(Function));
-			expect(window.removeEventListener).toBeCalledWith('mousemove', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('blur', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('keyup', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('mouseover', expect.any(Function));
+			expect(window.removeEventListener).toHaveBeenCalledWith('mousemove', expect.any(Function));
 		});
 	});
 });

--- a/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
+++ b/packages/ui/FloatingLayer/tests/FloatingLayer-specs.js
@@ -44,7 +44,7 @@ describe('FloatingLayer Specs', () => {
 		const expectedType = {type: 'onOpen'};
 		const actual = handleOpen.mock.calls.length && handleOpen.mock.calls[0][0];
 
-		expect(handleOpen).toBeCalledTimes(expected);
+		expect(handleOpen).toHaveBeenCalledTimes(expected);
 		expect(actual).toMatchObject(expectedType);
 	});
 

--- a/packages/ui/Icon/tests/Icon-specs.js
+++ b/packages/ui/Icon/tests/Icon-specs.js
@@ -82,12 +82,23 @@ describe('Icon', () => {
 		render(<IconBase data-testid="icon" style={{color: 'green'}}>{src}</IconBase>);
 		const icon = screen.getByTestId('icon');
 
-		const expected = {
+		const expected1 = {
 			color: 'green',
 			backgroundImage: `url(${src})`
 		};
 
-		expect(icon).toHaveStyle(expected);
+		const expected2 = {
+			color: 'rgb(0, 128, 0)',
+			backgroundImage: `url(${src})`
+		};
+
+		try {
+			expect(icon).toHaveStyle(expected1);
+		} catch (error) {
+			// Fix and adjust for known toHaveStyle issues
+			// https://github.com/testing-library/jest-dom/issues/350
+			expect(icon).toHaveStyle(expected2);
+		}
 	});
 
 	test('should return a DOM node reference for `componentRef`', () => {

--- a/packages/ui/Icon/tests/Icon-specs.js
+++ b/packages/ui/Icon/tests/Icon-specs.js
@@ -82,23 +82,12 @@ describe('Icon', () => {
 		render(<IconBase data-testid="icon" style={{color: 'green'}}>{src}</IconBase>);
 		const icon = screen.getByTestId('icon');
 
-		const expected1 = {
+		const expected = {
 			color: 'green',
 			backgroundImage: `url(${src})`
 		};
 
-		const expected2 = {
-			color: 'rgb(0, 128, 0)',
-			backgroundImage: `url(${src})`
-		};
-
-		try {
-			expect(icon).toHaveStyle(expected1);
-		} catch (error) {
-			// Fix and adjust for known toHaveStyle issues
-			// https://github.com/testing-library/jest-dom/issues/350
-			expect(icon).toHaveStyle(expected2);
-		}
+		expect(icon).toHaveStyle(expected);
 	});
 
 	test('should return a DOM node reference for `componentRef`', () => {

--- a/packages/ui/Media/tests/Media-specs.js
+++ b/packages/ui/Media/tests/Media-specs.js
@@ -61,7 +61,7 @@ describe('Media', () => {
 		const canPlayEvent = createEvent('canplay', video);
 		fireEvent(video, canPlayEvent);
 
-		expect(handleCanPlay).toBeCalled();
+		expect(handleCanPlay).toHaveBeenCalled();
 	});
 
 	test('should fire `onCustom` when custom event is fired', () => {
@@ -75,7 +75,7 @@ describe('Media', () => {
 		const customEvent = createEvent('custom', video);
 		fireEvent(video, customEvent);
 
-		expect(handleCustom).toBeCalled();
+		expect(handleCustom).toHaveBeenCalled();
 	});
 
 	test('should call load', () => {

--- a/packages/ui/Transition/tests/Transition-specs.js
+++ b/packages/ui/Transition/tests/Transition-specs.js
@@ -100,7 +100,7 @@ describe('Transition Specs', () => {
 		const expectedType = {type: 'onShow'};
 		const actual = handleShow.mock.calls.length && handleShow.mock.calls[0][0];
 
-		expect(handleShow).toBeCalledTimes(expected);
+		expect(handleShow).toHaveBeenCalledTimes(expected);
 		expect(actual).toMatchObject(expectedType);
 	});
 
@@ -124,7 +124,7 @@ describe('Transition Specs', () => {
 		const expectedType = {type: 'onHide'};
 		const actual = handleHide.mock.calls.length && handleHide.mock.calls[0][0];
 
-		expect(handleHide).toBeCalledTimes(expected);
+		expect(handleHide).toHaveBeenCalledTimes(expected);
 		expect(actual).toMatchObject(expectedType);
 	});
 

--- a/packages/ui/ViewManager/tests/View-specs.js
+++ b/packages/ui/ViewManager/tests/View-specs.js
@@ -245,7 +245,7 @@ describe('View', () => {
 			);
 
 			act(() => ref.current.componentWillEnter());
-			expect(arranger.enter).toBeCalledWith(arrangerStruct);
+			expect(arranger.enter).toHaveBeenCalledWith(arrangerStruct);
 		});
 	});
 });

--- a/packages/ui/VirtualList/tests/VirtualGridList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualGridList-specs.js
@@ -487,7 +487,7 @@ describe('VirtualGridList', () => {
 
 			act(() => jest.advanceTimersByTime(1000)); // Wait onScrollStop
 
-			expect(fn).toBeCalled();
+			expect(fn).toHaveBeenCalled();
 		});
 
 		test('should not scroll by wheel when `noScrollByWheel` prop is true', (done) => {
@@ -545,7 +545,7 @@ describe('VirtualGridList', () => {
 
 			act(() => jest.advanceTimersByTime(1000)); // Wait onScrollStop
 
-			expect(fn).toBeCalled();
+			expect(fn).toHaveBeenCalled();
 		});
 
 		test('should not scroll by key', (done) => {

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -585,7 +585,7 @@ describe('VirtualList', () => {
 
 			act(() => jest.advanceTimersByTime(1000)); // Wait onScrollStop
 
-			expect(fn).toBeCalled();
+			expect(fn).toHaveBeenCalled();
 		});
 
 		test('should not scroll by wheel when `noScrollByWheel` prop is true', (done) => {
@@ -643,7 +643,7 @@ describe('VirtualList', () => {
 
 			act(() => jest.advanceTimersByTime(1000)); // Wait onScrollStop
 
-			expect(fn).toBeCalled();
+			expect(fn).toHaveBeenCalled();
 		});
 
 		test('should not scroll by key', (done) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrate test code to apply Jest v30

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Migrate test code to apply Jest v30
https://jestjs.io/docs/upgrading-to-jest30#removal-of-alias-matcher-functions

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-30001

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)