### PR TITLE
NXT-8994: Add push trigger to CI workflow for codecov base coverage

### DIFF
--- a/.github/workflows/ci-branch.yml
+++ b/.github/workflows/ci-branch.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - develop
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -9,12 +13,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-branch-${{ github.event.pull_request.number }}
+  group: ci-branch-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   branch:
     uses: ./.github/workflows/ci-reusable.yml
     with:
-      checkout-ref: ${{ github.event.pull_request.head.sha }}
+      checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added

After migrating from Travis CI to GitHub Actions (#3397), codecov base coverage for the `develop` branch was never updated because the CI workflow only triggers on `pull_request` events. This caused PR codecov reports to compare against stale Travis-era baseline data, showing false coverage decreases (e.g., -2.74% in #3379) and blocking PR merges.

### Resolution

Add `push` trigger on `develop` and `master` branches to `ci-branch.yml` so that codecov base coverage is updated when PRs are merged. Also fix `concurrency` group and `checkout-ref` to work correctly for both push and pull_request events.

### Additional Considerations

- After this PR is merged, the next push to develop will update the codecov baseline with GitHub Actions coverage data
- Subsequent PR codecov reports will show accurate coverage diffs
- No API-breaking changes

### Links

- NXT-8994

### Comments
Enact-DCO-1.0-Signed-off-by: kyuman lim (kyuman.lim@lge.com)