### PR TITLE
NXT-12921: Fix useScroll scroll animation

### DIFF
--- a/packages/ui/useScroll/tests/useScroll-specs.js
+++ b/packages/ui/useScroll/tests/useScroll-specs.js
@@ -400,6 +400,7 @@ describe('useScroll', () => {
 				scrollMode: 'native',
 				rtl: true,
 				...mocks,
+				addEventListeners: jest.fn(),
 				assignProperties: jest.fn(),
 				horizontalScrollbar: 'auto',
 				verticalScrollbar: 'auto'

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -907,7 +907,7 @@ const useScrollBase = (props) => {
 	 * Handler for scrollend event
 	 */
 	function onScrollEnd (ev) {
-		if (!mutableRef.current.scrolling) {
+		if (!mutableRef.current.scrolling || mutableRef.current.keyPressed) {
 			return;
 		}
 
@@ -917,7 +917,7 @@ const useScrollBase = (props) => {
 		mutableRef.current.scrollStopJob.stop();
 
 		// stop for non-accumulating scrolls (mouse/touch)
-		if (!mutableRef.current.isScrollAnimationTargetAccumulated) {
+		if (!mutableRef.current.isScrollAnimationTargetAccumulated && !mutableRef.current.keyScroll) {
 			scrollStopOnScroll();
 			return;
 		}
@@ -929,6 +929,7 @@ const useScrollBase = (props) => {
 
 		mutableRef.current.scrollEndGraceTimer = setTimeout(() => {
 			mutableRef.current.scrollEndGraceTimer = null;
+			mutableRef.current.keyScroll = false;
 			scrollStopOnScroll();
 		}, 100);
 	}
@@ -953,6 +954,7 @@ const useScrollBase = (props) => {
 
 	function onKeyUp (ev) {
 		mutableRef.current.keyPressed = false;
+		mutableRef.current.keyScroll = true;
 		forward('onKeyUp', ev, props);
 	}
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I fixed scrollEnd feature to work with scroll by key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Scroll by key was not treated as an accumulating scroll and was not stopped by the first condition. I added a new key for the object called `keyScroll` that is applied on `onKeyUp`. This will make sure we handle the scroll properly.  I also added a check for `keyPress` on the exit condition that prevents `onScrollEnd` to trigger while we are scrolling.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-12921

### Comments
