### PR TITLE
NXT-618: Fixed ui/scroller calculation of targetX and targetY 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` to calculate correctly targetX and targetY when scrolling to a position
+
 ## [5.3.0] - 2025-09-24
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` to calculate correctly targetX and targetY when scrolling to a position
+
 ## [5.3.0] - 2025-09-24
 
 ### Added

--- a/packages/ui/useScroll/tests/useScroll-specs.js
+++ b/packages/ui/useScroll/tests/useScroll-specs.js
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom';
+
+describe('useScroll', () => {
+	describe('Rounding target scroll position', () => {
+		beforeEach(() => {
+			jest.resetModules(); // important! clears cached modules
+		});
+
+		test('should round target position upwards when target is bigger than current position', () => {
+			jest.doMock('@enact/core/platform', () => ({
+				__esModule: true,
+				platform: {chrome: 132}
+			}));
+
+			const {roundTarget} = require('../useScroll');
+
+			const currentPosition = {
+				scrollPos: {
+					left: 100,
+					top: 100
+				}
+			};
+
+			const {roundedTargetX, roundedTargetY} = roundTarget(currentPosition, 120.5, 120.4);
+
+			expect(roundedTargetX).toEqual(121);
+			expect(roundedTargetY).toEqual(121);
+		});
+
+		test('should round target position downwards when target is bigger than current position', () => {
+			jest.doMock('@enact/core/platform', () => ({
+				__esModule: true,
+				platform: {chrome: 132}
+			}));
+
+			const {roundTarget} = require('../useScroll');
+
+			const currentPosition = {
+				scrollPos: {
+					left: 100,
+					top: 100
+				}
+			};
+
+			const {roundedTargetX, roundedTargetY} = roundTarget(currentPosition, 90.4, 80.8);
+
+			expect(roundedTargetX).toEqual(90);
+			expect(roundedTargetY).toEqual(80);
+		});
+
+		test('should not round target position when chrome <= 120', () => {
+			jest.doMock('@enact/core/platform', () => ({
+				__esModule: true,
+				platform: {chrome: 119}
+			}));
+
+			const {roundTarget} = require('../useScroll');
+
+			const currentPosition = {
+				scrollPos: {
+					left: 100,
+					top: 100
+				}
+			};
+
+			const {roundedTargetX, roundedTargetY} = roundTarget(currentPosition, 90.4, 80.8);
+
+			expect(roundedTargetX).toEqual(90.4);
+			expect(roundedTargetY).toEqual(80.8);
+		});
+	});
+});

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1146,7 +1146,7 @@ const useScrollBase = (props) => {
 		} else { // scrollMode 'native'
 			let roundedTargetX, roundedTargetY;
 
-			if (scrollContentHandle.current?.scrollPos) {
+			if (scrollContentHandle.current?.scrollPos && platform.chrome > 120) {
 				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
 				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
 			} else {
@@ -1155,9 +1155,9 @@ const useScrollBase = (props) => {
 			}
 
 			if (animate) {
-				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1148,9 +1148,9 @@ const useScrollBase = (props) => {
 			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
 
 			if (animate) {
-				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
+				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
+				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1144,10 +1144,13 @@ const useScrollBase = (props) => {
 				stop();
 			}
 		} else { // scrollMode 'native'
+			const roundedTargetX = scrollContentHandle.current.scrollPos.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
+			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+
 			if (animate) {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
 			} else {
-				scrollContentHandle.current.scrollToPosition(targetX, targetY, 'instant');
+				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'instant');
 			}
 
 			if (props.start) {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1146,7 +1146,7 @@ const useScrollBase = (props) => {
 		} else { // scrollMode 'native'
 			let roundedTargetX, roundedTargetY;
 
-			if (scrollContentHandle.current.scrollPos) {
+			if (scrollContentHandle.current?.scrollPos) {
 				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
 				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
 			} else {

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -69,6 +69,20 @@ const TouchableDiv = Touchable(({ref, ...rest}) => (<div {...rest} ref={ref} />)
 
 const useForceUpdate = () => (useReducer(x => x + 1, 0));
 
+function roundTarget (currentPosition, targetX, targetY) {
+	let roundedTargetX, roundedTargetY;
+
+	if (currentPosition?.scrollPos && platform.chrome > 120) {
+		roundedTargetX = currentPosition?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
+		roundedTargetY = currentPosition?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+	} else {
+		roundedTargetX = targetX;
+		roundedTargetY = targetY;
+	}
+
+	return {roundedTargetX, roundedTargetY};
+}
+
 /**
  * A custom hook that passes scrollable behavior information as its render prop.
  *
@@ -1144,15 +1158,7 @@ const useScrollBase = (props) => {
 				stop();
 			}
 		} else { // scrollMode 'native'
-			let roundedTargetX, roundedTargetY;
-
-			if (scrollContentHandle.current?.scrollPos && platform.chrome > 120) {
-				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
-				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
-			} else {
-				roundedTargetX = targetX;
-				roundedTargetY = targetY;
-			}
+			let {roundedTargetX, roundedTargetY} = roundTarget(scrollContentHandle.current, targetX, targetY);
 
 			if (animate) {
 				scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');
@@ -1685,6 +1691,7 @@ export default useScroll;
 export {
 	assignPropertiesOf,
 	constants,
+	roundTarget,
 	useScroll,
 	useScrollBase
 };

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -1144,8 +1144,15 @@ const useScrollBase = (props) => {
 				stop();
 			}
 		} else { // scrollMode 'native'
-			const roundedTargetX = scrollContentHandle.current.scrollPos.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
-			const roundedTargetY = scrollContentHandle.current.scrollPos.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+			let roundedTargetX, roundedTargetY;
+
+			if (scrollContentHandle.current.scrollPos) {
+				roundedTargetX = scrollContentHandle.current?.scrollPos?.left < targetX ? Math.ceil(targetX) : Math.floor(targetX);
+				roundedTargetY = scrollContentHandle.current?.scrollPos?.top < targetY ? Math.ceil(targetY) : Math.floor(targetY);
+			} else {
+				roundedTargetX = targetX;
+				roundedTargetY = targetY;
+			}
 
 			if (animate) {
 				platform.chrome <= 120 ? scrollContentHandle.current.scrollToPosition(targetX, targetY, 'smooth') : scrollContentHandle.current.scrollToPosition(roundedTargetX, roundedTargetY, 'smooth');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scrollbar was not returning to the initial position after a simple left-righ-left change or a top-down-top change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I discovered that targetX and targetY are rounded up or down, based on the decimal value
I forced the round to go in the desired direction, based on the direction of the scroll change

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
NXT-618

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)
