### PR TITLE
NXT-10868: Added support for linear scaling type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact project, newest changes 
 ### Added
 
 - `core/util` function `checkPropTypes` to check the prop types of a component
+- `ui/resolution` Added support for linear scaling type
 
 ### Fixed
 

--- a/packages/sampler/stories/default/ResolutionDecorator.js
+++ b/packages/sampler/stories/default/ResolutionDecorator.js
@@ -1,0 +1,136 @@
+import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
+import BodyText from '@enact/ui/BodyText';
+import Card from '@enact/ui/Card';
+import Item from '@enact/ui/Item';
+import VirtualList from '@enact/ui/VirtualList';
+import ri, {ResolutionDecorator, getScreenTypeObject, getScreenType} from '@enact/ui/resolution';
+import {Fragment, useCallback, useState, useEffect} from 'react';
+
+Card.displayName = 'Card';
+ResolutionDecorator.displayName = 'ResolutionDecorator';
+VirtualList.displayName = 'VirtualList';
+
+export default {
+	title: 'UI/ResolutionDecorator',
+	component: ResolutionDecorator
+};
+
+const config = {
+	linearScaling: {
+		active: false,
+		type: 'currentScreen'
+	}
+};
+
+const screenTypes = [
+	{name: 'vga', pxPerRem: 8, width: 640, height: 480, aspectRatioName: 'standard'},
+	{name: 'xga', pxPerRem: 16, width: 1024, height: 768, aspectRatioName: 'standard'},
+	{name: 'hd', pxPerRem: 16, width: 1280, height: 720, aspectRatioName: 'hdtv'},
+	{name: 'uw-hd', pxPerRem: 16, width: 1920, height: 804, aspectRatioName: 'cinema'},
+	{name: 'fhd', pxPerRem: 24, width: 1920, height: 1080, aspectRatioName: 'hdtv'},
+	{name: 'uw-uxga', pxPerRem: 24, width: 2560, height: 1080, aspectRatioName: 'cinema'},
+	{name: 'qhd', pxPerRem: 32, width: 2560, height: 1440, aspectRatioName: 'hdtv'},
+	{name: 'wqhd', pxPerRem: 32, width: 3440, height: 1440, aspectRatioName: 'cinema'},
+	{name: 'uhd', pxPerRem: 48, width: 3840, height: 2160, aspectRatioName: 'hdtv', base: true},
+	{name: 'wuhd', pxPerRem: 48, width: 5158, height: 2160, aspectRatioName: 'cinema'},
+	{name: 'uhd2', pxPerRem: 96, width: 7680, height: 4320, aspectRatioName: 'hdtv'}
+];
+
+const ResolutionDecoratorView = ({
+	args,
+	currentFontSize,
+	screenInfo
+}) => {
+	// eslint-disable-next-line enact/display-name
+	const itemRenderer = useCallback(({index, ...rest}) => {
+		return <Item {...rest}>Item {index}</Item>;
+	}, []);
+
+	return (
+		<Fragment>
+			<div style={{height: 'fit-content'}}>
+				<div style={{padding: '1rem', border: '1px solid #ccc', marginBottom: '1rem'}}>
+					<BodyText><strong>Current Resolution:</strong> {screenInfo.width}x{screenInfo.height} ({screenInfo.name})</BodyText>
+					<BodyText><strong>Font Size:</strong> {currentFontSize}</BodyText>
+				</div>
+				<BodyText><strong>Select Scaling Type and Resize the Window</strong></BodyText>
+				<hr />
+			</div>
+
+			<div style={{padding: '1rem', border: '2px solid #ccc', height: '50%', display: 'flex', gap: '1rem'}}>
+				<VirtualList
+					dataSize={args['dataSize']}
+					itemRenderer={itemRenderer}
+					itemSize={ri.scale(args['itemSize'])}
+				/>
+				<hr />
+				<div>
+					<Card
+						captionOverlay="Resolution TEsting"
+						src="https://placehold.co/300x300/69cdff/ffffff/png?text=Card Component"
+						style={{
+							width: ri.scaleToRem(args['width']),
+							height: ri.scaleToRem(args['height'])
+						}}
+					/>
+					<h1>Text to test resolution changes</h1>
+					<h2>Text to test resolution changes</h2>
+					<h3>Text to test resolution changes</h3>
+				</div>
+			</div>
+		</Fragment>
+	);
+};
+
+export const ResolutionDecorator_ = (args) => {
+	const [currentFontSize, setCurrentFontSize] = useState('');
+	const [screenInfo, setScreenInfo] = useState({name: '', width: 0, height: 0});
+
+	const updateInfo = useCallback(() => {
+		const type = getScreenType({width: window.innerWidth, height: window.innerHeight});
+		const screenTypeObject = getScreenTypeObject(type);
+		if (screenTypeObject) {
+			setScreenInfo({
+				name: screenTypeObject.name,
+				width: window.innerWidth,
+				height: window.innerHeight
+			});
+		}
+		setCurrentFontSize(document.documentElement.style.fontSize);
+	}, []);
+
+	useEffect(() => {
+		updateInfo();
+		window.addEventListener('resize', updateInfo);
+		return () => window.removeEventListener('resize', updateInfo);
+	}, [updateInfo]);
+
+	config.linearScaling.type = args['scalingType'];
+	config.linearScaling.active = args['linearScaling'];
+
+	const View = ResolutionDecorator({
+		...config,
+		screenTypes: screenTypes
+	}, ResolutionDecoratorView);
+
+	return (
+		<View
+			args={args}
+			currentFontSize={currentFontSize}
+			screenInfo={screenInfo}
+		/>
+	);
+};
+
+boolean('linearScaling', ResolutionDecorator_, ResolutionDecorator);
+select('scalingType', ResolutionDecorator_, ['currentScreen', 'baseScreen'], ResolutionDecorator, 'currentScreen');
+number('dataSize', ResolutionDecorator_, VirtualList, 100);
+number('itemSize', ResolutionDecorator_, VirtualList, 156);
+number('width', ResolutionDecorator_, Card, 500);
+number('height', ResolutionDecorator_, Card, 250);
+
+ResolutionDecorator_.parameters = {
+	info: {
+		text: 'Basic Usage of Linear Scaling'
+	}
+};

--- a/packages/sampler/stories/default/ResolutionDecorator.js
+++ b/packages/sampler/stories/default/ResolutionDecorator.js
@@ -41,7 +41,6 @@ const ResolutionDecoratorView = ({
 	currentFontSize,
 	screenInfo
 }) => {
-	// eslint-disable-next-line enact/display-name
 	const itemRenderer = useCallback(({index, ...rest}) => {
 		return <Item {...rest}>Item {index}</Item>;
 	}, []);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ## [unreleased]
 
+### Added
+
+- `ui/resolution` Added support for linear scaling type
+
 ### Fixed
 
 - `ui/VirtualList.VirtualList`, to adjust itemSize properly when resizing window

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -100,12 +100,7 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			checkPropTypes(this, props);
 			riConfig.fontSizeHandling = config.fontSizeHandling;
 
-			if (config.linearScaling) {
-				riConfig.linearScaling = {
-					...riConfig.linearScaling,
-					...config.linearScaling
-				};
-			}
+			if (config.linearScaling) riConfig.linearScaling = config.linearScaling;
 
 			init({measurementNode: (typeof window !== 'undefined' && window)});
 			this.state = {

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -99,6 +99,14 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			super(props);
 			checkPropTypes(this, props);
 			riConfig.fontSizeHandling = config.fontSizeHandling;
+
+			if (config.linearScaling) {
+				riConfig.linearScaling = {
+					...riConfig.linearScaling,
+					...config.linearScaling
+				};
+			}
+
 			init({measurementNode: (typeof window !== 'undefined' && window)});
 			this.state = {
 				resolutionClasses: ''

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -41,12 +41,12 @@ const linearScalingType = {
 	/**
 	 * Scales based on the `baseScreen` (the screen type marked as `base: true`).
 	 */
-	baseScreenReport: 'baseScreen',
+	baseScreen: 'baseScreen',
 
 	/**
 	 * Scales based on the current detected `screenType`.
 	 */
-	currentScreenReport: 'currentScreen'
+	currentScreen: 'currentScreen'
 };
 
 /**
@@ -63,7 +63,7 @@ const configDefaults = {
 	orientationHandling: 'normal',
 	linearScaling: {
 		active: true,
-		type: linearScalingType.baseScreenReport
+		type: linearScalingType.baseScreen
 	}
 };
 
@@ -80,7 +80,7 @@ const configDefaults = {
  * @private
  */
 function getLinearSize () {
-	const reportScreen = config.linearScaling.type === linearScalingType.currentScreenReport ? screenTypeObject : baseScreen;
+	const reportScreen = config.linearScaling.type === linearScalingType.currentScreen ? screenTypeObject : baseScreen;
 
 	const scaleX = workspaceBounds.width / reportScreen.width;
 	const scaleY = workspaceBounds.height / reportScreen.height;

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -62,7 +62,7 @@ const configDefaults = {
 	fontSizeHandling: 'scale',
 	orientationHandling: 'normal',
 	linearScaling: {
-		active: false,
+		active: true,
 		type: linearScalingType.baseScreenReport
 	}
 };

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -63,7 +63,7 @@ const configDefaults = {
 	orientationHandling: 'normal',
 	linearScaling: {
 		active: true,
-		type: linearScalingType.baseScreen
+		type: linearScalingType.currentScreen
 	}
 };
 
@@ -72,7 +72,8 @@ const configDefaults = {
  * relative to a reference screen (either the base screen or the current screen type).
  *
  * The calculation uses the geometric mean of horizontal and vertical scale factors,
- * constrained between 0.125 and 2.0 to prevent extreme scaling.
+ * constrained between 0.01 and 2.0 for base screen type and 0.005 and 1 for current
+ * screen type to prevent extreme scaling.
  *
  * @function
  * @returns {Number} The calculated pixel size for 1rem.
@@ -80,13 +81,16 @@ const configDefaults = {
  * @private
  */
 function getLinearSize () {
-	const reportScreen = config.linearScaling.type === linearScalingType.currentScreen ? screenTypeObject : baseScreen;
+	const isCurrentScreen = config.linearScaling.type === linearScalingType.currentScreen;
+	const reportScreen = isCurrentScreen ? screenTypeObject : baseScreen;
+	const minRation = isCurrentScreen ? 0.005 : 0.01;
+	const maxRatio = isCurrentScreen ? 1 : 2;
 
 	const scaleX = workspaceBounds.width / reportScreen.width;
 	const scaleY = workspaceBounds.height / reportScreen.height;
 
 	const ratio = Math.sqrt(scaleX * scaleY);
-	const finalRatio = Math.max(0.125, Math.min(ratio, 2));
+	const finalRatio = Math.max(minRation, Math.min(ratio, maxRatio));
 
 	return Math.round(reportScreen.pxPerRem * finalRatio * 10) / 10;
 }

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -54,7 +54,7 @@ const configDefaults = {
 	fontSizeHandling: 'scale',
 	orientationHandling: 'normal',
 	linearScaling: {
-		active: true,
+		active: false,
 		type: linearScalingType.currentScreen
 	}
 };

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -30,6 +30,26 @@ const unitToPixelFactors = {
 };
 
 /**
+ * Enumerates the available reporting types for linear scaling.
+ *
+ * @enum {String}
+ * @memberof ui/resolution
+ * @readonly
+ * @private
+ */
+const linearScalingType = {
+	/**
+	 * Scales based on the `baseScreen` (the screen type marked as `base: true`).
+	 */
+	baseScreenReport: 'baseScreen',
+
+	/**
+	 * Scales based on the current detected `screenType`.
+	 */
+	currentScreenReport: 'currentScreen'
+};
+
+/**
  * Default configuration values.
  *
  * See {@link ui/resolution.config} for full documentation.
@@ -40,8 +60,36 @@ const unitToPixelFactors = {
  */
 const configDefaults = {
 	fontSizeHandling: 'scale',
-	orientationHandling: 'normal'
+	orientationHandling: 'normal',
+	linearScaling: {
+		active: false,
+		type: linearScalingType.baseScreenReport
+	}
 };
+
+/**
+ * Calculates a linearly scaled size based on the current workspace dimensions
+ * relative to a reference screen (either the base screen or the current screen type).
+ *
+ * The calculation uses the geometric mean of horizontal and vertical scale factors,
+ * constrained between 0.125 and 2.0 to prevent extreme scaling.
+ *
+ * @function
+ * @returns {Number} The calculated pixel size for 1rem.
+ * @memberof ui/resolution
+ * @private
+ */
+function getLinearSize () {
+	const reportScreen = config.linearScaling.type === linearScalingType.currentScreenReport ? screenTypeObject : baseScreen;
+
+	const scaleX = workspaceBounds.width / reportScreen.width;
+	const scaleY = workspaceBounds.height / reportScreen.height;
+
+	const ratio = Math.sqrt(scaleX * scaleY);
+	const finalRatio = Math.max(0.125, Math.min(ratio, 2));
+
+	return Math.round(reportScreen.pxPerRem * finalRatio * 10) / 10;
+}
 
 /**
  * Get the closest resolution type based on the `resolution`
@@ -227,6 +275,11 @@ function getScreenType (rez) {
  * @public
  */
 function calculateFontSize (type) {
+	// If linear scaling is enabled, bypass standard screen-type-based calculation and use the dynamic linear size
+	if (config.linearScaling.active) {
+		return getLinearSize() + 'px';
+	}
+
 	const scrObj = getScreenTypeObject(type);
 	const shouldScaleFontSize = (config.fontSizeHandling === 'scale') && (workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height);
 	let size;
@@ -326,6 +379,11 @@ function getRiRatio (type = screenType) {
  * @returns {Number}          pixels per rem
  */
 function getUnitToPixelFactors (type = screenType) {
+	// Use linear scaling for the current screen type if active.
+	if (config.linearScaling.active && (!type || type === screenType)) {
+		return getLinearSize();
+	}
+
 	if (type) {
 		return getScreenTypeObject(type).pxPerRem;
 	}
@@ -411,7 +469,7 @@ function scale (px) {
  */
 function unit (pixels, toUnit) {
 	if (!toUnit || !unitToPixelFactors[toUnit]) return;
-	if (typeof pixels === 'string' && pixels.substr(-2) === 'px') pixels = parseInt(pixels.substr(0, pixels.length - 2));
+	if (typeof pixels === 'string' && pixels.substring(-2) === 'px') pixels = parseInt(pixels.substring(0, pixels.length - 2));
 	if (typeof pixels !== 'number') return;
 
 	return (pixels / unitToPixelFactors[toUnit]) + '' + toUnit;
@@ -531,6 +589,12 @@ function init (args = {}) {
 }
 
 /**
+ * @typedef {Object} LinearScalingConfig
+ * @property {Boolean} active - Enables linear scaling.
+ * @property {('baseScreen'|'currentScreen')} type - Reference screen type.
+ */
+
+/**
  * Configuration options for resolution independence behavior.
  *
  * @typedef {Object} ResolutionConfig
@@ -546,6 +610,12 @@ function init (args = {}) {
  *           based on proportional scaling. When set to `'normal'`, uses the standard pxPerRem
  *           value. This is particularly useful for supporting device rotation scenarios.
  *           Default: `'normal'`
+ * @property {LinearScalingConfig} [linearScaling] - Configuration for linear scaling mode.
+ * @property {Boolean} linearScaling.active - Enables linear scaling calculation for
+ *           font sizes and unit conversions. Default: `false`.
+ * @property {ui/resolution.linearScalingType} linearScaling.type - Determines the
+ *           reference screen used for linear scaling calculation.
+ *           Default: `linearScalingType.baseScreenReport`.
  * @public
  */
 

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -34,13 +34,10 @@ const unitToPixelFactors = {
  *
  * @enum {String}
  * @memberof ui/resolution
- * @readonly
- * @private
+ * @public
  */
 const linearScalingType = {
-	// Scales based on the `baseScreen` (the screen type marked as `base: true`).
 	baseScreen: 'baseScreen',
-	 //Scales based on the current detected `screenType`.
 	currentScreen: 'currentScreen'
 };
 
@@ -592,8 +589,12 @@ function init (args = {}) {
 
 /**
  * @typedef {Object} LinearScalingConfig
- * @property {Boolean} active - Enables linear scaling.
- * @property {('baseScreen'|'currentScreen')} type - Reference screen type.
+ * @memberof ui/resolution
+ * @property {Boolean} active - Enables linear scaling calculation for
+ *           font sizes and unit conversions. Default: `true`.
+ * @property {ui/resolution.linearScalingType} type - Determines the
+ *           reference screen used for linear scaling calculation.
+ *           Default: `linearScalingType.currentScreen`.
  */
 
 /**
@@ -612,12 +613,7 @@ function init (args = {}) {
  *           based on proportional scaling. When set to `'normal'`, uses the standard pxPerRem
  *           value. This is particularly useful for supporting device rotation scenarios.
  *           Default: `'normal'`
- * @property {LinearScalingConfig} [linearScaling] - Configuration for linear scaling mode.
- * @property {Boolean} linearScaling.active - Enables linear scaling calculation for
- *           font sizes and unit conversions. Default: `false`.
- * @property {ui/resolution.linearScalingType} linearScaling.type - Determines the
- *           reference screen used for linear scaling calculation.
- *           Default: `linearScalingType.baseScreenReport`.
+ * @property {LinearScalingConfig} linearScaling - Configuration for linear scaling mode.
  * @public
  */
 
@@ -644,6 +640,7 @@ export {
 	getScreenTypeObject,
 	getScreenType,
 	init,
+	linearScalingType,
 	scale,
 	scaleToRem,
 	selectSrc,

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -68,31 +68,34 @@ const configDefaults = {
 };
 
 /**
- * Calculates a linearly scaled size based on the current workspace dimensions
- * relative to a reference screen (either the base screen or the current screen type).
+ * Calculates a linearly scaled size for 1rem based on the current workspace dimensions.
  *
- * The calculation uses the geometric mean of horizontal and vertical scale factors,
- * constrained between 0.01 and 2.0 for base screen type and 0.005 and 1 for current
- * screen type to prevent extreme scaling.
+ * The calculation determines a scaling factor using the geometric mean of horizontal
+ * and vertical scale factors relative to a reference screen (either the `baseScreen`
+ * or the currently matched `screenTypeObject`).
+ *
+ * The resulting size is rounded to one decimal place and constrained to a minimum
+ * of 1px and a maximum of the `pxPerRem` value defined for the largest screen type
+ * (the last element in `screenTypes`).
  *
  * @function
- * @returns {Number} The calculated pixel size for 1rem.
  * @memberof ui/resolution
+ * @returns {Number} The calculated pixel size for 1rem, clamped between 1 and the
+ *                   maximum defined pxPerRem.
  * @private
  */
 function getLinearSize () {
 	const isCurrentScreen = config.linearScaling.type === linearScalingType.currentScreen;
 	const reportScreen = isCurrentScreen ? screenTypeObject : baseScreen;
-	const minRation = isCurrentScreen ? 0.005 : 0.01;
-	const maxRatio = isCurrentScreen ? 1 : 2;
+	const maxSize = screenTypes.at(-1).pxPerRem;
 
 	const scaleX = workspaceBounds.width / reportScreen.width;
 	const scaleY = workspaceBounds.height / reportScreen.height;
 
 	const ratio = Math.sqrt(scaleX * scaleY);
-	const finalRatio = Math.max(minRation, Math.min(ratio, maxRatio));
+	const size = Math.round(reportScreen.pxPerRem * ratio * 10) / 10;
 
-	return Math.round(reportScreen.pxPerRem * finalRatio * 10) / 10;
+	return Math.max(1, Math.min(size, maxSize));
 }
 
 /**
@@ -280,7 +283,7 @@ function getScreenType (rez) {
  */
 function calculateFontSize (type) {
 	// If linear scaling is enabled, bypass standard screen-type-based calculation and use the dynamic linear size
-	if (config.linearScaling.active) {
+	if (config.linearScaling.active && !type) {
 		return getLinearSize() + 'px';
 	}
 

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -38,14 +38,9 @@ const unitToPixelFactors = {
  * @private
  */
 const linearScalingType = {
-	/**
-	 * Scales based on the `baseScreen` (the screen type marked as `base: true`).
-	 */
+	// Scales based on the `baseScreen` (the screen type marked as `base: true`).
 	baseScreen: 'baseScreen',
-
-	/**
-	 * Scales based on the current detected `screenType`.
-	 */
+	 //Scales based on the current detected `screenType`.
 	currentScreen: 'currentScreen'
 };
 

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -1,5 +1,6 @@
 import {
 	calculateFontSize,
+	config,
 	defineScreenTypes,
 	getScreenType,
 	init,
@@ -210,5 +211,25 @@ describe('Resolution Specs', () => {
 		measurementNode = {innerWidth: UHD2.width, innerHeight: UHD2.height};
 		init({measurementNode});
 		expect(selectSrc(src)).toBe(src.uhd);
+	});
+
+	test('should calculate linearly scaled font size based on workspace bounds and current screen', () => {
+		config.linearScaling.type = 'currentScreen';
+
+		screenTypes.forEach((type, index, arr) => {
+			init({measurementNode: {innerWidth: type.width, innerHeight: type.height}});
+			let actual = calculateFontSize();
+			expect(actual).toBe(type.pxPerRem + 'px');
+
+			init({measurementNode: {innerWidth: type.width - 10, innerHeight: type.height - 10}});
+			actual = Number(calculateFontSize().split('px').at(0));
+			expect(actual).toBeLessThan(type.pxPerRem);
+
+			init({measurementNode: {innerWidth: type.width + 10, innerHeight: type.height + 10}});
+			actual = Number(calculateFontSize().split('px').at(0));
+
+			const expectCondition = arr.length - 1 === index ? 'toEqual' : 'toBeGreaterThan';
+			expect(actual)[expectCondition](type.pxPerRem);
+		});
 	});
 });

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -1,5 +1,6 @@
 import {
 	calculateFontSize,
+	config,
 	defineScreenTypes,
 	getScreenType,
 	init,
@@ -213,6 +214,7 @@ describe('Resolution Specs', () => {
 	});
 
 	test('should calculate linearly scaled font size based on workspace bounds and current screen', () => {
+		config.linearScaling.active = true;
 		screenTypes.forEach((type, index, arr) => {
 			init({measurementNode: {innerWidth: type.width, innerHeight: type.height}});
 			let actual = calculateFontSize();
@@ -228,5 +230,6 @@ describe('Resolution Specs', () => {
 			const expectCondition = arr.length - 1 === index ? 'toEqual' : 'toBeGreaterThan';
 			expect(actual)[expectCondition](type.pxPerRem);
 		});
+		config.linearScaling.active = false;
 	});
 });

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -1,6 +1,5 @@
 import {
 	calculateFontSize,
-	config,
 	defineScreenTypes,
 	getScreenType,
 	init,
@@ -214,8 +213,6 @@ describe('Resolution Specs', () => {
 	});
 
 	test('should calculate linearly scaled font size based on workspace bounds and current screen', () => {
-		config.linearScaling.type = 'currentScreen';
-
 		screenTypes.forEach((type, index, arr) => {
 			init({measurementNode: {innerWidth: type.width, innerHeight: type.height}});
 			let actual = calculateFontSize();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added support for linear scaling type. Previously, the system primarily relied on discrete screenTypes (breakpoints) to determine pxPerRem. While effective for standard resolutions, it didn't always provide a smooth transition for intermediate window sizes or non-standard aspect ratios.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- When `linearScaling.active: true`, the font size scales linearly as the window resizes, avoiding sudden jumps between breakpoints.
- By using `type: 'currentScreen'`, the system guarantees that the UI looks exactly as defined when the resolution matches a known `screenType`
- Constraint logic `(Math.min/max)` prevents the scale factor from becoming too small or too large, protecting the UI on extreme display setups.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- The choice of the geometric mean ($\sqrt{scaleX \times scaleY}$) ensures that the scaling factor accounts for both width and height changes. This prevents the UI from appearing overly large on ultra-wide monitors where only the width increases significantly.
- Using `baseScreen mode`, creates a global linear curve where defined `pxPerRem` values for non-base screens are treated as suggestions/breakpoints for standard mode, but are overridden by the fluid math in linear mode.

### Links
[//]: # (Related issues, references)
NXT-10868

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com