### PR TITLE
NXT-9871: Fixed overscroll effect VirtualList items have margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` overscroll effect at the bottom of the list
+
 ## [5.5.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The following is a curated list of changes in the Enact project, newest changes 
 
 ### Fixed
 
-- `ui/VirtualList` overscroll effect at the bottom of the list
 - `ui/Scroller` jumping back when scrolled by long press
+- `ui/VirtualList` overscroll effect at the bottom of the list
+- `ui/VirtualList.VirtualList` overscroll effect at the bottom of the list
+- `ui/VirtualList.VirtualGridList` overscroll effect at the bottom of the list
 
 ## [5.5.0] - 2026-05-08
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,8 +6,10 @@ The following is a curated list of changes in the Enact ui module, newest change
 
 ### Fixed
 
-- `ui/VirtualList` overscroll effect at the bottom of the list
 - `ui/Scroller` jumping back when scrolled by long press
+- `ui/VirtualList` overscroll effect at the bottom of the list
+- `ui/VirtualList.VirtualList` overscroll effect at the bottom of the list
+- `ui/VirtualList.VirtualGridList` overscroll effect at the bottom of the list
 
 ## [5.5.0] - 2026-05-08
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `ui/VirtualList` overscroll effect at the bottom of the list
+
 ## [5.5.0] - 2026-05-08
 
 ### Added

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -358,10 +358,15 @@ class VirtualListBasic extends Component {
 			this.itemMarginLeft = Number(firstItemStyle.getPropertyValue('margin-left').slice(0, -2));
 			this.itemMarginRight = Number(firstItemStyle.getPropertyValue('margin-right').slice(0, -2));
 			if (this.isPrimaryDirectionVertical) {
-				this.scrollBounds.maxTop += this.itemMarginTop + this.itemMarginBottom;
+				const marginSum = this.itemMarginTop + this.itemMarginBottom;
+				this.scrollBounds.scrollHeight += marginSum;
+				this.scrollBounds.maxTop += marginSum;
 			} else {
-				this.scrollBounds.maxLeft += this.itemMarginLeft + this.itemMarginRight;
+				const marginSum = this.itemMarginLeft + this.itemMarginRight;
+				this.scrollBounds.scrollWidth += marginSum;
+				this.scrollBounds.maxLeft += marginSum;
 			}
+			this.setContainerSize();
 		}
 
 		let deferScrollTo = false;

--- a/packages/ui/VirtualList/tests/VirtualList-native-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-native-specs.js
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom';
 import {act, render, screen} from '@testing-library/react';
+import {createRef} from 'react';
 
-import VirtualList from '../VirtualList';
+import VirtualList, {VirtualListBasic} from '../VirtualList';
 
 describe('VirtualList with native scrollMode', () => {
 	let
@@ -177,5 +178,114 @@ describe('VirtualList with native scrollMode', () => {
 			done();
 			jest.useRealTimers();
 		});
+	});
+});
+
+describe('VirtualListBasic scrollBounds consistency after item margin detection', () => {
+	let originalGetComputedStyle;
+
+	const nop = () => {};
+
+	function renderVirtualListBasic ({direction = 'vertical', ...rest} = {}) {
+		const scrollContentRef = createRef();
+		const itemRefs = createRef();
+		itemRefs.current = [];
+
+		const ref = createRef();
+
+		render(
+			<VirtualListBasic
+				clientSize={{clientWidth: 1280, clientHeight: 720}}
+				dataSize={100}
+				direction={direction}
+				getAffordance={() => 0}
+				itemRefs={itemRefs}
+				itemRenderer={({index, ...rest2}) => <div {...rest2} data-index={index} />} // eslint-disable-line enact/display-name
+				itemSize={30}
+				overhang={3}
+				placeholderRenderer={nop}
+				role="list"
+				scrollContentRef={scrollContentRef}
+				scrollMode="native"
+				spacing={0}
+				cbScrollTo={nop}
+				ref={ref}
+				{...rest}
+			/>
+		);
+
+		return {ref};
+	}
+
+	beforeEach(() => {
+		originalGetComputedStyle = window.getComputedStyle;
+	});
+
+	afterEach(() => {
+		window.getComputedStyle = originalGetComputedStyle;
+	});
+
+	test('should increment scrollHeight and maxTop by the same margin sum when vertical item margins are detected, and not re-apply on subsequent updates', () => {
+		const {ref} = renderVirtualListBasic();
+		const instance = ref.current;
+
+		const marginTop = 10;
+		const marginBottom = 5;
+
+		window.getComputedStyle = (el) => {
+			if (el === instance.props.itemRefs.current[0]) {
+				return {
+					getPropertyValue: (prop) => {
+						if (prop === 'margin-top') return `${marginTop}px`;
+						if (prop === 'margin-bottom') return `${marginBottom}px`;
+						if (prop === 'margin-left') return '0px';
+						if (prop === 'margin-right') return '0px';
+						return '0px';
+					}
+				};
+			}
+			return originalGetComputedStyle(el);
+		};
+
+		instance.itemMarginTop = null;
+		act(() => { instance.forceUpdate(); });
+
+		const scrollHeightAfterFirst = instance.scrollBounds.scrollHeight;
+		const maxTopAfterFirst = instance.scrollBounds.maxTop;
+		expect(scrollHeightAfterFirst - maxTopAfterFirst).toBe(instance.props.clientSize.clientHeight);
+		expect(instance.scrollBounds.maxTop).toBe(instance.scrollBounds.scrollHeight - instance.props.clientSize.clientHeight);
+
+		// guard prevents re-applying on subsequent updates
+		act(() => { instance.forceUpdate(); });
+		expect(instance.scrollBounds.scrollHeight).toBe(scrollHeightAfterFirst);
+		expect(instance.scrollBounds.maxTop).toBe(maxTopAfterFirst);
+	});
+
+	test('should increment scrollWidth and maxLeft by the same margin sum when horizontal item margins are detected', () => {
+		const {ref} = renderVirtualListBasic({direction: 'horizontal'});
+		const instance = ref.current;
+
+		const marginLeft = 8;
+		const marginRight = 8;
+
+		window.getComputedStyle = (el) => {
+			if (el === instance.props.itemRefs.current[0]) {
+				return {
+					getPropertyValue: (prop) => {
+						if (prop === 'margin-top') return '0px';
+						if (prop === 'margin-bottom') return '0px';
+						if (prop === 'margin-left') return `${marginLeft}px`;
+						if (prop === 'margin-right') return `${marginRight}px`;
+						return '0px';
+					}
+				};
+			}
+			return originalGetComputedStyle(el);
+		};
+
+		instance.itemMarginTop = null;
+		act(() => { instance.forceUpdate(); });
+
+		expect(instance.scrollBounds.scrollWidth - instance.scrollBounds.maxLeft).toBe(instance.props.clientSize.clientWidth);
 	});
 });

--- a/packages/ui/VirtualList/tests/VirtualList-native-specs.js
+++ b/packages/ui/VirtualList/tests/VirtualList-native-specs.js
@@ -200,7 +200,7 @@ describe('VirtualListBasic scrollBounds consistency after item margin detection'
 				direction={direction}
 				getAffordance={() => 0}
 				itemRefs={itemRefs}
-				itemRenderer={({index, ...rest2}) => <div {...rest2} data-index={index} />} // eslint-disable-line enact/display-name
+				itemRenderer={({index, ...rest2}) => <div {...rest2} data-index={index} />}
 				itemSize={30}
 				overhang={3}
 				placeholderRenderer={nop}
@@ -248,7 +248,9 @@ describe('VirtualListBasic scrollBounds consistency after item margin detection'
 		};
 
 		instance.itemMarginTop = null;
-		act(() => { instance.forceUpdate(); });
+		act(() => {
+			instance.forceUpdate();
+		});
 
 		const scrollHeightAfterFirst = instance.scrollBounds.scrollHeight;
 		const maxTopAfterFirst = instance.scrollBounds.maxTop;
@@ -256,7 +258,9 @@ describe('VirtualListBasic scrollBounds consistency after item margin detection'
 		expect(instance.scrollBounds.maxTop).toBe(instance.scrollBounds.scrollHeight - instance.props.clientSize.clientHeight);
 
 		// guard prevents re-applying on subsequent updates
-		act(() => { instance.forceUpdate(); });
+		act(() => {
+			instance.forceUpdate();
+		});
 		expect(instance.scrollBounds.scrollHeight).toBe(scrollHeightAfterFirst);
 		expect(instance.scrollBounds.maxTop).toBe(maxTopAfterFirst);
 	});
@@ -284,7 +288,9 @@ describe('VirtualListBasic scrollBounds consistency after item margin detection'
 		};
 
 		instance.itemMarginTop = null;
-		act(() => { instance.forceUpdate(); });
+		act(() => {
+			instance.forceUpdate();
+		});
 
 		expect(instance.scrollBounds.scrollWidth - instance.scrollBounds.maxLeft).toBe(instance.props.clientSize.clientWidth);
 	});

--- a/packages/ui/useScroll/tests/useScroll-specs.js
+++ b/packages/ui/useScroll/tests/useScroll-specs.js
@@ -99,6 +99,7 @@ describe('useScroll', () => {
 			};
 
 			const mocks = createMockRefs();
+			const assignProperties = jest.fn();
 
 			const props = {
 				itemRenderer: jest.fn(),
@@ -106,7 +107,7 @@ describe('useScroll', () => {
 				direction: 'vertical',
 				scrollMode: 'translate',
 				...mocks,
-				assignProperties: jest.fn(),
+				assignProperties,
 				horizontalScrollbar: 'auto',
 				verticalScrollbar: 'auto'
 			};
@@ -121,8 +122,16 @@ describe('useScroll', () => {
 				jest.runAllTimers();
 			});
 
-			expect(itemSize.minWidth).toBe(200);
-			expect(itemSize.minHeight).toBe(100);
+			// Original props object must not be mutated
+			expect(itemSize.minWidth).toBe(100);
+			expect(itemSize.minHeight).toBe(50);
+
+			// The scaled values should be passed to scrollContentProps via assignProperties
+			const scrollContentPropsCall = assignProperties.mock.calls.findLast(([name]) => name === 'scrollContentProps');
+			const passedItemSize = scrollContentPropsCall?.[1]?.itemSize;
+
+			expect(passedItemSize?.minWidth).toBe(200);
+			expect(passedItemSize?.minHeight).toBe(100);
 		});
 
 		test('should scale itemSizes when ri.scale(1) changes from 1 to 2', () => {
@@ -132,6 +141,7 @@ describe('useScroll', () => {
 			const itemSizes = [100, 100, 100, 100, 100];
 
 			const mocks = createMockRefs();
+			const assignProperties = jest.fn();
 
 			const props = {
 				itemRenderer: jest.fn(),
@@ -140,7 +150,7 @@ describe('useScroll', () => {
 				direction: 'vertical',
 				scrollMode: 'translate',
 				...mocks,
-				assignProperties: jest.fn(),
+				assignProperties,
 				horizontalScrollbar: 'auto',
 				verticalScrollbar: 'auto'
 			};
@@ -155,7 +165,14 @@ describe('useScroll', () => {
 				jest.runAllTimers();
 			});
 
-			expect(itemSizes[1]).toBe(200);
+			// Original props array must not be mutated
+			expect(itemSizes[1]).toBe(100);
+
+			// The scaled values should be passed to scrollContentProps via assignProperties
+			const scrollContentPropsCall = assignProperties.mock.calls.findLast(([name]) => name === 'scrollContentProps');
+			const passedItemSizes = scrollContentPropsCall?.[1]?.itemSizes;
+
+			expect(passedItemSizes?.[1]).toBe(200);
 		});
 
 		test('should NOT scale itemSize when ri.scale(1) remains unchanged', () => {
@@ -314,7 +331,7 @@ describe('useScroll', () => {
 			expect(roundedTargetY).toEqual(121);
 		});
 
-		test('should round target position downwards when target is bi than current position', () => {
+		test('should round target position downwards when target is less than current position', () => {
 			mockPlatform = {chrome: 132};
 
 			const {roundTarget} = require('../useScroll');

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -119,7 +119,6 @@ const useScrollBase = (props) => {
 			horizontalScrollbar,
 			horizontalScrollbarHandle,
 			itemRenderer,
-			itemSizes,
 			noScrollByDrag,
 			noScrollByWheel,
 			overhang,
@@ -151,6 +150,7 @@ const useScrollBase = (props) => {
 	delete rest.clearOverscrollEffect;
 	delete rest.handleResizeWindow;
 	delete rest.itemSize;
+	delete rest.itemSizes;
 	delete rest.onFlick;
 	delete rest.onKeyDown;
 	delete rest.onMouseDown;
@@ -176,6 +176,7 @@ const useScrollBase = (props) => {
 	const [riRatio, setRiRatio] = useState(ri.scale(1));
 	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize);
 	const [itemSize, setItemSize] = useState(props.itemSize);
+	const scaledItemSizesRef = useRef(null);
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),
@@ -419,7 +420,7 @@ const useScrollBase = (props) => {
 			dataSize,
 			itemRenderer,
 			itemSize,
-			itemSizes,
+			itemSizes: scaledItemSizesRef.current ?? props.itemSizes,
 			overhang,
 			pageScroll,
 			spacing,
@@ -432,15 +433,17 @@ const useScrollBase = (props) => {
 
 		if (ri.scale(1) !== riRatio) {
 			if (scrollContentProps.itemSize) {
+				const ratio = ri.scale(1) / riRatio;
 				if (scrollContentProps.itemSize.minWidth && scrollContentProps.itemSize.minHeight) {
-					scrollContentProps.itemSize.minWidth *= ri.scale(1) / riRatio;
-					scrollContentProps.itemSize.minHeight *= ri.scale(1) / riRatio;
+					scrollContentProps.itemSize = {
+						...scrollContentProps.itemSize,
+						minWidth: scrollContentProps.itemSize.minWidth * ratio,
+						minHeight: scrollContentProps.itemSize.minHeight * ratio
+					};
 				} else {
-					scrollContentProps.itemSize *= ri.scale(1) / riRatio;
+					scrollContentProps.itemSize *= ratio;
 					if (scrollContentProps.itemSizes) {
-						for (let i = 0; i < scrollContentProps.itemSizes.length; i++) {
-							scrollContentProps.itemSizes[i] *= ri.scale(1) / riRatio;
-						}
+						scaledItemSizesRef.current = scrollContentProps.itemSizes.map((s) => s * ratio);
 					}
 				}
 				setItemSize(scrollContentProps.itemSize);

--- a/packages/ui/useScroll/useScroll.js
+++ b/packages/ui/useScroll/useScroll.js
@@ -177,6 +177,12 @@ const useScrollBase = (props) => {
 	const [originalItemSize, setOriginalItemSize] = useState(props.itemSize);
 	const [itemSize, setItemSize] = useState(props.itemSize);
 	const scaledItemSizesRef = useRef(null);
+	const scaledItemSizesSourceRef = useRef(props.itemSizes);
+
+	if (scaledItemSizesSourceRef.current !== props.itemSizes) {
+		scaledItemSizesRef.current = null;
+		scaledItemSizesSourceRef.current = props.itemSizes;
+	}
 
 	const mutableRef = useRef({
 		overscrollEnabled: !!(props.applyOverscrollEffect),


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The overscroll effect did not trigger when VirtualList items had CSS margin.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When item margins are first detected, `scrollHeight` (vertical) or `scrollWidth` (horizontal) was not updated alongside `maxTop`/`maxLeft`.
This broke the overscroll trigger condition `curPos >= maxPos`, because `scrollHeight - clientHeight !== maxTop`.
Fixed by incrementing both fields by the margin sum and calling `setContainerSize()`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Additionally, `itemSize` and `itemSizes` props were mutated in-place during window resize handling in `useScroll`, which could cause unexpected behavior when the same object reference was reused.
 Fixed `itemSize` by creating a new object via spread and also fixed `itemSizes` by using `map` and storing the result in a ref (`scaledItemSizesRef`) so re-renders reflect the scaled values without mutating the original array.

### Links
[//]: # (Related issues, references)
NXT-9871

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)