### PR TITLE
WRR-31889: `Spotlight`: the last focused item is not restored in scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to preserve the last focused element on component unmount
+
 ## [5.2.0] - 2025-08-08
 
 ### Added

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to preserve the last focused element on component unmount
+
 ## [5.2.0] - 2025-08-08
 
 ### Added

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -343,14 +343,15 @@ const getSpottableDescendants = (containerId) => {
  * Recursively get spottable descendants by including elements within sub-containers that do not
  * have `enterTo` configured or which are not hidden due to overflow
  *
- * @param   {String}    containerId          ID of container
- * @param   {String[]}  [excludedContainers] IDs of containers to exclude from result set
+ * @param   {String}    containerId          	ID of container
+ * @param   {String[]}  [excludedContainers] 	IDs of containers to exclude from result set
+ * @param	{Boolean}	useLastFocusedElement	Determines whether to use the last focused element
  *
- * @returns {Node[]}                         Array of spottable elements and containers
+ * @returns {Node[]}                         	Array of spottable elements and containers
  * @memberof spotlight/container
  * @private
  */
-const getDeepSpottableDescendants = (containerId, excludedContainers) => {
+const getDeepSpottableDescendants = (containerId, excludedContainers, useLastFocusedElement) => {
 	return getSpottableDescendants(containerId)
 		.map(n => {
 			if (isContainer(n)) {
@@ -360,7 +361,7 @@ const getDeepSpottableDescendants = (containerId, excludedContainers) => {
 
 				if (excludedContainers && excludedContainers.indexOf(id) >= 0) {
 					return [];
-				} else if (config && !config.enterTo && (!hasSpottedControl || (hasSpottedControl && !config.overflow))) {
+				} else if (config && !config.enterTo && (useLastFocusedElement || !hasSpottedControl || (hasSpottedControl && !config.overflow))) {
 					return getDeepSpottableDescendants(id, excludedContainers);
 				}
 			}
@@ -864,7 +865,7 @@ function persistLastFocusedElement (containerId) {
 	if (cfg) {
 		const {lastFocusedElement} = cfg;
 		if (lastFocusedElement) {
-			const all = getDeepSpottableDescendants(containerId);
+			const all = getDeepSpottableDescendants(containerId, [], true);
 			const lastFocusedKey = cfg.lastFocusedPersist(lastFocusedElement, all);
 
 			// store lastFocusedKey and release node reference to lastFocusedElement
@@ -887,7 +888,7 @@ function persistLastFocusedElement (containerId) {
 function restoreLastFocusedElement (containerId) {
 	const cfg = getContainerConfig(containerId);
 	if (cfg && cfg.lastFocusedKey) {
-		const all = getDeepSpottableDescendants(containerId);
+		const all = getDeepSpottableDescendants(containerId, [], true);
 		const lastFocusedElement = cfg.lastFocusedRestore(cfg.lastFocusedKey, all);
 
 		// restore lastFocusedElement and release lastFocusedKey


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Spotlight`: the last focused item is not restored in scroller

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-31889

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com