### PR TITLE
NXT-13084: Reverted logic for the `shouldScaleFontSize`

### DIFF
--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -51,7 +51,7 @@ const linearScalingType = {
  * @private
  */
 const configDefaults = {
-	fontSizeHandling: 'normal',
+	fontSizeHandling: 'scale',
 	orientationHandling: 'normal',
 	linearScaling: {
 		active: false,

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -51,7 +51,7 @@ const linearScalingType = {
  * @private
  */
 const configDefaults = {
-	fontSizeHandling: 'scale',
+	fontSizeHandling: 'normal',
 	orientationHandling: 'normal',
 	linearScaling: {
 		active: false,
@@ -298,7 +298,7 @@ function calculateFontSize (type) {
 	}
 
 	const scrObj = getScreenTypeObject(type);
-	const shouldScaleFontSize = (config.fontSizeHandling === 'scale') && (workspaceBounds.width < scrObj.width || workspaceBounds.height < scrObj.height);
+	const shouldScaleFontSize = (config.fontSizeHandling === 'scale') && (workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height);
 	let size;
 
 	if (orientation === 'portrait' && config.orientationHandling === 'scale') {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Reverted logic for the `shouldScaleFontSize`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reverted the condition to preserve extreme scaling behavior, which prevents font size to became very small un ultra wide resolutions

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-13084

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com