### PR TITLE
NXT-618: Fixed ui/scroller calculation of targetX and targetY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 - `spotlight` to not prioritize elements which are invisible due to overflow as next spottable elements
 - `spotlight` to preserve the last focused element on component unmount
+- `ui/Scroller` to calculate correctly targetX and targetY when scrolling to a position
 
 ## [4.9.8] - 2025-04-24
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+- `ui/Scroller` to calculate correctly targetX and targetY when scrolling to a position
+
 ## [4.9.8] - 2025-04-24
 
 No significant changes.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Fixed
+
 - `ui/Scroller` to calculate correctly targetX and targetY when scrolling to a position
 
 ## [4.9.8] - 2025-04-24

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1153,7 +1153,7 @@ const useScrollBase = (props) => {
 			if (animate) {
 				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant');
+				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1147,8 +1147,15 @@ const useScrollBase = (props) => {
 				stop();
 			}
 		} else { // scrollMode 'native'
-			const roundedTargetX = scrollContentHandle.current.scrollPos.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
-			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+			let roundedTargetX, roundedTargetY;
+
+			if (scrollContentHandle.current?.scrollPos) {
+				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
+				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+			} else {
+				roundedTargetX = targetX;
+				roundedTargetY = targetY;
+			}
 
 			if (animate) {
 				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1147,10 +1147,13 @@ const useScrollBase = (props) => {
 				stop();
 			}
 		} else { // scrollMode 'native'
+			const roundedTargetX = scrollContentHandle.current.scrollPos.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
+			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+
 			if (animate) {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1151,9 +1151,9 @@ const useScrollBase = (props) => {
 			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
 
 			if (animate) {
-				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
+				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
+				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1149,7 +1149,7 @@ const useScrollBase = (props) => {
 		} else { // scrollMode 'native'
 			let roundedTargetX, roundedTargetY;
 
-			if (scrollContentHandle.current?.scrollPos) {
+			if (scrollContentHandle.current?.scrollPos && platform.chrome > 120) {
 				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
 				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
 			} else {
@@ -1158,9 +1158,9 @@ const useScrollBase = (props) => {
 			}
 
 			if (animate) {
-				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scrollbar was not returning to the initial position after a simple left-righ-left change or a top-down-top change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I discovered that targetX and targetY are rounded up or down, based on the decimal value
I forced the round to go in the desired direction, based on the direction of the scroll change

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
NXT-618

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)
