### PR TITLE
NXT-7491 [2027TV] POC on 2way focus browsing

### DIFF
--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -14,6 +14,11 @@ No significant changes.
 ## [5.4.4] - 2026-05-22
 
 No significant changes.
+## [unreleased]
+
+### Fixed
+
+- `spotlight` keyboard focus flow for open dropdown popups so Tab/Shift+Tab traversal is predictable between open lists and can continue to nearby controls after popup navigation
 
 ## [5.5.0] - 2026-05-08
 
@@ -28,7 +33,6 @@ No significant changes.
 ### Fixed
 
 - `spotlight` to focus visible children of elements which do not have `overflow:true`
-- `spotlight` keyboard focus flow for open dropdown popups so Tab/Shift+Tab traversal is predictable between open lists and can continue to nearby controls after popup navigation
 
 ## [5.4.3] - 2026-02-26
 

--- a/packages/spotlight/CHANGELOG.md
+++ b/packages/spotlight/CHANGELOG.md
@@ -28,6 +28,7 @@ No significant changes.
 ### Fixed
 
 - `spotlight` to focus visible children of elements which do not have `overflow:true`
+- `spotlight` keyboard focus flow for open dropdown popups so Tab/Shift+Tab traversal is predictable between open lists and can continue to nearby controls after popup navigation
 
 ## [5.4.3] - 2026-02-26
 

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -244,11 +244,20 @@ const getSubContainerSelector = (node) => {
 const getContainerNode = (containerId) => {
 	if (!containerId) {
 		return null;
-	} else if (containerId === rootContainerId) {
+	}
+
+	const node = document.querySelector(`[${containerAttribute}="${containerId}"]`);
+	if (node) {
+		return node;
+	}
+
+	// rootContainerId may not have a matching DOM node (e.g. during tests or SSR), in which case
+	// the document itself is used so that queries still traverse the full DOM tree.
+	if (containerId === rootContainerId) {
 		return document;
 	}
 
-	return document.querySelector(`[${containerAttribute}="${containerId}"]`);
+	return null;
 };
 
 /**
@@ -300,6 +309,61 @@ const getOwnedNodes = (node, selector) => {
 	}
 
 	return [];
+};
+
+/**
+ * Returns the nearest `[aria-owns]` owner whose owned subtree contains `containerNode`.
+ *
+ * @param   {Node}    containerNode  Popup container node or descendant
+ * @returns {Node|null}              Owner element, or null
+ * @memberof spotlight/container
+ * @private
+ */
+const getPopupOwnerElement = (containerNode) => {
+	if (!containerNode) {
+		return null;
+	}
+
+	const owners = document.querySelectorAll('[aria-owns]');
+	for (const owner of owners) {
+		if (getOwnedNodes(owner, '*').some(n => n.contains(containerNode))) {
+			return owner;
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Returns IDs of `self-only` spotlight containers reachable through the `aria-owns` of
+ * `ownerNode`, excluding `excludeContainerId`.
+ *
+ * @param   {Node}      ownerNode            Owner element carrying `aria-owns`
+ * @param   {String}    excludeContainerId   Container ID to skip
+ * @returns {String[]}                       Owned self-only container IDs
+ * @memberof spotlight/container
+ * @private
+ */
+const getOwnedSelfOnlyContainerIds = (ownerNode, excludeContainerId) => {
+	const ownedContainerSelector = '[data-spotlight-container][data-spotlight-id]';
+	const ids = [];
+
+	for (const ownedNode of getOwnedNodes(ownerNode, '*')) {
+		const containerNodes = [
+			...(ownedNode.matches?.(ownedContainerSelector) ? [ownedNode] : []),
+			...ownedNode.querySelectorAll(ownedContainerSelector)
+		];
+		for (const containerNode of containerNodes) {
+			const id = getContainerId(containerNode);
+			if (!id || id === excludeContainerId) continue;
+			const cfg = getContainerConfig(id);
+			if (cfg?.restrict === 'self-only') {
+				ids.push(id);
+			}
+		}
+	}
+
+	return ids;
 };
 
 /**
@@ -1136,6 +1200,9 @@ export {
 	// Keep
 	addContainer,
 	containerAttribute,
+	getOwnedNodes,
+	getOwnedSelfOnlyContainerIds,
+	getPopupOwnerElement,
 	configureDefaults,
 	configureContainer,
 	getContainerFocusTarget,

--- a/packages/spotlight/src/container.js
+++ b/packages/spotlight/src/container.js
@@ -376,7 +376,7 @@ const getOwnedSelfOnlyContainerIds = (ownerNode, excludeContainerId) => {
  * @memberof spotlight/container
  * @public
  */
-const getSpottableDescendants = (containerId) => {
+const getSpottableCandidates = (containerId, applyNavigableFilter = true) => {
 	const node = getContainerNode(containerId);
 
 	// if it's falsy or is a disabled container, return an empty set
@@ -400,8 +400,23 @@ const getSpottableDescendants = (containerId) => {
 
 	candidates.push(...getOwnedNodes(node, selector));
 
-	return candidates.filter(n => navigableFilter(n, containerId));
+	return applyNavigableFilter ?
+		candidates.filter(n => navigableFilter(n, containerId)) :
+		candidates;
 };
+
+const getSpottableDescendants = (containerId) => getSpottableCandidates(containerId, true);
+
+/**
+ * Like {@link getSpottableDescendants} but ignores `navigableFilter`. Used by Tab linear traversal
+ * so 5-way-only filters (e.g. TabLayout collapsed tabs) do not remove controls from Tab order.
+ *
+ * @param   {String}  containerId  ID of container
+ * @returns {Node[]}               Array of spottable elements and containers.
+ * @memberof spotlight/container
+ * @private
+ */
+const getSpottableDescendantsForTab = (containerId) => getSpottableCandidates(containerId, false);
 
 /**
  * Recursively get spottable descendants by including elements within sub-containers that do not
@@ -669,6 +684,48 @@ const isNavigable = (node, containerId, verify) => {
 	}
 
 	return navigableFilter(node, containerId);
+};
+
+/**
+ * Like {@link isNavigable} but ignores `navigableFilter` (still checks visibility and disabled state).
+ *
+ * @param   {Node}     node         DOM node to check if it is navigable
+ * @param   {String}   containerId  ID of the container containing `node`
+ * @param   {Boolean}  verify       `true` to verify the node matches the container's `selector`
+ * @returns {Boolean}               `true` if `node` is navigable for Tab traversal
+ * @memberof spotlight/container
+ * @private
+ */
+const isNavigableForTab = (node, containerId, verify) => {
+	if (!node) {
+		return false;
+	}
+
+	// Prefer layout bounds over offset* — collapsed/icon-only controls can report 0 offset* while
+	// still being visible (e.g. TabLayout sidebar tabs).
+	if (process.env.NODE_ENV !== 'test') {
+		const {width, height} = getRect(node);
+		if (width <= 0 && height <= 0) {
+			return false;
+		}
+	}
+
+	const containerNode = getContainerNode(containerId);
+	if (containerNode !== document && containerNode.dataset[disabledKey] === 'true') {
+		return false;
+	}
+
+	const nodeStyle = node && isWindowReady() && window.getComputedStyle(node);
+	if (!nodeStyle || nodeStyle.display === 'none' || nodeStyle.visibility === 'hidden') {
+		return false;
+	}
+
+	const config = getContainerConfig(containerId);
+	if (verify && config && config.selector && !isContainer(node) && !matchSelector(config.selector, node) && !(GlobalConfig.isStandardFocusableMode && isStandardFocusable(node))) {
+		return false;
+	}
+
+	return true;
 };
 
 /**
@@ -1214,8 +1271,10 @@ export {
 	getNavigableContainersForNode,
 	getPositionTargetOnFocus,
 	getSpottableDescendants,
+	getSpottableDescendantsForTab,
 	isContainer,
 	isNavigable,
+	isNavigableForTab,
 	isWithinOverflowContainer,
 	mayActivateContainer,
 	notifyLeaveContainer,

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -28,6 +28,7 @@ import {spottableClass} from '../Spottable';
 import {getPausedInstance, isPaused, pause, resume} from '../Pause';
 
 import {getInputType} from './inputType';
+import {createTabTraversal} from './tabTraversal';
 import {contains} from './utils';
 
 import {
@@ -41,8 +42,6 @@ import {
 	getContainerNode,
 	getContainersForNode,
 	getLastContainer,
-	getOwnedSelfOnlyContainerIds,
-	getPopupOwnerElement,
 	getSpottableDescendants,
 	isContainer,
 	isContainer5WayHoldable,
@@ -98,17 +97,6 @@ const isLeft = is('left');
 const isRight = is('right');
 const isTab = is('tab');
 const isUp = is('up');
-
-// Vertical centers within this distance share a Tab row; horizontal position breaks ties.
-const TAB_ROW_THRESHOLD = 24;
-
-// CSS class applied by @enact/i18n I18nDecorator to the app root for RTL locales.
-const I18N_RTL_CLASS = 'enact-locale-right-to-left';
-
-// Per-keypress cache for getLinearTargetsInContainer, scoped to one handleTab call.
-let _linearTargetsCache = null;
-
-let _tabNavTestHooks = {};
 
 /**
  * Translates keyCodes into 5-way direction descriptions (e.g. `'down'`)
@@ -322,6 +310,13 @@ const Spotlight = (function () {
 		return next.reduce((focused, target) => focused || Spotlight.focus(target), false);
 	}
 
+	const {runWithLinearTargetsCache, spotLinear} = createTabTraversal({
+		focusElement,
+		getCurrent,
+		isPaused,
+		restoreFocus
+	});
+
 	// The below should be gated on non-production environment only.
 	function assignFocusPreview (elem) {
 		const directions = ['up', 'right', 'down', 'left'],
@@ -484,311 +479,6 @@ const Spotlight = (function () {
 	}
 
 	/*
-	 * Whether the document uses right-to-left layout for Tab ordering.
-	 *
-	 * Intentionally does not import @enact/i18n:
-	 * - `locale.isRtlLocale` is callback-based and depends on ilib; Tab handling needs a
-	 *   synchronous answer on every keydown without adding that heavyweight dependency to spotlight.
-	 * - `util.isRtlText` detects RTL characters in a string, not page layout direction.
-	 *
-	 * Instead, read layout direction already reflected on the DOM by the app or I18nDecorator:
-	 * the `dir` attribute when set, and the `enact-locale-right-to-left` class on the app root.
-	 */
-	function isRtlDocument () {
-		const root = document.documentElement;
-		const body = document.body;
-		const dir = (root && root.dir) || (body && body.dir);
-
-		if (typeof dir === 'string' && dir.toLowerCase() === 'rtl') {
-			return true;
-		}
-
-		if (root?.classList.contains(I18N_RTL_CLASS) || body?.classList.contains(I18N_RTL_CLASS)) {
-			return true;
-		}
-
-		return Boolean(document.querySelector('.' + I18N_RTL_CLASS));
-	}
-
-	/*
-	 * Chooses the subtree root for Tab linear traversal. When focus sits inside a portaled
-	 * `self-only` container (e.g. contextual popup list), descendants of the app root do not
-	 * include that subtree, so using the root container would mix in unrelated controls. The
-	 * innermost `self-only` ancestor matches the modal boundary the user is in.
-	 */
-	function getLinearTabSearchContainerId (focused) {
-		if (isPaused()) {
-			return getLastContainer() || rootContainerId;
-		}
-		if (!focused) {
-			return rootContainerId;
-		}
-		const ids = getContainersForNode(focused);
-		for (let i = ids.length - 1; i > 0; i--) {
-			const cfg = getContainerConfig(ids[i]);
-			if (cfg && cfg.restrict === 'self-only') {
-				return ids[i];
-			}
-		}
-
-		return rootContainerId;
-	}
-
-	/*
-	 * Whether point (aX,aY) comes before (bX,bY) in the same top-to-bottom, left-to-right order
-	 * used by `getLinearTargetsInContainer` (must stay in sync with that sort).
-	 */
-	function comesBeforeInTabOrder (aX, aY, bX, bY, isRtl) {
-		if (Math.abs(aY - bY) > TAB_ROW_THRESHOLD) {
-			return aY < bY;
-		}
-		if (aX !== bX) {
-			return isRtl ? aX > bX : aX < bX;
-		}
-
-		return false;
-	}
-
-	function resolveTargetToOpenPopupItem (target, currentPopupContainerId, isForward) {
-		const ownerNode = target?.closest?.('[aria-owns]');
-		if (!ownerNode || ownerNode === document.body) {
-			return target;
-		}
-
-		for (const popupContainerId of getOwnedSelfOnlyContainerIds(ownerNode, currentPopupContainerId)) {
-			const popupTargets = getLinearTargetsInContainer(popupContainerId);
-			const popupTargetEntry = isForward ? popupTargets[0] : popupTargets[popupTargets.length - 1];
-			const popupTarget = popupTargetEntry?.target || getTargetByContainer(popupContainerId);
-			if (popupTarget) {
-				return popupTarget;
-			}
-		}
-
-		return target;
-	}
-
-	function isTargetInSelfOnlyContainer (target) {
-		if (!target) {
-			return false;
-		}
-
-		// Use DOM ancestry only. `getContainersForNode()` may include containers connected via
-		// `aria-owns`, which would incorrectly mark popup owner controls as inside self-only popups.
-		const containerNode = target.closest?.('[data-spotlight-container][data-spotlight-id]');
-		if (!containerNode) {
-			return false;
-		}
-
-		const containerId = getContainerId(containerNode);
-		if (!containerId || containerId === rootContainerId) {
-			return false;
-		}
-
-		const config = getContainerConfig(containerId);
-		return Boolean(config && config.restrict === 'self-only');
-	}
-
-	function findLinearTabExitTargetInTargets (targets, ax, ay, isRtl, isForward) {
-		const orderedTargets = isForward ? targets : [...targets].reverse();
-
-		for (const {target, x: cx, y: cy} of orderedTargets) {
-			if (!target || isTargetInSelfOnlyContainer(target)) {
-				continue;
-			}
-			const inOrder = isForward ?
-				comesBeforeInTabOrder(ax, ay, cx, cy, isRtl) :
-				comesBeforeInTabOrder(cx, cy, ax, ay, isRtl);
-			if (inOrder) {
-				// Do not defer popup owners; resolveTargetToOpenPopupItem redirects into open popups.
-				return target;
-			}
-		}
-
-		return null;
-	}
-
-	/*
-	 * After Tab reaches the end (or start) of a `self-only` popup list, pick the next spottable
-	 * outside the popup: the immediate successor (or predecessor) in the same global linear order
-	 * as the root container, so grids work for horizontal and vertical neighbors.
-	 */
-	function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, isForward) {
-		const containerNode = getContainerNode(selfOnlyContainerId);
-		if (!containerNode) {
-			return null;
-		}
-
-		const popupOwner = getPopupOwnerElement(containerNode);
-		const focusCenter = getRect(focusedElement).center;
-		const isRtl = isRtlDocument();
-		const rootTargets = getLinearTargetsInContainer(rootContainerId);
-
-		const pickExitTarget = (x, y, searchForward) => {
-			const candidate = findLinearTabExitTargetInTargets(
-				rootTargets,
-				x,
-				y,
-				isRtl,
-				searchForward
-			);
-			return candidate ?
-				resolveTargetToOpenPopupItem(candidate, selfOnlyContainerId, isForward) :
-				null;
-		};
-
-		if (isForward) {
-			const exitTarget = pickExitTarget(focusCenter.x, focusCenter.y, true);
-			if (exitTarget) {
-				return exitTarget;
-			}
-		}
-
-		if (popupOwner) {
-			const ownerRect = getRect(popupOwner);
-			// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
-			const exitTarget = pickExitTarget(ownerRect.center.x, ownerRect.top + 1, isForward);
-			if (exitTarget) {
-				return exitTarget;
-			}
-		}
-
-		if (!isForward) {
-			return pickExitTarget(focusCenter.x, focusCenter.y, false);
-		}
-
-		return null;
-	}
-
-	function getLinearTargetContainerId (target) {
-		// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
-		const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
-		if (containerNode) {
-			const domContainerId = getContainerId(containerNode);
-			if (domContainerId) {
-				return domContainerId;
-			}
-		}
-
-		const containerIds = getContainersForNode(target);
-		return last(containerIds);
-	}
-
-	function getLinearTargetsInContainer (containerId) {
-		if (_linearTargetsCache?.has(containerId)) {
-			return _linearTargetsCache.get(containerId);
-		}
-
-		const isRtl = isRtlDocument();
-		const visitedContainers = new Set();
-		const visitedTargets = new Set();
-
-		const gatherSpottableLeaves = (id) => {
-			if (!id || visitedContainers.has(id)) {
-				return [];
-			}
-
-			visitedContainers.add(id);
-
-			return getSpottableDescendants(id).reduce((result, candidate) => {
-				if (isContainer(candidate)) {
-					const nestedContainerId = getContainerId(candidate);
-					result.push(...gatherSpottableLeaves(nestedContainerId));
-				} else if (!visitedTargets.has(candidate)) {
-					visitedTargets.add(candidate);
-					result.push(candidate);
-				}
-
-				return result;
-			}, []);
-		};
-
-		const targets = gatherSpottableLeaves(containerId)
-			.filter((target) => {
-				const targetContainerId = getLinearTargetContainerId(target);
-				return isNavigable(target, targetContainerId, true);
-			})
-			.map((target, order) => {
-				const {center} = getRect(target);
-				return {order, target, x: center.x, y: center.y};
-			})
-			.sort((a, b) => {
-				if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
-				if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
-				return a.order - b.order;
-			});
-
-		if (_linearTargetsCache) {
-			_linearTargetsCache.set(containerId, targets);
-		}
-
-		return targets;
-	}
-
-	function spotLinear (isForward) {
-		let currentFocusedElement = getCurrent();
-
-		if (!currentFocusedElement) {
-			if (!restoreFocus()) {
-				return false;
-			}
-			currentFocusedElement = getCurrent();
-			if (!currentFocusedElement) {
-				return false;
-			}
-		}
-
-		const searchContainerId = getLinearTabSearchContainerId(currentFocusedElement);
-		const linearTargets = getLinearTargetsInContainer(searchContainerId);
-		if (!linearTargets.length) {
-			return false;
-		}
-		let currentIndex = linearTargets.findIndex(({target}) => target === currentFocusedElement);
-		if (currentIndex < 0) {
-			const nearestTarget = getNearestTargetFromPosition(getRect(currentFocusedElement).center, searchContainerId);
-			currentIndex = nearestTarget ?
-				linearTargets.findIndex(({target}) => target === nearestTarget) :
-				-1;
-			// When no nearest target can be found (e.g. position is NaN), keep currentIndex at -1
-			// so that nextIndex = -1 + 1 = 0, landing on the first element in the list.
-			// Treating 0 as the virtual "current" would skip the first element entirely.
-		}
-
-		const nextIndex = currentIndex + (isForward ? 1 : -1);
-		const scopeIsSelfOnly = searchContainerId !== rootContainerId &&
-			getContainerConfig(searchContainerId)?.restrict === 'self-only';
-
-		if (nextIndex >= linearTargets.length) {
-			if (scopeIsSelfOnly && isForward) {
-				const exitTarget = findLinearTabExitTarget(
-					currentFocusedElement,
-					searchContainerId,
-					true
-				);
-				if (exitTarget) {
-					return focusElement(exitTarget, getContainersForNode(exitTarget));
-				}
-			}
-			return false;
-		}
-		if (nextIndex < 0) {
-			if (scopeIsSelfOnly && !isForward) {
-				const exitTarget = findLinearTabExitTarget(
-					currentFocusedElement,
-					searchContainerId,
-					false
-				);
-				if (exitTarget) {
-					return focusElement(exitTarget, getContainersForNode(exitTarget));
-				}
-			}
-			return false;
-		}
-
-		const nextTarget = linearTargets[nextIndex].target;
-		return focusElement(nextTarget, getContainersForNode(nextTarget));
-	}
-
-	/*
 	 * Tab/Shift+Tab handler. Runs spotLinear with a per-keypress target cache and calls
 	 * preventDefault when focus moved or when paused (to keep Tab inside a modal overlay).
 	 */
@@ -804,13 +494,7 @@ const Spotlight = (function () {
 			}
 		}
 
-		_linearTargetsCache = new Map();
-		let handled;
-		try {
-			handled = spotLinear(!evt.shiftKey);
-		} finally {
-			_linearTargetsCache = null;
-		}
+		const handled = runWithLinearTargetsCache(() => spotLinear(!evt.shiftKey));
 
 		if (handled || (blocked && isPaused())) {
 			preventDefault(evt);
@@ -1356,33 +1040,12 @@ const Spotlight = (function () {
 
 	};
 
-	_tabNavTestHooks = {
-		findLinearTabExitTarget,
-		getLinearTabSearchContainerId,
-		comesBeforeInTabOrder,
-		resolveTargetToOpenPopupItem,
-		isTargetInSelfOnlyContainer,
-		findLinearTabExitTargetInTargets,
-		getLinearTargetContainerId,
-		getLinearTargetsInContainer,
-		runWithLinearTargetsCache: (fn) => {
-			_linearTargetsCache = new Map();
-			try {
-				return fn();
-			} finally {
-				_linearTargetsCache = null;
-			}
-		},
-		spotLinear
-	};
-
 	return exports;
 
 })();
 
 export default Spotlight;
 export {
-	_tabNavTestHooks,
 	getDirection,
 	Spotlight
 };

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -605,46 +605,39 @@ const Spotlight = (function () {
 		const isRtl = isRtlDocument();
 		const rootTargets = getLinearTargetsInContainer(rootContainerId);
 
-		if (isForward) {
-			const fallbackTarget = findLinearTabExitTargetInTargets(
+		const pickExitTarget = (x, y, searchForward) => {
+			const candidate = findLinearTabExitTargetInTargets(
 				rootTargets,
-				focusCenter.x,
-				focusCenter.y,
+				x,
+				y,
 				isRtl,
-				true
+				searchForward
 			);
-			if (fallbackTarget) {
-				return resolveTargetToOpenPopupItem(fallbackTarget, selfOnlyContainerId, true);
+			return candidate ?
+				resolveTargetToOpenPopupItem(candidate, selfOnlyContainerId, isForward) :
+				null;
+		};
+
+		if (isForward) {
+			const exitTarget = pickExitTarget(focusCenter.x, focusCenter.y, true);
+			if (exitTarget) {
+				return exitTarget;
 			}
 		}
 
 		if (popupOwner) {
 			const ownerRect = getRect(popupOwner);
 			// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
-			const ownerTarget = findLinearTabExitTargetInTargets(
-				rootTargets,
-				ownerRect.center.x,
-				ownerRect.top + 1,
-				isRtl,
-				isForward
-			);
-			if (ownerTarget) {
-				return resolveTargetToOpenPopupItem(ownerTarget, selfOnlyContainerId, isForward);
+			const exitTarget = pickExitTarget(ownerRect.center.x, ownerRect.top + 1, isForward);
+			if (exitTarget) {
+				return exitTarget;
 			}
 		}
 
 		if (!isForward) {
-			const fallbackTarget = findLinearTabExitTargetInTargets(
-				rootTargets,
-				focusCenter.x,
-				focusCenter.y,
-				isRtl,
-				false
-			);
-			if (fallbackTarget) {
-				return resolveTargetToOpenPopupItem(fallbackTarget, selfOnlyContainerId, false);
-			}
+			return pickExitTarget(focusCenter.x, focusCenter.y, false);
 		}
+
 		return null;
 	}
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -1344,6 +1344,14 @@ const Spotlight = (function () {
 		findLinearTabExitTargetInTargets,
 		getLinearTargetContainerId,
 		getLinearTargetsInContainer,
+		runWithLinearTargetsCache: (fn) => {
+			_linearTargetsCache = new Map();
+			try {
+				return fn();
+			} finally {
+				_linearTargetsCache = null;
+			}
+		},
 		spotLinear
 	};
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -312,7 +312,6 @@ const Spotlight = (function () {
 	const {runWithLinearTargetsCache, spotLinear} = createTabTraversal({
 		focusElement,
 		getCurrent,
-		isPaused,
 		restoreFocus
 	});
 

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -102,6 +102,9 @@ const isUp = is('up');
 // Vertical centers within this distance share a Tab row; horizontal position breaks ties.
 const TAB_ROW_THRESHOLD = 24;
 
+// CSS class applied by @enact/i18n I18nDecorator to the app root for RTL locales.
+const I18N_RTL_CLASS = 'enact-locale-right-to-left';
+
 // Per-keypress cache for getLinearTargetsInContainer, scoped to one handleTab call.
 let _linearTargetsCache = null;
 
@@ -480,16 +483,31 @@ const Spotlight = (function () {
 		}
 	}
 
-	// Reads the `dir` attribute already written to the DOM by I18nDecorator after locale resolution.
-	// i18n/locale.isRtlLocale is async (callback-based) and i18n/util.isRtlText operates on string
-	// content, so neither is a suitable synchronous replacement here. spotlight does not depend on
-	// @enact/i18n, so we read the DOM directly rather than introduce that package dependency.
+	/*
+	 * Whether the document uses right-to-left layout for Tab ordering.
+	 *
+	 * Intentionally does not import @enact/i18n:
+	 * - `locale.isRtlLocale` is callback-based and depends on ilib; Tab handling needs a
+	 *   synchronous answer on every keydown without adding that heavyweight dependency to spotlight.
+	 * - `util.isRtlText` detects RTL characters in a string, not page layout direction.
+	 *
+	 * Instead, read layout direction already reflected on the DOM by the app or I18nDecorator:
+	 * the `dir` attribute when set, and the `enact-locale-right-to-left` class on the app root.
+	 */
 	function isRtlDocument () {
-		const rootDir = document.documentElement && document.documentElement.dir;
-		const bodyDir = document.body && document.body.dir;
-		const dir = rootDir || bodyDir;
+		const root = document.documentElement;
+		const body = document.body;
+		const dir = (root && root.dir) || (body && body.dir);
 
-		return typeof dir === 'string' && dir.toLowerCase() === 'rtl';
+		if (typeof dir === 'string' && dir.toLowerCase() === 'rtl') {
+			return true;
+		}
+
+		if (root?.classList.contains(I18N_RTL_CLASS) || body?.classList.contains(I18N_RTL_CLASS)) {
+			return true;
+		}
+
+		return Boolean(document.querySelector('.' + I18N_RTL_CLASS));
 	}
 
 	/*

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -82,7 +82,6 @@ import {
 } from './target';
 
 import {
-	getRect,
 	matchSelector,
 	parseSelector
 } from './utils';

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -18,7 +18,7 @@
  * @exports getDirection
  */
 
-import {is} from '@enact/core/keymap';
+import {add as addKeyCode, is} from '@enact/core/keymap';
 import {isWindowReady} from '@enact/core/snapshot';
 import platform from '@enact/core/platform';
 import last from 'ramda/src/last';
@@ -41,6 +41,8 @@ import {
 	getContainerNode,
 	getContainersForNode,
 	getLastContainer,
+	getOwnedSelfOnlyContainerIds,
+	getPopupOwnerElement,
 	getSpottableDescendants,
 	isContainer,
 	isContainer5WayHoldable,
@@ -81,15 +83,29 @@ import {
 } from './target';
 
 import {
+	getRect,
 	matchSelector,
 	parseSelector
 } from './utils';
+
+// Tab (9) is not part of the default Enact keymap (which only covers 5-way keys registered
+// by the platform/app). Spotlight owns Tab navigation, so it registers the key code here.
+addKeyCode('tab', 9);
 
 const isDown = is('down');
 const isEnter = is('enter');
 const isLeft = is('left');
 const isRight = is('right');
+const isTab = is('tab');
 const isUp = is('up');
+
+// Vertical centers within this distance share a Tab row; horizontal position breaks ties.
+const TAB_ROW_THRESHOLD = 24;
+
+// Per-keypress cache for getLinearTargetsInContainer, scoped to one handleTab call.
+let _linearTargetsCache = null;
+
+let _tabNavTestHooks = {};
 
 /**
  * Translates keyCodes into 5-way direction descriptions (e.g. `'down'`)
@@ -464,19 +480,344 @@ const Spotlight = (function () {
 		}
 	}
 
+	// Reads the `dir` attribute already written to the DOM by I18nDecorator after locale resolution.
+	// i18n/locale.isRtlLocale is async (callback-based) and i18n/util.isRtlText operates on string
+	// content, so neither is a suitable synchronous replacement here. spotlight does not depend on
+	// @enact/i18n, so we read the DOM directly rather than introduce that package dependency.
+	function isRtlDocument () {
+		const rootDir = document.documentElement && document.documentElement.dir;
+		const bodyDir = document.body && document.body.dir;
+		const dir = rootDir || bodyDir;
+
+		return typeof dir === 'string' && dir.toLowerCase() === 'rtl';
+	}
+
+	/*
+	 * Chooses the subtree root for Tab linear traversal. When focus sits inside a portaled
+	 * `self-only` container (e.g. contextual popup list), descendants of the app root do not
+	 * include that subtree, so using the root container would mix in unrelated controls. The
+	 * innermost `self-only` ancestor matches the modal boundary the user is in.
+	 */
+	function getLinearTabSearchContainerId (focused) {
+		if (isPaused()) {
+			return getLastContainer() || rootContainerId;
+		}
+		if (!focused) {
+			return rootContainerId;
+		}
+		const ids = getContainersForNode(focused);
+		for (let i = ids.length - 1; i > 0; i--) {
+			const cfg = getContainerConfig(ids[i]);
+			if (cfg && cfg.restrict === 'self-only') {
+				return ids[i];
+			}
+		}
+
+		return rootContainerId;
+	}
+
+	/*
+	 * Whether point (aX,aY) comes before (bX,bY) in the same top-to-bottom, left-to-right order
+	 * used by `getLinearTargetsInContainer` (must stay in sync with that sort).
+	 */
+	function comesBeforeInTabOrder (aX, aY, bX, bY, isRtl) {
+		if (Math.abs(aY - bY) > TAB_ROW_THRESHOLD) {
+			return aY < bY;
+		}
+		if (aX !== bX) {
+			return isRtl ? aX > bX : aX < bX;
+		}
+
+		return false;
+	}
+
+	function resolveTargetToOpenPopupItem (target, currentPopupContainerId, isForward) {
+		const ownerNode = target?.closest?.('[aria-owns]');
+		if (!ownerNode || ownerNode === document.body) {
+			return target;
+		}
+
+		for (const popupContainerId of getOwnedSelfOnlyContainerIds(ownerNode, currentPopupContainerId)) {
+			const popupTargets = getLinearTargetsInContainer(popupContainerId);
+			const popupTargetEntry = isForward ? popupTargets[0] : popupTargets[popupTargets.length - 1];
+			const popupTarget = popupTargetEntry?.target || getTargetByContainer(popupContainerId);
+			if (popupTarget) {
+				return popupTarget;
+			}
+		}
+
+		return target;
+	}
+
+	function isTargetInSelfOnlyContainer (target) {
+		if (!target) {
+			return false;
+		}
+
+		// Use DOM ancestry only. `getContainersForNode()` may include containers connected via
+		// `aria-owns`, which would incorrectly mark popup owner controls as inside self-only popups.
+		const containerNode = target.closest?.('[data-spotlight-container][data-spotlight-id]');
+		if (!containerNode) {
+			return false;
+		}
+
+		const containerId = getContainerId(containerNode);
+		if (!containerId || containerId === rootContainerId) {
+			return false;
+		}
+
+		const config = getContainerConfig(containerId);
+		return Boolean(config && config.restrict === 'self-only');
+	}
+
+	function findLinearTabExitTargetInTargets (targets, ax, ay, isRtl, isForward) {
+		const orderedTargets = isForward ? targets : [...targets].reverse();
+
+		for (const {target, x: cx, y: cy} of orderedTargets) {
+			if (!target || isTargetInSelfOnlyContainer(target)) {
+				continue;
+			}
+			const inOrder = isForward ?
+				comesBeforeInTabOrder(ax, ay, cx, cy, isRtl) :
+				comesBeforeInTabOrder(cx, cy, ax, ay, isRtl);
+			if (inOrder) {
+				// Do not defer popup owners; resolveTargetToOpenPopupItem redirects into open popups.
+				return target;
+			}
+		}
+
+		return null;
+	}
+
+	/*
+	 * After Tab reaches the end (or start) of a `self-only` popup list, pick the next spottable
+	 * outside the popup: the immediate successor (or predecessor) in the same global linear order
+	 * as the root container, so grids work for horizontal and vertical neighbors.
+	 */
+	function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, isForward) {
+		const containerNode = getContainerNode(selfOnlyContainerId);
+		if (!containerNode) {
+			return null;
+		}
+
+		const popupOwner = getPopupOwnerElement(containerNode);
+		const focusCenter = getRect(focusedElement).center;
+		const isRtl = isRtlDocument();
+		const rootTargets = getLinearTargetsInContainer(rootContainerId);
+
+		if (isForward) {
+			const fallbackTarget = findLinearTabExitTargetInTargets(
+				rootTargets,
+				focusCenter.x,
+				focusCenter.y,
+				isRtl,
+				true
+			);
+			if (fallbackTarget) {
+				return resolveTargetToOpenPopupItem(fallbackTarget, selfOnlyContainerId, true);
+			}
+		}
+
+		if (popupOwner) {
+			const ownerRect = getRect(popupOwner);
+			// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
+			const ownerTarget = findLinearTabExitTargetInTargets(
+				rootTargets,
+				ownerRect.center.x,
+				ownerRect.top + 1,
+				isRtl,
+				isForward
+			);
+			if (ownerTarget) {
+				return resolveTargetToOpenPopupItem(ownerTarget, selfOnlyContainerId, isForward);
+			}
+		}
+
+		if (!isForward) {
+			const fallbackTarget = findLinearTabExitTargetInTargets(
+				rootTargets,
+				focusCenter.x,
+				focusCenter.y,
+				isRtl,
+				false
+			);
+			if (fallbackTarget) {
+				return resolveTargetToOpenPopupItem(fallbackTarget, selfOnlyContainerId, false);
+			}
+		}
+		return null;
+	}
+
+	function getLinearTargetContainerId (target) {
+		// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
+		const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
+		if (containerNode) {
+			const domContainerId = getContainerId(containerNode);
+			if (domContainerId) {
+				return domContainerId;
+			}
+		}
+
+		const containerIds = getContainersForNode(target);
+		return last(containerIds);
+	}
+
+	function getLinearTargetsInContainer (containerId) {
+		if (_linearTargetsCache?.has(containerId)) {
+			return _linearTargetsCache.get(containerId);
+		}
+
+		const isRtl = isRtlDocument();
+		const visitedContainers = new Set();
+		const visitedTargets = new Set();
+
+		const gatherSpottableLeaves = (id) => {
+			if (!id || visitedContainers.has(id)) {
+				return [];
+			}
+
+			visitedContainers.add(id);
+
+			return getSpottableDescendants(id).reduce((result, candidate) => {
+				if (isContainer(candidate)) {
+					const nestedContainerId = getContainerId(candidate);
+					result.push(...gatherSpottableLeaves(nestedContainerId));
+				} else if (!visitedTargets.has(candidate)) {
+					visitedTargets.add(candidate);
+					result.push(candidate);
+				}
+
+				return result;
+			}, []);
+		};
+
+		const targets = gatherSpottableLeaves(containerId)
+			.filter((target) => {
+				const targetContainerId = getLinearTargetContainerId(target);
+				return isNavigable(target, targetContainerId, true);
+			})
+			.map((target, order) => {
+				const {center} = getRect(target);
+				return {order, target, x: center.x, y: center.y};
+			})
+			.sort((a, b) => {
+				if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
+				if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
+				return a.order - b.order;
+			});
+
+		if (_linearTargetsCache) {
+			_linearTargetsCache.set(containerId, targets);
+		}
+
+		return targets;
+	}
+
+	function spotLinear (isForward) {
+		let currentFocusedElement = getCurrent();
+
+		if (!currentFocusedElement) {
+			if (!restoreFocus()) {
+				return false;
+			}
+			currentFocusedElement = getCurrent();
+			if (!currentFocusedElement) {
+				return false;
+			}
+		}
+
+		const searchContainerId = getLinearTabSearchContainerId(currentFocusedElement);
+		const linearTargets = getLinearTargetsInContainer(searchContainerId);
+		if (!linearTargets.length) {
+			return false;
+		}
+		let currentIndex = linearTargets.findIndex(({target}) => target === currentFocusedElement);
+		if (currentIndex < 0) {
+			const nearestTarget = getNearestTargetFromPosition(getRect(currentFocusedElement).center, searchContainerId);
+			currentIndex = nearestTarget ?
+				linearTargets.findIndex(({target}) => target === nearestTarget) :
+				-1;
+			// When no nearest target can be found (e.g. position is NaN), keep currentIndex at -1
+			// so that nextIndex = -1 + 1 = 0, landing on the first element in the list.
+			// Treating 0 as the virtual "current" would skip the first element entirely.
+		}
+
+		const nextIndex = currentIndex + (isForward ? 1 : -1);
+		const scopeIsSelfOnly = searchContainerId !== rootContainerId &&
+			getContainerConfig(searchContainerId)?.restrict === 'self-only';
+
+		if (nextIndex >= linearTargets.length) {
+			if (scopeIsSelfOnly && isForward) {
+				const exitTarget = findLinearTabExitTarget(
+					currentFocusedElement,
+					searchContainerId,
+					true
+				);
+				if (exitTarget) {
+					return focusElement(exitTarget, getContainersForNode(exitTarget));
+				}
+			}
+			return false;
+		}
+		if (nextIndex < 0) {
+			if (scopeIsSelfOnly && !isForward) {
+				const exitTarget = findLinearTabExitTarget(
+					currentFocusedElement,
+					searchContainerId,
+					false
+				);
+				if (exitTarget) {
+					return focusElement(exitTarget, getContainersForNode(exitTarget));
+				}
+			}
+			return false;
+		}
+
+		const nextTarget = linearTargets[nextIndex].target;
+		return focusElement(nextTarget, getContainersForNode(nextTarget));
+	}
+
+	/*
+	 * Tab/Shift+Tab handler. Runs spotLinear with a per-keypress target cache and calls
+	 * preventDefault when focus moved or when paused (to keep Tab inside a modal overlay).
+	 */
+	function handleTab (evt) {
+		const keyCode = evt.keyCode;
+		const blocked = shouldPreventNavigation();
+
+		if (blocked) {
+			notifyKeyDown(keyCode);
+		} else {
+			notifyKeyDown(keyCode, handlePointerHide);
+			if (_pointerMoveDuringKeyPress) return;
+		}
+
+		_linearTargetsCache = new Map();
+		const handled = spotLinear(!evt.shiftKey);
+		_linearTargetsCache = null;
+
+		if (handled || (blocked && isPaused())) {
+			preventDefault(evt);
+		}
+	}
+
 	function onKeyDown (evt) {
-		if (shouldPreventNavigation()) {
-			notifyKeyDown(evt.keyCode);
+		const keyCode = evt.keyCode;
+
+		if (isTab(keyCode)) {
+			handleTab(evt);
 			return;
 		}
 
-		const keyCode = evt.keyCode;
+		if (shouldPreventNavigation()) {
+			notifyKeyDown(keyCode);
+			return;
+		}
+
 		const direction = getDirection(keyCode);
 		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
 
-		if (pointerHandled || !(direction || isEnter(keyCode))) {
-			return;
-		}
+		if (pointerHandled || !(direction || isEnter(keyCode))) return;
 
 		if (!isPaused() && !_pointerMoveDuringKeyPress) {
 			if (getCurrent()) {
@@ -989,7 +1330,21 @@ const Spotlight = (function () {
 		resetKeyHoldState: function () {
 			SpotlightAccelerator.reset();
 			_5WayKeyHold = false;
+			_pointerMoveDuringKeyPress = false;
 		}
+
+	};
+
+	_tabNavTestHooks = {
+		findLinearTabExitTarget,
+		getLinearTabSearchContainerId,
+		comesBeforeInTabOrder,
+		resolveTargetToOpenPopupItem,
+		isTargetInSelfOnlyContainer,
+		findLinearTabExitTargetInTargets,
+		getLinearTargetContainerId,
+		getLinearTargetsInContainer,
+		spotLinear
 	};
 
 	return exports;
@@ -998,6 +1353,7 @@ const Spotlight = (function () {
 
 export default Spotlight;
 export {
+	_tabNavTestHooks,
 	getDirection,
 	Spotlight
 };

--- a/packages/spotlight/src/spotlight.js
+++ b/packages/spotlight/src/spotlight.js
@@ -775,42 +775,43 @@ const Spotlight = (function () {
 	 * preventDefault when focus moved or when paused (to keep Tab inside a modal overlay).
 	 */
 	function handleTab (evt) {
-		const keyCode = evt.keyCode;
 		const blocked = shouldPreventNavigation();
 
 		if (blocked) {
-			notifyKeyDown(keyCode);
+			notifyKeyDown(evt.keyCode);
 		} else {
-			notifyKeyDown(keyCode, handlePointerHide);
-			if (_pointerMoveDuringKeyPress) return;
+			notifyKeyDown(evt.keyCode, handlePointerHide);
+			if (_pointerMoveDuringKeyPress) {
+				return;
+			}
 		}
 
 		_linearTargetsCache = new Map();
-		const handled = spotLinear(!evt.shiftKey);
-		_linearTargetsCache = null;
+		let handled;
+		try {
+			handled = spotLinear(!evt.shiftKey);
+		} finally {
+			_linearTargetsCache = null;
+		}
 
 		if (handled || (blocked && isPaused())) {
 			preventDefault(evt);
 		}
 	}
 
-	function onKeyDown (evt) {
-		const keyCode = evt.keyCode;
-
-		if (isTab(keyCode)) {
-			handleTab(evt);
-			return;
-		}
-
+	function handleFiveWayKeyDown (evt) {
 		if (shouldPreventNavigation()) {
-			notifyKeyDown(keyCode);
+			notifyKeyDown(evt.keyCode);
 			return;
 		}
 
+		const keyCode = evt.keyCode;
 		const direction = getDirection(keyCode);
 		const pointerHandled = notifyKeyDown(keyCode, handlePointerHide);
 
-		if (pointerHandled || !(direction || isEnter(keyCode))) return;
+		if (pointerHandled || !(direction || isEnter(keyCode))) {
+			return;
+		}
 
 		if (!isPaused() && !_pointerMoveDuringKeyPress) {
 			if (getCurrent()) {
@@ -824,6 +825,15 @@ const Spotlight = (function () {
 		if (direction) {
 			preventDefault(evt);
 		}
+	}
+
+	function onKeyDown (evt) {
+		if (isTab(evt.keyCode)) {
+			handleTab(evt);
+			return;
+		}
+
+		handleFiveWayKeyDown(evt);
 	}
 
 	function onMouseMove ({target, clientX, clientY}) {

--- a/packages/spotlight/src/tabTraversal.js
+++ b/packages/spotlight/src/tabTraversal.js
@@ -1,0 +1,384 @@
+/*
+ * Tab key linear focus traversal for Spotlight.
+ */
+
+import last from 'ramda/src/last';
+
+import {
+	getContainerConfig,
+	getContainerId,
+	getContainerNode,
+	getContainersForNode,
+	getLastContainer,
+	getOwnedSelfOnlyContainerIds,
+	getPopupOwnerElement,
+	getSpottableDescendants,
+	isContainer,
+	isNavigable,
+	rootContainerId
+} from './container';
+
+import {getNearestTargetFromPosition, getTargetByContainer} from './target';
+import {getRect} from './utils';
+
+// Vertical centers within this distance share a Tab row; horizontal position breaks ties.
+const TAB_ROW_THRESHOLD = 24;
+
+// CSS class applied by @enact/i18n I18nDecorator to the app root for RTL locales.
+const I18N_RTL_CLASS = 'enact-locale-right-to-left';
+
+/**
+ * Live tab traversal API, set when Spotlight initializes via {@link createTabTraversal}.
+ *
+ * @type {Object|null}
+ */
+export let tabTraversal = null;
+
+/**
+ * Creates tab traversal helpers wired to Spotlight focus routines.
+ *
+ * @param {Object} deps
+ * @param {Function} deps.focusElement
+ * @param {Function} deps.getCurrent
+ * @param {Function} deps.isPaused
+ * @param {Function} deps.restoreFocus
+ * @returns {Object} Tab traversal API
+ */
+export function createTabTraversal ({
+	focusElement,
+	getCurrent,
+	isPaused,
+	restoreFocus
+}) {
+	let _linearTargetsCache = null;
+
+	/*
+	 * Whether the document uses right-to-left layout for Tab ordering.
+	 *
+	 * Intentionally does not import @enact/i18n:
+	 * - `locale.isRtlLocale` is callback-based and depends on ilib; Tab handling needs a
+	 *   synchronous answer on every keydown without adding that heavyweight dependency to spotlight.
+	 * - `util.isRtlText` detects RTL characters in a string, not page layout direction.
+	 *
+	 * Instead, read layout direction already reflected on the DOM by the app or I18nDecorator:
+	 * the `dir` attribute when set, and the `enact-locale-right-to-left` class on the app root.
+	 */
+	function isRtlDocument () {
+		const root = document.documentElement;
+		const body = document.body;
+		const dir = (root && root.dir) || (body && body.dir);
+
+		if (typeof dir === 'string' && dir.toLowerCase() === 'rtl') {
+			return true;
+		}
+
+		if (root?.classList.contains(I18N_RTL_CLASS) || body?.classList.contains(I18N_RTL_CLASS)) {
+			return true;
+		}
+
+		return Boolean(document.querySelector('.' + I18N_RTL_CLASS));
+	}
+
+	/*
+	 * Chooses the subtree root for Tab linear traversal. When focus sits inside a portaled
+	 * `self-only` container (e.g. contextual popup list), descendants of the app root do not
+	 * include that subtree, so using the root container would mix in unrelated controls. The
+	 * innermost `self-only` ancestor matches the modal boundary the user is in.
+	 */
+	function getLinearTabSearchContainerId (focused) {
+		if (isPaused()) {
+			return getLastContainer() || rootContainerId;
+		}
+		if (!focused) {
+			return rootContainerId;
+		}
+		const ids = getContainersForNode(focused);
+		for (let i = ids.length - 1; i > 0; i--) {
+			const cfg = getContainerConfig(ids[i]);
+			if (cfg && cfg.restrict === 'self-only') {
+				return ids[i];
+			}
+		}
+
+		return rootContainerId;
+	}
+
+	/*
+	 * Whether point (aX,aY) comes before (bX,bY) in the same top-to-bottom, left-to-right order
+	 * used by `getLinearTargetsInContainer` (must stay in sync with that sort).
+	 */
+	function comesBeforeInTabOrder (aX, aY, bX, bY, isRtl) {
+		if (Math.abs(aY - bY) > TAB_ROW_THRESHOLD) {
+			return aY < bY;
+		}
+		if (aX !== bX) {
+			return isRtl ? aX > bX : aX < bX;
+		}
+
+		return false;
+	}
+
+	function resolveTargetToOpenPopupItem (target, currentPopupContainerId, isForward) {
+		const ownerNode = target?.closest?.('[aria-owns]');
+		if (!ownerNode || ownerNode === document.body) {
+			return target;
+		}
+
+		for (const popupContainerId of getOwnedSelfOnlyContainerIds(ownerNode, currentPopupContainerId)) {
+			const popupTargets = getLinearTargetsInContainer(popupContainerId);
+			const popupTargetEntry = isForward ? popupTargets[0] : popupTargets[popupTargets.length - 1];
+			const popupTarget = popupTargetEntry?.target || getTargetByContainer(popupContainerId);
+			if (popupTarget) {
+				return popupTarget;
+			}
+		}
+
+		return target;
+	}
+
+	function isTargetInSelfOnlyContainer (target) {
+		if (!target) {
+			return false;
+		}
+
+		// Use DOM ancestry only. `getContainersForNode()` may include containers connected via
+		// `aria-owns`, which would incorrectly mark popup owner controls as inside self-only popups.
+		const containerNode = target.closest?.('[data-spotlight-container][data-spotlight-id]');
+		if (!containerNode) {
+			return false;
+		}
+
+		const containerId = getContainerId(containerNode);
+		if (!containerId || containerId === rootContainerId) {
+			return false;
+		}
+
+		const config = getContainerConfig(containerId);
+		return Boolean(config && config.restrict === 'self-only');
+	}
+
+	function findLinearTabExitTargetInTargets (targets, ax, ay, isRtl, isForward) {
+		const orderedTargets = isForward ? targets : [...targets].reverse();
+
+		for (const {target, x: cx, y: cy} of orderedTargets) {
+			if (!target || isTargetInSelfOnlyContainer(target)) {
+				continue;
+			}
+			const inOrder = isForward ?
+				comesBeforeInTabOrder(ax, ay, cx, cy, isRtl) :
+				comesBeforeInTabOrder(cx, cy, ax, ay, isRtl);
+			if (inOrder) {
+				// Do not defer popup owners; resolveTargetToOpenPopupItem redirects into open popups.
+				return target;
+			}
+		}
+
+		return null;
+	}
+
+	/*
+	 * After Tab reaches the end (or start) of a `self-only` popup list, pick the next spottable
+	 * outside the popup: the immediate successor (or predecessor) in the same global linear order
+	 * as the root container, so grids work for horizontal and vertical neighbors.
+	 */
+	function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, isForward) {
+		const containerNode = getContainerNode(selfOnlyContainerId);
+		if (!containerNode) {
+			return null;
+		}
+
+		const popupOwner = getPopupOwnerElement(containerNode);
+		const focusCenter = getRect(focusedElement).center;
+		const isRtl = isRtlDocument();
+		const rootTargets = getLinearTargetsInContainer(rootContainerId);
+
+		const pickExitTarget = (x, y, searchForward) => {
+			const candidate = findLinearTabExitTargetInTargets(
+				rootTargets,
+				x,
+				y,
+				isRtl,
+				searchForward
+			);
+			return candidate ?
+				resolveTargetToOpenPopupItem(candidate, selfOnlyContainerId, isForward) :
+				null;
+		};
+
+		if (isForward) {
+			const exitTarget = pickExitTarget(focusCenter.x, focusCenter.y, true);
+			if (exitTarget) {
+				return exitTarget;
+			}
+		}
+
+		if (popupOwner) {
+			const ownerRect = getRect(popupOwner);
+			// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
+			const exitTarget = pickExitTarget(ownerRect.center.x, ownerRect.top + 1, isForward);
+			if (exitTarget) {
+				return exitTarget;
+			}
+		}
+
+		if (!isForward) {
+			return pickExitTarget(focusCenter.x, focusCenter.y, false);
+		}
+
+		return null;
+	}
+
+	function getLinearTargetContainerId (target) {
+		// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
+		const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
+		if (containerNode) {
+			const domContainerId = getContainerId(containerNode);
+			if (domContainerId) {
+				return domContainerId;
+			}
+		}
+
+		const containerIds = getContainersForNode(target);
+		return last(containerIds);
+	}
+
+	function getLinearTargetsInContainer (containerId) {
+		if (_linearTargetsCache?.has(containerId)) {
+			return _linearTargetsCache.get(containerId);
+		}
+
+		const isRtl = isRtlDocument();
+		const visitedContainers = new Set();
+		const visitedTargets = new Set();
+
+		const gatherSpottableLeaves = (id) => {
+			if (!id || visitedContainers.has(id)) {
+				return [];
+			}
+
+			visitedContainers.add(id);
+
+			return getSpottableDescendants(id).reduce((result, candidate) => {
+				if (isContainer(candidate)) {
+					const nestedContainerId = getContainerId(candidate);
+					result.push(...gatherSpottableLeaves(nestedContainerId));
+				} else if (!visitedTargets.has(candidate)) {
+					visitedTargets.add(candidate);
+					result.push(candidate);
+				}
+
+				return result;
+			}, []);
+		};
+
+		const targets = gatherSpottableLeaves(containerId)
+			.filter((target) => {
+				const targetContainerId = getLinearTargetContainerId(target);
+				return isNavigable(target, targetContainerId, true);
+			})
+			.map((target, order) => {
+				const {center} = getRect(target);
+				return {order, target, x: center.x, y: center.y};
+			})
+			.sort((a, b) => {
+				if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
+				if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
+				return a.order - b.order;
+			});
+
+		if (_linearTargetsCache) {
+			_linearTargetsCache.set(containerId, targets);
+		}
+
+		return targets;
+	}
+
+	function runWithLinearTargetsCache (fn) {
+		_linearTargetsCache = new Map();
+		try {
+			return fn();
+		} finally {
+			_linearTargetsCache = null;
+		}
+	}
+
+	function spotLinear (isForward) {
+		let currentFocusedElement = getCurrent();
+
+		if (!currentFocusedElement) {
+			if (!restoreFocus()) {
+				return false;
+			}
+			currentFocusedElement = getCurrent();
+			if (!currentFocusedElement) {
+				return false;
+			}
+		}
+
+		const searchContainerId = getLinearTabSearchContainerId(currentFocusedElement);
+		const linearTargets = getLinearTargetsInContainer(searchContainerId);
+		if (!linearTargets.length) {
+			return false;
+		}
+		let currentIndex = linearTargets.findIndex(({target}) => target === currentFocusedElement);
+		if (currentIndex < 0) {
+			const nearestTarget = getNearestTargetFromPosition(getRect(currentFocusedElement).center, searchContainerId);
+			currentIndex = nearestTarget ?
+				linearTargets.findIndex(({target}) => target === nearestTarget) :
+				-1;
+			// When no nearest target can be found (e.g. position is NaN), keep currentIndex at -1
+			// so that nextIndex = -1 + 1 = 0, landing on the first element in the list.
+			// Treating 0 as the virtual "current" would skip the first element entirely.
+		}
+
+		const nextIndex = currentIndex + (isForward ? 1 : -1);
+		const scopeIsSelfOnly = searchContainerId !== rootContainerId &&
+			getContainerConfig(searchContainerId)?.restrict === 'self-only';
+
+		if (nextIndex >= linearTargets.length) {
+			if (scopeIsSelfOnly && isForward) {
+				const exitTarget = findLinearTabExitTarget(
+					currentFocusedElement,
+					searchContainerId,
+					true
+				);
+				if (exitTarget) {
+					return focusElement(exitTarget, getContainersForNode(exitTarget));
+				}
+			}
+			return false;
+		}
+		if (nextIndex < 0) {
+			if (scopeIsSelfOnly && !isForward) {
+				const exitTarget = findLinearTabExitTarget(
+					currentFocusedElement,
+					searchContainerId,
+					false
+				);
+				if (exitTarget) {
+					return focusElement(exitTarget, getContainersForNode(exitTarget));
+				}
+			}
+			return false;
+		}
+
+		const nextTarget = linearTargets[nextIndex].target;
+		return focusElement(nextTarget, getContainersForNode(nextTarget));
+	}
+
+	const api = {
+		comesBeforeInTabOrder,
+		findLinearTabExitTarget,
+		findLinearTabExitTargetInTargets,
+		getLinearTabSearchContainerId,
+		getLinearTargetContainerId,
+		getLinearTargetsInContainer,
+		isTargetInSelfOnlyContainer,
+		resolveTargetToOpenPopupItem,
+		runWithLinearTargetsCache,
+		spotLinear
+	};
+
+	tabTraversal = api;
+	return api;
+}

--- a/packages/spotlight/src/tabTraversal.js
+++ b/packages/spotlight/src/tabTraversal.js
@@ -7,6 +7,8 @@
 
 import last from 'ramda/src/last';
 
+import {isPaused} from '../Pause';
+
 import {
 	getContainerConfig,
 	getContainerId,
@@ -30,267 +32,263 @@ const TAB_ROW_THRESHOLD = 24;
 // CSS class applied by @enact/i18n I18nDecorator to the app root for RTL locales.
 const I18N_RTL_CLASS = 'enact-locale-right-to-left';
 
-// Live tab traversal API, set when Spotlight initializes via createTabTraversal.
-export let tabTraversal = null;
+let _linearTargetsCache = null;
+
+export function runWithLinearTargetsCache (fn) {
+	_linearTargetsCache = new Map();
+	try {
+		return fn();
+	} finally {
+		_linearTargetsCache = null;
+	}
+}
+
+/*
+ * Whether the document uses right-to-left layout for Tab ordering.
+ *
+ * Intentionally does not import @enact/i18n:
+ * - `locale.isRtlLocale` is callback-based and depends on ilib; Tab handling needs a
+ *   synchronous answer on every keydown without adding that heavyweight dependency to spotlight.
+ * - `util.isRtlText` detects RTL characters in a string, not page layout direction.
+ *
+ * Instead, read layout direction already reflected on the DOM by the app or I18nDecorator:
+ * the `dir` attribute when set, and the `enact-locale-right-to-left` class on the app root.
+ */
+function isRtlDocument () {
+	const root = document.documentElement;
+	const body = document.body;
+	const dir = (root && root.dir) || (body && body.dir);
+
+	if (typeof dir === 'string' && dir.toLowerCase() === 'rtl') {
+		return true;
+	}
+
+	if (root?.classList.contains(I18N_RTL_CLASS) || body?.classList.contains(I18N_RTL_CLASS)) {
+		return true;
+	}
+
+	return Boolean(document.querySelector('.' + I18N_RTL_CLASS));
+}
+
+/*
+ * Chooses the subtree root for Tab linear traversal. When focus sits inside a portaled
+ * `self-only` container (e.g. contextual popup list), descendants of the app root do not
+ * include that subtree, so using the root container would mix in unrelated controls. The
+ * innermost `self-only` ancestor matches the modal boundary the user is in.
+ */
+export function getLinearTabSearchContainerId (focused) {
+	if (isPaused()) {
+		return getLastContainer() || rootContainerId;
+	}
+	if (!focused) {
+		return rootContainerId;
+	}
+	const ids = getContainersForNode(focused);
+	for (let i = ids.length - 1; i > 0; i--) {
+		const cfg = getContainerConfig(ids[i]);
+		if (cfg && cfg.restrict === 'self-only') {
+			return ids[i];
+		}
+	}
+
+	return rootContainerId;
+}
+
+/*
+ * Whether point (aX,aY) comes before (bX,bY) in the same top-to-bottom, left-to-right order
+ * used by `getLinearTargetsInContainer` (must stay in sync with that sort).
+ */
+export function comesBeforeInTabOrder (aX, aY, bX, bY, isRtl) {
+	if (Math.abs(aY - bY) > TAB_ROW_THRESHOLD) {
+		return aY < bY;
+	}
+	if (aX !== bX) {
+		return isRtl ? aX > bX : aX < bX;
+	}
+
+	return false;
+}
+
+export function resolveTargetToOpenPopupItem (target, currentPopupContainerId, isForward) {
+	const ownerNode = target?.closest?.('[aria-owns]');
+	if (!ownerNode || ownerNode === document.body) {
+		return target;
+	}
+
+	for (const popupContainerId of getOwnedSelfOnlyContainerIds(ownerNode, currentPopupContainerId)) {
+		const popupTargets = getLinearTargetsInContainer(popupContainerId);
+		const popupTargetEntry = isForward ? popupTargets[0] : popupTargets[popupTargets.length - 1];
+		const popupTarget = popupTargetEntry?.target || getTargetByContainer(popupContainerId);
+		if (popupTarget) {
+			return popupTarget;
+		}
+	}
+
+	return target;
+}
+
+export function isTargetInSelfOnlyContainer (target) {
+	if (!target) {
+		return false;
+	}
+
+	// Use DOM ancestry only. `getContainersForNode()` may include containers connected via
+	// `aria-owns`, which would incorrectly mark popup owner controls as inside self-only popups.
+	const containerNode = target.closest?.('[data-spotlight-container][data-spotlight-id]');
+	if (!containerNode) {
+		return false;
+	}
+
+	const containerId = getContainerId(containerNode);
+	if (!containerId || containerId === rootContainerId) {
+		return false;
+	}
+
+	const config = getContainerConfig(containerId);
+	return Boolean(config && config.restrict === 'self-only');
+}
+
+export function findLinearTabExitTargetInTargets (targets, ax, ay, isRtl, isForward) {
+	const orderedTargets = isForward ? targets : [...targets].reverse();
+
+	for (const {target, x: cx, y: cy} of orderedTargets) {
+		if (!target || isTargetInSelfOnlyContainer(target)) {
+			continue;
+		}
+		const inOrder = isForward ?
+			comesBeforeInTabOrder(ax, ay, cx, cy, isRtl) :
+			comesBeforeInTabOrder(cx, cy, ax, ay, isRtl);
+		if (inOrder) {
+			// Do not defer popup owners; resolveTargetToOpenPopupItem redirects into open popups.
+			return target;
+		}
+	}
+
+	return null;
+}
+
+/*
+ * After Tab reaches the end (or start) of a `self-only` popup list, pick the next spottable
+ * outside the popup: the immediate successor (or predecessor) in the same global linear order
+ * as the root container, so grids work for horizontal and vertical neighbors.
+ */
+export function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, isForward) {
+	const containerNode = getContainerNode(selfOnlyContainerId);
+	if (!containerNode) {
+		return null;
+	}
+
+	const popupOwner = getPopupOwnerElement(containerNode);
+	const focusCenter = getRect(focusedElement).center;
+	const isRtl = isRtlDocument();
+	const rootTargets = getLinearTargetsInContainer(rootContainerId);
+
+	const pickExitTarget = (x, y, searchForward) => {
+		const candidate = findLinearTabExitTargetInTargets(
+			rootTargets,
+			x,
+			y,
+			isRtl,
+			searchForward
+		);
+		return candidate ?
+			resolveTargetToOpenPopupItem(candidate, selfOnlyContainerId, isForward) :
+			null;
+	};
+
+	if (isForward) {
+		const exitTarget = pickExitTarget(focusCenter.x, focusCenter.y, true);
+		if (exitTarget) {
+			return exitTarget;
+		}
+	}
+
+	if (popupOwner) {
+		const ownerRect = getRect(popupOwner);
+		// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
+		const exitTarget = pickExitTarget(ownerRect.center.x, ownerRect.top + 1, isForward);
+		if (exitTarget) {
+			return exitTarget;
+		}
+	}
+
+	if (!isForward) {
+		return pickExitTarget(focusCenter.x, focusCenter.y, false);
+	}
+
+	return null;
+}
+
+export function getLinearTargetContainerId (target) {
+	// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
+	const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
+	if (containerNode) {
+		const domContainerId = getContainerId(containerNode);
+		if (domContainerId) {
+			return domContainerId;
+		}
+	}
+
+	const containerIds = getContainersForNode(target);
+	return last(containerIds);
+}
+
+export function getLinearTargetsInContainer (containerId) {
+	if (_linearTargetsCache?.has(containerId)) {
+		return _linearTargetsCache.get(containerId);
+	}
+
+	const isRtl = isRtlDocument();
+	const visitedContainers = new Set();
+	const visitedTargets = new Set();
+
+	const gatherSpottableLeaves = (id) => {
+		if (!id || visitedContainers.has(id)) {
+			return [];
+		}
+
+		visitedContainers.add(id);
+
+		return getSpottableDescendants(id).reduce((result, candidate) => {
+			if (isContainer(candidate)) {
+				const nestedContainerId = getContainerId(candidate);
+				result.push(...gatherSpottableLeaves(nestedContainerId));
+			} else if (!visitedTargets.has(candidate)) {
+				visitedTargets.add(candidate);
+				result.push(candidate);
+			}
+
+			return result;
+		}, []);
+	};
+
+	const targets = gatherSpottableLeaves(containerId)
+		.filter((target) => {
+			const targetContainerId = getLinearTargetContainerId(target);
+			return isNavigable(target, targetContainerId, true);
+		})
+		.map((target, order) => {
+			const {center} = getRect(target);
+			return {order, target, x: center.x, y: center.y};
+		})
+		.sort((a, b) => {
+			if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
+			if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
+			return a.order - b.order;
+		});
+
+	if (_linearTargetsCache) {
+		_linearTargetsCache.set(containerId, targets);
+	}
+
+	return targets;
+}
 
 export function createTabTraversal ({
 	focusElement,
 	getCurrent,
-	isPaused,
 	restoreFocus
 }) {
-	let _linearTargetsCache = null;
-
-	/*
-	 * Whether the document uses right-to-left layout for Tab ordering.
-	 *
-	 * Intentionally does not import @enact/i18n:
-	 * - `locale.isRtlLocale` is callback-based and depends on ilib; Tab handling needs a
-	 *   synchronous answer on every keydown without adding that heavyweight dependency to spotlight.
-	 * - `util.isRtlText` detects RTL characters in a string, not page layout direction.
-	 *
-	 * Instead, read layout direction already reflected on the DOM by the app or I18nDecorator:
-	 * the `dir` attribute when set, and the `enact-locale-right-to-left` class on the app root.
-	 */
-	function isRtlDocument () {
-		const root = document.documentElement;
-		const body = document.body;
-		const dir = (root && root.dir) || (body && body.dir);
-
-		if (typeof dir === 'string' && dir.toLowerCase() === 'rtl') {
-			return true;
-		}
-
-		if (root?.classList.contains(I18N_RTL_CLASS) || body?.classList.contains(I18N_RTL_CLASS)) {
-			return true;
-		}
-
-		return Boolean(document.querySelector('.' + I18N_RTL_CLASS));
-	}
-
-	/*
-	 * Chooses the subtree root for Tab linear traversal. When focus sits inside a portaled
-	 * `self-only` container (e.g. contextual popup list), descendants of the app root do not
-	 * include that subtree, so using the root container would mix in unrelated controls. The
-	 * innermost `self-only` ancestor matches the modal boundary the user is in.
-	 */
-	function getLinearTabSearchContainerId (focused) {
-		if (isPaused()) {
-			return getLastContainer() || rootContainerId;
-		}
-		if (!focused) {
-			return rootContainerId;
-		}
-		const ids = getContainersForNode(focused);
-		for (let i = ids.length - 1; i > 0; i--) {
-			const cfg = getContainerConfig(ids[i]);
-			if (cfg && cfg.restrict === 'self-only') {
-				return ids[i];
-			}
-		}
-
-		return rootContainerId;
-	}
-
-	/*
-	 * Whether point (aX,aY) comes before (bX,bY) in the same top-to-bottom, left-to-right order
-	 * used by `getLinearTargetsInContainer` (must stay in sync with that sort).
-	 */
-	function comesBeforeInTabOrder (aX, aY, bX, bY, isRtl) {
-		if (Math.abs(aY - bY) > TAB_ROW_THRESHOLD) {
-			return aY < bY;
-		}
-		if (aX !== bX) {
-			return isRtl ? aX > bX : aX < bX;
-		}
-
-		return false;
-	}
-
-	function resolveTargetToOpenPopupItem (target, currentPopupContainerId, isForward) {
-		const ownerNode = target?.closest?.('[aria-owns]');
-		if (!ownerNode || ownerNode === document.body) {
-			return target;
-		}
-
-		for (const popupContainerId of getOwnedSelfOnlyContainerIds(ownerNode, currentPopupContainerId)) {
-			const popupTargets = getLinearTargetsInContainer(popupContainerId);
-			const popupTargetEntry = isForward ? popupTargets[0] : popupTargets[popupTargets.length - 1];
-			const popupTarget = popupTargetEntry?.target || getTargetByContainer(popupContainerId);
-			if (popupTarget) {
-				return popupTarget;
-			}
-		}
-
-		return target;
-	}
-
-	function isTargetInSelfOnlyContainer (target) {
-		if (!target) {
-			return false;
-		}
-
-		// Use DOM ancestry only. `getContainersForNode()` may include containers connected via
-		// `aria-owns`, which would incorrectly mark popup owner controls as inside self-only popups.
-		const containerNode = target.closest?.('[data-spotlight-container][data-spotlight-id]');
-		if (!containerNode) {
-			return false;
-		}
-
-		const containerId = getContainerId(containerNode);
-		if (!containerId || containerId === rootContainerId) {
-			return false;
-		}
-
-		const config = getContainerConfig(containerId);
-		return Boolean(config && config.restrict === 'self-only');
-	}
-
-	function findLinearTabExitTargetInTargets (targets, ax, ay, isRtl, isForward) {
-		const orderedTargets = isForward ? targets : [...targets].reverse();
-
-		for (const {target, x: cx, y: cy} of orderedTargets) {
-			if (!target || isTargetInSelfOnlyContainer(target)) {
-				continue;
-			}
-			const inOrder = isForward ?
-				comesBeforeInTabOrder(ax, ay, cx, cy, isRtl) :
-				comesBeforeInTabOrder(cx, cy, ax, ay, isRtl);
-			if (inOrder) {
-				// Do not defer popup owners; resolveTargetToOpenPopupItem redirects into open popups.
-				return target;
-			}
-		}
-
-		return null;
-	}
-
-	/*
-	 * After Tab reaches the end (or start) of a `self-only` popup list, pick the next spottable
-	 * outside the popup: the immediate successor (or predecessor) in the same global linear order
-	 * as the root container, so grids work for horizontal and vertical neighbors.
-	 */
-	function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, isForward) {
-		const containerNode = getContainerNode(selfOnlyContainerId);
-		if (!containerNode) {
-			return null;
-		}
-
-		const popupOwner = getPopupOwnerElement(containerNode);
-		const focusCenter = getRect(focusedElement).center;
-		const isRtl = isRtlDocument();
-		const rootTargets = getLinearTargetsInContainer(rootContainerId);
-
-		const pickExitTarget = (x, y, searchForward) => {
-			const candidate = findLinearTabExitTargetInTargets(
-				rootTargets,
-				x,
-				y,
-				isRtl,
-				searchForward
-			);
-			return candidate ?
-				resolveTargetToOpenPopupItem(candidate, selfOnlyContainerId, isForward) :
-				null;
-		};
-
-		if (isForward) {
-			const exitTarget = pickExitTarget(focusCenter.x, focusCenter.y, true);
-			if (exitTarget) {
-				return exitTarget;
-			}
-		}
-
-		if (popupOwner) {
-			const ownerRect = getRect(popupOwner);
-			// top+1 keeps row-level neighbors in the same TAB_ROW_THRESHOLD band as a tall owner button.
-			const exitTarget = pickExitTarget(ownerRect.center.x, ownerRect.top + 1, isForward);
-			if (exitTarget) {
-				return exitTarget;
-			}
-		}
-
-		if (!isForward) {
-			return pickExitTarget(focusCenter.x, focusCenter.y, false);
-		}
-
-		return null;
-	}
-
-	function getLinearTargetContainerId (target) {
-		// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
-		const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
-		if (containerNode) {
-			const domContainerId = getContainerId(containerNode);
-			if (domContainerId) {
-				return domContainerId;
-			}
-		}
-
-		const containerIds = getContainersForNode(target);
-		return last(containerIds);
-	}
-
-	function getLinearTargetsInContainer (containerId) {
-		if (_linearTargetsCache?.has(containerId)) {
-			return _linearTargetsCache.get(containerId);
-		}
-
-		const isRtl = isRtlDocument();
-		const visitedContainers = new Set();
-		const visitedTargets = new Set();
-
-		const gatherSpottableLeaves = (id) => {
-			if (!id || visitedContainers.has(id)) {
-				return [];
-			}
-
-			visitedContainers.add(id);
-
-			return getSpottableDescendants(id).reduce((result, candidate) => {
-				if (isContainer(candidate)) {
-					const nestedContainerId = getContainerId(candidate);
-					result.push(...gatherSpottableLeaves(nestedContainerId));
-				} else if (!visitedTargets.has(candidate)) {
-					visitedTargets.add(candidate);
-					result.push(candidate);
-				}
-
-				return result;
-			}, []);
-		};
-
-		const targets = gatherSpottableLeaves(containerId)
-			.filter((target) => {
-				const targetContainerId = getLinearTargetContainerId(target);
-				return isNavigable(target, targetContainerId, true);
-			})
-			.map((target, order) => {
-				const {center} = getRect(target);
-				return {order, target, x: center.x, y: center.y};
-			})
-			.sort((a, b) => {
-				if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
-				if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
-				return a.order - b.order;
-			});
-
-		if (_linearTargetsCache) {
-			_linearTargetsCache.set(containerId, targets);
-		}
-
-		return targets;
-	}
-
-	function runWithLinearTargetsCache (fn) {
-		_linearTargetsCache = new Map();
-		try {
-			return fn();
-		} finally {
-			_linearTargetsCache = null;
-		}
-	}
-
 	function spotLinear (isForward) {
 		let currentFocusedElement = getCurrent();
 
@@ -355,19 +353,5 @@ export function createTabTraversal ({
 		return focusElement(nextTarget, getContainersForNode(nextTarget));
 	}
 
-	const api = {
-		comesBeforeInTabOrder,
-		findLinearTabExitTarget,
-		findLinearTabExitTargetInTargets,
-		getLinearTabSearchContainerId,
-		getLinearTargetContainerId,
-		getLinearTargetsInContainer,
-		isTargetInSelfOnlyContainer,
-		resolveTargetToOpenPopupItem,
-		runWithLinearTargetsCache,
-		spotLinear
-	};
-
-	tabTraversal = api;
-	return api;
+	return {runWithLinearTargetsCache, spotLinear};
 }

--- a/packages/spotlight/src/tabTraversal.js
+++ b/packages/spotlight/src/tabTraversal.js
@@ -1,5 +1,8 @@
-/*
+/**
  * Tab key linear focus traversal for Spotlight.
+ *
+ * @module spotlight/tabTraversal
+ * @private
  */
 
 import last from 'ramda/src/last';
@@ -27,23 +30,9 @@ const TAB_ROW_THRESHOLD = 24;
 // CSS class applied by @enact/i18n I18nDecorator to the app root for RTL locales.
 const I18N_RTL_CLASS = 'enact-locale-right-to-left';
 
-/**
- * Live tab traversal API, set when Spotlight initializes via {@link createTabTraversal}.
- *
- * @type {Object|null}
- */
+// Live tab traversal API, set when Spotlight initializes via createTabTraversal.
 export let tabTraversal = null;
 
-/**
- * Creates tab traversal helpers wired to Spotlight focus routines.
- *
- * @param {Object} deps
- * @param {Function} deps.focusElement
- * @param {Function} deps.getCurrent
- * @param {Function} deps.isPaused
- * @param {Function} deps.restoreFocus
- * @returns {Object} Tab traversal API
- */
 export function createTabTraversal ({
 	focusElement,
 	getCurrent,

--- a/packages/spotlight/src/tabTraversal.js
+++ b/packages/spotlight/src/tabTraversal.js
@@ -17,14 +17,14 @@ import {
 	getLastContainer,
 	getOwnedSelfOnlyContainerIds,
 	getPopupOwnerElement,
-	getSpottableDescendants,
+	getSpottableDescendantsForTab,
 	isContainer,
-	isNavigable,
+	isNavigableForTab,
 	rootContainerId
 } from './container';
 
 import {getNearestTargetFromPosition, getTargetByContainer} from './target';
-import {getRect} from './utils';
+import {getContainerRect, getRect} from './utils';
 
 // Vertical centers within this distance share a Tab row; horizontal position breaks ties.
 const TAB_ROW_THRESHOLD = 24;
@@ -219,6 +219,97 @@ export function findLinearTabExitTarget (focusedElement, selfOnlyContainerId, is
 	return null;
 }
 
+/*
+ * Innermost `partition: true` spotlight container ancestor of `target`, if any.
+ * Matches 5-way navigation: controls in a partition group (e.g. TabLayout sidebar tabs)
+ * share the container bounds instead of individual positions for ordering.
+ */
+function getInnermostPartitionContainerId (target) {
+	let node = target;
+
+	while (node && node !== document) {
+		if (isContainer(node)) {
+			const containerId = getContainerId(node);
+			if (containerId && getContainerConfig(containerId)?.partition) {
+				return containerId;
+			}
+		}
+		node = node.parentNode;
+	}
+
+	return null;
+}
+
+/*
+ * Whether `target` lies outside the DOM subtree of a `partition` container. TabLayout sidebar
+ * tabs and main-panel controls are siblings — comparing viewport x/y alone can interleave them
+ * when rows overlap; DOM containment keeps the whole partition group ahead of outside content.
+ */
+function isOutsidePartitionContainer (target, partitionContainerId) {
+	const partitionNode = getContainerNode(partitionContainerId);
+
+	return Boolean(partitionNode && !partitionNode.contains(target));
+}
+
+function compareVisualTabOrder (a, b, isRtl) {
+	if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) {
+		return -1;
+	}
+	if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) {
+		return 1;
+	}
+
+	return a.order - b.order;
+}
+
+function compareTabOrderEntries (a, b, isRtl) {
+	const partitionA = a.partitionId;
+	const partitionB = b.partitionId;
+
+	if (partitionA && partitionA === partitionB) {
+		return a.order - b.order;
+	}
+
+	const partitionRectA = partitionA ? getContainerRect(partitionA) : null;
+	const partitionRectB = partitionB ? getContainerRect(partitionB) : null;
+
+	if (partitionA && !partitionB) {
+		if (isOutsidePartitionContainer(b.target, partitionA)) {
+			return -1;
+		}
+
+		return compareVisualTabOrder(a, b, isRtl);
+	}
+
+	if (!partitionA && partitionB) {
+		if (isOutsidePartitionContainer(a.target, partitionB)) {
+			return 1;
+		}
+
+		return compareVisualTabOrder(a, b, isRtl);
+	}
+
+	if (partitionA && partitionB) {
+		const visual = compareVisualTabOrder(
+			{
+				order: a.order,
+				x: partitionRectA.center.x,
+				y: partitionRectA.top + 1
+			},
+			{
+				order: b.order,
+				x: partitionRectB.center.x,
+				y: partitionRectB.top + 1
+			},
+			isRtl
+		);
+
+		return visual || a.order - b.order;
+	}
+
+	return compareVisualTabOrder(a, b, isRtl);
+}
+
 export function getLinearTargetContainerId (target) {
 	// Prefer DOM ancestry over getContainersForNode so aria-owns owners stay in root Tab order.
 	const containerNode = target?.closest?.('[data-spotlight-container][data-spotlight-id]');
@@ -249,7 +340,7 @@ export function getLinearTargetsInContainer (containerId) {
 
 		visitedContainers.add(id);
 
-		return getSpottableDescendants(id).reduce((result, candidate) => {
+		return getSpottableDescendantsForTab(id).reduce((result, candidate) => {
 			if (isContainer(candidate)) {
 				const nestedContainerId = getContainerId(candidate);
 				result.push(...gatherSpottableLeaves(nestedContainerId));
@@ -265,17 +356,19 @@ export function getLinearTargetsInContainer (containerId) {
 	const targets = gatherSpottableLeaves(containerId)
 		.filter((target) => {
 			const targetContainerId = getLinearTargetContainerId(target);
-			return isNavigable(target, targetContainerId, true);
+			return isNavigableForTab(target, targetContainerId, true);
 		})
 		.map((target, order) => {
 			const {center} = getRect(target);
-			return {order, target, x: center.x, y: center.y};
+			return {
+				order,
+				partitionId: getInnermostPartitionContainerId(target),
+				target,
+				x: center.x,
+				y: center.y
+			};
 		})
-		.sort((a, b) => {
-			if (comesBeforeInTabOrder(a.x, a.y, b.x, b.y, isRtl)) return -1;
-			if (comesBeforeInTabOrder(b.x, b.y, a.x, a.y, isRtl)) return 1;
-			return a.order - b.order;
-		});
+		.sort((a, b) => compareTabOrderEntries(a, b, isRtl));
 
 	if (_linearTargetsCache) {
 		_linearTargetsCache.set(containerId, targets);
@@ -333,6 +426,10 @@ export function createTabTraversal ({
 					return focusElement(exitTarget, getContainersForNode(exitTarget));
 				}
 			}
+			if (searchContainerId === rootContainerId && linearTargets.length > 1) {
+				const wrapTarget = linearTargets[0].target;
+				return focusElement(wrapTarget, getContainersForNode(wrapTarget));
+			}
 			return false;
 		}
 		if (nextIndex < 0) {
@@ -345,6 +442,10 @@ export function createTabTraversal ({
 				if (exitTarget) {
 					return focusElement(exitTarget, getContainersForNode(exitTarget));
 				}
+			}
+			if (searchContainerId === rootContainerId && linearTargets.length > 1) {
+				const wrapTarget = linearTargets[linearTargets.length - 1].target;
+				return focusElement(wrapTarget, getContainersForNode(wrapTarget));
 			}
 			return false;
 		}

--- a/packages/spotlight/src/tests/container-specs.js
+++ b/packages/spotlight/src/tests/container-specs.js
@@ -10,13 +10,18 @@ import {
 	getContainerLastFocusedElement,
 	getContainerNavigableElements,
 	getContainersForNode,
+	getContainerNode,
 	getDefaultContainer,
 	getLastContainer,
 	getNavigableContainersForNode,
+	getOwnedSelfOnlyContainerIds,
+	getPopupOwnerElement,
 	getPositionTargetOnFocus,
 	getSpottableDescendants,
+	getSpottableDescendantsForTab,
 	isContainer,
 	isNavigable,
+	isNavigableForTab,
 	unmountContainer,
 	removeContainer,
 	removeAllContainers,
@@ -25,6 +30,7 @@ import {
 	setLastContainer,
 	setLastContainerFromTarget
 } from '../container';
+import * as spotlightUtils from '../utils';
 
 import {
 	container,
@@ -1297,5 +1303,185 @@ describe('container', () => {
 				}
 			)
 		);
+	});
+
+	describe('Tab traversal container helpers', () => {
+		beforeEach(setupContainers);
+		afterEach(teardownContainers);
+
+		describe('#getContainerNode', () => {
+			test('returns null for a falsy container id', () => {
+				expect(getContainerNode('')).toBeNull();
+				expect(getContainerNode(null)).toBeNull();
+			});
+
+			test('returns null for an unknown container id', () => {
+				expect(getContainerNode('missing-container')).toBeNull();
+			});
+		});
+
+		describe('#getPopupOwnerElement', () => {
+			test('returns null when no aria-owns owner contains the container', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button id="owner" aria-owns="layerA">Owner</button>
+						<div id="layerA">
+							<div data-spotlight-container="true" data-spotlight-id="popup-a">
+								<button class="spottable">A</button>
+							</div>
+						</div>
+						<div data-spotlight-container="true" data-spotlight-id="popup-b">
+							<button class="spottable">B</button>
+						</div>
+					</div>
+				`;
+				configureContainer('popup-a', {restrict: 'self-only', selector: '.spottable'});
+				configureContainer('popup-b', {restrict: 'self-only', selector: '.spottable'});
+
+				expect(
+					getPopupOwnerElement(document.querySelector('[data-spotlight-id="popup-b"]'))
+				).toBeNull();
+			});
+		});
+
+		describe('#getOwnedSelfOnlyContainerIds', () => {
+			test('returns self-only ids from aria-owns layers and excludes the current popup', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button id="owner" aria-owns="layerA layerB">Owner</button>
+						<div id="layerA">
+							<div data-spotlight-container="true" data-spotlight-id="popup-a">
+								<button class="spottable">A</button>
+							</div>
+						</div>
+						<div id="layerB">
+							<div data-spotlight-container="true" data-spotlight-id="popup-b">
+								<button class="spottable">B</button>
+							</div>
+						</div>
+					</div>
+				`;
+				configureContainer('popup-a', {restrict: 'self-only', selector: '.spottable'});
+				configureContainer('popup-b', {restrict: 'self-only', selector: '.spottable'});
+
+				const ids = getOwnedSelfOnlyContainerIds(document.getElementById('owner'), 'popup-a');
+
+				expect(ids).toEqual(['popup-b']);
+			});
+
+			test('includes owned spotlight containers when the owned node is itself a container', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button id="owner" aria-owns="popup-b-node">Owner</button>
+						<div id="popup-b-node" data-spotlight-container="true" data-spotlight-id="popup-b">
+							<button class="spottable">B</button>
+						</div>
+					</div>
+				`;
+				configureContainer('popup-b', {restrict: 'self-only', selector: '.spottable'});
+
+				expect(getOwnedSelfOnlyContainerIds(document.getElementById('owner'), '')).toEqual(['popup-b']);
+			});
+
+			test('skips owned containers that are not self-only', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button id="owner" aria-owns="layerZ">Owner</button>
+						<div id="layerZ">
+							<div data-spotlight-container="true" data-spotlight-id="popup-z">
+								<button class="spottable">Z</button>
+							</div>
+						</div>
+					</div>
+				`;
+				configureContainer('popup-z', {restrict: 'self-first', selector: '.spottable'});
+
+				expect(getOwnedSelfOnlyContainerIds(document.getElementById('owner'), '')).toEqual([]);
+			});
+		});
+
+		describe('#getSpottableDescendantsForTab', () => {
+			test('includes nodes filtered out by navigableFilter', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button class="spottable tab" id="tab">Tab</button>
+						<button class="spottable" id="content">Content</button>
+					</div>
+				`;
+				configureContainer(rootContainerId, {
+					navigableFilter: (elem) => !elem.classList.contains('tab'),
+					selector: '.spottable'
+				});
+
+				expect(getSpottableDescendants(rootContainerId)).toHaveLength(1);
+				expect(getSpottableDescendantsForTab(rootContainerId)).toHaveLength(2);
+			});
+		});
+
+		describe('#isNavigableForTab', () => {
+			test('returns false for a null node', () => {
+				expect(isNavigableForTab(null, rootContainerId, true)).toBe(false);
+			});
+
+			test('returns false for nodes in a disabled container', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}" data-spotlight-container-disabled="true">
+						<button class="spottable" id="btn">Btn</button>
+					</div>
+				`;
+				configureContainer(rootContainerId, {selector: '.spottable'});
+
+				expect(isNavigableForTab(document.getElementById('btn'), rootContainerId, true)).toBe(false);
+			});
+
+			test('returns false for hidden nodes', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button class="spottable" id="btn" style="display: none">Btn</button>
+					</div>
+				`;
+				configureContainer(rootContainerId, {selector: '.spottable'});
+
+				expect(isNavigableForTab(document.getElementById('btn'), rootContainerId, true)).toBe(false);
+			});
+
+			test('returns false when verify is true and the node does not match the selector', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button id="btn">Btn</button>
+					</div>
+				`;
+				configureContainer(rootContainerId, {selector: '.spottable'});
+
+				expect(isNavigableForTab(document.getElementById('btn'), rootContainerId, true)).toBe(false);
+			});
+
+			test('returns false for zero-size nodes outside test mode', () => {
+				document.body.innerHTML = `
+					<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+						<button class="spottable" id="btn">Btn</button>
+					</div>
+				`;
+				configureContainer(rootContainerId, {selector: '.spottable'});
+
+				const nodeEnv = process.env.NODE_ENV;
+				const rectSpy = jest.spyOn(spotlightUtils, 'getRect').mockReturnValue({
+					width: 0,
+					height: 0,
+					left: 0,
+					top: 0,
+					right: 0,
+					bottom: 0,
+					center: {x: 0, y: 0}
+				});
+				process.env.NODE_ENV = 'production';
+				try {
+					expect(isNavigableForTab(document.getElementById('btn'), rootContainerId, true)).toBe(false);
+				} finally {
+					process.env.NODE_ENV = nodeEnv;
+					rectSpy.mockRestore();
+				}
+			});
+		});
 	});
 });

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -201,14 +201,14 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		handlers.keyup({keyCode: 39});
 	});
 
-	test('should not call preventDefault when Tab reaches end of a non-self-only linear list', () => {
+	test('should wrap Tab focus to the first target after the last root target', () => {
 		setupSimpleDocument();
 		focusForTest(document.getElementById('second'));
 
 		const ev = dispatchTab(handlers.keydown);
 
-		expect(ev.preventDefault).not.toHaveBeenCalled();
-		expect(document.activeElement.id).toBe('second');
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('first');
 	});
 
 	test('should move focus to nearest element when current focus is outside the linear list', () => {
@@ -268,14 +268,61 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		}
 	});
 
-	test('should not call preventDefault when Shift+Tab goes before the start of a non-self-only list', () => {
+	test('should wrap Shift+Tab focus to the last root target before the first', () => {
 		setupPopupDocument();
 		focusForTest(document.getElementById('ownerA'));
 
 		const ev = dispatchTab(handlers.keydown, true);
 
-		expect(ev.preventDefault).not.toHaveBeenCalled();
-		expect(document.activeElement.id).toBe('ownerA');
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('b2');
+	});
+
+	test('should move focus from sidebar Button tab to Home on Shift+Tab in TabLayout-like layout', () => {
+		document.body.innerHTML = `
+			<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div data-spotlight-container="true" data-spotlight-id="tablayout">
+					<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+						<button id="home" class="spottable tab">Home</button>
+						<button id="gear" class="spottable tab">Button</button>
+						<button id="item" class="spottable tab">Item</button>
+					</div>
+					<button id="closex" class="spottable">X</button>
+					<button id="btn1" class="spottable">Button 1</button>
+					<button id="btn2" class="spottable">Button 2</button>
+					<button id="btn3" class="spottable">Button 3</button>
+					<button id="btn4" class="spottable">Button 4</button>
+					<button id="btn5" class="spottable">Button 5</button>
+				</div>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 100, width: 60, height: 400});
+		setRect(document.getElementById('home'), {left: 20, top: 110});
+		setRect(document.getElementById('gear'), {left: 20, top: 200});
+		setRect(document.getElementById('item'), {left: 20, top: 290});
+		setRect(document.getElementById('closex'), {left: 900, top: 40, width: 48, height: 48});
+		setRect(document.getElementById('btn1'), {left: 300, top: 200});
+		setRect(document.getElementById('btn2'), {left: 400, top: 200});
+		setRect(document.getElementById('btn3'), {left: 500, top: 200});
+		setRect(document.getElementById('btn4'), {left: 600, top: 200});
+		setRect(document.getElementById('btn5'), {left: 700, top: 200});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tablayout', {
+			navigableFilter: (elem) => (
+				elem.dataset.spotlightId !== 'tabs-collapsed' &&
+				!elem.classList.contains('tab')
+			),
+			selector: '.spottable'
+		});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		focusForTest(document.getElementById('gear'));
+		const ev = dispatchTab(handlers.keydown, true);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('home');
 	});
 
 	test('should bootstrap focus via restoreFocus when nothing is focused', () => {
@@ -599,5 +646,135 @@ describe('tabTraversal — pure helpers', () => {
 		const linear = getLinearTargetsInContainer(rootContainerId);
 		expect(linear[0].target.id).toBe('first');
 		expect(linear[1].target.id).toBe('second');
+	});
+
+	test('getLinearTargetsInContainer: includes spottables inside navigableFilter-excluded subcontainers', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+					<button id="gear" class="spottable tab">Gear</button>
+				</div>
+				<button id="content" class="spottable">Content</button>
+			</div>
+		`;
+		setRect(document.getElementById('home'), {left: 20, top: 20});
+		setRect(document.getElementById('gear'), {left: 20, top: 60});
+		// Content sits below the sidebar tabs so visual Tab order matches TabLayout.
+		setRect(document.getElementById('content'), {left: 200, top: 100});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {
+			navigableFilter: (elem) => (
+				elem.dataset.spotlightId !== 'tabs-collapsed' &&
+				!elem.classList.contains('tab')
+			),
+			selector: '.spottable'
+		});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual(['home', 'gear', 'content']);
+	});
+
+	test('getLinearTargetsInContainer: orders partition sidebar before content even when x coordinates overlap', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div id="tablayout-body">
+					<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+						<button id="home" class="spottable tab">Home</button>
+						<button id="gear" class="spottable tab">Button</button>
+						<button id="item" class="spottable tab">Item</button>
+					</div>
+					<button id="btn1" class="spottable">Button 1</button>
+					<button id="btn5" class="spottable">Button 5</button>
+				</div>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 100, width: 200, height: 400});
+		setRect(document.getElementById('home'), {left: 20, top: 110});
+		setRect(document.getElementById('gear'), {left: 20, top: 200});
+		setRect(document.getElementById('item'), {left: 20, top: 290});
+		// Same row as the sidebar Button tab; x still inside the partition rect width.
+		setRect(document.getElementById('btn1'), {left: 120, top: 200});
+		setRect(document.getElementById('btn5'), {left: 180, top: 200});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual(['home', 'gear', 'item', 'btn1', 'btn5']);
+	});
+
+	test('getLinearTargetsInContainer: orders partition groups in DOM order before visually overlapping controls', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+					<button id="gear" class="spottable tab">Button</button>
+					<button id="item" class="spottable tab">Item</button>
+				</div>
+				<button id="btn1" class="spottable">Button 1</button>
+				<button id="btn2" class="spottable">Button 2</button>
+				<button id="btn3" class="spottable">Button 3</button>
+				<button id="btn4" class="spottable">Button 4</button>
+				<button id="btn5" class="spottable">Button 5</button>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 10, width: 60, height: 150});
+		setRect(document.getElementById('home'), {left: 20, top: 20});
+		setRect(document.getElementById('gear'), {left: 20, top: 60});
+		setRect(document.getElementById('item'), {left: 20, top: 100});
+		setRect(document.getElementById('btn1'), {left: 200, top: 60});
+		setRect(document.getElementById('btn2'), {left: 280, top: 60});
+		setRect(document.getElementById('btn3'), {left: 360, top: 60});
+		setRect(document.getElementById('btn4'), {left: 440, top: 60});
+		setRect(document.getElementById('btn5'), {left: 520, top: 60});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {
+			navigableFilter: (elem) => (
+				elem.dataset.spotlightId !== 'tabs-collapsed' &&
+				!elem.classList.contains('tab')
+			),
+			selector: '.spottable'
+		});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual([
+			'home', 'gear', 'item', 'btn1', 'btn2', 'btn3', 'btn4', 'btn5'
+		]);
+	});
+
+	test('getLinearTargetsInContainer: keeps partition sidebar before scrolled content in the same panel', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+					<button id="gear" class="spottable tab">Button</button>
+					<button id="item" class="spottable tab">Item</button>
+				</div>
+				<button id="img11" class="spottable">ImageItem 11</button>
+				<button id="img12" class="spottable">ImageItem 12</button>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 10, width: 60, height: 400});
+		setRect(document.getElementById('home'), {left: 20, top: 20});
+		setRect(document.getElementById('gear'), {left: 20, top: 200});
+		setRect(document.getElementById('item'), {left: 20, top: 380});
+		// Scrolled content: item 11 can sit above the sidebar Button tab in viewport coordinates.
+		setRect(document.getElementById('img11'), {left: 300, top: 50});
+		setRect(document.getElementById('img12'), {left: 300, top: 700});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual([
+			'home', 'gear', 'item', 'img11', 'img12'
+		]);
 	});
 });

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -380,6 +380,32 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		expect(ev.preventDefault).toHaveBeenCalled();
 		expect(document.activeElement.id).toBe('ownerB');
 	});
+
+	test('should exit self-only popup backward on Shift+Tab from first item', () => {
+		setupPopupDocument();
+		setLastContainer('popup-b');
+		focusForTest(document.getElementById('b1'));
+
+		const ev = dispatchTab(handlers.keydown, true);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('a2');
+	});
+
+	test('should not call preventDefault when self-only popup has no reverse exit target', () => {
+		setupPopupDocument();
+		document.getElementById('ownerA').remove();
+		document.getElementById('ownerB').remove();
+		document.getElementById('layerA').remove();
+		document.getElementById('outside').remove();
+		setLastContainer('popup-b');
+		focusForTest(document.getElementById('b1'));
+
+		const ev = dispatchTab(handlers.keydown, true);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('b1');
+	});
 });
 
 describe('tabTraversal — pure helpers', () => {
@@ -462,6 +488,14 @@ describe('tabTraversal — pure helpers', () => {
 		expect(res.id).toBe('b1');
 	});
 
+	test('resolveTargetToOpenPopupItem: redirects into the last item of an open popup on reverse traversal', () => {
+		setupPopupDocument();
+		const res = resolveTargetToOpenPopupItem(
+			document.getElementById('ownerB'), 'popup-a', false
+		);
+		expect(res.id).toBe('b2');
+	});
+
 	test('resolveTargetToOpenPopupItem: passes through when aria-owns is removed', () => {
 		setupPopupDocument();
 		document.getElementById('ownerB').removeAttribute('aria-owns');
@@ -501,6 +535,11 @@ describe('tabTraversal — pure helpers', () => {
 		} finally {
 			document.body.removeAttribute('aria-owns');
 		}
+	});
+
+	test('findLinearTabExitTarget: returns null for an unknown container id', () => {
+		setupPopupDocument();
+		expect(findLinearTabExitTarget(document.getElementById('a1'), 'missing-popup', true)).toBeNull();
 	});
 
 	test('findLinearTabExitTarget: uses forward fallback path when popup owner has no aria-owns', () => {
@@ -580,6 +619,11 @@ describe('tabTraversal — pure helpers', () => {
 		configureContainer(rootContainerId, {selector: '.spottable'});
 
 		expect(getLinearTargetsInContainer(rootContainerId)).toEqual([]);
+	});
+
+	test('getLinearTargetContainerId: prefers DOM ancestry over aria-owns containers', () => {
+		setupPopupDocument();
+		expect(getLinearTargetContainerId(document.getElementById('ownerA'))).toBe(rootContainerId);
 	});
 
 	test('getLinearTargetContainerId: falls back to getContainersForNode when closest container has empty id', () => {
@@ -677,6 +721,27 @@ describe('tabTraversal — pure helpers', () => {
 		expect(linear.map(({target: t}) => t.id)).toEqual(['home', 'gear', 'content']);
 	});
 
+	test('getLinearTargetsInContainer: keeps partition group before an earlier sibling control', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<button id="outside" class="spottable">Outside</button>
+				<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+				</div>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 160, top: 10, width: 60, height: 40});
+		setRect(document.getElementById('outside'), {left: 20, top: 20});
+		setRect(document.getElementById('home'), {left: 170, top: 20});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual(['home', 'outside']);
+	});
+
 	test('getLinearTargetsInContainer: orders partition sidebar before content even when x coordinates overlap', () => {
 		document.body.innerHTML = `
 			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
@@ -746,6 +811,98 @@ describe('tabTraversal — pure helpers', () => {
 		expect(linear.map(({target: t}) => t.id)).toEqual([
 			'home', 'gear', 'item', 'btn1', 'btn2', 'btn3', 'btn4', 'btn5'
 		]);
+	});
+
+	test('getLinearTargetsInContainer: uses visual order for external controls when partition node is unavailable', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+				</div>
+				<button id="content" class="spottable">Content</button>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 10, width: 60, height: 100});
+		setRect(document.getElementById('home'), {left: 200, top: 20});
+		setRect(document.getElementById('content'), {left: 20, top: 20});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const containerNodeSpy = jest.spyOn(container, 'getContainerNode').mockImplementation((id) => {
+			if (id === 'tabs-collapsed') {
+				return null;
+			}
+			return document.querySelector(`[data-spotlight-id="${id}"]`) ||
+				(id === rootContainerId ? document : null);
+		});
+		try {
+			const linear = getLinearTargetsInContainer(rootContainerId);
+			expect(linear.map(({target: t}) => t.id)).toEqual(['content', 'home']);
+		} finally {
+			containerNodeSpy.mockRestore();
+		}
+	});
+
+	test('getLinearTargetsInContainer: uses visual order when partition container node is unavailable', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<button id="content" class="spottable">Content</button>
+				<div id="tabs-collapsed" data-spotlight-container="true" data-spotlight-id="tabs-collapsed">
+					<button id="home" class="spottable tab">Home</button>
+				</div>
+			</div>
+		`;
+		setRect(document.getElementById('tabs-collapsed'), {left: 10, top: 10, width: 60, height: 100});
+		setRect(document.getElementById('home'), {left: 20, top: 20});
+		setRect(document.getElementById('content'), {left: 200, top: 20});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('tabs-collapsed', {partition: true, selector: '.spottable'});
+
+		const containerNodeSpy = jest.spyOn(container, 'getContainerNode').mockImplementation((id) => {
+			if (id === 'tabs-collapsed') {
+				return null;
+			}
+			return document.querySelector(`[data-spotlight-id="${id}"]`) ||
+				(id === rootContainerId ? document : null);
+		});
+		try {
+			const linear = getLinearTargetsInContainer(rootContainerId);
+			expect(linear.map(({target: t}) => t.id)).toEqual(['home', 'content']);
+			expect(containerNodeSpy).toHaveBeenCalledWith('tabs-collapsed');
+		} finally {
+			containerNodeSpy.mockRestore();
+		}
+	});
+
+	test('getLinearTargetsInContainer: orders two partition groups before non-partition controls', () => {
+		document.body.innerHTML = `
+			<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div id="group-a" data-spotlight-container="true" data-spotlight-id="group-a">
+					<button id="a1" class="spottable">A1</button>
+				</div>
+				<div id="group-b" data-spotlight-container="true" data-spotlight-id="group-b">
+					<button id="b1" class="spottable">B1</button>
+				</div>
+				<button id="free" class="spottable">Free</button>
+			</div>
+		`;
+		setRect(document.getElementById('group-a'), {left: 10, top: 10, width: 50, height: 100});
+		setRect(document.getElementById('group-b'), {left: 70, top: 10, width: 50, height: 100});
+		setRect(document.getElementById('a1'), {left: 15, top: 20});
+		setRect(document.getElementById('b1'), {left: 75, top: 20});
+		setRect(document.getElementById('free'), {left: 200, top: 20});
+
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		configureContainer('group-a', {partition: true, selector: '.spottable'});
+		configureContainer('group-b', {partition: true, selector: '.spottable'});
+
+		const linear = getLinearTargetsInContainer(rootContainerId);
+		expect(linear.map(({target: t}) => t.id)).toEqual(['a1', 'b1', 'free']);
 	});
 
 	test('getLinearTargetsInContainer: keeps partition sidebar before scrolled content in the same panel', () => {

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -7,8 +7,10 @@ import {
 	rootContainerId,
 	setLastContainer
 } from '../container';
+import * as container from '../container';
 import {pause, resume} from '../../Pause';
-import Spotlight, {_tabNavTestHooks as tabNavTestHooks} from '../spotlight';
+import Spotlight from '../spotlight';
+import {tabTraversal as tabNavTestHooks} from '../tabTraversal';
 import * as target from '../target';
 
 import {
@@ -546,7 +548,12 @@ describe('Spotlight Tab helpers (integration)', () => {
 		wrap.appendChild(btn);
 		document.getElementById('root').appendChild(wrap);
 
-		expect(tabNavTestHooks.getLinearTargetContainerId(btn)).toBe('');
+		const containersSpy = jest.spyOn(container, 'getContainersForNode')
+			.mockReturnValue([rootContainerId, 'sentinel']);
+
+		expect(tabNavTestHooks.getLinearTargetContainerId(btn)).toBe('sentinel');
+
+		containersSpy.mockRestore();
 	});
 
 	test('getLinearTargetsInContainer: reuses the per-keypress cache on repeated lookups', () => {

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -51,6 +51,25 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		}
 	});
 
+	test('should ignore non-Tab keys while Spotlight is paused', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('first'));
+		pause();
+		try {
+			const ev = {
+				keyCode: 37,
+				shiftKey: false,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn()
+			};
+			handlers.keydown(ev);
+			expect(document.activeElement.id).toBe('first');
+			expect(ev.preventDefault).not.toHaveBeenCalled();
+		} finally {
+			resume();
+		}
+	});
+
 	test('should move focus forward on Tab', () => {
 		setupSimpleDocument();
 		focusForTest(document.getElementById('first'));
@@ -442,6 +461,17 @@ describe('Spotlight Tab helpers (integration)', () => {
 		document.getElementById('root').appendChild(wrap);
 
 		expect(tabNavTestHooks.getLinearTargetContainerId(btn)).toBe('');
+	});
+
+	test('getLinearTargetsInContainer: reuses the per-keypress cache on repeated lookups', () => {
+		setupPopupDocument();
+
+		tabNavTestHooks.runWithLinearTargetsCache(() => {
+			const first = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+			const second = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+
+			expect(second).toBe(first);
+		});
 	});
 
 	test('getLinearTargetsInContainer: lists root and portaled controls in visual order with finite coordinates', () => {

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -1,5 +1,6 @@
 // Integration tests for Spotlight keyboard dispatch and Tab navigation.
 
+import * as container from '../container';
 import {
 	configureContainer,
 	configureDefaults,
@@ -7,10 +8,19 @@ import {
 	rootContainerId,
 	setLastContainer
 } from '../container';
-import * as container from '../container';
 import {pause, resume} from '../../Pause';
 import Spotlight from '../spotlight';
-import {tabTraversal as tabNavTestHooks} from '../tabTraversal';
+import {
+	comesBeforeInTabOrder,
+	findLinearTabExitTarget,
+	findLinearTabExitTargetInTargets,
+	getLinearTabSearchContainerId,
+	getLinearTargetContainerId,
+	getLinearTargetsInContainer,
+	isTargetInSelfOnlyContainer,
+	resolveTargetToOpenPopupItem,
+	runWithLinearTargetsCache
+} from '../tabTraversal';
 import * as target from '../target';
 
 import {
@@ -214,13 +224,8 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		expect(ev.preventDefault).toHaveBeenCalled();
 		expect(document.activeElement.id).toBe('second');
 	});
-});
 
-describe('Spotlight spotLinear (integration)', () => {
-	beforeEach(() => Spotlight.setPointerMode(false));
-	afterEach(teardownTabTest);
-
-	test('should return false when nothing is focused and focus cannot be restored', () => {
+	test('should not call preventDefault when Tab cannot restore focus in an empty container', () => {
 		document.body.innerHTML = `
 			<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}"></div>
 		`;
@@ -228,35 +233,21 @@ describe('Spotlight spotLinear (integration)', () => {
 		configureContainer(rootContainerId, {selector: '.spottable'});
 		setLastContainer(rootContainerId);
 
-		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
 	});
 
-	test('should return false when restoreFocus appears to succeed but leaves no active element', () => {
+	test('should not call preventDefault when restoreFocus succeeds but leaves no active element', () => {
 		setupSimpleDocument();
 		document.getElementById('first').blur?.();
 		const focusSpy = jest.spyOn(Spotlight, 'focus').mockImplementation(() => true);
 		try {
-			expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+			const ev = dispatchTab(handlers.keydown);
+			expect(ev.preventDefault).not.toHaveBeenCalled();
 		} finally {
 			focusSpy.mockRestore();
 		}
-	});
-
-	test('should advance focus to the next spottable element', () => {
-		setupSimpleDocument();
-		focusForTest(document.getElementById('first'));
-
-		const moved = tabNavTestHooks.spotLinear(true);
-
-		expect(moved).toBe(true);
-		expect(document.activeElement.id).toBe('second');
-	});
-
-	test('should return false at the end of the linear list', () => {
-		setupSimpleDocument();
-		focusForTest(document.getElementById('second'));
-
-		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
 	});
 
 	test('should fall back to first element when nearest target cannot be resolved', () => {
@@ -269,33 +260,22 @@ describe('Spotlight spotLinear (integration)', () => {
 
 		const nearestSpy = jest.spyOn(target, 'getNearestTargetFromPosition').mockReturnValue(null);
 		try {
-			const moved = tabNavTestHooks.spotLinear(true);
-			expect(moved).toBe(true);
+			const ev = dispatchTab(handlers.keydown);
+			expect(ev.preventDefault).toHaveBeenCalled();
 			expect(document.activeElement.id).toBe('ownerA');
 		} finally {
 			nearestSpy.mockRestore();
 		}
 	});
 
-	test('should use the nearest linear element when current focus is outside the list', () => {
-		setupPopupDocument();
-		const orphan = document.createElement('button');
-		orphan.id = 'orphan-near-ownerB';
-		document.body.appendChild(orphan);
-		setRect(orphan, {left: 144, top: 18, width: 16, height: 10});
-		focusForTest(orphan);
-
-		const moved = tabNavTestHooks.spotLinear(true);
-
-		expect(moved).toBe(true);
-		expect(document.activeElement.id).toBe('outside');
-	});
-
-	test('should return false when reverse index goes before start in non-self-only scope', () => {
+	test('should not call preventDefault when Shift+Tab goes before the start of a non-self-only list', () => {
 		setupPopupDocument();
 		focusForTest(document.getElementById('ownerA'));
 
-		expect(tabNavTestHooks.spotLinear(false)).toBe(false);
+		const ev = dispatchTab(handlers.keydown, true);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('ownerA');
 	});
 
 	test('should bootstrap focus via restoreFocus when nothing is focused', () => {
@@ -304,13 +284,13 @@ describe('Spotlight spotLinear (integration)', () => {
 			document.activeElement.blur();
 		}
 
-		const moved = tabNavTestHooks.spotLinear(true);
+		const ev = dispatchTab(handlers.keydown);
 
-		expect(moved).toBe(true);
+		expect(ev.preventDefault).toHaveBeenCalled();
 		expect(document.activeElement.id).toBe('second');
 	});
 
-	test('should return false when self-only popup has no spottable linear targets', () => {
+	test('should not call preventDefault when self-only popup has no spottable linear targets', () => {
 		setupPopupDocument();
 		const popup = document.querySelector('[data-spotlight-id="popup-a"]');
 		popup.innerHTML = '';
@@ -320,10 +300,13 @@ describe('Spotlight spotLinear (integration)', () => {
 		setLastContainer('popup-a');
 		focusForTest(btn);
 
-		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('non-spottable-inside');
 	});
 
-	test('should return false when self-only container has no valid exit target', () => {
+	test('should not call preventDefault when self-only container has no valid exit target', () => {
 		setupPopupDocument();
 		document.getElementById('ownerA').removeAttribute('aria-owns');
 		document.getElementById('ownerB').remove();
@@ -332,23 +315,39 @@ describe('Spotlight spotLinear (integration)', () => {
 		setLastContainer('popup-a');
 		focusForTest(document.getElementById('a2'));
 
-		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('a2');
+	});
+
+	test('should complete Tab handoff when owned popup is empty and aria-owns lists duplicate layers', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').setAttribute('aria-owns', 'layerB layerB');
+		document.querySelector('[data-spotlight-id="popup-b"]').innerHTML = '';
+		setLastContainer('popup-a');
+		focusForTest(document.getElementById('a2'));
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('ownerB');
 	});
 });
 
-describe('Spotlight Tab helpers (integration)', () => {
+describe('tabTraversal — pure helpers', () => {
 	afterEach(teardownTabTest);
 
 	test('getLinearTabSearchContainerId: returns root for null focus', () => {
 		setupPopupDocument();
-		expect(tabNavTestHooks.getLinearTabSearchContainerId(null)).toBe(rootContainerId);
+		expect(getLinearTabSearchContainerId(null)).toBe(rootContainerId);
 	});
 
 	test('getLinearTabSearchContainerId: returns root when paused', () => {
 		setupPopupDocument();
 		pause();
 		try {
-			expect(tabNavTestHooks.getLinearTabSearchContainerId(document.getElementById('a1'))).toBe(rootContainerId);
+			expect(getLinearTabSearchContainerId(document.getElementById('a1'))).toBe(rootContainerId);
 		} finally {
 			resume();
 		}
@@ -357,7 +356,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 	test('getLinearTabSearchContainerId: returns self-only container for an element inside one', () => {
 		setupPopupDocument();
 		setLastContainer('popup-a');
-		expect(tabNavTestHooks.getLinearTabSearchContainerId(document.getElementById('a1'))).toBe('popup-a');
+		expect(getLinearTabSearchContainerId(document.getElementById('a1'))).toBe('popup-a');
 	});
 
 	test.each([
@@ -366,7 +365,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		['same row rtl', 30, 10, 10, 12, true, true],
 		['same row same X', 10, 10, 10, 12, false, false]
 	])('comesBeforeInTabOrder: %s', (_label, ax, ay, bx, by, rtl, expected) => {
-		expect(tabNavTestHooks.comesBeforeInTabOrder(ax, ay, bx, by, rtl)).toBe(expected);
+		expect(comesBeforeInTabOrder(ax, ay, bx, by, rtl)).toBe(expected);
 	});
 
 	test('getPopupOwnerElement: finds the aria-owns trigger for a popup container', () => {
@@ -383,17 +382,17 @@ describe('Spotlight Tab helpers (integration)', () => {
 
 	test('isTargetInSelfOnlyContainer: true for popup items, false for root-level elements and null', () => {
 		setupPopupDocument();
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('a2'))).toBe(true);
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('ownerB'))).toBe(false);
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('outside'))).toBe(false);
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(null)).toBe(false);
+		expect(isTargetInSelfOnlyContainer(document.getElementById('a2'))).toBe(true);
+		expect(isTargetInSelfOnlyContainer(document.getElementById('ownerB'))).toBe(false);
+		expect(isTargetInSelfOnlyContainer(document.getElementById('outside'))).toBe(false);
+		expect(isTargetInSelfOnlyContainer(null)).toBe(false);
 	});
 
 	test('isTargetInSelfOnlyContainer: false when target has no spotlight container ancestor', () => {
 		setupPopupDocument();
 		const orphan = document.createElement('button');
 		document.body.appendChild(orphan);
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(orphan)).toBe(false);
+		expect(isTargetInSelfOnlyContainer(orphan)).toBe(false);
 	});
 
 	test('isTargetInSelfOnlyContainer: false for a node inside the root container itself', () => {
@@ -405,12 +404,12 @@ describe('Spotlight Tab helpers (integration)', () => {
 		configureDefaults({selector: '.spottable'});
 		configureContainer(rootContainerId, {selector: '.spottable'});
 
-		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('root-child'))).toBe(false);
+		expect(isTargetInSelfOnlyContainer(document.getElementById('root-child'))).toBe(false);
 	});
 
 	test('resolveTargetToOpenPopupItem: redirects into the first item of an open popup', () => {
 		setupPopupDocument();
-		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+		const res = resolveTargetToOpenPopupItem(
 			document.getElementById('ownerB'), 'popup-a', true
 		);
 		expect(res.id).toBe('b1');
@@ -419,7 +418,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 	test('resolveTargetToOpenPopupItem: passes through when aria-owns is removed', () => {
 		setupPopupDocument();
 		document.getElementById('ownerB').removeAttribute('aria-owns');
-		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+		const res = resolveTargetToOpenPopupItem(
 			document.getElementById('ownerB'), 'popup-a', true
 		);
 		expect(res.id).toBe('ownerB');
@@ -428,7 +427,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 	test('resolveTargetToOpenPopupItem: passes through when aria-owns is empty string', () => {
 		setupPopupDocument();
 		document.getElementById('ownerB').setAttribute('aria-owns', '');
-		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+		const res = resolveTargetToOpenPopupItem(
 			document.getElementById('ownerB'), 'popup-a', true
 		);
 		expect(res.id).toBe('ownerB');
@@ -437,7 +436,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 	test('resolveTargetToOpenPopupItem: passes through when aria-owns points to a non-container element', () => {
 		setupPopupDocument();
 		document.getElementById('ownerB').setAttribute('aria-owns', 'outside');
-		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+		const res = resolveTargetToOpenPopupItem(
 			document.getElementById('ownerB'), 'popup-a', true
 		);
 		expect(res.id).toBe('ownerB');
@@ -448,7 +447,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		document.getElementById('ownerA').removeAttribute('aria-owns');
 		document.body.setAttribute('aria-owns', 'layerB');
 		try {
-			const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+			const res = resolveTargetToOpenPopupItem(
 				document.getElementById('ownerA'), 'popup-b', true
 			);
 			expect(res.id).toBe('ownerA');
@@ -462,7 +461,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		document.getElementById('ownerA').removeAttribute('aria-owns');
 		setRect(document.getElementById('outside'), {left: 320, top: 160});
 
-		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a2'), 'popup-a', true);
+		const exitTarget = findLinearTabExitTarget(document.getElementById('a2'), 'popup-a', true);
 
 		expect(exitTarget).not.toBeNull();
 		expect(exitTarget.id).toBe('outside');
@@ -472,7 +471,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		setupPopupDocument();
 		document.getElementById('ownerB').removeAttribute('aria-owns');
 
-		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
+		const exitTarget = findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
 
 		expect(exitTarget).not.toBeNull();
 		expect(exitTarget.id).toBe('outside');
@@ -480,7 +479,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 
 	test('findLinearTabExitTarget: exits second popup forward to the element after it in root order', () => {
 		setupPopupDocument();
-		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(
+		const exitTarget = findLinearTabExitTarget(
 			document.getElementById('b2'), 'popup-b', true
 		);
 		expect(exitTarget).not.toBeNull();
@@ -494,7 +493,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 			{target: document.getElementById('b1'), x: 180, y: 92},
 			{target: document.getElementById('outside'), x: 360, y: 32}
 		];
-		expect(tabNavTestHooks.findLinearTabExitTargetInTargets(targets, 60, 90, false, true)).toBeNull();
+		expect(findLinearTabExitTargetInTargets(targets, 60, 90, false, true)).toBeNull();
 	});
 
 	test('findLinearTabExitTargetInTargets: returns outside in reverse order', () => {
@@ -504,7 +503,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 			{target: document.getElementById('b1'), x: 180, y: 92},
 			{target: document.getElementById('outside'), x: 360, y: 32}
 		];
-		const reverse = tabNavTestHooks.findLinearTabExitTargetInTargets(targets, 180, 90, false, false);
+		const reverse = findLinearTabExitTargetInTargets(targets, 180, 90, false, false);
 		expect(reverse).not.toBeNull();
 		expect(reverse.id).toBe('outside');
 	});
@@ -517,7 +516,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		ownerLike.setAttribute('aria-owns', '');
 		document.getElementById('root').appendChild(ownerLike);
 
-		const result = tabNavTestHooks.findLinearTabExitTargetInTargets(
+		const result = findLinearTabExitTargetInTargets(
 			[{target: ownerLike, x: 300, y: 90}],
 			60, 90, false, true
 		);
@@ -533,7 +532,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		`;
 		configureContainer(rootContainerId, {selector: '.spottable'});
 
-		expect(tabNavTestHooks.getLinearTargetsInContainer(rootContainerId)).toEqual([]);
+		expect(getLinearTargetsInContainer(rootContainerId)).toEqual([]);
 	});
 
 	test('getLinearTargetContainerId: falls back to getContainersForNode when closest container has empty id', () => {
@@ -551,7 +550,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 		const containersSpy = jest.spyOn(container, 'getContainersForNode')
 			.mockReturnValue([rootContainerId, 'sentinel']);
 
-		expect(tabNavTestHooks.getLinearTargetContainerId(btn)).toBe('sentinel');
+		expect(getLinearTargetContainerId(btn)).toBe('sentinel');
 
 		containersSpy.mockRestore();
 	});
@@ -559,9 +558,9 @@ describe('Spotlight Tab helpers (integration)', () => {
 	test('getLinearTargetsInContainer: reuses the per-keypress cache on repeated lookups', () => {
 		setupPopupDocument();
 
-		tabNavTestHooks.runWithLinearTargetsCache(() => {
-			const first = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
-			const second = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		runWithLinearTargetsCache(() => {
+			const first = getLinearTargetsInContainer(rootContainerId);
+			const second = getLinearTargetsInContainer(rootContainerId);
 
 			expect(second).toBe(first);
 		});
@@ -569,7 +568,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 
 	test('getLinearTargetsInContainer: lists root and portaled controls in visual order with finite coordinates', () => {
 		setupPopupDocument();
-		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		const linear = getLinearTargetsInContainer(rootContainerId);
 		const ids = linear.map(({target: t}) => t.id);
 
 		expect(ids).toEqual(['ownerA', 'ownerB', 'outside', 'a1', 'b1', 'a2', 'b2']);
@@ -578,7 +577,7 @@ describe('Spotlight Tab helpers (integration)', () => {
 
 	test('getLinearTargetsInContainer: computes correct centre coordinates from getBoundingClientRect', () => {
 		setupPopupDocument();
-		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		const linear = getLinearTargetsInContainer(rootContainerId);
 
 		const ownerAEntry = linear.find(({target: t}) => t.id === 'ownerA');
 		expect(ownerAEntry).toBeDefined();
@@ -597,24 +596,8 @@ describe('Spotlight Tab helpers (integration)', () => {
 		setRect(document.getElementById('first'), sameRect);
 		setRect(document.getElementById('second'), sameRect);
 
-		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		const linear = getLinearTargetsInContainer(rootContainerId);
 		expect(linear[0].target.id).toBe('first');
 		expect(linear[1].target.id).toBe('second');
-	});
-
-	test('should complete Tab handoff when owned popup is empty and aria-owns lists duplicate layers', () => {
-		setupPopupDocument();
-		document.getElementById('ownerB').setAttribute('aria-owns', 'layerB layerB');
-		document.querySelector('[data-spotlight-id="popup-b"]').innerHTML = '';
-		setLastContainer('popup-a');
-		focusForTest(document.getElementById('a2'));
-
-		Spotlight.terminate();
-		const {keydown} = captureHandlers();
-		Spotlight.setPointerMode(false);
-		const ev = dispatchTab(keydown);
-
-		expect(ev.preventDefault).toHaveBeenCalled();
-		expect(document.activeElement.id).toBe('ownerB');
 	});
 });

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -1,0 +1,497 @@
+// Integration tests for Spotlight keyboard dispatch and Tab navigation.
+
+import {
+	configureContainer,
+	configureDefaults,
+	getPopupOwnerElement,
+	rootContainerId,
+	setLastContainer
+} from '../container';
+import {pause, resume} from '../../Pause';
+import Spotlight, {_tabNavTestHooks as tabNavTestHooks} from '../spotlight';
+import * as target from '../target';
+
+import {
+	captureHandlers,
+	dispatchTab,
+	focusForTest,
+	installTabTestEnvironment,
+	makeTabEvent,
+	setRect,
+	setupPopupDocument,
+	setupSimpleDocument,
+	teardownTabTest,
+	uninstallTabTestEnvironment
+} from './tab-fixtures';
+
+beforeAll(installTabTestEnvironment);
+afterAll(uninstallTabTestEnvironment);
+
+describe('Spotlight Tab key dispatch (integration)', () => {
+	let handlers;
+
+	beforeEach(() => {
+		Spotlight.terminate();
+		handlers = captureHandlers();
+		Spotlight.setPointerMode(false);
+	});
+
+	afterEach(teardownTabTest);
+
+	test('should call preventDefault for Tab while Spotlight is paused', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('first'));
+		pause();
+		try {
+			const ev = makeTabEvent();
+			handlers.keydown(ev);
+			expect(ev.preventDefault).toHaveBeenCalled();
+		} finally {
+			resume();
+		}
+	});
+
+	test('should move focus forward on Tab', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('first'));
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('second');
+	});
+
+	test('should move focus backward on Shift+Tab', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('second'));
+
+		const ev = dispatchTab(handlers.keydown, true);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('first');
+	});
+
+	test('should skip Tab focus movement when pointer moved during key press', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('first'));
+		handlers.keydown({keyCode: 39, shiftKey: false, preventDefault: jest.fn(), stopPropagation: jest.fn()});
+		handlers.mousemove({target: document.getElementById('first'), clientX: 30, clientY: 30});
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(document.activeElement.id).toBe('first');
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		handlers.keyup({keyCode: 39});
+	});
+
+	test('should not call preventDefault when Tab reaches end of a non-self-only linear list', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('second'));
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).not.toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('second');
+	});
+
+	test('should move focus to nearest element when current focus is outside the linear list', () => {
+		setupSimpleDocument();
+		const orphan = document.createElement('button');
+		orphan.id = 'orphan';
+		document.body.appendChild(orphan);
+		setRect(orphan, {left: 110, top: 14, width: 10, height: 10});
+		focusForTest(orphan);
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('second');
+	});
+});
+
+describe('Spotlight spotLinear (integration)', () => {
+	beforeEach(() => Spotlight.setPointerMode(false));
+	afterEach(teardownTabTest);
+
+	test('should return false when nothing is focused and focus cannot be restored', () => {
+		document.body.innerHTML = `
+			<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}"></div>
+		`;
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+		setLastContainer(rootContainerId);
+
+		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+	});
+
+	test('should return false when restoreFocus appears to succeed but leaves no active element', () => {
+		setupSimpleDocument();
+		document.getElementById('first').blur?.();
+		const focusSpy = jest.spyOn(Spotlight, 'focus').mockImplementation(() => true);
+		try {
+			expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+		} finally {
+			focusSpy.mockRestore();
+		}
+	});
+
+	test('should advance focus to the next spottable element', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('first'));
+
+		const moved = tabNavTestHooks.spotLinear(true);
+
+		expect(moved).toBe(true);
+		expect(document.activeElement.id).toBe('second');
+	});
+
+	test('should return false at the end of the linear list', () => {
+		setupSimpleDocument();
+		focusForTest(document.getElementById('second'));
+
+		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+	});
+
+	test('should fall back to first element when nearest target cannot be resolved', () => {
+		setupPopupDocument();
+		const orphan = document.createElement('button');
+		orphan.id = 'orphan-outside-list';
+		document.body.appendChild(orphan);
+		setRect(orphan, {left: 500, top: 500, width: 10, height: 10});
+		focusForTest(orphan);
+
+		const nearestSpy = jest.spyOn(target, 'getNearestTargetFromPosition').mockReturnValue(null);
+		try {
+			const moved = tabNavTestHooks.spotLinear(true);
+			expect(moved).toBe(true);
+			expect(document.activeElement.id).toBe('ownerA');
+		} finally {
+			nearestSpy.mockRestore();
+		}
+	});
+
+	test('should use the nearest linear element when current focus is outside the list', () => {
+		setupPopupDocument();
+		const orphan = document.createElement('button');
+		orphan.id = 'orphan-near-ownerB';
+		document.body.appendChild(orphan);
+		setRect(orphan, {left: 144, top: 18, width: 16, height: 10});
+		focusForTest(orphan);
+
+		const moved = tabNavTestHooks.spotLinear(true);
+
+		expect(moved).toBe(true);
+		expect(document.activeElement.id).toBe('outside');
+	});
+
+	test('should return false when reverse index goes before start in non-self-only scope', () => {
+		setupPopupDocument();
+		focusForTest(document.getElementById('ownerA'));
+
+		expect(tabNavTestHooks.spotLinear(false)).toBe(false);
+	});
+
+	test('should bootstrap focus via restoreFocus when nothing is focused', () => {
+		setupSimpleDocument();
+		if (document.activeElement?.blur) {
+			document.activeElement.blur();
+		}
+
+		const moved = tabNavTestHooks.spotLinear(true);
+
+		expect(moved).toBe(true);
+		expect(document.activeElement.id).toBe('second');
+	});
+
+	test('should return false when self-only popup has no spottable linear targets', () => {
+		setupPopupDocument();
+		const popup = document.querySelector('[data-spotlight-id="popup-a"]');
+		popup.innerHTML = '';
+		const btn = document.createElement('button');
+		btn.id = 'non-spottable-inside';
+		popup.appendChild(btn);
+		setLastContainer('popup-a');
+		focusForTest(btn);
+
+		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+	});
+
+	test('should return false when self-only container has no valid exit target', () => {
+		setupPopupDocument();
+		document.getElementById('ownerA').removeAttribute('aria-owns');
+		document.getElementById('ownerB').remove();
+		document.getElementById('layerB').remove();
+		document.getElementById('outside').remove();
+		setLastContainer('popup-a');
+		focusForTest(document.getElementById('a2'));
+
+		expect(tabNavTestHooks.spotLinear(true)).toBe(false);
+	});
+});
+
+describe('Spotlight Tab helpers (integration)', () => {
+	afterEach(teardownTabTest);
+
+	test('getLinearTabSearchContainerId: returns root for null focus', () => {
+		setupPopupDocument();
+		expect(tabNavTestHooks.getLinearTabSearchContainerId(null)).toBe(rootContainerId);
+	});
+
+	test('getLinearTabSearchContainerId: returns root when paused', () => {
+		setupPopupDocument();
+		pause();
+		try {
+			expect(tabNavTestHooks.getLinearTabSearchContainerId(document.getElementById('a1'))).toBe(rootContainerId);
+		} finally {
+			resume();
+		}
+	});
+
+	test('getLinearTabSearchContainerId: returns self-only container for an element inside one', () => {
+		setupPopupDocument();
+		setLastContainer('popup-a');
+		expect(tabNavTestHooks.getLinearTabSearchContainerId(document.getElementById('a1'))).toBe('popup-a');
+	});
+
+	test.each([
+		['different rows', 10, 10, 10, 40, false, true],
+		['same row ltr', 10, 10, 30, 12, false, true],
+		['same row rtl', 30, 10, 10, 12, true, true],
+		['same row same X', 10, 10, 10, 12, false, false]
+	])('comesBeforeInTabOrder: %s', (_label, ax, ay, bx, by, rtl, expected) => {
+		expect(tabNavTestHooks.comesBeforeInTabOrder(ax, ay, bx, by, rtl)).toBe(expected);
+	});
+
+	test('getPopupOwnerElement: finds the aria-owns trigger for a popup container', () => {
+		setupPopupDocument();
+		expect(
+			getPopupOwnerElement(document.querySelector('[data-spotlight-id="popup-a"]')).id
+		).toBe('ownerA');
+	});
+
+	test('getPopupOwnerElement: returns null for a null input', () => {
+		setupPopupDocument();
+		expect(getPopupOwnerElement(null)).toBeNull();
+	});
+
+	test('isTargetInSelfOnlyContainer: true for popup items, false for root-level elements and null', () => {
+		setupPopupDocument();
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('a2'))).toBe(true);
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('ownerB'))).toBe(false);
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('outside'))).toBe(false);
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(null)).toBe(false);
+	});
+
+	test('isTargetInSelfOnlyContainer: false when target has no spotlight container ancestor', () => {
+		setupPopupDocument();
+		const orphan = document.createElement('button');
+		document.body.appendChild(orphan);
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(orphan)).toBe(false);
+	});
+
+	test('isTargetInSelfOnlyContainer: false for a node inside the root container itself', () => {
+		document.body.innerHTML = `
+			<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<button id="root-child" class="spottable">Root Child</button>
+			</div>
+		`;
+		configureDefaults({selector: '.spottable'});
+		configureContainer(rootContainerId, {selector: '.spottable'});
+
+		expect(tabNavTestHooks.isTargetInSelfOnlyContainer(document.getElementById('root-child'))).toBe(false);
+	});
+
+	test('resolveTargetToOpenPopupItem: redirects into the first item of an open popup', () => {
+		setupPopupDocument();
+		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+			document.getElementById('ownerB'), 'popup-a', true
+		);
+		expect(res.id).toBe('b1');
+	});
+
+	test('resolveTargetToOpenPopupItem: passes through when aria-owns is removed', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').removeAttribute('aria-owns');
+		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+			document.getElementById('ownerB'), 'popup-a', true
+		);
+		expect(res.id).toBe('ownerB');
+	});
+
+	test('resolveTargetToOpenPopupItem: passes through when aria-owns is empty string', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').setAttribute('aria-owns', '');
+		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+			document.getElementById('ownerB'), 'popup-a', true
+		);
+		expect(res.id).toBe('ownerB');
+	});
+
+	test('resolveTargetToOpenPopupItem: passes through when aria-owns points to a non-container element', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').setAttribute('aria-owns', 'outside');
+		const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+			document.getElementById('ownerB'), 'popup-a', true
+		);
+		expect(res.id).toBe('ownerB');
+	});
+
+	test('resolveTargetToOpenPopupItem: passes through when nearest aria-owns ancestor is document.body', () => {
+		setupPopupDocument();
+		document.getElementById('ownerA').removeAttribute('aria-owns');
+		document.body.setAttribute('aria-owns', 'layerB');
+		try {
+			const res = tabNavTestHooks.resolveTargetToOpenPopupItem(
+				document.getElementById('ownerA'), 'popup-b', true
+			);
+			expect(res.id).toBe('ownerA');
+		} finally {
+			document.body.removeAttribute('aria-owns');
+		}
+	});
+
+	test('findLinearTabExitTarget: uses forward fallback path when popup owner has no aria-owns', () => {
+		setupPopupDocument();
+		document.getElementById('ownerA').removeAttribute('aria-owns');
+		setRect(document.getElementById('outside'), {left: 320, top: 160});
+
+		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a2'), 'popup-a', true);
+
+		expect(exitTarget).not.toBeNull();
+		expect(exitTarget.id).toBe('outside');
+	});
+
+	test('findLinearTabExitTarget: uses reverse fallback path when popup owner has no aria-owns', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').removeAttribute('aria-owns');
+
+		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
+
+		expect(exitTarget).not.toBeNull();
+		expect(exitTarget.id).toBe('outside');
+	});
+
+	test('findLinearTabExitTarget: exits second popup forward to the element after it in root order', () => {
+		setupPopupDocument();
+		const exitTarget = tabNavTestHooks.findLinearTabExitTarget(
+			document.getElementById('b2'), 'popup-b', true
+		);
+		expect(exitTarget).not.toBeNull();
+		expect(exitTarget.id).toBe('outside');
+	});
+
+	test('findLinearTabExitTargetInTargets: skips self-only members and returns null when nothing qualifies', () => {
+		setupPopupDocument();
+		const targets = [
+			{target: document.getElementById('a2'), x: 40, y: 120},
+			{target: document.getElementById('b1'), x: 180, y: 92},
+			{target: document.getElementById('outside'), x: 360, y: 32}
+		];
+		expect(tabNavTestHooks.findLinearTabExitTargetInTargets(targets, 60, 90, false, true)).toBeNull();
+	});
+
+	test('findLinearTabExitTargetInTargets: returns outside in reverse order', () => {
+		setupPopupDocument();
+		const targets = [
+			{target: document.getElementById('a2'), x: 40, y: 120},
+			{target: document.getElementById('b1'), x: 180, y: 92},
+			{target: document.getElementById('outside'), x: 360, y: 32}
+		];
+		const reverse = tabNavTestHooks.findLinearTabExitTargetInTargets(targets, 180, 90, false, false);
+		expect(reverse).not.toBeNull();
+		expect(reverse.id).toBe('outside');
+	});
+
+	test('findLinearTabExitTargetInTargets: returns a non-popup owner with empty aria-owns directly', () => {
+		setupPopupDocument();
+		const ownerLike = document.createElement('button');
+		ownerLike.id = 'owner-empty-owns';
+		ownerLike.className = 'spottable';
+		ownerLike.setAttribute('aria-owns', '');
+		document.getElementById('root').appendChild(ownerLike);
+
+		const result = tabNavTestHooks.findLinearTabExitTargetInTargets(
+			[{target: ownerLike, x: 300, y: 90}],
+			60, 90, false, true
+		);
+		expect(result.id).toBe('owner-empty-owns');
+	});
+
+	test('getLinearTargetsInContainer: skips nested containers that have no spotlight id', () => {
+		configureDefaults({selector: '.spottable'});
+		document.body.innerHTML = `
+			<div data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+				<div data-spotlight-container="true"></div>
+			</div>
+		`;
+		configureContainer(rootContainerId, {selector: '.spottable'});
+
+		expect(tabNavTestHooks.getLinearTargetsInContainer(rootContainerId)).toEqual([]);
+	});
+
+	test('getLinearTargetContainerId: falls back to getContainersForNode when closest container has empty id', () => {
+		setupSimpleDocument();
+		const wrap = document.createElement('div');
+		wrap.setAttribute('data-spotlight-container', 'true');
+		wrap.setAttribute('data-spotlight-id', '');
+		const btn = document.createElement('button');
+		btn.className = 'spottable';
+		btn.id = 'empty-id-wrapper-child';
+		setRect(btn, {left: 260, top: 20});
+		wrap.appendChild(btn);
+		document.getElementById('root').appendChild(wrap);
+
+		expect(tabNavTestHooks.getLinearTargetContainerId(btn)).toBe('');
+	});
+
+	test('getLinearTargetsInContainer: lists root and portaled controls in visual order with finite coordinates', () => {
+		setupPopupDocument();
+		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		const ids = linear.map(({target: t}) => t.id);
+
+		expect(ids).toEqual(['ownerA', 'ownerB', 'outside', 'a1', 'b1', 'a2', 'b2']);
+		expect(linear.every(({x, y}) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+	});
+
+	test('getLinearTargetsInContainer: computes correct centre coordinates from getBoundingClientRect', () => {
+		setupPopupDocument();
+		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+
+		const ownerAEntry = linear.find(({target: t}) => t.id === 'ownerA');
+		expect(ownerAEntry).toBeDefined();
+		expect(ownerAEntry.x).toBe(60);
+		expect(ownerAEntry.y).toBe(32);
+
+		const outsideEntry = linear.find(({target: t}) => t.id === 'outside');
+		expect(outsideEntry).toBeDefined();
+		expect(outsideEntry.x).toBe(360);
+		expect(outsideEntry.y).toBe(32);
+	});
+
+	test('getLinearTargetsInContainer: preserves DOM insertion order when coordinates are equal', () => {
+		setupSimpleDocument();
+		const sameRect = {left: 20, top: 20, width: 80, height: 24};
+		setRect(document.getElementById('first'), sameRect);
+		setRect(document.getElementById('second'), sameRect);
+
+		const linear = tabNavTestHooks.getLinearTargetsInContainer(rootContainerId);
+		expect(linear[0].target.id).toBe('first');
+		expect(linear[1].target.id).toBe('second');
+	});
+
+	test('should complete Tab handoff when owned popup is empty and aria-owns lists duplicate layers', () => {
+		setupPopupDocument();
+		document.getElementById('ownerB').setAttribute('aria-owns', 'layerB layerB');
+		document.querySelector('[data-spotlight-id="popup-b"]').innerHTML = '';
+		setLastContainer('popup-a');
+		focusForTest(document.getElementById('a2'));
+
+		Spotlight.terminate();
+		const {keydown} = captureHandlers();
+		Spotlight.setPointerMode(false);
+		const ev = dispatchTab(keydown);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('ownerB');
+	});
+});

--- a/packages/spotlight/src/tests/spotlight-keydown-specs.js
+++ b/packages/spotlight/src/tests/spotlight-keydown-specs.js
@@ -80,6 +80,92 @@ describe('Spotlight Tab key dispatch (integration)', () => {
 		expect(document.activeElement.id).toBe('second');
 	});
 
+	test('should move focus forward on Tab when document dir is rtl', () => {
+		setupSimpleDocument();
+		document.documentElement.setAttribute('dir', 'rtl');
+		try {
+			focusForTest(document.getElementById('second'));
+
+			const ev = dispatchTab(handlers.keydown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('first');
+		} finally {
+			document.documentElement.removeAttribute('dir');
+		}
+	});
+
+	test('should move focus forward on Tab when I18nDecorator RTL class is present', () => {
+		setupSimpleDocument();
+		document.getElementById('root').classList.add('enact-locale-right-to-left');
+		focusForTest(document.getElementById('second'));
+
+		const ev = dispatchTab(handlers.keydown);
+
+		expect(ev.preventDefault).toHaveBeenCalled();
+		expect(document.activeElement.id).toBe('first');
+	});
+
+	test('should move focus forward on Tab when body dir is rtl', () => {
+		setupSimpleDocument();
+		document.body.setAttribute('dir', 'rtl');
+		try {
+			focusForTest(document.getElementById('second'));
+
+			const ev = dispatchTab(handlers.keydown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('first');
+		} finally {
+			document.body.removeAttribute('dir');
+		}
+	});
+
+	test('should move focus forward on Tab when dir is RTL (case insensitive)', () => {
+		setupSimpleDocument();
+		document.documentElement.setAttribute('dir', 'RTL');
+		try {
+			focusForTest(document.getElementById('second'));
+
+			const ev = dispatchTab(handlers.keydown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('first');
+		} finally {
+			document.documentElement.removeAttribute('dir');
+		}
+	});
+
+	test('should move focus forward on Tab when RTL class is on documentElement', () => {
+		setupSimpleDocument();
+		document.documentElement.classList.add('enact-locale-right-to-left');
+		try {
+			focusForTest(document.getElementById('second'));
+
+			const ev = dispatchTab(handlers.keydown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('first');
+		} finally {
+			document.documentElement.classList.remove('enact-locale-right-to-left');
+		}
+	});
+
+	test('should move focus forward on Tab when RTL class is on body', () => {
+		setupSimpleDocument();
+		document.body.classList.add('enact-locale-right-to-left');
+		try {
+			focusForTest(document.getElementById('second'));
+
+			const ev = dispatchTab(handlers.keydown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('first');
+		} finally {
+			document.body.classList.remove('enact-locale-right-to-left');
+		}
+	});
+
 	test('should move focus backward on Shift+Tab', () => {
 		setupSimpleDocument();
 		focusForTest(document.getElementById('second'));

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -8,7 +8,8 @@ import {
 	rootContainerId,
 	setLastContainer
 } from '../container';
-import Spotlight, {_tabNavTestHooks as tabNavTestHooks} from '../spotlight';
+import Spotlight from '../spotlight';
+import {tabTraversal as tabNavTestHooks} from '../tabTraversal';
 
 import {
 	captureHandlers,

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -1,3 +1,5 @@
+// Public Spotlight API and Tab handoff across multi-popup scenarios.
+
 import {
 	configureContainer,
 	configureDefaults,
@@ -6,7 +8,18 @@ import {
 	rootContainerId,
 	setLastContainer
 } from '../container';
-import Spotlight from '../spotlight';
+import Spotlight, {_tabNavTestHooks as tabNavTestHooks} from '../spotlight';
+
+import {
+	captureHandlers,
+	dispatchTab,
+	focusForTest,
+	installTabTestEnvironment,
+	setupPopupDocument,
+	setupTabHandoffScenario,
+	teardownTabTest,
+	uninstallTabTestEnvironment
+} from './tab-fixtures';
 
 import {
 	container,
@@ -51,8 +64,8 @@ const setupContainers = () => {
 };
 
 const teardownContainers = () => {
-	// clean up any containers we create for safe tests
 	removeAllContainers();
+	document.body.innerHTML = '';
 };
 
 const mockFocus = (n) => {
@@ -202,4 +215,136 @@ describe('Spotlight', () => {
 			expect(window.removeEventListener).toHaveBeenCalledWith('mousemove', expect.any(Function));
 		});
 	});
+
+	describe('Tab handoff across open popups (internal hook integration)', () => {
+		afterEach(teardownTabTest);
+
+		test('should find a DOM element target when tabbing forward out of a popup with two open', () => {
+			setupTabHandoffScenario({openA: true, openB: true, openC: false});
+			const next = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+
+			expect(next).not.toBeNull();
+			expect(next.id).toBe('b1');
+		});
+
+		test('should find a DOM element target when shift-tabbing backward out of a popup', () => {
+			setupTabHandoffScenario({openA: true, openB: true, openC: false});
+			const previous = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
+
+			expect(previous).not.toBeNull();
+			expect(previous.id).toBe('a5');
+		});
+
+		test('should chain forward handoff a5 -> b1, b5 -> c1, c5 -> closeX when three popups are open', () => {
+			setupTabHandoffScenario({openA: true, openB: true, openC: true});
+			const fromA = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+			const fromB = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b5'), 'popup-b', true);
+			const fromC = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('c5'), 'popup-c', true);
+
+			expect(fromA).not.toBeNull();
+			expect(fromA.id).toBe('b1');
+			expect(fromB).not.toBeNull();
+			expect(fromB.id).toBe('c1');
+			expect(fromC).not.toBeNull();
+			expect(fromC.id).toBe('closeX');
+		});
+
+		test('should return null when popup container id is invalid', () => {
+			setupTabHandoffScenario({openA: true, openB: true, openC: false});
+			const result = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'missing-popup', true);
+
+			expect(result).toBeNull();
+		});
+
+		test('should find a DOM element target when the adjacent popup is closed', () => {
+			setupTabHandoffScenario({openA: true, openB: false, openC: false});
+			const next = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+
+			expect(next).not.toBeNull();
+			expect(next.id).toBe('bOwner');
+		});
+	});
+
+	describe('Tab keydown (integration — real modules, real DOM, real keydown events)', () => {
+		let onKeyDown;
+
+		beforeAll(installTabTestEnvironment);
+		afterAll(uninstallTabTestEnvironment);
+
+		beforeEach(() => {
+			Spotlight.terminate();
+			onKeyDown = captureHandlers().keydown;
+			Spotlight.setPointerMode(false);
+		});
+
+		afterEach(teardownTabTest);
+
+		test('should move focus from popup-a last option to popup-b first option on Tab', () => {
+			setupPopupDocument();
+			setLastContainer('popup-a');
+			focusForTest(document.getElementById('a2'));
+
+			const ev = dispatchTab(onKeyDown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('b1');
+		});
+
+		test('should move focus from popup-b first option back to popup-a last option on Shift+Tab', () => {
+			setupPopupDocument();
+			setLastContainer('popup-b');
+			focusForTest(document.getElementById('b1'));
+
+			const ev = dispatchTab(onKeyDown, true);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('a2');
+		});
+
+		test('should hand off to trigger button ownerB when it has no aria-owns', () => {
+			setupPopupDocument();
+			document.getElementById('ownerB').removeAttribute('aria-owns');
+			setLastContainer('popup-a');
+			focusForTest(document.getElementById('a2'));
+
+			const ev = dispatchTab(onKeyDown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('ownerB');
+		});
+
+		test('should chain Tab across three open popups: a5 → b1, b5 → c1, c5 → closeX', () => {
+			setupTabHandoffScenario({openA: true, openB: true, openC: true});
+
+			setLastContainer('popup-a');
+			focusForTest(document.getElementById('a5'));
+			let ev = dispatchTab(onKeyDown);
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('b1');
+
+			setLastContainer('popup-b');
+			focusForTest(document.getElementById('b5'));
+			ev = dispatchTab(onKeyDown);
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('c1');
+
+			setLastContainer('popup-c');
+			focusForTest(document.getElementById('c5'));
+			ev = dispatchTab(onKeyDown);
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('closeX');
+		});
+
+		test('should hand off to nearest owner button when adjacent popup is closed', () => {
+			setupTabHandoffScenario({openA: true, openB: false, openC: false});
+			setLastContainer('popup-a');
+			focusForTest(document.getElementById('a5'));
+
+			const ev = dispatchTab(onKeyDown);
+
+			expect(ev.preventDefault).toHaveBeenCalled();
+			expect(document.activeElement.id).toBe('bOwner');
+		});
+	});
+
 });

--- a/packages/spotlight/src/tests/spotlight-specs.js
+++ b/packages/spotlight/src/tests/spotlight-specs.js
@@ -9,7 +9,7 @@ import {
 	setLastContainer
 } from '../container';
 import Spotlight from '../spotlight';
-import {tabTraversal as tabNavTestHooks} from '../tabTraversal';
+import {findLinearTabExitTarget} from '../tabTraversal';
 
 import {
 	captureHandlers,
@@ -217,12 +217,12 @@ describe('Spotlight', () => {
 		});
 	});
 
-	describe('Tab handoff across open popups (internal hook integration)', () => {
+	describe('tabTraversal — findLinearTabExitTarget', () => {
 		afterEach(teardownTabTest);
 
 		test('should find a DOM element target when tabbing forward out of a popup with two open', () => {
 			setupTabHandoffScenario({openA: true, openB: true, openC: false});
-			const next = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+			const next = findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
 
 			expect(next).not.toBeNull();
 			expect(next.id).toBe('b1');
@@ -230,7 +230,7 @@ describe('Spotlight', () => {
 
 		test('should find a DOM element target when shift-tabbing backward out of a popup', () => {
 			setupTabHandoffScenario({openA: true, openB: true, openC: false});
-			const previous = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
+			const previous = findLinearTabExitTarget(document.getElementById('b1'), 'popup-b', false);
 
 			expect(previous).not.toBeNull();
 			expect(previous.id).toBe('a5');
@@ -238,9 +238,9 @@ describe('Spotlight', () => {
 
 		test('should chain forward handoff a5 -> b1, b5 -> c1, c5 -> closeX when three popups are open', () => {
 			setupTabHandoffScenario({openA: true, openB: true, openC: true});
-			const fromA = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
-			const fromB = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('b5'), 'popup-b', true);
-			const fromC = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('c5'), 'popup-c', true);
+			const fromA = findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+			const fromB = findLinearTabExitTarget(document.getElementById('b5'), 'popup-b', true);
+			const fromC = findLinearTabExitTarget(document.getElementById('c5'), 'popup-c', true);
 
 			expect(fromA).not.toBeNull();
 			expect(fromA.id).toBe('b1');
@@ -252,14 +252,14 @@ describe('Spotlight', () => {
 
 		test('should return null when popup container id is invalid', () => {
 			setupTabHandoffScenario({openA: true, openB: true, openC: false});
-			const result = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'missing-popup', true);
+			const result = findLinearTabExitTarget(document.getElementById('a5'), 'missing-popup', true);
 
 			expect(result).toBeNull();
 		});
 
 		test('should find a DOM element target when the adjacent popup is closed', () => {
 			setupTabHandoffScenario({openA: true, openB: false, openC: false});
-			const next = tabNavTestHooks.findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
+			const next = findLinearTabExitTarget(document.getElementById('a5'), 'popup-a', true);
 
 			expect(next).not.toBeNull();
 			expect(next.id).toBe('bOwner');

--- a/packages/spotlight/src/tests/tab-fixtures.js
+++ b/packages/spotlight/src/tests/tab-fixtures.js
@@ -1,0 +1,188 @@
+/* global jest, expect */
+// Shared DOM fixtures and event helpers for Tab navigation tests.
+
+import {add as addKeyCode, remove as removeKeyCode} from '@enact/core/keymap';
+import {
+	configureContainer,
+	configureDefaults,
+	removeAllContainers,
+	rootContainerId,
+	setLastContainer
+} from '../container';
+import Spotlight from '../spotlight';
+
+export const TAB = 9;
+
+export const setRect = (elem, {left, top, width = 80, height = 24}) => {
+	const rect = {left, top, width, height, right: left + width, bottom: top + height};
+	Object.defineProperty(elem, 'getBoundingClientRect', {configurable: true, value: () => rect});
+	Object.defineProperty(elem, 'offsetWidth', {configurable: true, value: width});
+	Object.defineProperty(elem, 'offsetHeight', {configurable: true, value: height});
+};
+
+// Two spottable buttons side-by-side: first (20,20), second (140,20).
+export const setupSimpleDocument = () => {
+	document.body.innerHTML = `
+		<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+			<button id="first"  class="spottable">First</button>
+			<button id="second" class="spottable">Second</button>
+		</div>
+	`;
+	setRect(document.getElementById('first'),  {left: 20,  top: 20});
+	setRect(document.getElementById('second'), {left: 140, top: 20});
+
+	configureDefaults({selector: '.spottable'});
+	configureContainer(rootContainerId, {selector: '.spottable'});
+	setLastContainer(rootContainerId);
+};
+
+// Popup dropdowns (popup-a, popup-b) with aria-owns owners plus an outside control.
+export const setupPopupDocument = () => {
+	document.body.innerHTML = `
+		<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+			<button id="ownerA"  class="spottable" data-spotlight-id="ownerA"  aria-owns="layerA">Owner A</button>
+			<button id="ownerB"  class="spottable" data-spotlight-id="ownerB"  aria-owns="layerB">Owner B</button>
+			<button id="outside" class="spottable" data-spotlight-id="outside">Outside</button>
+			<div id="layerA">
+				<div data-spotlight-container="true" data-spotlight-id="popup-a">
+					<button id="a1" class="spottable" data-spotlight-id="a1">A1</button>
+					<button id="a2" class="spottable" data-spotlight-id="a2">A2</button>
+				</div>
+			</div>
+			<div id="layerB">
+				<div data-spotlight-container="true" data-spotlight-id="popup-b">
+					<button id="b1" class="spottable" data-spotlight-id="b1">B1</button>
+					<button id="b2" class="spottable" data-spotlight-id="b2">B2</button>
+				</div>
+			</div>
+		</div>
+	`;
+
+	[['ownerA', 20, 20], ['ownerB', 160, 20], ['outside', 320, 20],
+		['a1', 20, 80], ['a2', 20, 108], ['b1', 160, 80], ['b2', 160, 108]
+	].forEach(([id, left, top]) => setRect(document.getElementById(id), {left, top}));
+
+	setRect(document.querySelector('[data-spotlight-id="popup-a"]'), {left: 20,  top: 72, width: 110, height: 90});
+	setRect(document.querySelector('[data-spotlight-id="popup-b"]'), {left: 160, top: 72, width: 110, height: 90});
+
+	configureDefaults({selector: '.spottable'});
+	configureContainer(rootContainerId, {selector: '.spottable'});
+	setLastContainer(rootContainerId);
+	configureContainer('popup-a', {restrict: 'self-only', selector: '.spottable'});
+	configureContainer('popup-b', {restrict: 'self-only', selector: '.spottable'});
+};
+
+export const setupTabHandoffScenario = ({openA = true, openB = true, openC = false} = {}) => {
+	const layerId = (id) => `${id}_floatLayer`;
+	const ownerAttrs = (ownerId, popupId, open) => (
+		`id="${ownerId}" class="spottable" data-spotlight-id="${ownerId}"` +
+		(open ? ` aria-owns="${layerId(popupId)}"` : '')
+	);
+
+	const popupMarkup = (id) => `
+		<div id="${layerId(id)}">
+			<div data-spotlight-container="true" data-spotlight-id="popup-${id}">
+				<button id="${id}1" class="spottable" data-spotlight-id="${id}1">Option 1</button>
+				<button id="${id}2" class="spottable" data-spotlight-id="${id}2">Option 2</button>
+				<button id="${id}3" class="spottable" data-spotlight-id="${id}3">Option 3</button>
+				<button id="${id}4" class="spottable" data-spotlight-id="${id}4">Option 4</button>
+				<button id="${id}5" class="spottable" data-spotlight-id="${id}5">Option 5</button>
+			</div>
+		</div>
+	`;
+
+	document.body.innerHTML = `
+		<div id="root" data-spotlight-container="true" data-spotlight-id="${rootContainerId}">
+			<button ${ownerAttrs('aOwner', 'a', openA)}>Dropdown A</button>
+			<button ${ownerAttrs('bOwner', 'b', openB)}>Dropdown B</button>
+			<button ${ownerAttrs('cOwner', 'c', openC)}>Dropdown C</button>
+			<button id="dOwner" class="spottable" data-spotlight-id="dOwner">Dropdown D</button>
+			<button id="closeX" class="spottable" data-spotlight-id="closeX">X</button>
+			${openA ? popupMarkup('a') : ''}
+			${openB ? popupMarkup('b') : ''}
+			${openC ? popupMarkup('c') : ''}
+		</div>
+	`;
+
+	configureDefaults({selector: '.spottable'});
+	configureContainer(rootContainerId, {selector: '.spottable'});
+	setLastContainer(rootContainerId);
+
+	if (openA) configureContainer('popup-a', {restrict: 'self-only', selector: '.spottable'});
+	if (openB) configureContainer('popup-b', {restrict: 'self-only', selector: '.spottable'});
+	if (openC) configureContainer('popup-c', {restrict: 'self-only', selector: '.spottable'});
+
+	setRect(document.getElementById('aOwner'), {left: 20, top: 20});
+	setRect(document.getElementById('bOwner'), {left: 160, top: 20});
+	setRect(document.getElementById('cOwner'), {left: 300, top: 20});
+	setRect(document.getElementById('dOwner'), {left: 20, top: 120});
+	setRect(document.getElementById('closeX'), {left: 440, top: 20, width: 24, height: 24});
+
+	const optionRect = (id, left) => {
+		for (let i = 1; i <= 5; i++) {
+			const optionNode = document.getElementById(`${id}${i}`);
+			if (optionNode) {
+				setRect(optionNode, {left, top: 80 + ((i - 1) * 28)});
+			}
+		}
+		const popupContainer = document.querySelector(`[data-spotlight-id="popup-${id}"]`);
+		if (popupContainer) {
+			setRect(popupContainer, {left, top: 72, width: 110, height: 180});
+		}
+	};
+
+	optionRect('a', 20);
+	optionRect('b', 160);
+	optionRect('c', 300);
+};
+
+export const captureHandlers = () => {
+	const handlers = {};
+	const spy = jest.spyOn(window, 'addEventListener').mockImplementation((type, handler) => {
+		handlers[type] = handler;
+	});
+	Spotlight.initialize();
+	spy.mockRestore();
+	return handlers;
+};
+
+export const makeTabEvent = (shiftKey = false) => ({
+	keyCode: TAB,
+	shiftKey,
+	preventDefault: jest.fn(),
+	stopPropagation: jest.fn()
+});
+
+// Blur stale focus then focus element.
+export const focusForTest = (element) => {
+	if (document.activeElement && document.activeElement !== document.body) {
+		document.activeElement.blur();
+	}
+	element.focus();
+	expect(document.activeElement).toBe(element);
+};
+
+// Dispatch Tab/Shift+Tab through a captured keydown handler.
+export const dispatchTab = (keydown, shiftKey = false) => {
+	const ev = makeTabEvent(shiftKey);
+	keydown(ev);
+	return ev;
+};
+
+export const teardownTabTest = () => {
+	Spotlight.terminate();
+	Spotlight.resetKeyHoldState();
+	removeAllContainers();
+	document.body.innerHTML = '';
+};
+
+export const installTabTestEnvironment = () => {
+	addKeyCode('tab', TAB);
+	if (typeof document.elementFromPoint !== 'function') {
+		Object.defineProperty(document, 'elementFromPoint', {configurable: true, value: () => null});
+	}
+};
+
+export const uninstallTabTestEnvironment = () => {
+	removeKeyCode('tab', TAB);
+};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added

This change adds Tab / Shift+Tab keyboard navigation to Spotlight for Enact apps.

Before: Spotlight did not handle the Tab key. Tab used the browser’s default focus behavior, which does not understand Enact’s focus model (spottable controls, spotlight containers, portaled content). Keyboard users could not rely on Tab to move focus in a consistent, layout-based order across the UI.

After: Spotlight handles Tab and Shift+Tab and moves focus among spottable controls in visual order on screen (top to bottom, then left to right; mirrored for RTL).

This applies broadly—to any spottable UI, including lists, grids (e.g. VirtualGridList items), buttons, and form controls. The PR also adds extra behavior for open dropdown popups (portaled lists linked to triggers via aria-owns), which was the main motivation and test focus for this story.


### Resolution

What this PR introduces
1. General Tab navigation (all spottable controls)

When the user presses Tab or Shift+Tab, Spotlight:

- finds focusable (spottable) controls in the current scope;
- sorts them by where they appear on screen, not by DOM order alone;
- moves focus to the next or previous control in that order.

This works for normal page content, grid layouts, lists, and any other component built with spottable children—including VirtualGridList, for rendered/visible items in the DOM.

Note: Virtualized lists only include items currently in the DOM, so Tab moves through visible spottable items, not the full virtual dataset.

2. Additional behavior for open dropdown popups

Dropdown option lists use a special Enact pattern: a portaled popup list in a self-only spotlight container, linked to its trigger through aria-owns. For this case, Spotlight adds:

- Tab / Shift+Tab through options inside an open list;
- at the end or start of a list, handoff to the next control in layout order;
- when the next control is another open dropdown, focus enters that list at the first (Tab) or last (Shift+Tab) option;
- when a dropdown is closed, focus lands on its trigger button only.

Example (three open dropdowns):

last option in A → first option in B → first option in C → close button
(one Tab per step; Shift+Tab reverses)

Unchanged

5-way (arrow key) navigation — not modified
Public Spotlight API — no breaking changes; apps do not need code updates

How it works (simple overview)

1. User presses Tab or Shift+Tab.
2. Spotlight builds a list of spottable controls in screen order.
3. If focus is inside an open dropdown list, Tab stays within that list until the last/first option.
4. At a list boundary, Spotlight picks the next nearby control on the page.
5. If that control opens another list, focus enters that list; otherwise focus moves to the control itself (button, grid item, etc.).

Other cases: Tab is managed while Spotlight is paused (modal); Tab is skipped if the pointer moved during the key press; RTL layouts are supported.



### Additional Considerations


### Links

NXT-7491


### Comments

Enact-DCO-1.0-Signed-off-by: Dan Ichim ([dan.ichim@lgepartner.com](mailto:dan.ichim@lgepartner.com))