### PR TITLE
NXT-12773: Fixed ` TypeError: Cannot read properties of undefined` for handleResizeWindow in useScroll

### DIFF
--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -431,18 +431,20 @@ const useScrollBase = (props) => {
 		const propsHandleResizeWindow = props.handleResizeWindow;
 
 		if (ri.scale(1) !== riRatio) {
-			if (scrollContentProps.itemSize.minWidth && scrollContentProps.itemSize.minHeight) {
-				scrollContentProps.itemSize.minWidth *= ri.scale(1) / riRatio;
-				scrollContentProps.itemSize.minHeight *= ri.scale(1) / riRatio;
-			} else {
-				scrollContentProps.itemSize *= ri.scale(1) / riRatio;
-				if (scrollContentProps.itemSizes) {
-					for (let i = 0; i < scrollContentProps.itemSizes.length; i++) {
-						scrollContentProps.itemSizes[i] *= ri.scale(1) / riRatio;
+			if (scrollContentProps.itemSize) {
+				if (scrollContentProps.itemSize.minWidth && scrollContentProps.itemSize.minHeight) {
+					scrollContentProps.itemSize.minWidth *= ri.scale(1) / riRatio;
+					scrollContentProps.itemSize.minHeight *= ri.scale(1) / riRatio;
+				} else {
+					scrollContentProps.itemSize *= ri.scale(1) / riRatio;
+					if (scrollContentProps.itemSizes) {
+						for (let i = 0; i < scrollContentProps.itemSizes.length; i++) {
+							scrollContentProps.itemSizes[i] *= ri.scale(1) / riRatio;
+						}
 					}
 				}
+				setItemSize(scrollContentProps.itemSize);
 			}
-			setItemSize(scrollContentProps.itemSize);
 			setRiRatio(ri.scale(1));
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was a console error on Scroller component:
useScroll.js:434 Uncaught TypeError: Cannot read properties of undefined (reading 'minWidth')
    at handleResizeWindow (useScroll.js:434:36)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The logic was introduced in https://github.com/enactjs/enact/pull/3374, but it did not take into account the usage of useScroll of non-virtualList.
 Added condition to avoid error

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-12773

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))
