### PR TITLE
NXT-13542: Removed guard for spotlight disabled

### DIFF
--- a/packages/spotlight/Spottable/tests/useSpot-specs.js
+++ b/packages/spotlight/Spottable/tests/useSpot-specs.js
@@ -294,4 +294,79 @@ describe('useSpottable', () => {
 			expect(spy).toHaveBeenCalledTimes(expected);
 		});
 	});
+
+	describe('focus restoration on spotlightDisabled transition', () => {
+		let focusSpy;
+		let isPausedSpy;
+		let pointerModeSpy;
+		let setPointerModeSpy;
+
+		beforeEach(() => {
+			focusSpy = jest.spyOn(Spotlight, 'focus').mockImplementation(() => true);
+			isPausedSpy = jest.spyOn(Spotlight, 'isPaused').mockReturnValue(false);
+			// Drive the pointer-mode + hover branch of focus restoration;
+			pointerModeSpy = jest.spyOn(Spotlight, 'getPointerMode').mockReturnValue(true);
+			setPointerModeSpy = jest.spyOn(Spotlight, 'setPointerMode').mockImplementation(() => {});
+			// Override the wrapper's getCurrent mock: simulate "focus is on something outside Spotlight's tracking"
+			Spotlight.getCurrent = () => null;
+		});
+
+		afterEach(() => {
+			focusSpy.mockRestore();
+			isPausedSpy.mockRestore();
+			pointerModeSpy.mockRestore();
+			setPointerModeSpy.mockRestore();
+		});
+
+		test('should restore focus exactly once on a true→false transition', () => {
+			const {rerender} = render(<SpottableComponent data-testid={id} spotlightDisabled />);
+			// isHovered must be true for the pointer-mode restoration branch to fire.
+			fireEvent.mouseEnter(screen.getByTestId(id));
+
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('should not re-restore focus on no-change rerenders after the transition', () => {
+			const {rerender} = render(<SpottableComponent data-testid={id} spotlightDisabled />);
+			fireEvent.mouseEnter(screen.getByTestId(id));
+
+			// Transition true → false: legitimate restore, fires once.
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+
+			// Subsequent no-change rerenders simulate the parent re-rendering for
+			// reasons unrelated to spotlightDisabled (e.g. a sibling prop changing_
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('should restore focus again on a second true→false transition', () => {
+			const {rerender} = render(<SpottableComponent data-testid={id} spotlightDisabled />);
+			fireEvent.mouseEnter(screen.getByTestId(id));
+
+			// First transition.
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+
+			// No-change rerender between transitions
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+
+			// Toggle back to disabled (no restoration on this direction).
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled />);
+			expect(focusSpy).toHaveBeenCalledTimes(1);
+
+			// Second true → false transition — restoration must fire again.
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			expect(focusSpy).toHaveBeenCalledTimes(2);
+
+			rerender(<SpottableComponent data-testid={id} spotlightDisabled={false} />);
+			expect(focusSpy).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/packages/spotlight/Spottable/useSpottable.js
+++ b/packages/spotlight/Spottable/useSpottable.js
@@ -66,11 +66,9 @@ const useSpottable = ({emulateMouse, getSpotRef, selectionKeys = [ENTER_KEY, REM
 
 	const attributes = props.spotlightId ? {'data-spotlight-id': props.spotlightId} : EMPTY_ATTRIBUTES;
 
-	if (context.spotlightDisabled !== spotlightDisabled) { // eslint-disable-line react-hooks/refs
-		// Mutate in-place to avoid a new object allocation on every render.
-		context.prevSpotlightDisabled = context.spotlightDisabled; // eslint-disable-line react-hooks/refs
-		context.spotlightDisabled = spotlightDisabled; // eslint-disable-line react-hooks/refs
-	}
+	// Mutate in-place to avoid a new object allocation on every render.
+	context.prevSpotlightDisabled = context.spotlightDisabled; // eslint-disable-line react-hooks/refs
+	context.spotlightDisabled = spotlightDisabled; // eslint-disable-line react-hooks/refs
 
 	hook.setPropsAndContext({selectionKeys, spotlightDisabled, ...props}, context); // eslint-disable-line react-hooks/refs
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spottable  tracks a flag called prevSpotlightDisabled. It's used inside SpottableCore.didUpdate to detect a spotlightDisabled: true → false transition and, when it sees one, restores Spotlight focus to the container.
For that detection to work, prev must reliably mean "the value of spotlightDisabled in the previous render". In NXT-8994 https://github.com/enactjs/enact/pull/3379 , code only refreshed prev when the prop changed:

```
  if (context.spotlightDisabled !== spotlightDisabled) {
      context.prevSpotlightDisabled = context.spotlightDisabled;
      context.spotlightDisabled = spotlightDisabled;
  }
```

  Once a Spottable component went through one true → false transition (which every media-control button does when the controls auto-show), prev was set to true and never cleared again. From that render onward, every render saw prev === true and re-ran the focus restoration.


In normal use you don't notice, because Spotlight.getCurrent() already returns one of the Spotlight buttons, so the `else if (!Spotlight.getCurrent()) ` branch is skipped. But the Storybook controls input is not a Spotlight element. That means Spotlight.getCurrent() returns null while the user is typing. Each keystroke triggered:

```
   else if (!Spotlight.getCurrent()) {
      Spotlight.focus(containerId);   // ← focuses into the VideoPlayer
  }
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There is no changelog as the component is private
Added unit test for the affected scenario

### Links
[//]: # (Related issues, references)
NXT-13542

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))