### PR TITLE
WRR-29962: Fixed Spotlight to not choose next target to include overflow elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+[unreleased]
+
+### Fixed
+
+- `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
+
 ## [5.1.0] - 2025-07-11
 
 ### Added

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,10 +4,13 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Added
+
+- `spotlight` methods `getPausedInstance` to get the name of the paused instance
+
 ### Fixed
 
 - `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
-- `spotlight` methods `getPausedInstance` to get the name of the paused instance
 
 ## [5.1.0] - 2025-07-11
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
+
 ## [5.1.0] - 2025-07-11
 
 No significant changes.

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -341,7 +341,7 @@ const getSpottableDescendants = (containerId) => {
 
 /**
  * Recursively get spottable descendants by including elements within sub-containers that do not
- * have `enterTo` configured or which are not hidden because of overflow
+ * have `enterTo` configured or which are not hidden due  of overflow
  *
  * @param   {String}    containerId          ID of container
  * @param   {String[]}  [excludedContainers] IDs of containers to exclude from result set

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -341,7 +341,7 @@ const getSpottableDescendants = (containerId) => {
 
 /**
  * Recursively get spottable descendants by including elements within sub-containers that do not
- * have `enterTo` configured
+ * have `enterTo` configured or which are not hidden because of overflow
  *
  * @param   {String}    containerId          ID of container
  * @param   {String[]}  [excludedContainers] IDs of containers to exclude from result set
@@ -356,9 +356,11 @@ const getDeepSpottableDescendants = (containerId, excludedContainers) => {
 			if (isContainer(n)) {
 				const id = getContainerId(n);
 				const config = getContainerConfig(id);
+				const hasSpottedControl = getContainerLastFocusedElement(id);
+				
 				if (excludedContainers && excludedContainers.indexOf(id) >= 0) {
 					return [];
-				} else if (config && !config.enterTo && !config.overflow) {
+				} else if (config && !config.enterTo && (!hasSpottedControl || (hasSpottedControl && !config.overflow))) {
 					return getDeepSpottableDescendants(id, excludedContainers);
 				}
 			}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -358,7 +358,7 @@ const getDeepSpottableDescendants = (containerId, excludedContainers) => {
 				const config = getContainerConfig(id);
 				if (excludedContainers && excludedContainers.indexOf(id) >= 0) {
 					return [];
-				} else if (config && !config.enterTo) {
+				} else if (config && !config.enterTo && !config.overflow) {
 					return getDeepSpottableDescendants(id, excludedContainers);
 				}
 			}

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -357,7 +357,7 @@ const getDeepSpottableDescendants = (containerId, excludedContainers) => {
 				const id = getContainerId(n);
 				const config = getContainerConfig(id);
 				const hasSpottedControl = getContainerLastFocusedElement(id);
-				
+
 				if (excludedContainers && excludedContainers.indexOf(id) >= 0) {
 					return [];
 				} else if (config && !config.enterTo && (!hasSpottedControl || (hasSpottedControl && !config.overflow))) {

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -341,7 +341,7 @@ const getSpottableDescendants = (containerId) => {
 
 /**
  * Recursively get spottable descendants by including elements within sub-containers that do not
- * have `enterTo` configured or which are not hidden due  of overflow
+ * have `enterTo` configured or which are not hidden due to overflow
  *
  * @param   {String}    containerId          ID of container
  * @param   {String[]}  [excludedContainers] IDs of containers to exclude from result set

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -99,12 +99,6 @@ function getTargetBySelector (selector) {
 	return null;
 }
 
-function getSpottableDescendantsWithoutContainers (containerId, containerIds) {
-	return getSpottableDescendants(containerId).filter(n => {
-		return !isContainer(n) || containerIds.indexOf(n.dataset.spotlightId) === -1;
-	});
-}
-
 function isRestrictedContainer (containerId) {
 	const config = getContainerConfig(containerId);
 	return config && (config.enterTo === 'last-focused' || config.enterTo === 'default-element');
@@ -185,7 +179,7 @@ function getOverflowContainerRect (containerId) {
 }
 
 function getTargetInContainerByDirectionFromPosition (direction, containerId, positionRect, elementContainerIds, boundingRect) {
-	const elements = direction === 'left' || direction === 'right' ? getDeepSpottableDescendants(containerId) : getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
+	const elements = getDeepSpottableDescendants(containerId);
 	let elementRects = filterRects(getRects(elements), boundingRect);
 
 	let next = null;
@@ -256,7 +250,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 
 
 function getTargetInContainerByDirectionFromElement (direction, containerId, element, elementRect, elementContainerIds, boundingRect) {
-	const elements = direction === 'left' || direction === 'right' ? getDeepSpottableDescendants(containerId) : getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
+	const elements = getDeepSpottableDescendants(containerId)
 
 	// shortcut for previous target from element if it were saved
 	const previous = getContainerPreviousTarget(containerId, direction, element);

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -12,7 +12,7 @@ import {
 	getDeepSpottableDescendants,
 	getDefaultContainer,
 	getLastContainer,
-	getNavigableContainersForNode, getSpottableDescendants,
+	getNavigableContainersForNode,
 	isContainer,
 	isNavigable,
 	rootContainerId
@@ -250,7 +250,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 
 
 function getTargetInContainerByDirectionFromElement (direction, containerId, element, elementRect, elementContainerIds, boundingRect) {
-	const elements = getDeepSpottableDescendants(containerId)
+	const elements = getDeepSpottableDescendants(containerId);
 
 	// shortcut for previous target from element if it were saved
 	const previous = getContainerPreviousTarget(containerId, direction, element);

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -12,7 +12,7 @@ import {
 	getDeepSpottableDescendants,
 	getDefaultContainer,
 	getLastContainer,
-	getNavigableContainersForNode,
+	getNavigableContainersForNode, getSpottableDescendants,
 	isContainer,
 	isNavigable,
 	rootContainerId
@@ -99,6 +99,12 @@ function getTargetBySelector (selector) {
 	return null;
 }
 
+function getSpottableDescendantsWithoutContainers (containerId, containerIds) {
+	return getSpottableDescendants(containerId).filter(n => {
+		return !isContainer(n) || containerIds.indexOf(n.dataset.spotlightId) === -1;
+	});
+}
+
 function isRestrictedContainer (containerId) {
 	const config = getContainerConfig(containerId);
 	return config && (config.enterTo === 'last-focused' || config.enterTo === 'default-element');
@@ -179,7 +185,7 @@ function getOverflowContainerRect (containerId) {
 }
 
 function getTargetInContainerByDirectionFromPosition (direction, containerId, positionRect, elementContainerIds, boundingRect) {
-	const elements = getDeepSpottableDescendants(containerId);
+	const elements = direction === 'left' || direction === 'right' ? getDeepSpottableDescendants(containerId) : getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
 	let elementRects = filterRects(getRects(elements), boundingRect);
 
 	let next = null;
@@ -250,7 +256,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 
 
 function getTargetInContainerByDirectionFromElement (direction, containerId, element, elementRect, elementContainerIds, boundingRect) {
-	const elements = getDeepSpottableDescendants(containerId);
+	const elements = direction === 'left' || direction === 'right' ? getDeepSpottableDescendants(containerId) : getSpottableDescendantsWithoutContainers(containerId, elementContainerIds);
 
 	// shortcut for previous target from element if it were saved
 	const previous = getContainerPreviousTarget(containerId, direction, element);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In #2848, Spotlight was fixed to set next target to include all eligible elements, but also included hidden elements due to overflow

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed Spotlight to not choose next target to include hidden elements.
This condition is not applied when there is no previous focused element, to let spotlight focus any element on page load

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-29962

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)