### PR TITLE
NXT-10084: Fixed VirtualList to find item with itemRef

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,7 +6,8 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/VirtualList.VirtualList`, to adjust itemSize properly when resizing window
+- `ui/VirtualList.VirtualList` to adjust itemSize properly when resizing window
+- `ui/VirtualList.VirtualList` to scroll properly when another VirtualList exist
 
 ## [5.4.2] - 2026-01-28
 

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -357,9 +357,9 @@ class VirtualListBasic extends Component {
 			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));
 			this.itemMarginLeft = Number(firstItemStyle.getPropertyValue('margin-left').slice(0, -2));
 			this.itemMarginRight = Number(firstItemStyle.getPropertyValue('margin-right').slice(0, -2));
+			this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
+			this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
 		}
-		this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
-		this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
 
 		let deferScrollTo = false;
 		const {firstIndex, numOfItems} = this.state;

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -348,11 +348,11 @@ class VirtualListBasic extends Component {
 	}
 
 	componentDidUpdate (prevProps, prevState) {
-		const items = document.getElementsByClassName(css.listItem);
+		const items = this.props.itemRefs.current;
 
 		checkPropTypes(this, this.props, prevProps);
 		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items.length > 0) {
-			const firstItemStyle = window.getComputedStyle(items[0].children[0]);
+			const firstItemStyle = window.getComputedStyle(items[0]);
 			this.itemMarginTop = Number(firstItemStyle.getPropertyValue('margin-top').slice(0, -2));
 			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));
 			this.itemMarginLeft = Number(firstItemStyle.getPropertyValue('margin-left').slice(0, -2));

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -351,7 +351,7 @@ class VirtualListBasic extends Component {
 		const items = this.props.itemRefs.current;
 
 		checkPropTypes(this, this.props, prevProps);
-		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items.length > 0 && items[0] instanceof HTMLElement) {
+		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items[0]) {
 			const firstItemStyle = window.getComputedStyle(items[0]);
 			this.itemMarginTop = Number(firstItemStyle.getPropertyValue('margin-top').slice(0, -2));
 			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -607,11 +607,11 @@ class VirtualListBasic extends Component {
 		if (stickTo === 'start') {         // 'start'
 			offset = optionalOffset;
 		} else if (this.props.itemSizes) { // 'end' for different item sizes
-			offset = primary.clientSize - this.props.itemSizes[index] - marginOffset - optionalOffset;
+			offset = primary.clientSize - this.props.itemSizes[index] - (optionalOffset || marginOffset);
 		} else if (stickTo === 'center') { // 'center'
 			offset = (primary.clientSize / 2) - (primary.gridSize / 2) - optionalOffset;
 		} else {                           // 'end' for same item sizes
-			offset = primary.clientSize - primary.itemSize - marginOffset - optionalOffset;
+			offset = primary.clientSize - primary.itemSize - (optionalOffset || marginOffset);
 		}
 
 		/* istanbul ignore next */

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -357,8 +357,11 @@ class VirtualListBasic extends Component {
 			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));
 			this.itemMarginLeft = Number(firstItemStyle.getPropertyValue('margin-left').slice(0, -2));
 			this.itemMarginRight = Number(firstItemStyle.getPropertyValue('margin-right').slice(0, -2));
-			this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
-			this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
+			if (this.isPrimaryDirectionVertical) {
+				this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
+			} else {
+				this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
+			}
 		}
 
 		let deferScrollTo = false;

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -351,7 +351,7 @@ class VirtualListBasic extends Component {
 		const items = this.props.itemRefs.current;
 
 		checkPropTypes(this, this.props, prevProps);
-		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items.length > 0) {
+		if (!this.itemMarginTop && this.itemMarginTop !== 0 && items.length > 0 && items[0] instanceof HTMLElement) {
 			const firstItemStyle = window.getComputedStyle(items[0]);
 			this.itemMarginTop = Number(firstItemStyle.getPropertyValue('margin-top').slice(0, -2));
 			this.itemMarginBottom = Number(firstItemStyle.getPropertyValue('margin-bottom').slice(0, -2));

--- a/packages/ui/VirtualList/tests/VirtualList-native-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-native-specs.js
@@ -55,6 +55,24 @@ describe('VirtualList with native scrollMode', () => {
 		expect(actual).toBe(expected);
 	});
 
+	test('should render a list of \'items\' with horizontal direction', () => {
+		render(
+			<VirtualList
+				clientSize={clientSize}
+				dataSize={dataSize}
+				direction="horizontal"
+				itemRenderer={renderItem}
+				itemSize={itemSize}
+				scrollMode="native"
+			/>
+		);
+
+		const expected = 'Account 0';
+		const actual = screen.getByRole('list').children.item(0).textContent;
+
+		expect(actual).toBe(expected);
+	});
+
 	test('should render overhang items when clientSize is not given', () => {
 		render(
 			<VirtualList

--- a/packages/ui/VirtualList/tests/VirtualList-native-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-native-specs.js
@@ -19,7 +19,7 @@ describe('VirtualList with native scrollMode', () => {
 
 		renderItem = ({index, ...rest}) => {	// eslint-disable-line enact/display-name
 			return (
-				<div {...rest} id={'item' + index}>
+				<div {...rest} data-index={index} id={'item' + index}>
 					{items[index].name}
 				</div>
 			);

--- a/packages/ui/VirtualList/tests/VirtualList-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-specs.js
@@ -80,7 +80,7 @@ describe('VirtualList', () => {
 		};
 		renderItem = ({index, ...rest}) => {	// eslint-disable-line enact/display-name
 			return (
-				<div {...rest} id={'item' + index}>
+				<div {...rest} data-index={index} id={'item' + index}>
 					{items[index].name}
 				</div>
 			);
@@ -114,6 +114,23 @@ describe('VirtualList', () => {
 			<VirtualList
 				clientSize={clientSize}
 				dataSize={dataSize}
+				itemRenderer={renderItem}
+				itemSize={itemSize}
+			/>
+		);
+
+		const expected = 'Account 0';
+		const actual = screen.getByRole('list').children.item(0).textContent;
+
+		expect(actual).toBe(expected);
+	});
+
+	test('should render a list of \'items\' with horizontal direction', () => {
+		render(
+			<VirtualList
+				clientSize={clientSize}
+				dataSize={dataSize}
+				direction="horizontal"
 				itemRenderer={renderItem}
 				itemSize={itemSize}
 			/>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When getting item margin in VirtualList, wrong item is targeted sometimes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I changed the code to get item with itemRef instead of getting item by class name.
And updating scrollBound for every component update could be the reason of the issue.
I changed the code to update the scrollBound for once when itemMargin is calculated.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
For vertical orientation, optional offset is already considered and calculated so we don't need margin offset.
So margin offset is applied only when there isn't optional offset.

### Links
[//]: # (Related issues, references)
NXT-10084

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)