### PR TITLE
NXT-8190: Fixed VirtualGridList itemSize when resizing window

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -142,6 +142,10 @@ const useScrollBase = (props) => {
 		} = props,
 		scrollClasses = classNames(css.scroll, className);
 
+	if (typeof props.itemSize === 'object') {
+		props.itemSize.minWidth = props.itemSize.minWidth || 0;
+		props.itemSize.minHeight = props.itemSize.minHeight || 0;
+	}
 	const propsItemSize = props.itemSize || 0;
 
 	// The following props are the one having the same naming function in this scope.
@@ -302,10 +306,16 @@ const useScrollBase = (props) => {
 		}
 	});
 
-	if (originalItemSize !== (propsItemSize)) {
+	if (originalItemSize !== propsItemSize) {
 		setOriginalItemSize(propsItemSize);
-		if (ri.scale(1) / riRatio !== ((propsItemSize / itemSize) || (propsItemSize.minWidth / itemSize.minWidth))) {
-			setItemSize(propsItemSize);
+		if (typeof propsItemSize === 'object') {
+			if ((ri.scale(1) / riRatio !== propsItemSize.minWidth / itemSize.minWidth) || (ri.scale(1) / riRatio !== propsItemSize.minHeight / itemSize.minHeight)) {
+				setItemSize(propsItemSize);
+			}
+		} else {
+			if (ri.scale(1) / riRatio !== propsItemSize / itemSize) {
+				setItemSize(propsItemSize);
+			}
 		}
 	}
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -142,12 +142,6 @@ const useScrollBase = (props) => {
 		} = props,
 		scrollClasses = classNames(css.scroll, className);
 
-	if (typeof props.itemSize === 'object') {
-		props.itemSize.minWidth = props.itemSize.minWidth || 0;
-		props.itemSize.minHeight = props.itemSize.minHeight || 0;
-	}
-	const propsItemSize = props.itemSize || 0;
-
 	// The following props are the one having the same naming function in this scope.
 	// So it is better to use props[propName]
 	// instead of extracting it from the `props` and renaming it
@@ -180,8 +174,8 @@ const useScrollBase = (props) => {
 	const [isHorizontalScrollbarVisible, setIsHorizontalScrollbarVisible] = useState(horizontalScrollbar === 'visible');
 	const [isVerticalScrollbarVisible, setIsVerticalScrollbarVisible] = useState(verticalScrollbar === 'visible');
 	const [riRatio, setRiRatio] = useState(ri.scale(1));
-	const [originalItemSize, setOriginalItemSize] = useState(propsItemSize);
-	const [itemSize, setItemSize] = useState(propsItemSize);
+	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize);
+	const [itemSize, setItemSize] = useState(props.itemSize);
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),
@@ -306,16 +300,14 @@ const useScrollBase = (props) => {
 		}
 	});
 
-	if (originalItemSize !== propsItemSize) {
-		setOriginalItemSize(propsItemSize);
-		if (typeof propsItemSize === 'object') {
-			if ((ri.scale(1) / riRatio !== propsItemSize.minWidth / itemSize.minWidth) || (ri.scale(1) / riRatio !== propsItemSize.minHeight / itemSize.minHeight)) {
-				setItemSize(propsItemSize);
+	if ((originalItemSize || originalItemSize === 0 || props.itemSize || props.itemSize === 0) && (originalItemSize !== props.itemSize)) {
+		setOriginalItemSize(props.itemSize);
+		if (typeof props.itemSize === 'object') {
+			if ((ri.scale(1) / riRatio !== props.itemSize.minWidth / itemSize.minWidth) || (ri.scale(1) / riRatio !== props.itemSize.minHeight / itemSize.minHeight)) {
+				setItemSize(props.itemSize);
 			}
-		} else {
-			if (ri.scale(1) / riRatio !== propsItemSize / itemSize) {
-				setItemSize(propsItemSize);
-			}
+		} else if (ri.scale(1) / riRatio !== props.itemSize / itemSize) {
+			setItemSize(props.itemSize);
 		}
 	}
 

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -304,7 +304,7 @@ const useScrollBase = (props) => {
 
 	if (originalItemSize !== (propsItemSize)) {
 		setOriginalItemSize(propsItemSize);
-		if (ri.scale(1) / riRatio !== (propsItemSize) / itemSize) {
+		if (ri.scale(1) / riRatio !== ((propsItemSize / itemSize) || (propsItemSize.minWidth / itemSize.minWidth))) {
 			setItemSize(propsItemSize);
 		}
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/enact/pull/3374 and https://github.com/enactjs/enact/pull/3382, I fixed VirtualGridList and VirtualList to be responsive while resizing window.
And more fixed for the case that itemSize is null in https://github.com/enactjs/enact/pull/3387.
But https://github.com/enactjs/enact/pull/3382 and https://github.com/enactjs/enact/pull/3387 only considered VirtualList, so VirtualGridList samples became not responsive again when resizing window.
I need to consider VirtualGridList case for https://github.com/enactjs/enact/pull/3382 and https://github.com/enactjs/enact/pull/3387 solution.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
For VirtualGridList, `itemSize` is an object with `minWidth`, `minHeight` properties.
I should calculate with itemSize.minWidth or itemSize.minHeight if I want to.
So I changed `itemSize` to `itemSize.minWidth` and `itemSize.minHeight` if itemSize type is object.

And it is better to keep empty itemSize value than change it to 0.
(We have unit test cases for empty itemSize)
So I removed the code to change empty itemSize to 0, and changed the logic setting itemSize to be run only when itemSize is not empty

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-8190

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)