### PR TITLE
NXT-10247: Fixed spotlight to focus elements that are visible in the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to focus visible children of elements which do not have `overflow:true`
+
 ## [5.4.2] - 2026-01-28
 
 ### Changed

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact spotlight module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `spotlight` to focus visible children of elements which do not have `overflow:true`
+
 ## [5.4.2] - 2026-01-28
 
 No significant changes.

--- a/packages/spotlight/src/target.js
+++ b/packages/spotlight/src/target.js
@@ -245,7 +245,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 		if (next && containerId !== nextCandidateContainerId) {
 			// Don't apply visibility check when entering a restricted container. The container's own enterTo logic (last-focused, default-element) handles entry
 			// OR verify if the element from another container is visible (only for non-restricted)
-			if (isRestrictedContainer(nextCandidateContainerId) || isElementVisibleInContainer(next, nextCandidateContainerId)) {
+			if (isRestrictedContainer(nextCandidateContainerId) || isElementVisibleInContainer(next, nextCandidateContainerId) || isElementVisibleInViewport(next, nextCandidateContainerId)) {
 				return next;
 			} else {
 				// otherwise, try to navigate to an element that is visible in its container
@@ -254,7 +254,7 @@ function getTargetInContainerByDirectionFromPosition (direction, containerId, po
 					direction,
 					elementRects.filter((rect) => {
 						const elementContainerId = getContainersForNode(rect.element).pop();
-						return isElementVisibleInContainer(rect.element, elementContainerId);
+						return isElementVisibleInContainer(rect.element, elementContainerId) || isElementVisibleInViewport(rect.element, elementContainerId);
 					}),
 					getContainerConfig(containerId)
 				);
@@ -377,7 +377,7 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 		if (next && containerId !== nextCandidateContainerId) {
 			// Don't apply visibility check when entering a restricted container. The container's own enterTo logic (last-focused, default-element) handles entry
 			// OR verify if the element from another container is visible
-			if (isRestrictedContainer(nextCandidateContainerId) || isElementVisibleInContainer(next, nextCandidateContainerId)) {
+			if (isRestrictedContainer(nextCandidateContainerId) || isElementVisibleInContainer(next, nextCandidateContainerId) || isElementVisibleInViewport(next, nextCandidateContainerId)) {
 				return next;
 			} else {
 				// otherwise, try to navigate to an element that is visible in its container
@@ -386,7 +386,7 @@ function getTargetInContainerByDirectionFromElement (direction, containerId, ele
 					direction,
 					elementRects.filter((rect) => {
 						const elementContainerId = getContainersForNode(rect.element).pop();
-						return isElementVisibleInContainer(rect.element, elementContainerId);
+						return isElementVisibleInContainer(rect.element, elementContainerId) || isElementVisibleInViewport(rect.element, elementContainerId);
 					}),
 					getContainerConfig(containerId),
 					partitionRect
@@ -523,6 +523,18 @@ function isElementVisibleInContainer (element, containerId) {
 	const isHorizontallyVisible = elementRight >= containerLeft && elementLeft <= containerRight;
 
 	return isVerticallyVisible && isHorizontallyVisible;
+}
+
+function isElementVisibleInViewport (element, containerId) {
+	// If the element's spotlight container has overflow:true, that container is the authority
+	// on what's visible (e.g., a Scroller hiding scrolled-away items).
+	const config = getContainerConfig(containerId);
+	if (config && config.overflow) {
+		return false;
+	}
+
+	const {top, right, bottom, left} = element.getBoundingClientRect();
+	return (bottom > 0 && right > 0 && top < window.innerHeight && left < window.innerWidth);
 }
 
 const getOffsetDistanceToTargetFromPosition = (distance, direction, {x, y}, {left, right, top, bottom}) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Elements visible in viewport, but outsie the bounds of thei parent container, did not receive focus on spotlight navigation

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added condition to focus visible children of elements which do not have overflow:true

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-10247

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))