### PR TITLE
NXT-8190: Fixed VirtualList when itemSize is null

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -174,8 +174,8 @@ const useScrollBase = (props) => {
 	const [isHorizontalScrollbarVisible, setIsHorizontalScrollbarVisible] = useState(horizontalScrollbar === 'visible');
 	const [isVerticalScrollbarVisible, setIsVerticalScrollbarVisible] = useState(verticalScrollbar === 'visible');
 	const [riRatio, setRiRatio] = useState(ri.scale(1));
-	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize);
-	const [itemSize, setItemSize] = useState(props.itemSize);
+	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize || 0);
+	const [itemSize, setItemSize] = useState(props.itemSize || 0);
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),
@@ -300,10 +300,10 @@ const useScrollBase = (props) => {
 		}
 	});
 
-	if (originalItemSize !== props.itemSize) {
-		setOriginalItemSize(props.itemSize);
-		if (ri.scale(1) / riRatio !== props.itemSize / itemSize) {
-			setItemSize(props.itemSize);
+	if (originalItemSize !== (props.itemSize || 0)) {
+		setOriginalItemSize(props.itemSize || 0);
+		if (ri.scale(1) / riRatio !== (props.itemSize || 0) / itemSize) {
+			setItemSize(props.itemSize || 0);
 		}
 	}
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -142,6 +142,8 @@ const useScrollBase = (props) => {
 		} = props,
 		scrollClasses = classNames(css.scroll, className);
 
+	const propsItemSize = props.itemSize || 0;
+
 	// The following props are the one having the same naming function in this scope.
 	// So it is better to use props[propName]
 	// instead of extracting it from the `props` and renaming it
@@ -174,8 +176,8 @@ const useScrollBase = (props) => {
 	const [isHorizontalScrollbarVisible, setIsHorizontalScrollbarVisible] = useState(horizontalScrollbar === 'visible');
 	const [isVerticalScrollbarVisible, setIsVerticalScrollbarVisible] = useState(verticalScrollbar === 'visible');
 	const [riRatio, setRiRatio] = useState(ri.scale(1));
-	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize || 0);
-	const [itemSize, setItemSize] = useState(props.itemSize || 0);
+	const [originalItemSize, setOriginalItemSize] = useState(propsItemSize);
+	const [itemSize, setItemSize] = useState(propsItemSize);
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),
@@ -300,10 +302,10 @@ const useScrollBase = (props) => {
 		}
 	});
 
-	if (originalItemSize !== (props.itemSize || 0)) {
-		setOriginalItemSize(props.itemSize || 0);
-		if (ri.scale(1) / riRatio !== (props.itemSize || 0) / itemSize) {
-			setItemSize(props.itemSize || 0);
+	if (originalItemSize !== (propsItemSize)) {
+		setOriginalItemSize(propsItemSize);
+		if (ri.scale(1) / riRatio !== (propsItemSize) / itemSize) {
+			setItemSize(propsItemSize);
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After https://github.com/enactjs/enact/pull/3382 is merged,
VirtualList is rerendered infinitely if itemSize is null.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set itemSize as 0 when it is null.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-8190

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)