### PR TITLE
NXT-7706: Applied item margin in VirtualList when scroll by pressing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
+- `ui/VirtulList` not to cut off focused item when scroll by pressing key
 - `ui/VirtualList.VirtualGridList` to adjust itemSize properly when resizing window
 
 ## [5.4.1] - 2025-12-30

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtulList` not to cut off focused item when scroll by pressing key
+
 ## [5.4.1] - 2025-12-30
 
 No significant changes.

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -347,6 +347,17 @@ class VirtualListBasic extends Component {
 	}
 
 	componentDidUpdate (prevProps, prevState) {
+		const items = document.getElementsByClassName(css.listItem);
+		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items.length > 0) {
+			const firstItemStyle = window.getComputedStyle(items[0].children[0]);
+			this.itemMarginTop = Number(firstItemStyle.getPropertyValue('margin-top').slice(0, -2));
+			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));
+			this.itemMarginLeft = Number(firstItemStyle.getPropertyValue('margin-left').slice(0, -2));
+			this.itemMarginRight = Number(firstItemStyle.getPropertyValue('margin-right').slice(0, -2));
+		}
+		this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
+		this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
+
 		let deferScrollTo = false;
 		const {firstIndex, numOfItems} = this.state;
 
@@ -471,6 +482,10 @@ class VirtualListBasic extends Component {
 	shouldUpdateBounds = false;
 
 	dimensionToExtent = 0;
+	itemMarginLeft = null;
+	itemMarginRight = null;
+	itemMarginTop = null;
+	itemMarginBottom = null;
 	threshold = 0;
 	maxFirstIndex = 0;
 	curDataSize = 0;
@@ -556,15 +571,16 @@ class VirtualListBasic extends Component {
 		const maxPos = isPrimaryDirectionVertical ? scrollBounds.maxTop : scrollBounds.maxLeft;
 		const position = this.getGridPosition(index);
 		let offset = 0;
+		const marginOffset = isPrimaryDirectionVertical ? this.itemMarginTop + this.itemMarginBottom : this.itemMarginLeft + this.itemMarginRight;
 
 		if (stickTo === 'start') {         // 'start'
 			offset = optionalOffset;
 		} else if (this.props.itemSizes) { // 'end' for different item sizes
-			offset = primary.clientSize - this.props.itemSizes[index] - optionalOffset;
+			offset = primary.clientSize - this.props.itemSizes[index] - marginOffset - optionalOffset;
 		} else if (stickTo === 'center') { // 'center'
 			offset = (primary.clientSize / 2) - (primary.gridSize / 2) - optionalOffset;
 		} else {                           // 'end' for same item sizes
-			offset = primary.clientSize - primary.itemSize - optionalOffset;
+			offset = primary.clientSize - primary.itemSize - marginOffset - optionalOffset;
 		}
 
 		/* istanbul ignore next */


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In VirtualList when scroll by focus an item with key, sometimes focused item was cut and not fully shown.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Item margin was not considered when calculate the scroll position.
If an item has margin-left (or margin-top), scroll length is not enough so cut area width (or height) is same as the item margin-left (or margin-top).
The item will not cut if scroll more as much as the item margin-left (or margin top).
And because item margin-left is shown (margin-top) in VirtualList, I thought margin-right (or margin-bottom) shoud be shown  too.
To show the item margin-right/bottom on the right side of VirtualList, just scroll as much as the item margin-right/bottom like the above.
So I changed the scroll position to consider both margin-left/top and margin-right/bottom. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-7706

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)