### PR TITLE
NXT-560: Updated minimum supported safari version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ## [unreleased]
 
+### Changed
+
+- `core/platform` to support `safari` 16.6, `chrome` 119, and `firefox` 128 or later
+
 ### Fixed
 
 - `ui/VirtulList` not to cut off focused item when scroll by pressing key

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact core module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `core/platform` to support `safari` 16.6, `chrome` 119, and `firefox` 128 or later
+
 ## [5.4.1] - 2025-12-30
 
 No significant changes.

--- a/packages/core/platform/platform.js
+++ b/packages/core/platform/platform.js
@@ -34,7 +34,7 @@ const userAgentPatterns = [
 ];
 
 // The base supported versions: Used in DEPRECATED warning
-const supportedVersions = {safari: 16.4, chrome: 119, firefox: 128};
+const supportedVersions = {safari: 16.6, chrome: 119, firefox: 128};
 
 const parseUserAgent = (userAgent) => {
 	const detectedInfo = {
@@ -70,7 +70,7 @@ const parseUserAgent = (userAgent) => {
 
 	// deprecation warning for browser versions older than our support policy
 	if (supportedVersions[detectedInfo.browserName] > detectedInfo.browserVersion) {
-		deprecate({name: `supporting ${detectedInfo.browserName} version older than ${supportedVersions[detectedInfo.browserName]}`, until: '5.0.0'});
+		deprecate({name: `supporting ${detectedInfo.browserName} version older than ${supportedVersions[detectedInfo.browserName]}`, until: '6.0.0'});
 	}
 
 	return detectedInfo;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We need to update supported browser versions, based on usage and webOS needs

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- webOS 2025 TV products have Chrome 120, so at least we need to support Chrome 120.

For general environment including desktop and mobile that browsers are frequently updated on, we don't have a clear year-based rule.
More reasonable rule would be usage-based.
I refer https://caniuse.com/usage-table and https://www.whatismybrowser.com/guides/the-latest-version/
Blink (Chrome/Edge): version 103 is the oldest version of at least 0.1% usage
WebKit (Safari): 16.6 for desktop(released 2023) and 15.8 for mobile (released 2021) are oldest version that has a usage over 0.1%.
Gecko (Firefox): 115 version is the oldest version that has a usage over 0.1% and this version is released 2023. Since Firefox is NOT shipped as a pre-installed manner, users of Firefox usually update their browser.
Trident (Internet Explorer): we should not support that.
 
In #3295, minimum versions were raised safari: 16.4, chrome: 119, firefox: 128 
Currently, we don't check node version since it is related to isomorphic build only that is possibly covered by polyfills handled by CLI.
 

So, our supported oldest versions of rendering engines are:

Blink (Chrome): 119
WebKit (Safari): 16.6
Gecko (Firefox): 128

Only Safari requires change

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-560

### Comments


Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))
