### PR TITLE
WRR-29962: Fixed Spotlight to not choose next target to include overflow elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+[unreleased]
+
+### Fixed
+
+- `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
+
 ## [4.9.8] - 2025-04-24
 
 No significant changes.

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,7 +4,13 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Added
+
 - `spotlight` methods `getPausedInstance` to get the name of the paused instance
+
+### Fixed
+
+- `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
 
 ## [4.9.8] - 2025-04-24
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -341,7 +341,7 @@ const getSpottableDescendants = (containerId) => {
 
 /**
  * Recursively get spottable descendants by including elements within sub-containers that do not
- * have `enterTo` configured
+ * have `enterTo` configured or which are not hidden due to overflow
  *
  * @param   {String}    containerId          ID of container
  * @param   {String[]}  [excludedContainers] IDs of containers to exclude from result set
@@ -356,9 +356,11 @@ const getDeepSpottableDescendants = (containerId, excludedContainers) => {
 			if (isContainer(n)) {
 				const id = getContainerId(n);
 				const config = getContainerConfig(id);
+				const hasSpottedControl = getContainerLastFocusedElement(id);
+
 				if (excludedContainers && excludedContainers.indexOf(id) >= 0) {
 					return [];
-				} else if (config && !config.enterTo) {
+				} else if (config && !config.enterTo && (!hasSpottedControl || (hasSpottedControl && !config.overflow))) {
 					return getDeepSpottableDescendants(id, excludedContainers);
 				}
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In #2848, Spotlight was fixed to set next target to include all eligible elements, but also included hidden elements due to overflow

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed Spotlight to not choose next target to include hidden elements.
This condition is not applied when there is no previous focused element, to let spotlight focus any element on page load

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-29962

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)