### PR TITLE
NXT-14097: Fixed wrong scroll position and screen freeze in Scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` jumping back when scrolled by long press
+
 ## [5.5.0] - 2026-05-08
 
 ### Added

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/Scroller` jumping back when scrolled by long press
+
 ## [5.5.0] - 2026-05-08
 
 ### Added

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -158,7 +158,7 @@ class ScrollerBasic extends Component {
 			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
 
 			// Stop animating if the target is reached or 1s has elapsed since animation started
-			if (!scrollTop && !scrollLeft || elapsed > 1) {
+			if ((!scrollTop && !scrollLeft) || elapsed > 1) {
 				// Fallback: if timed out before reaching target, jump there with smooth scroll
 				if (elapsed > 1 && (node.scrollLeft !== left || node.scrollTop !== top)) {
 					node.scrollTo({top, left, behavior: 'smooth'});

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -133,6 +133,7 @@ class ScrollerBasic extends Component {
 		if (platform.chrome && smoothBehavior && repeat) {
 			this.animateScroll(this.getRtlPositionX(left), top, node);
 		} else {
+			if (node.scrolling && this.scrollAnimationId) window.cancelAnimationFrame(this.scrollAnimationId);
 			node.scrollTo({left: this.getRtlPositionX(left), top, behavior});
 		}
 	}
@@ -140,8 +141,8 @@ class ScrollerBasic extends Component {
 	/**
 	 * Programmatically animates the native scroll position of `node` toward the target `left`/`top`
 	 * offsets using `requestAnimationFrame`. It computes the scroll direction on each axis, then repeatedly
-	 * calls `scrollBy` in small 8px steps (instant behavior) until the target is reached or a scroll bound
-	 * is hit. Used as a Chrome fallback when repeating a smooth scroll.
+	 * calls `scrollBy` in small 15px steps (instant behavior) until the target is reached or the time since last
+	 * function call is longer than 1s. Used as a Chrome fallback when repeating a smooth scroll.
 	 */
 	animateScroll (left, top, node) {
 		const directionX = Math.sign(left - node.scrollLeft);
@@ -150,9 +151,12 @@ class ScrollerBasic extends Component {
 
 		const animateScroll = (currentTime) => {
 			const elapsed = (currentTime - startTime) / 1000;
+			const horizontalScrollFactor = Math.max(Math.abs(left - node.scrollLeft) * 0.1, 8);
+			const verticalScrollFactor = Math.max(Math.abs(top - node.scrollTop) * 0.1, 8);
 
-			node.scrollBy({top: directionY * 8, left: directionX * 8, behavior: 'instant'});
+			node.scrollBy({top: directionY * verticalScrollFactor, left: directionX * horizontalScrollFactor, behavior: 'instant'});
 			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
+			node.scrolling = true;
 
 			const scrollLeft = directionX > 0 ? node.scrollLeft < left : node.scrollLeft > left;
 			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
@@ -162,6 +166,13 @@ class ScrollerBasic extends Component {
 			if (!scrollTop && !scrollLeft || elapsed > 1) {
 				window.cancelAnimationFrame(this.scrollAnimationId);
 				this.scrollAnimationId = null;
+				node.scrolling = false;
+
+				const targetReached = node.scrollLeft === left && node.scrollTop === top;
+				// Fallback in case time since last function call is longer than 1s and target is not reached
+				if (elapsed > 1 && !targetReached) {
+					node.scrollTo({top, left, behavior: 'smooth'});
+				}
 			}
 		};
 

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -133,7 +133,10 @@ class ScrollerBasic extends Component {
 		if (platform.chrome && smoothBehavior && repeat) {
 			this.animateScroll(this.getRtlPositionX(left), top, node);
 		} else {
-			if (node.scrolling && this.scrollAnimationId) window.cancelAnimationFrame(this.scrollAnimationId);
+			if (this.scrollAnimationId) {
+				window.cancelAnimationFrame(this.scrollAnimationId);
+				this.scrollAnimationId = null;
+			}
 			node.scrollTo({left: this.getRtlPositionX(left), top, behavior});
 		}
 	}
@@ -141,8 +144,8 @@ class ScrollerBasic extends Component {
 	/**
 	 * Programmatically animates the native scroll position of `node` toward the target `left`/`top`
 	 * offsets using `requestAnimationFrame`. It computes the scroll direction on each axis, then repeatedly
-	 * calls `scrollBy` in small 15px steps (instant behavior) until the target is reached or the time since last
-	 * function call is longer than 1s. Used as a Chrome fallback when repeating a smooth scroll.
+	 * calls `scrollBy` with a dynamic step (10% of remaining distance, minimum 8px) until the target is reached
+	 * or 1s has elapsed. Used as a Chrome fallback when repeating a smooth scroll.
 	 */
 	animateScroll (left, top, node) {
 		const directionX = Math.sign(left - node.scrollLeft);
@@ -151,29 +154,23 @@ class ScrollerBasic extends Component {
 
 		const animateScroll = (currentTime) => {
 			const elapsed = (currentTime - startTime) / 1000;
+			const scrollLeft = directionX > 0 ? node.scrollLeft < left : node.scrollLeft > left;
+			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
+
+			// Stop animating if the target is reached or 1s has elapsed since animation started
+			if (!scrollTop && !scrollLeft || elapsed > 1) {
+				// Fallback: if timed out before reaching target, jump there with smooth scroll
+				if (elapsed > 1 && (node.scrollLeft !== left || node.scrollTop !== top)) {
+					node.scrollTo({top, left, behavior: 'smooth'});
+				}
+				return;
+			}
+
 			const horizontalScrollFactor = Math.max(Math.abs(left - node.scrollLeft) * 0.1, 8);
 			const verticalScrollFactor = Math.max(Math.abs(top - node.scrollTop) * 0.1, 8);
 
 			node.scrollBy({top: directionY * verticalScrollFactor, left: directionX * horizontalScrollFactor, behavior: 'instant'});
 			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
-			node.scrolling = true;
-
-			const scrollLeft = directionX > 0 ? node.scrollLeft < left : node.scrollLeft > left;
-			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
-
-			// Check if we've reached the needed scroll position
-			// or the elapsed time since last call is longer than 1s and cancel the animation
-			if (!scrollTop && !scrollLeft || elapsed > 1) {
-				window.cancelAnimationFrame(this.scrollAnimationId);
-				this.scrollAnimationId = null;
-				node.scrolling = false;
-
-				const targetReached = node.scrollLeft === left && node.scrollTop === top;
-				// Fallback in case time since last function call is longer than 1s and target is not reached
-				if (elapsed > 1 && !targetReached) {
-					node.scrollTo({top, left, behavior: 'smooth'});
-				}
-			}
 		};
 
 		this.scrollAnimationId = window.requestAnimationFrame(animateScroll);

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -140,31 +140,28 @@ class ScrollerBasic extends Component {
 	/**
 	 * Programmatically animates the native scroll position of `node` toward the target `left`/`top`
 	 * offsets using `requestAnimationFrame`. It computes the scroll direction on each axis, then repeatedly
-	 * calls `scrollBy` in small 18px steps (instant behavior) until the target is reached or a scroll bound
+	 * calls `scrollBy` in small 8px steps (instant behavior) until the target is reached or a scroll bound
 	 * is hit. Used as a Chrome fallback when repeating a smooth scroll.
 	 */
 	animateScroll (left, top, node) {
 		const directionX = Math.sign(left - node.scrollLeft);
 		const directionY = Math.sign(top - node.scrollTop);
+		const startTime = performance.now();
 
-		const animateScroll = () => {
+		const animateScroll = (currentTime) => {
+			const elapsed = (currentTime - startTime) / 500;
+
+			node.scrollBy({top: directionY * 8, left: directionX * 8, behavior: 'instant'});
+			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
+
 			const scrollLeft = directionX > 0 ? node.scrollLeft < left : node.scrollLeft > left;
 			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
 
-			// Check if we reached the scroll bounds and cancel the animation
-			if (
-				top > this.scrollBounds.maxTop && node.scrollTop === this.scrollBounds.maxTop ||
-				left > this.scrollBounds.maxLeft && node.scrollLeft === this.scrollBounds.maxLeft ||
-				top < 0 && node.scrollTop === 0 ||
-				left < 0 && node.scrollLeft === 0
-			) {
+			// Check if we've reached the needed scroll position
+			// or the elapsed time since last call is longer than 0.5s and cancel the animation
+			if (!scrollTop && !scrollLeft || elapsed > 1) {
 				window.cancelAnimationFrame(this.scrollAnimationId);
-				return;
-			}
-
-			if (scrollTop || scrollLeft) {
-				node.scrollBy({top: directionY * 8, left: directionX * 8, behavior: 'instant'});
-				this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
+				this.scrollAnimationId = null;
 			}
 		};
 

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -149,7 +149,7 @@ class ScrollerBasic extends Component {
 		const startTime = performance.now();
 
 		const animateScroll = (currentTime) => {
-			const elapsed = (currentTime - startTime) / 500;
+			const elapsed = (currentTime - startTime) / 1000;
 
 			node.scrollBy({top: directionY * 8, left: directionX * 8, behavior: 'instant'});
 			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
@@ -158,7 +158,7 @@ class ScrollerBasic extends Component {
 			const scrollTop = directionY > 0 ? node.scrollTop < top : node.scrollTop > top;
 
 			// Check if we've reached the needed scroll position
-			// or the elapsed time since last call is longer than 0.5s and cancel the animation
+			// or the elapsed time since last call is longer than 1s and cancel the animation
 			if (!scrollTop && !scrollLeft || elapsed > 1) {
 				window.cancelAnimationFrame(this.scrollAnimationId);
 				this.scrollAnimationId = null;

--- a/packages/ui/Scroller/tests/ScrollerBasic-specs.js
+++ b/packages/ui/Scroller/tests/ScrollerBasic-specs.js
@@ -1,5 +1,13 @@
 import '@testing-library/jest-dom';
 
+const mockPlatform = {};
+
+jest.mock('@enact/core/platform', () => ({
+	get platform () {
+		return mockPlatform;
+	}
+}));
+
 import {ScrollerBasic} from '../Scroller';
 
 describe('ScrollBasic', () => {
@@ -23,7 +31,7 @@ describe('ScrollBasic', () => {
 	});
 
 	test(
-		'should call scrollBy on scrollToPosition',
+		'should call scrollTo on scrollToPosition',
 		() => {
 			const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
 
@@ -36,26 +44,209 @@ describe('ScrollBasic', () => {
 	);
 
 	test(
-		'should call scrollBy with animated values during animateScroll',
+		'should cancel pending animation before calling scrollTo on scrollToPosition',
 		() => {
-			let rafCallback;
 			const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
-			instance.scrollBounds.maxTop = 500;
-			instance.scrollBounds.maxLeft = 500;
+			const mockAnimationId = 42;
+			instance.scrollAnimationId = mockAnimationId;
 
-			window.requestAnimationFrame = jest.fn((cb) => {
-				rafCallback = cb;
-			});
 			window.cancelAnimationFrame = jest.fn();
 
-			instance.animateScroll(100, 200, scrollContentRef.current);
-			rafCallback();
-			expect(scrollContentRef.current.scrollBy).toHaveBeenCalled();
+			instance.scrollToPosition(100, 200, 'instant');
 
-			scrollContentRef.current.scrollTop = 500;
-			instance.animateScroll(550, 550, scrollContentRef.current);
-			rafCallback();
-			expect(window.cancelAnimationFrame).toHaveBeenCalled();
+			expect(window.cancelAnimationFrame).toHaveBeenCalledWith(mockAnimationId);
+			expect(instance.scrollAnimationId).toBeNull();
+			expect(scrollContentRef.current.scrollTo).toHaveBeenCalledWith({left: 100, top: 200, behavior: 'instant'});
 		}
 	);
+
+	test(
+		'should not call cancelAnimationFrame when scrollAnimationId is null on scrollToPosition',
+		() => {
+			const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+			instance.scrollAnimationId = null;
+
+			window.cancelAnimationFrame = jest.fn();
+
+			instance.scrollToPosition(100, 200, 'instant');
+
+			expect(window.cancelAnimationFrame).not.toHaveBeenCalled();
+		}
+	);
+
+	test(
+		'should call animateScroll instead of scrollTo when platform is Chrome, behavior is smooth, and repeat is true',
+		() => {
+			mockPlatform.chrome = 132;
+
+			const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+			instance.animateScroll = jest.fn();
+
+			instance.scrollToPosition(100, 200, 'smooth', true);
+
+			expect(instance.animateScroll).toHaveBeenCalledWith(100, 200, scrollContentRef.current);
+			expect(scrollContentRef.current.scrollTo).not.toHaveBeenCalled();
+
+			delete mockPlatform.chrome;
+		}
+	);
+
+	describe('animateScroll', () => {
+		let rafCallbacks;
+		let rafIdCounter;
+		let nowValue;
+
+		beforeEach(() => {
+			rafCallbacks = [];
+			rafIdCounter = 1;
+			nowValue = 0;
+
+			window.requestAnimationFrame = jest.fn((cb) => {
+				const id = rafIdCounter++;
+				rafCallbacks.push({id, cb});
+				return id;
+			});
+			window.cancelAnimationFrame = jest.fn((id) => {
+				rafCallbacks = rafCallbacks.filter((entry) => entry.id !== id);
+			});
+
+			jest.spyOn(performance, 'now').mockImplementation(() => nowValue);
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		function flushRaf (time) {
+			nowValue = time;
+			const callbacks = rafCallbacks.splice(0);
+			callbacks.forEach(({cb}) => cb(time));
+		}
+
+		test(
+			'should call scrollBy with a dynamic step (10% of remaining distance) during animateScroll',
+			() => {
+				scrollContentRef.current.scrollLeft = 0;
+				scrollContentRef.current.scrollTop = 0;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				instance.animateScroll(200, 100, node);
+
+				// First frame at t=0
+				flushRaf(0);
+
+				expect(node.scrollBy).toHaveBeenCalledWith(expect.objectContaining({
+					left: expect.closeTo(20, 1),  // 10% of 200
+					top: expect.closeTo(10, 1),   // 10% of 100
+					behavior: 'instant'
+				}));
+			}
+		);
+
+		test(
+			'should use minimum step of 8px when remaining distance is less than 80px',
+			() => {
+				scrollContentRef.current.scrollLeft = 0;
+				scrollContentRef.current.scrollTop = 0;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				// 50px remaining → 10% = 5px < 8px minimum
+				instance.animateScroll(50, 50, node);
+
+				flushRaf(0);
+
+				expect(node.scrollBy).toHaveBeenCalledWith(expect.objectContaining({
+					left: 8,
+					top: 8,
+					behavior: 'instant'
+				}));
+			}
+		);
+
+		test(
+			'should stop animating and not call scrollBy when target is already reached',
+			() => {
+				scrollContentRef.current.scrollLeft = 100;
+				scrollContentRef.current.scrollTop = 200;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				// Target equals current position → already reached
+				instance.animateScroll(100, 200, node);
+
+				flushRaf(0);
+
+				expect(node.scrollBy).not.toHaveBeenCalled();
+				expect(node.scrollTo).not.toHaveBeenCalled();
+			}
+		);
+
+		test(
+			'should stop animation and call scrollTo with smooth behavior when 1s timeout elapses before reaching target',
+			() => {
+				scrollContentRef.current.scrollLeft = 0;
+				scrollContentRef.current.scrollTop = 0;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				instance.animateScroll(500, 500, node);
+
+				// Advance past 1s timeout without updating scroll position
+				flushRaf(1100);
+
+				expect(node.scrollTo).toHaveBeenCalledWith({top: 500, left: 500, behavior: 'smooth'});
+			}
+		);
+
+		test(
+			'should not call scrollTo fallback when target is reached exactly at timeout boundary',
+			() => {
+				scrollContentRef.current.scrollLeft = 500;
+				scrollContentRef.current.scrollTop = 500;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				// Target already reached
+				instance.animateScroll(500, 500, node);
+
+				flushRaf(1100);
+
+				expect(node.scrollTo).not.toHaveBeenCalled();
+			}
+		);
+
+		test(
+			'should continue requesting animation frames until target is reached',
+			() => {
+				scrollContentRef.current.scrollLeft = 0;
+				scrollContentRef.current.scrollTop = 0;
+
+				const instance = new ScrollerBasic({scrollContentRef, direction: 'both'});
+				const node = scrollContentRef.current;
+
+				instance.animateScroll(100, 0, node);
+
+				// First frame: scrollBy called, new rAF registered
+				flushRaf(0);
+				expect(node.scrollBy).toHaveBeenCalledTimes(1);
+
+				// Simulate scroll progress
+				node.scrollLeft = 50;
+				flushRaf(100);
+				expect(node.scrollBy).toHaveBeenCalledTimes(2);
+
+				// Simulate reaching target
+				node.scrollLeft = 100;
+				flushRaf(200);
+				expect(node.scrollBy).toHaveBeenCalledTimes(2);
+			}
+		);
+	});
 });

--- a/packages/ui/useScroll/tests/useScroll-specs.js
+++ b/packages/ui/useScroll/tests/useScroll-specs.js
@@ -476,7 +476,6 @@ describe('useScroll', () => {
 			renderHook(() => useScrollBase(props));
 
 			// Set lastInputType to arrowKey via the exposed themeScrollContainerHandle
-			// eslint-disable-next-line testing-library/no-unnecessary-act
 			act(() => {
 				if (scrollContainerHandle) {
 					scrollContainerHandle.lastInputType = 'arrowKey';
@@ -506,7 +505,6 @@ describe('useScroll', () => {
 			renderHook(() => useScrollBase(props));
 
 			// Set lastInputType to pageKey via the exposed themeScrollContainerHandle
-			// eslint-disable-next-line testing-library/no-unnecessary-act
 			act(() => {
 				if (scrollContainerHandle) {
 					scrollContainerHandle.lastInputType = 'pageKey';
@@ -536,7 +534,6 @@ describe('useScroll', () => {
 			renderHook(() => useScrollBase(props));
 
 			// Set lastInputType to wheel (not arrowKey or pageKey)
-			// eslint-disable-next-line testing-library/no-unnecessary-act
 			act(() => {
 				if (scrollContainerHandle) {
 					scrollContainerHandle.lastInputType = 'wheel';

--- a/packages/ui/useScroll/tests/useScroll-specs.js
+++ b/packages/ui/useScroll/tests/useScroll-specs.js
@@ -421,4 +421,134 @@ describe('useScroll', () => {
 			expect(mocks.scrollContentHandle.current.didScroll).toHaveBeenCalledWith(50, 0);
 		});
 	});
+
+	describe('onKeyDown repeat handling (native scroll mode)', () => {
+		beforeEach(() => {
+			jest.useFakeTimers();
+			mockPlatform = {chrome: 132};
+			mockRiScale = jest.fn((val) => val);
+		});
+
+		afterEach(() => {
+			jest.runOnlyPendingTimers();
+			jest.useRealTimers();
+		});
+
+		function createNativeScrollProps (mocks, extra = {}) {
+			return {
+				direction: 'vertical',
+				scrollMode: 'native',
+				...mocks,
+				assignProperties: jest.fn(),
+				horizontalScrollbar: 'auto',
+				verticalScrollbar: 'auto',
+				...extra
+			};
+		}
+
+		test('should forward onKeyDown event when key is not repeated', () => {
+			const mocks = createMockRefs();
+			const onKeyDown = jest.fn();
+			const props = createNativeScrollProps(mocks, {onKeyDown});
+
+			renderHook(() => useScrollBase(props));
+
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				fireEvent.keyDown(mocks.scrollContainerRef.current, {keyCode: 40, repeat: false});
+			});
+
+			expect(onKeyDown).toHaveBeenCalledTimes(1);
+		});
+
+		test('should not forward onKeyDown event when arrowKey is repeated and lastInputType is arrowKey', () => {
+			const mocks = createMockRefs();
+			const onKeyDown = jest.fn();
+			let scrollContainerHandle = null;
+
+			const props = createNativeScrollProps(mocks, {
+				onKeyDown,
+				setScrollContainerHandle: (handle) => {
+					scrollContainerHandle = handle;
+				}
+			});
+
+			renderHook(() => useScrollBase(props));
+
+			// Set lastInputType to arrowKey via the exposed themeScrollContainerHandle
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				if (scrollContainerHandle) {
+					scrollContainerHandle.lastInputType = 'arrowKey';
+				}
+			});
+
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				fireEvent.keyDown(mocks.scrollContainerRef.current, {keyCode: 40, repeat: true});
+			});
+
+			expect(onKeyDown).not.toHaveBeenCalled();
+		});
+
+		test('should not forward onKeyDown event when pageKey is repeated and lastInputType is pageKey', () => {
+			const mocks = createMockRefs();
+			const onKeyDown = jest.fn();
+			let scrollContainerHandle = null;
+
+			const props = createNativeScrollProps(mocks, {
+				onKeyDown,
+				setScrollContainerHandle: (handle) => {
+					scrollContainerHandle = handle;
+				}
+			});
+
+			renderHook(() => useScrollBase(props));
+
+			// Set lastInputType to pageKey via the exposed themeScrollContainerHandle
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				if (scrollContainerHandle) {
+					scrollContainerHandle.lastInputType = 'pageKey';
+				}
+			});
+
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				fireEvent.keyDown(mocks.scrollContainerRef.current, {keyCode: 33, repeat: true});
+			});
+
+			expect(onKeyDown).not.toHaveBeenCalled();
+		});
+
+		test('should forward onKeyDown event when repeat is true but lastInputType is neither arrowKey nor pageKey', () => {
+			const mocks = createMockRefs();
+			const onKeyDown = jest.fn();
+			let scrollContainerHandle = null;
+
+			const props = createNativeScrollProps(mocks, {
+				onKeyDown,
+				setScrollContainerHandle: (handle) => {
+					scrollContainerHandle = handle;
+				}
+			});
+
+			renderHook(() => useScrollBase(props));
+
+			// Set lastInputType to wheel (not arrowKey or pageKey)
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				if (scrollContainerHandle) {
+					scrollContainerHandle.lastInputType = 'wheel';
+				}
+			});
+
+			// eslint-disable-next-line testing-library/no-unnecessary-act
+			act(() => {
+				fireEvent.keyDown(mocks.scrollContainerRef.current, {keyCode: 40, repeat: true});
+			});
+
+			expect(onKeyDown).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -945,11 +945,11 @@ const useScrollBase = (props) => {
 				scrollByPage(ev.keyCode);
 			}
 		} else {
-			const isArrowKey = mutableRef.current.lastInputType === 'arrowKey';
-			const isPageKey = mutableRef.current.lastInputType === 'pageKey';
-
 			props.preventScroll?.(ev);
 			mutableRef.current.repeat = ev.repeat;
+
+			const isArrowKey = mutableRef.current.lastInputType === 'arrowKey';
+			const isPageKey = mutableRef.current.lastInputType === 'pageKey';
 
 			if (ev.repeat && (isArrowKey || isPageKey)) return;
 			forward('onKeyDown', ev, props);

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -945,9 +945,13 @@ const useScrollBase = (props) => {
 				scrollByPage(ev.keyCode);
 			}
 		} else {
+			const isArrowKey = mutableRef.current.lastInputType === 'arrowKey';
+			const isPageKey = mutableRef.current.lastInputType === 'pageKey';
+
 			props.preventScroll?.(ev);
 			mutableRef.current.repeat = ev.repeat;
-			if (ev.repeat && mutableRef.current.lastInputType === 'arrowKey') return;
+
+			if (ev.repeat && (isArrowKey || isPageKey)) return;
 			forward('onKeyDown', ev, props);
 		}
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller stutters when scrolled by long press.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

1. Slow scroll speed during arrow key long press
- Replaced with a dynamic step of 10% of the remaining distance (minimum 8px), so scrolling starts fast and eases in as it approaches the target.

2. Screen clipped when reversing scroll direction during long press
- Added `cancelAnimationFrame` guards to cancel.
- Replaced the bounds check with a target-reached check.
- Added a condition to stop animation: if 1s has elapsed since animation started.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-14097

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)