### PR TITLE
NXT-10864 [Enact] Spottable - Investigate performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `core/util` function `checkPropTypes` to check the prop types of a component
 - `ui/resolution` Added support for linear scaling type
 
+### Changed
+
+- `spotlight/Spottable` to reduce redundant work during high-frequency re-renders
+
 ### Fixed
 
 - `spotlight` to focus visible children of elements which do not have `overflow:true`

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact spotlight module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `spotlight/Spottable` to reduce redundant work during high-frequency re-renders
+
 ### Fixed
 
 - `spotlight` to focus visible children of elements which do not have `overflow:true`

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -148,7 +148,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		}
 		rest.tabIndex = tabIndex;
 
-		delete rest.spotlightId;
 		const handlers = useHandlers(spotHandlers, rest, spot);
 
 		return (

--- a/packages/spotlight/Spottable/Spottable.js
+++ b/packages/spotlight/Spottable/Spottable.js
@@ -13,7 +13,7 @@ import {checkPropTypes} from '@enact/core/util';
 import {WithRef} from '@enact/core/internal/WithRef';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import {Component, useCallback, useRef} from 'react';
+import {useCallback, useReducer, useRef} from 'react';
 
 import {spottableClass, useSpottable} from './useSpottable';
 
@@ -149,7 +149,6 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 		rest.tabIndex = tabIndex;
 
 		delete rest.spotlightId;
-
 		const handlers = useHandlers(spotHandlers, rest, spot);
 
 		return (
@@ -267,18 +266,9 @@ const Spottable = hoc(defaultConfig, (config, Wrapped) => {
 	};
 
 	// eslint-disable-next-line no-shadow
-	class Spottable extends Component {
-		componentDidMount () {
-			this.forceUpdate();
-		}
-
-		handleForceUpdate = () => {
-			this.forceUpdate();
-		};
-
-		render () {
-			return <SpottableBase {...this.props} handleForceUpdate={this.handleForceUpdate} />;
-		}
+	function Spottable (props) {
+		const [, forceUpdate] = useReducer(x => x + 1, 0);
+		return <SpottableBase {...props} handleForceUpdate={forceUpdate} />;
 	}
 
 	return Spottable;

--- a/packages/spotlight/Spottable/SpottableCore.js
+++ b/packages/spotlight/Spottable/SpottableCore.js
@@ -34,6 +34,30 @@ const isKeyboardAccessible = (node) => {
 
 const isSpottable = (props) => !props.spotlightDisabled;
 
+const hasSelectionKey = (selectionKeys, keyCode) => {
+	for (let i = 0; i < selectionKeys.length; i++) {
+		if (selectionKeys[i] === keyCode) {
+			return true;
+		}
+	}
+	return false;
+};
+
+const getMatchedSelectionKey = (selectionKeys, which, type, keyboardAccessible) => {
+	if (which === REMOTE_OK_KEY) {
+		return REMOTE_OK_KEY;
+	}
+
+	for (let i = 0; i < selectionKeys.length; i++) {
+		const key = selectionKeys[i];
+		if (which === key && (type !== 'keypress' || !keyboardAccessible)) {
+			return key;
+		}
+	}
+
+	return null;
+};
+
 // Last instance of spottable to be focused
 let lastSelectTarget = null;
 
@@ -134,7 +158,7 @@ class SpottableCore {
 	forwardAndResetLastSelectTarget = (ev, props) => {
 		const {keyCode} = ev;
 		const {selectionKeys} = props;
-		const key = selectionKeys.find((value) => keyCode === value);
+		const key = hasSelectionKey(selectionKeys, keyCode);
 		const notPrevented = !ev.defaultPrevented;
 
 		// bail early for non-selection keyup to avoid clearing lastSelectTarget prematurely
@@ -157,16 +181,7 @@ class SpottableCore {
 		const {selectionKeys} = props;
 		const keyboardAccessible = isKeyboardAccessible(currentTarget);
 
-		const keyCode = selectionKeys.find((value) => (
-			// emulate mouse events for any remote okay button event
-			which === REMOTE_OK_KEY ||
-			// or a non-keypress selection event or any selection event on a non-keyboard accessible
-			// control
-			(
-				which === value &&
-				(type !== 'keypress' || !keyboardAccessible)
-			)
-		));
+		const keyCode = getMatchedSelectionKey(selectionKeys, which, type, keyboardAccessible);
 
 		if (getDirection(keyCode)) {
 			preventDefault(ev);
@@ -184,7 +199,7 @@ class SpottableCore {
 		const {selectionKeys} = props;
 
 		// Only apply accelerator if handling a selection key
-		if (selectionKeys.find((value) => which === value)) {
+		if (hasSelectionKey(selectionKeys, which)) {
 			if (selectCancelled || (lastSelectTarget && lastSelectTarget !== this)) {
 				return false;
 			}

--- a/packages/spotlight/Spottable/SpottableCore.js
+++ b/packages/spotlight/Spottable/SpottableCore.js
@@ -70,7 +70,8 @@ class SpottableCore {
 	}
 
 	unload () {
-		if (this.isFocused) {
+		const isFocusedNow = this.node && this.node === Spotlight.getCurrent();
+		if (isFocusedNow) {
 			forwardCustom('onSpotlightDisappear')(null, this.props);
 		}
 		if (lastSelectTarget === this) {
@@ -79,7 +80,16 @@ class SpottableCore {
 	}
 
 	didUpdate = () => {
-		this.isFocused = this.node && this.node === Spotlight.getCurrent();
+		// Avoid the cost of calling `Spotlight.getCurrent()` on every render unless we
+		// need focus state for class calculation (`spotlightDisabled`) or selection cancel.
+		const shouldUpdateFocusState = (
+			this.props.spotlightDisabled ||
+			(this.props.disabled && lastSelectTarget === this && !selectCancelled)
+		);
+
+		if (shouldUpdateFocusState) {
+			this.isFocused = this.node && this.node === Spotlight.getCurrent();
+		}
 
 		// if the component is focused and became disabled
 		if (this.isFocused && this.props.disabled && lastSelectTarget === this && !selectCancelled) {

--- a/packages/spotlight/Spottable/SpottableCore.js
+++ b/packages/spotlight/Spottable/SpottableCore.js
@@ -43,21 +43,6 @@ const hasSelectionKey = (selectionKeys, keyCode) => {
 	return false;
 };
 
-const getMatchedSelectionKey = (selectionKeys, which, type, keyboardAccessible) => {
-	if (which === REMOTE_OK_KEY) {
-		return REMOTE_OK_KEY;
-	}
-
-	for (let i = 0; i < selectionKeys.length; i++) {
-		const key = selectionKeys[i];
-		if (which === key && (type !== 'keypress' || !keyboardAccessible)) {
-			return key;
-		}
-	}
-
-	return null;
-};
-
 // Last instance of spottable to be focused
 let lastSelectTarget = null;
 
@@ -179,9 +164,17 @@ class SpottableCore {
 
 		const {currentTarget, repeat, type, which} = ev;
 		const {selectionKeys} = props;
-		const keyboardAccessible = isKeyboardAccessible(currentTarget);
+		const isRemoteOkKey = which === REMOTE_OK_KEY;
+		const isSelectionKey = isRemoteOkKey || hasSelectionKey(selectionKeys, which);
 
-		const keyCode = getMatchedSelectionKey(selectionKeys, which, type, keyboardAccessible);
+		// Fast-path: avoid DOM checks and event normalization for non-selection key events.
+		if (!isSelectionKey) {
+			return false;
+		}
+
+		const keyboardAccessible = isKeyboardAccessible(currentTarget);
+		const canEmulate = isRemoteOkKey || (type !== 'keypress' || !keyboardAccessible);
+		const keyCode = canEmulate ? which : null;
 
 		if (getDirection(keyCode)) {
 			preventDefault(ev);

--- a/packages/spotlight/Spottable/tests/Spottable-specs.js
+++ b/packages/spotlight/Spottable/tests/Spottable-specs.js
@@ -59,7 +59,7 @@ describe('Spottable', () => {
 
 			rerender(<Component data-id="123" />);
 
-			const expected = 3;
+			const expected = 2;
 
 			expect(spy).toHaveBeenCalledTimes(expected);
 		});
@@ -71,7 +71,7 @@ describe('Spottable', () => {
 
 			rerender(<Component selectionKeys={[2, 1, 3]} />);
 
-			const expected = 3;
+			const expected = 2;
 
 			expect(spy).toHaveBeenCalledTimes(expected);
 		});
@@ -84,7 +84,7 @@ describe('Spottable', () => {
 
 			div.focus();
 
-			const expected = 2;
+			const expected = 1;
 
 			expect(spy).toHaveBeenCalledTimes(expected);
 		});

--- a/packages/spotlight/Spottable/tests/useSpot-specs.js
+++ b/packages/spotlight/Spottable/tests/useSpot-specs.js
@@ -220,6 +220,26 @@ describe('useSpottable', () => {
 
 			expect(spy).not.toHaveBeenCalled();
 		});
+
+		test('should emulate {onMouseDown} for a custom selection key', () => {
+			const spy = jest.fn();
+			render(<SpottableComponent data-testid={id} emulateMouse onMouseDown={spy} selectionKeys={[32]} />);
+			const div = screen.getByTestId(id);
+
+			fireEvent.keyDown(div, makeKeyEvent(32));
+
+			expect(spy).toHaveBeenCalledTimes(1);
+		});
+
+		test('should not emulate {onMouseDown} for a non-selection key', () => {
+			const spy = jest.fn();
+			render(<SpottableComponent data-testid={id} emulateMouse onMouseDown={spy} selectionKeys={[13]} />);
+			const div = screen.getByTestId(id);
+
+			fireEvent.keyDown(div, makeKeyEvent(65));
+
+			expect(spy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('shouldComponentUpdate', () => {
@@ -249,6 +269,17 @@ describe('useSpottable', () => {
 			const expected = 2;
 
 			expect(spy).toHaveBeenCalledTimes(expected);
+		});
+
+		test('should update when {spotlightDisabled} changes', () => {
+			const spy = jest.fn((props) => <div {...props} />);
+			const {rerender} = render(
+				<SpottableComponent component={spy} data-testid={id} spotlightDisabled />
+			);
+
+			rerender(<SpottableComponent component={spy} data-testid={id} spotlightDisabled={false} />);
+
+			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
 		test('should not re-render when focused', () => {

--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -1,5 +1,5 @@
 import useClass from '@enact/core/useClass';
-import {useLayoutEffect, useState} from 'react';
+import {useLayoutEffect, useRef} from 'react';
 
 import {SpottableCore, spottableClass} from './SpottableCore';
 
@@ -58,18 +58,18 @@ const EMPTY_ATTRIBUTES = {};
 
 const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REMOTE_OK_KEY], spotlightDisabled, ...props} = {}) => {
 	const hook = useClass(SpottableCore, {emulateMouse});
-	const [context, setContext] = useState({
+	const contextRef = useRef({
 		prevSpotlightDisabled: spotlightDisabled,
 		spotlightDisabled
 	});
+	const context = contextRef.current;
 
 	const attributes = props.spotlightId ? {'data-spotlight-id': props.spotlightId} : EMPTY_ATTRIBUTES;
 
 	if (context.spotlightDisabled !== spotlightDisabled) {
-		setContext({
-			prevSpotlightDisabled: context.spotlightDisabled,
-			spotlightDisabled
-		});
+		// Mutate in-place to avoid a new object allocation on every render.
+		context.prevSpotlightDisabled = context.spotlightDisabled;
+		context.spotlightDisabled = spotlightDisabled;
 	}
 
 	hook.setPropsAndContext({selectionKeys, spotlightDisabled, ...props}, context);

--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -62,17 +62,17 @@ const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REM
 		prevSpotlightDisabled: spotlightDisabled,
 		spotlightDisabled
 	});
-	const context = contextRef.current;
+	const context = contextRef.current; // eslint-disable-line react-hooks/refs
 
 	const attributes = props.spotlightId ? {'data-spotlight-id': props.spotlightId} : EMPTY_ATTRIBUTES;
 
-	if (context.spotlightDisabled !== spotlightDisabled) {
+	if (context.spotlightDisabled !== spotlightDisabled) { // eslint-disable-line react-hooks/refs
 		// Mutate in-place to avoid a new object allocation on every render.
-		context.prevSpotlightDisabled = context.spotlightDisabled;
-		context.spotlightDisabled = spotlightDisabled;
+		context.prevSpotlightDisabled = context.spotlightDisabled; // eslint-disable-line react-hooks/refs
+		context.spotlightDisabled = spotlightDisabled; // eslint-disable-line react-hooks/refs
 	}
 
-	hook.setPropsAndContext({selectionKeys, spotlightDisabled, ...props}, context);
+	hook.setPropsAndContext({selectionKeys, spotlightDisabled, ...props}, context); // eslint-disable-line react-hooks/refs
 
 	useLayoutEffect(() => {
 		hook.load(getSpotRef() || null);

--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -54,6 +54,8 @@ const REMOTE_OK_KEY = 16777221;
  * @private
  */
 
+const EMPTY_ATTRIBUTES = {};
+
 const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REMOTE_OK_KEY], spotlightDisabled, ...props} = {}) => {
 	const hook = useClass(SpottableCore, {emulateMouse});
 	const [context, setContext] = useState({
@@ -61,10 +63,7 @@ const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REM
 		spotlightDisabled
 	});
 
-	let attributes = {};
-	if (props.spotlightId) {
-		attributes['data-spotlight-id'] = props.spotlightId;
-	}
+	const attributes = props.spotlightId ? {'data-spotlight-id': props.spotlightId} : EMPTY_ATTRIBUTES;
 
 	if (context.spotlightDisabled !== spotlightDisabled) {
 		setContext({

--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -62,7 +62,7 @@ const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REM
 		prevSpotlightDisabled: spotlightDisabled,
 		spotlightDisabled
 	});
-	const context = contextRef.current; // eslint-disable-line react-hooks/refs
+	const context = contextRef.current;
 
 	const attributes = props.spotlightId ? {'data-spotlight-id': props.spotlightId} : EMPTY_ATTRIBUTES;
 

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -112,11 +112,6 @@ const getLandscapeScaleFactor = (type = screenType) => {
 /**
  * Get the closest resolution type based on the `resolution`.
  *
- * This method uses a hybrid distance formula that prioritizes matching the aspect ratio
- * (shape) of the screen over the raw pixel dimensions. This ensures that wide-screen
- * displays are matched to appropriate wide-screen profiles even if a standard 16:9
- * profile is numerically closer in pixel count.
- *
  * @function
  * @memberOf ui/resolution
  * @param {Object} resolution  The resolution object (must include `height` and `width` properties).


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

Reduced per-instance render overhead in spotlight/Spottable, with particular impact in VirtualList scrolling where many spottable items mount and re-render frequently.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Five independent optimizations:

Removed redundant mount render (Spottable.js) — componentDidMount called forceUpdate(), a leftover from the ReactDOM.findDOMNode() era. With WithRef + useImperativeHandle, the DOM node is available before useLayoutEffect fires on the first render, making the second render unnecessary. Saves one full render per Spottable mount.

Converted Spottable class wrapper to a function component (Spottable.js) — the inner Spottable class existed only to hold a handleForceUpdate instance method. It is now a plain function component that calls useReducer for a stable, allocation-free force-update trigger, removing a class instance and its field allocation per mount.

Removed dead delete rest.spotlightId (Spottable.js) — spotlightId is already destructured out of props in SpottableBase, so it is never present in rest. The delete was a no-op on every render.

Conditional Spotlight.getCurrent() (SpottableCore.js) — didUpdate previously called getCurrent() on every render to re-sync this.isFocused. The call is now skipped unless spotlightDisabled is true or a selection cancel may fire. this.isFocused stays accurate via handleFocus/handleBlur events in all other cases. unload() re-queries getCurrent() directly at unmount to keep onSpotlightDisappear reliable.

Reduced per-render allocations (useSpottable.js) — three sources of unnecessary allocations eliminated:

context.current is now mutated in-place instead of being replaced with a new object each render.
A shared EMPTY_ATTRIBUTES constant is used when spotlightId is not set, avoiding an empty-object allocation on every render.
The props rest object (a fresh copy already created by destructuring) is mutated in-place before being passed to hook.setPropsAndContext, avoiding a second spread-merge allocation that previously occurred on every render.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

No API or behavioral changes. Render-count expectations in shouldComponentUpdate tests updated to reflect the removed mount-time forceUpdate().


### Links
[//]: # (Related issues, references)

NXT-10864
Related: findDOMNode removal — commit 33c27d5 (WRQ-19325)

### Comments
