### PR TITLE
NXT-13027: [i18n] Investigate usage of  useSyncExternalStore

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -9,15 +9,6 @@ No significant changes.
 ## [5.4.4] - 2026-05-22
 
 No significant changes.
-## [unreleased]
-
-### Changed
-
-- `i18n/I18nDecorator` to use `useSyncExternalStore` for subscribing to the ilib locale store, replacing the manual `useState` + `setContext` pattern for safer concurrent rendering
-
-### Fixed
-
-- `i18n/I18nDecorator` to handle failed async resource requests instead of silently ignoring them
 
 ## [5.5.0] - 2026-05-08
 

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -9,6 +9,15 @@ No significant changes.
 ## [5.4.4] - 2026-05-22
 
 No significant changes.
+## [unreleased]
+
+### Changed
+
+- `i18n/I18nDecorator` to use `useSyncExternalStore` for subscribing to the ilib locale store, replacing the manual `useState` + `setContext` pattern for safer concurrent rendering
+
+### Fixed
+
+- `i18n/I18nDecorator` to handle failed async resource requests instead of silently ignoring them
 
 ## [5.5.0] - 2026-05-08
 

--- a/packages/i18n/I18nDecorator/I18n.js
+++ b/packages/i18n/I18nDecorator/I18n.js
@@ -26,7 +26,6 @@ class I18n {
 	}) {
 		this._locale = null;
 		this._ready = sync;
-		this._onLoadResources = () => {};
 		this.loadResourceJob = new Job(state => this._updateSnapshot(state));
 		this._listeners = new Set();
 		this._snapshot = {

--- a/packages/i18n/I18nDecorator/I18n.js
+++ b/packages/i18n/I18nDecorator/I18n.js
@@ -1,5 +1,4 @@
 import {on, off} from '@enact/core/dispatcher';
-import {Job} from '@enact/core/util';
 
 import {isRtlLocale, updateLocale} from '../locale';
 import {createResBundle, setResBundle} from '../src/resBundle';
@@ -10,6 +9,9 @@ import {onWindowFocus} from './windowFocus';
 
 /**
  * Manages i18n resource loading.
+ *
+ * Implements the external store contract expected by `useSyncExternalStore`:
+ * `subscribe`, `getSnapshot`, and `getServerSnapshot`.
  *
  * @class I18n
  * @private
@@ -23,8 +25,13 @@ class I18n {
 	}) {
 		this._locale = null;
 		this._ready = sync;
-		this._onLoadResources = () => {};
-		this.loadResourceJob = null;
+		this._listeners = new Set();
+		this._snapshot = {
+			className: null,
+			loaded: sync,
+			locale: null,
+			rtl: false
+		};
 
 		this.latinLanguageOverrides = latinLanguageOverrides;
 		this.nonLatinLanguageOverrides = nonLatinLanguageOverrides;
@@ -33,20 +40,81 @@ class I18n {
 	}
 
 	/**
-	 * Sets the current locale and load callback.
+	 * Subscribes a listener to store updates.
 	 *
-	 * Changing the locale will request new resource files for that locale.
+	 * Returns an unsubscribe function, as required by `useSyncExternalStore`.
 	 *
-	 * @type {String}
+	 * @param {Function} listener Called whenever the snapshot changes
+	 * @returns {Function} Unsubscribe function
 	 * @public
 	 */
-	setContext (locale, onLoadResources) {
-		this.loadResourceJob = new Job(onLoadResources);
-		this._onLoadResources = onLoadResources;
+	subscribe = (listener) => {
+		this._listeners.add(listener);
+		return () => this._listeners.delete(listener);
+	};
 
+	/**
+	 * Returns the current snapshot of the i18n state.
+	 *
+	 * @returns {{className: String, loaded: Boolean, locale: String, rtl: Boolean}}
+	 * @public
+	 */
+	getSnapshot = () => this._snapshot;
+
+	/**
+	 * Returns the server-side snapshot (for SSR).
+	 *
+	 * Sync mode is assumed on the server so `loaded` is always `true`.
+	 *
+	 * @returns {{className: String, loaded: Boolean, locale: String, rtl: Boolean}}
+	 * @public
+	 */
+	getServerSnapshot = () => ({
+		className: null,
+		loaded: true,
+		locale: this._locale,
+		rtl: false
+	});
+
+	/**
+	 * Notifies all subscribers that the snapshot has changed.
+	 *
+	 * @private
+	 */
+	_notifyListeners () {
+		this._listeners.forEach(l => l());
+	}
+
+	/**
+	 * Updates the snapshot and notifies all subscribers.
+	 *
+	 * Notifications are suppressed before `load()` is called (i.e. during render
+	 * in async mode) so that `setLocale` in render does not trigger store updates
+	 * mid-render. In sync mode `_ready` is already `true`, so `useSyncExternalStore`
+	 * handles the concurrent-rendering tearing check automatically.
+	 *
+	 * @param {Object} newState New snapshot values
+	 * @private
+	 */
+	_updateSnapshot (newState) {
+		this._snapshot = newState;
+		if (this._ready) {
+			this._notifyListeners();
+		}
+	}
+
+	/**
+	 * Updates the locale when it changes between renders.
+	 *
+	 * Unlike the former `setContext`, this method does not accept a React
+	 * `setState` callback — state propagation is handled by `useSyncExternalStore`.
+	 *
+	 * @param {String} locale BCP 47 locale identifier
+	 * @public
+	 */
+	setLocale (locale) {
 		if (this._locale !== locale) {
 			this._locale = locale;
-
 			this.loadResources(locale);
 		}
 	}
@@ -97,7 +165,6 @@ class I18n {
 	unload () {
 		this._ready = false;
 
-		this.loadResourceJob.stop();
 		if (typeof window === 'object') {
 			off('languagechange', this.handleLocaleChange, window);
 		}
@@ -122,13 +189,6 @@ class I18n {
 		const bundle = wrapIlibCallback(createResBundle, options);
 
 		if (this.sync) {
-			const state = {
-				className,
-				loaded: true,
-				locale,
-				rtl
-			};
-
 			setResBundle(bundle);
 
 			this.resources.forEach(({resource, onLoad}) => {
@@ -136,29 +196,42 @@ class I18n {
 				if (onLoad) onLoad(result);
 			});
 
-			this._onLoadResources(state);
+			this._updateSnapshot({
+				className,
+				loaded: true,
+				locale,
+				rtl
+			});
 		} else {
-			const resources = Promise.all([
+			Promise.all([
 				rtl,
 				className,
-				// move updating into a new method with call to setState
 				bundle,
 				...this.resources.map(res => wrapIlibCallback(res.resource, options))
 			]).then(([rtlResult, classNameResult, bundleResult, ...userResources]) => {
 				setResBundle(bundleResult);
 				this.resources.forEach(({onLoad}, i) => onLoad && onLoad(userResources[i]));
 
-				return {
+				this._updateSnapshot({
 					className: classNameResult,
 					loaded: true,
 					locale,
 					rtl: rtlResult
-				};
-			});
-			// TODO: Resolve how to handle failed resource requests
-			// .catch(...);
+				});
+			}).catch((error) => {
+				// Resource loading failed — update the snapshot with the last known locale
+				// so the app remains functional, and surface the error for diagnostics.
+				this._updateSnapshot({
+					...this._snapshot,
+					loaded: true,
+					locale
+				});
 
-			this.loadResourceJob.promise(resources);
+				if (typeof console !== 'undefined') {
+					// eslint-disable-next-line no-console
+					console.error('[I18n] Failed to load resources for locale', locale, error);
+				}
+			});
 		}
 	}
 

--- a/packages/i18n/I18nDecorator/I18n.js
+++ b/packages/i18n/I18nDecorator/I18n.js
@@ -1,4 +1,5 @@
 import {on, off} from '@enact/core/dispatcher';
+import {Job} from '@enact/core/util';
 
 import {isRtlLocale, updateLocale} from '../locale';
 import {createResBundle, setResBundle} from '../src/resBundle';
@@ -25,6 +26,8 @@ class I18n {
 	}) {
 		this._locale = null;
 		this._ready = sync;
+		this._onLoadResources = () => {};
+		this.loadResourceJob = new Job(state => this._updateSnapshot(state));
 		this._listeners = new Set();
 		this._snapshot = {
 			className: null,
@@ -86,12 +89,14 @@ class I18n {
 	}
 
 	/**
-	 * Updates the snapshot and notifies all subscribers.
+	 * Updates the snapshot and notifies subscribers when the store is ready.
 	 *
-	 * Notifications are suppressed before `load()` is called (i.e. during render
-	 * in async mode) so that `setLocale` in render does not trigger store updates
-	 * mid-render. In sync mode `_ready` is already `true`, so `useSyncExternalStore`
-	 * handles the concurrent-rendering tearing check automatically.
+	 * `_ready` reflects whether `load()` has run. In async mode it starts `false`,
+	 * which suppresses notifications for the synchronous `setContext` call made
+	 * during the first render (the initial snapshot is published by the first
+	 * `getSnapshot` read instead). In sync mode `_ready` is `true` from
+	 * construction, so updates notify immediately; `useSyncExternalStore` is
+	 * responsible for the tearing check under concurrent rendering.
 	 *
 	 * @param {Object} newState New snapshot values
 	 * @private
@@ -104,15 +109,14 @@ class I18n {
 	}
 
 	/**
-	 * Updates the locale when it changes between renders.
+	 * Sets the current locale.
 	 *
-	 * Unlike the former `setContext`, this method does not accept a React
-	 * `setState` callback — state propagation is handled by `useSyncExternalStore`.
+	 * Changing the locale will request new resource files for that locale.
 	 *
 	 * @param {String} locale BCP 47 locale identifier
 	 * @public
 	 */
-	setLocale (locale) {
+	setContext (locale) {
 		if (this._locale !== locale) {
 			this._locale = locale;
 			this.loadResources(locale);
@@ -165,6 +169,7 @@ class I18n {
 	unload () {
 		this._ready = false;
 
+		this.loadResourceJob.stop();
 		if (typeof window === 'object') {
 			off('languagechange', this.handleLocaleChange, window);
 		}
@@ -203,7 +208,7 @@ class I18n {
 				rtl
 			});
 		} else {
-			Promise.all([
+			const resources = Promise.all([
 				rtl,
 				className,
 				bundle,
@@ -212,26 +217,17 @@ class I18n {
 				setResBundle(bundleResult);
 				this.resources.forEach(({onLoad}, i) => onLoad && onLoad(userResources[i]));
 
-				this._updateSnapshot({
+				return {
 					className: classNameResult,
 					loaded: true,
 					locale,
 					rtl: rtlResult
-				});
-			}).catch((error) => {
-				// Resource loading failed — update the snapshot with the last known locale
-				// so the app remains functional, and surface the error for diagnostics.
-				this._updateSnapshot({
-					...this._snapshot,
-					loaded: true,
-					locale
-				});
-
-				if (typeof console !== 'undefined') {
-					// eslint-disable-next-line no-console
-					console.error('[I18n] Failed to load resources for locale', locale, error);
-				}
+				};
 			});
+			// TODO: Resolve how to handle failed resource requests
+			// .catch(...);
+
+			this.loadResourceJob.promise(resources);
 		}
 	}
 

--- a/packages/i18n/I18nDecorator/tests/useI18n-specs.js
+++ b/packages/i18n/I18nDecorator/tests/useI18n-specs.js
@@ -227,59 +227,11 @@ describe('useI18n', () => {
 		test('should return the current locale in server snapshot', () => {
 			const i18n = new I18n({sync: true});
 
-			i18n.setLocale('ar-SA');
+			i18n.setContext('ar-SA');
 
 			const snapshot = i18n.getServerSnapshot();
 
 			expect(snapshot.locale).toBe('ar-SA');
-		});
-	});
-
-	// async error handling — verifies .catch() path in loadResources
-	describe('async error handling', () => {
-		function AsyncComponentWithResources ({resources}) {
-			const {loaded} = useI18n({sync: false, resources});
-
-			return <div data-loaded={loaded} data-testid="i18nDiv" />;
-		}
-
-		test('should set loaded=true even when a resource fails to load', async () => {
-			// A resource that throws causes Promise.all to reject → .catch() path
-			const failingResource = () => {
-				throw new Error('resource load failed');
-			};
-
-			// Suppress the expected console.error from the catch handler
-			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-			render(<AsyncComponentWithResources resources={[failingResource]} />);
-
-			const i18nDiv = screen.getByTestId('i18nDiv');
-
-			await waitFor(() => {
-				expect(i18nDiv).toHaveAttribute('data-loaded', 'true');
-			});
-
-			errorSpy.mockRestore();
-		});
-
-		test('should log an error when resource loading fails', async () => {
-			const failingResource = () => {
-				throw new Error('resource load failed');
-			};
-			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-			render(<AsyncComponentWithResources resources={[failingResource]} />);
-
-			await waitFor(() => {
-				expect(errorSpy).toHaveBeenCalledWith(
-					'[I18n] Failed to load resources for locale',
-					expect.any(String),
-					expect.any(Error)
-				);
-			});
-
-			errorSpy.mockRestore();
 		});
 	});
 

--- a/packages/i18n/I18nDecorator/tests/useI18n-specs.js
+++ b/packages/i18n/I18nDecorator/tests/useI18n-specs.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import {useState} from 'react';
 
 import {updateLocale} from '../../locale';
@@ -16,20 +16,13 @@ describe('useI18n', () => {
 	});
 
 	function Component ({locale, latinLanguageOverrides, nonLatinLanguageOverrides}) {
-		const [state, setState] = useState({
-			rtl: false,
-			className: null
-		});
-		const i18n = useI18n({
+		const {className, rtl} = useI18n({
 			latinLanguageOverrides,
 			locale,
-			nonLatinLanguageOverrides,
-			onLoadResources: setState
+			nonLatinLanguageOverrides
 		});
 
-		const divProps = {...state, ...i18n};
-
-		return <div className={divProps.className} data-testid="i18nDiv">{divProps.rtl ? 'rtl' : 'ltr'}</div>;
+		return <div className={className} data-testid="i18nDiv">{rtl ? 'rtl' : 'ltr'}</div>;
 	}
 
 	test('should return rtl=false by default', () => {
@@ -95,5 +88,157 @@ describe('useI18n', () => {
 		expect(i18nDiv).toHaveClass('enact-locale-en-US');
 		expect(i18nDiv).toHaveClass('enact-locale-US');
 		expect(i18nDiv).toHaveClass('enact-locale-non-latin');
+	});
+
+	// Async mode (sync: false) — tests the Promise.all path in loadResources
+	describe('async mode', () => {
+		function AsyncComponent ({locale}) {
+			const {className, loaded, rtl} = useI18n({locale, sync: false});
+
+			return (
+				<div
+					className={className}
+					data-loaded={loaded}
+					data-testid="i18nDiv"
+				>
+					{rtl ? 'rtl' : 'ltr'}
+				</div>
+			);
+		}
+
+		test('should start with loaded=false', () => {
+			render(<AsyncComponent />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+
+			expect(i18nDiv).toHaveAttribute('data-loaded', 'false');
+		});
+
+		test('should set loaded=true after resources resolve', async () => {
+			render(<AsyncComponent />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+
+			await waitFor(() => {
+				expect(i18nDiv).toHaveAttribute('data-loaded', 'true');
+			});
+		});
+
+		test('should apply locale classes after async load', async () => {
+			render(<AsyncComponent locale="ar-SA" />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+
+			await waitFor(() => {
+				expect(i18nDiv).toHaveClass('enact-locale-ar-SA');
+				expect(i18nDiv).toHaveTextContent('rtl');
+			});
+		});
+	});
+
+	// Runtime locale change — verifies useSyncExternalStore re-renders on locale prop change
+	describe('runtime locale change', () => {
+		function LocaleSwitcherComponent () {
+			const [locale, setLocale] = useState('en-US');
+			const {className, rtl} = useI18n({locale});
+
+			return (
+				<div>
+					<div className={className} data-testid="i18nDiv">{rtl ? 'rtl' : 'ltr'}</div>
+					<button data-testid="switchBtn" onClick={() => setLocale('ar-SA')}>switch</button>
+				</div>
+			);
+		}
+
+		test('should update rtl when locale prop changes', async () => {
+			render(<LocaleSwitcherComponent />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+			const btn = screen.getByTestId('switchBtn');
+
+			expect(i18nDiv).toHaveTextContent('ltr');
+
+			act(() => { btn.click(); });
+
+			expect(i18nDiv).toHaveTextContent('rtl');
+		});
+
+		test('should update classes when locale prop changes', async () => {
+			render(<LocaleSwitcherComponent />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+			const btn = screen.getByTestId('switchBtn');
+
+			expect(i18nDiv).toHaveClass('enact-locale-en-US');
+
+			act(() => { btn.click(); });
+
+			expect(i18nDiv).toHaveClass('enact-locale-ar-SA');
+			expect(i18nDiv).not.toHaveClass('enact-locale-en-US');
+		});
+	});
+
+	// updateLocale — verifies the store notifies subscribers when called imperatively
+	describe('updateLocale', () => {
+		function UpdateLocaleComponent () {
+			const {className, rtl, updateLocale} = useI18n({});
+
+			return (
+				<div>
+					<div className={className} data-testid="i18nDiv">{rtl ? 'rtl' : 'ltr'}</div>
+					<button data-testid="updateBtn" onClick={() => updateLocale('ar-SA')}>update</button>
+				</div>
+			);
+		}
+
+		test('should re-render when updateLocale is called', () => {
+			render(<UpdateLocaleComponent />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+			const btn = screen.getByTestId('updateBtn');
+
+			expect(i18nDiv).toHaveTextContent('ltr');
+
+			act(() => { btn.click(); });
+
+			expect(i18nDiv).toHaveTextContent('rtl');
+		});
+	});
+
+	// No tearing — two components using the same store must stay in sync
+	describe('no tearing between multiple subscribers', () => {
+		function ComponentA () {
+			const {rtl} = useI18n({});
+			return <div data-testid="compA">{rtl ? 'rtl' : 'ltr'}</div>;
+		}
+
+		function ComponentB () {
+			const {rtl} = useI18n({});
+			return <div data-testid="compB">{rtl ? 'rtl' : 'ltr'}</div>;
+		}
+
+		test('should keep multiple components in sync after updateLocale', () => {
+			const {rerender} = render(
+				<div>
+					<ComponentA />
+					<ComponentB />
+				</div>
+			);
+
+			expect(screen.getByTestId('compA')).toHaveTextContent('ltr');
+			expect(screen.getByTestId('compB')).toHaveTextContent('ltr');
+
+			act(() => { updateLocale('ar-SA'); });
+
+			rerender(
+				<div>
+					<ComponentA />
+					<ComponentB />
+				</div>
+			);
+
+			expect(screen.getByTestId('compA')).toHaveTextContent('rtl');
+			expect(screen.getByTestId('compB')).toHaveTextContent('rtl');
+		});
 	});
 });

--- a/packages/i18n/I18nDecorator/tests/useI18n-specs.js
+++ b/packages/i18n/I18nDecorator/tests/useI18n-specs.js
@@ -3,6 +3,7 @@ import {act, render, screen, waitFor} from '@testing-library/react';
 import {useState} from 'react';
 
 import {updateLocale} from '../../locale';
+import {I18n} from '../I18n';
 import useI18n from '../useI18n';
 
 describe('useI18n', () => {
@@ -131,6 +132,8 @@ describe('useI18n', () => {
 
 			await waitFor(() => {
 				expect(i18nDiv).toHaveClass('enact-locale-ar-SA');
+			});
+			await waitFor(() => {
 				expect(i18nDiv).toHaveTextContent('rtl');
 			});
 		});
@@ -158,7 +161,9 @@ describe('useI18n', () => {
 
 			expect(i18nDiv).toHaveTextContent('ltr');
 
-			act(() => { btn.click(); });
+			act(() => {
+				btn.click();
+			});
 
 			expect(i18nDiv).toHaveTextContent('rtl');
 		});
@@ -171,7 +176,9 @@ describe('useI18n', () => {
 
 			expect(i18nDiv).toHaveClass('enact-locale-en-US');
 
-			act(() => { btn.click(); });
+			act(() => {
+				btn.click();
+			});
 
 			expect(i18nDiv).toHaveClass('enact-locale-ar-SA');
 			expect(i18nDiv).not.toHaveClass('enact-locale-en-US');
@@ -181,12 +188,12 @@ describe('useI18n', () => {
 	// updateLocale — verifies the store notifies subscribers when called imperatively
 	describe('updateLocale', () => {
 		function UpdateLocaleComponent () {
-			const {className, rtl, updateLocale} = useI18n({});
+			const {className, rtl, updateLocale: changeLocale} = useI18n({});
 
 			return (
 				<div>
 					<div className={className} data-testid="i18nDiv">{rtl ? 'rtl' : 'ltr'}</div>
-					<button data-testid="updateBtn" onClick={() => updateLocale('ar-SA')}>update</button>
+					<button data-testid="updateBtn" onClick={() => changeLocale('ar-SA')}>update</button>
 				</div>
 			);
 		}
@@ -199,9 +206,80 @@ describe('useI18n', () => {
 
 			expect(i18nDiv).toHaveTextContent('ltr');
 
-			act(() => { btn.click(); });
+			act(() => {
+				btn.click();
+			});
 
 			expect(i18nDiv).toHaveTextContent('rtl');
+		});
+	});
+
+	// getServerSnapshot — used by useSyncExternalStore for SSR
+	describe('getServerSnapshot', () => {
+		test('should return loaded=true for SSR', () => {
+			const i18n = new I18n({sync: false});
+
+			const snapshot = i18n.getServerSnapshot();
+
+			expect(snapshot.loaded).toBe(true);
+		});
+
+		test('should return the current locale in server snapshot', () => {
+			const i18n = new I18n({sync: true});
+
+			i18n.setLocale('ar-SA');
+
+			const snapshot = i18n.getServerSnapshot();
+
+			expect(snapshot.locale).toBe('ar-SA');
+		});
+	});
+
+	// async error handling — verifies .catch() path in loadResources
+	describe('async error handling', () => {
+		function AsyncComponentWithResources ({resources}) {
+			const {loaded} = useI18n({sync: false, resources});
+
+			return <div data-loaded={loaded} data-testid="i18nDiv" />;
+		}
+
+		test('should set loaded=true even when a resource fails to load', async () => {
+			// A resource that throws causes Promise.all to reject → .catch() path
+			const failingResource = () => {
+				throw new Error('resource load failed');
+			};
+
+			// Suppress the expected console.error from the catch handler
+			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+			render(<AsyncComponentWithResources resources={[failingResource]} />);
+
+			const i18nDiv = screen.getByTestId('i18nDiv');
+
+			await waitFor(() => {
+				expect(i18nDiv).toHaveAttribute('data-loaded', 'true');
+			});
+
+			errorSpy.mockRestore();
+		});
+
+		test('should log an error when resource loading fails', async () => {
+			const failingResource = () => {
+				throw new Error('resource load failed');
+			};
+			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+			render(<AsyncComponentWithResources resources={[failingResource]} />);
+
+			await waitFor(() => {
+				expect(errorSpy).toHaveBeenCalledWith(
+					'[I18n] Failed to load resources for locale',
+					expect.any(String),
+					expect.any(Error)
+				);
+			});
+
+			errorSpy.mockRestore();
 		});
 	});
 
@@ -228,7 +306,9 @@ describe('useI18n', () => {
 			expect(screen.getByTestId('compA')).toHaveTextContent('ltr');
 			expect(screen.getByTestId('compB')).toHaveTextContent('ltr');
 
-			act(() => { updateLocale('ar-SA'); });
+			act(() => {
+				updateLocale('ar-SA');
+			});
 
 			rerender(
 				<div>

--- a/packages/i18n/I18nDecorator/useI18n.js
+++ b/packages/i18n/I18nDecorator/useI18n.js
@@ -42,16 +42,14 @@ function useI18n ({locale, ...config} = {}) {
 
 	const i18n = useClass(I18n, config);
 
+	i18n.setLocale(locale);
+
 	// Subscribe to the ilib locale store — tearing-safe in concurrent rendering.
 	const state = useSyncExternalStore(
 		i18n.subscribe,
 		i18n.getSnapshot,
 		i18n.getServerSnapshot
 	);
-
-	// Propagate locale prop changes into the store.
-	// `setLocale` is a no-op when the locale has not changed.
-	i18n.setLocale(locale);
 
 	// Add/remove the `languagechange` event listener on mount/unmount.
 	useEffect(() => {

--- a/packages/i18n/I18nDecorator/useI18n.js
+++ b/packages/i18n/I18nDecorator/useI18n.js
@@ -12,8 +12,6 @@ import I18n from './I18n';
  * @memberof i18n/I18nDecorator
  * @property {String[]}   [latinLanguageOverrides]    Locales that should be treated as latin
  * @property {String[]}   [nonLatinLanguageOverrides] Locales that should be treated as non-latin
- * @property {Function}   [onLoadResources]           Called when resources have been loaded after a
- *                                                    locale change
  * @property {Function[]} [resources]                 Additional resource callbacks to be invoked
  *                                                    during a locale change
  * @property {Boolean}    [sync = false]              Load the resources synchronously

--- a/packages/i18n/I18nDecorator/useI18n.js
+++ b/packages/i18n/I18nDecorator/useI18n.js
@@ -1,5 +1,5 @@
 import useClass from '@enact/core/useClass';
-import {useState, useEffect} from 'react';
+import {useEffect, useSyncExternalStore} from 'react';
 
 import ilib from '../src/index.js';
 
@@ -12,8 +12,6 @@ import I18n from './I18n';
  * @memberof i18n/I18nDecorator
  * @property {String[]}   [latinLanguageOverrides]    Locales that should be treated as latin
  * @property {String[]}   [nonLatinLanguageOverrides] Locales that should be treated as non-latin
- * @property {Function}   [onLoadResources]           Called when resources have been loaded after a
- *                                                    locale change
  * @property {Function[]} [resources]                 Additional resource callbacks to be invoked
  *                                                    during a locale change
  * @property {Boolean}    [sync = false]              Load the resources synchronously
@@ -42,15 +40,20 @@ function useI18n ({locale, ...config} = {}) {
 	const ilibLocale = ilib.getLocale();
 	locale = locale && locale !== ilibLocale ? locale : ilibLocale;
 
-	const [state, setState] = useState({
-		locale,
-		loaded: Boolean(config.sync)
-	});
-
 	const i18n = useClass(I18n, config);
-	i18n.setContext(locale, setState);
 
-	// Add/remove listeners on mount/unmount
+	// Subscribe to the ilib locale store — tearing-safe in concurrent rendering.
+	const state = useSyncExternalStore(
+		i18n.subscribe,
+		i18n.getSnapshot,
+		i18n.getServerSnapshot
+	);
+
+	// Propagate locale prop changes into the store.
+	// `setLocale` is a no-op when the locale has not changed.
+	i18n.setLocale(locale);
+
+	// Add/remove the `languagechange` event listener on mount/unmount.
 	useEffect(() => {
 		i18n.load();
 

--- a/packages/i18n/I18nDecorator/useI18n.js
+++ b/packages/i18n/I18nDecorator/useI18n.js
@@ -12,6 +12,8 @@ import I18n from './I18n';
  * @memberof i18n/I18nDecorator
  * @property {String[]}   [latinLanguageOverrides]    Locales that should be treated as latin
  * @property {String[]}   [nonLatinLanguageOverrides] Locales that should be treated as non-latin
+ * @property {Function}   [onLoadResources]           Called when resources have been loaded after a
+ *                                                    locale change
  * @property {Function[]} [resources]                 Additional resource callbacks to be invoked
  *                                                    during a locale change
  * @property {Boolean}    [sync = false]              Load the resources synchronously
@@ -42,7 +44,7 @@ function useI18n ({locale, ...config} = {}) {
 
 	const i18n = useClass(I18n, config);
 
-	i18n.setLocale(locale);
+	i18n.setContext(locale);
 
 	// Subscribe to the ilib locale store — tearing-safe in concurrent rendering.
 	const state = useSyncExternalStore(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
 Refactor useI18n to subscribe to the i18n store via React's useSyncExternalStore, replacing the manual useState + setContext(locale, setState) pattern.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The I18n class now implements the external store contract (subscribe, getSnapshot, getServerSnapshot) and maintains an internal snapshot (className, loaded, locale, rtl) updated through _updateSnapshot. useI18n subscribes via useSyncExternalStore instead of passing setState into setContext.

Impact: subscribing to the i18n store is now safe under concurrent rendering (no tearing between components), with SSR support via getServerSnapshot. Observable behavior for consumers (className, loaded, locale, rtl, updateLocale) is unchanged.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-13027

### Comments
Enact-DCO-1.0-Signed-off-by: Dan Ichim ([dan.ichim@lgepartner.com](mailto:dan.ichim@lgepartner.com))