### PR TITLE
NXT-13084: Modified `resolution` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 The following is a curated list of changes in the Enact project, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
 
 ### Changed
 
 - `spotlight/SpotlightRootDecorator` to use a functional component
+- `ui/resolution` to not resize too often for some intermediate resolutions
 
-## [unreleased]
 ## [5.5.1] - 2026-06-01
 
 ### Changed

--- a/packages/sampler/stories/default/ResolutionDecorator.js
+++ b/packages/sampler/stories/default/ResolutionDecorator.js
@@ -115,7 +115,6 @@ export const ResolutionDecorator_ = (args) => {
 		config.orientationHandling = args['orientationHandling'];
 	}
 
-
 	const View = ResolutionDecorator({
 		...config,
 		screenTypes: screenTypes

--- a/packages/sampler/stories/default/ResolutionDecorator.js
+++ b/packages/sampler/stories/default/ResolutionDecorator.js
@@ -48,6 +48,9 @@ const ResolutionDecoratorView = ({
 	return (
 		<Fragment>
 			<div style={{height: 'fit-content'}}>
+				<BodyText>
+					<strong>fontSizeHandling (landscape)</strong> and <strong>orientationHandling (portrait)</strong> can be used only when <code>linearScaling = false</code>
+				</BodyText>
 				<div style={{padding: '1rem', border: '1px solid #ccc', marginBottom: '1rem'}}>
 					<BodyText><strong>Current Resolution:</strong> {screenInfo.width}x{screenInfo.height} ({screenInfo.name})</BodyText>
 					<BodyText><strong>Font Size:</strong> {currentFontSize}</BodyText>
@@ -107,6 +110,12 @@ export const ResolutionDecorator_ = (args) => {
 	config.linearScaling.type = args['scalingType'];
 	config.linearScaling.active = args['linearScaling'];
 
+	if (!config.linearScaling.active) {
+		config.fontSizeHandling = args['fontSizeHandling'];
+		config.orientationHandling = args['orientationHandling'];
+	}
+
+
 	const View = ResolutionDecorator({
 		...config,
 		screenTypes: screenTypes
@@ -123,6 +132,8 @@ export const ResolutionDecorator_ = (args) => {
 
 boolean('linearScaling', ResolutionDecorator_, ResolutionDecorator);
 select('scalingType', ResolutionDecorator_, ['currentScreen', 'baseScreen'], ResolutionDecorator, 'currentScreen');
+select('fontSizeHandling', ResolutionDecorator_, ['scale', 'normal'], ResolutionDecorator, 'scale');
+select('orientationHandling', ResolutionDecorator_, ['scale', 'normal'], ResolutionDecorator, 'normal');
 number('dataSize', ResolutionDecorator_, VirtualList, 100);
 number('itemSize', ResolutionDecorator_, VirtualList, 156);
 number('width', ResolutionDecorator_, Card, 500);
@@ -130,6 +141,6 @@ number('height', ResolutionDecorator_, Card, 250);
 
 ResolutionDecorator_.parameters = {
 	info: {
-		text: 'Basic Usage of Linear Scaling'
+		text: 'Basic Usage of ResolutionDecorator and Linear Scaling'
 	}
 };

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact ui module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `ui/resolution` to not resize too often for some intermediate resolutions
+
 ## [5.5.1] - 2026-06-01
 
 ### Changed

--- a/packages/ui/resolution/ResolutionDecorator.js
+++ b/packages/ui/resolution/ResolutionDecorator.js
@@ -98,8 +98,9 @@ const ResolutionDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		constructor (props) {
 			super(props);
 			checkPropTypes(this, props);
-			riConfig.fontSizeHandling = config.fontSizeHandling;
 
+			if (config.fontSizeHandling) riConfig.fontSizeHandling = config.fontSizeHandling;
+			if (config.orientationHandling) riConfig.orientationHandling = config.orientationHandling;
 			if (config.linearScaling) riConfig.linearScaling = config.linearScaling;
 
 			init({measurementNode: (typeof window !== 'undefined' && window)});

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -152,12 +152,12 @@ const getClosestResolutionType = (resolution, types) => {
 	// Calculates a score for a candidate resolution based on proximity to the target. A lower score indicates a better match.
 	const getDistanceScore = (p) => {
 		const distance = Math.sqrt(Math.pow(p.width - resolution.width, 2) + Math.pow(p.height - resolution.height, 2));
-		const currentRatio = resolution.width / resolution.height;
-		const targetRatio = getAspectRatio(p.name);
+		const inputRatio = resolution.width / resolution.height;
+		const candidateRatio = getAspectRatio(p.name);
 		// Apply a weighted penalty (x1000) for aspect ratio mismatch.
 		// This ensures that even if a resolution is close in size, it won't be chosen
 		// if its shape (e.g., UltraWide vs. Standard) is significantly different.
-		const ratioPenalty = Math.abs(currentRatio - targetRatio) * 1000;
+		const ratioPenalty = Math.abs(inputRatio - candidateRatio) * 1000;
 
 		return distance + ratioPenalty;
 	};
@@ -305,9 +305,12 @@ function getScreenType (rez) {
  * Calculate the base rem font size.
  *
  * This is how the magic happens. This accepts an optional `screenType` name. If one isn't provided,
- * the currently detected screen type is used. This uses the config option `orientationHandling`,
- * which when set to "scale" and the screen is in portrait orientation (such as after screen rotation), will dynamically calculate
- * what the base font size should be, if the width were proportionally scaled down to fit in the portrait space.
+ * the currently detected screen type is used. When the workspace is smaller than the matched screen
+ * type in both dimensions, the base font size is scaled proportionally based on the workspace height.
+ * This scaling is gated by the config options `fontSizeHandling` (landscape orientation) and
+ * `orientationHandling` (portrait orientation, such as after screen rotation); when the relevant
+ * option is set to `'scale'` the size is calculated dynamically, otherwise the screen type's
+ * `pxPerRem` value is used directly.
  *
  * To use, put the following in your application code:
  * ```
@@ -319,7 +322,6 @@ function getScreenType (rez) {
  *
  * This configuration is particularly useful for applications that support screen rotation and need
  * to maintain consistent scaling when the device orientation changes from landscape to portrait or vice versa.
- * This has no effect if the screen is in landscape, or if `orientationHandling` is unset.
  *
  * @function
  * @memberof ui/resolution

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -343,6 +343,7 @@ function calculateFontSize (type) {
 	} else {
 		size = scrObj.pxPerRem;
 	}
+
 	return size + 'px';
 }
 

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -130,6 +130,7 @@ const getScaleFactor = (type = screenType) => {
 
 	const scrObj = getScreenTypeObject(type);
 	const shouldScale = getShouldScale(scrObj);
+
 	return {shouldScale, factor: workspaceBounds.height / scrObj.height};
 };
 

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -91,8 +91,30 @@ function getLinearSize () {
 }
 
 /**
+ * Determines if the current workspace should be scaled based on the screen type,
+ * orientation, and configuration settings.
+ *
+ * @function
+ * @memberof ui/resolution
+ * @param {Object} scrObj 			The screen type object to compare against.
+ *
+ * @returns {boolean}
+ * @private
+ */
+const getShouldScale = (scrObj) => {
+	const isPortrait = orientation === 'portrait';
+	const isLandscape = orientation === 'landscape';
+	const shouldScale = workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height;
+
+	const shouldScaleLandscape = (config.fontSizeHandling === 'scale') && isLandscape && shouldScale;
+	const shouldScalePortrait = (config.orientationHandling === 'scale') && isPortrait && shouldScale;
+
+	return shouldScaleLandscape || shouldScalePortrait;
+};
+
+/**
  * Calculates the scale factor and determines if scaling is necessary
- * for the landscape workspace based on the screen type.
+ * for the landscape or portrait workspace based on the screen type.
  *
  * @function
  * @memberof ui/resolution
@@ -101,16 +123,18 @@ function getLinearSize () {
  * @returns {Object} 					Returns an object containing the scaling data.
  * @private
  */
-const getLandscapeScaleFactor = (type = screenType) => {
-	if (!type) return {shouldScale: false, factor: 1};
-
+const getScaleFactor = (type = screenType) => {
 	const scrObj = getScreenTypeObject(type);
-	const shouldScale = workspaceBounds.width < scrObj.width || workspaceBounds.height < scrObj.height;
+	const shouldScale = getShouldScale(scrObj);
 	return {shouldScale, factor: workspaceBounds.height / scrObj.height};
 };
 
 /**
- * Get the closest resolution type based on the `resolution`.
+ * Gets the closest resolution type based on the provided resolution by calculating a distance score.
+ *
+ * The score is determined by the Euclidean distance between the widths and heights of the
+ * resolutions, plus a weighted penalty for the difference in aspect ratios. This ensures that
+ * the matched resolution is not only close in size but also has a similar shape.
  *
  * @function
  * @memberOf ui/resolution
@@ -120,17 +144,25 @@ const getLandscapeScaleFactor = (type = screenType) => {
  * @private
  */
 const getClosestResolutionType = (resolution, types) => {
-	// Calculates the distance between two resolutions using their width and height as coordinates (x, y)
-	const getDistance = (p1, p2) => {
-		return Math.sqrt(Math.pow(p2.width - p1.width, 2) + Math.pow(p2.height - p1.height, 2));
+	// Calculates a score for a candidate resolution based on proximity to the target. A lower score indicates a better match.
+	const getDistanceScore = (p) => {
+		const distance = Math.sqrt(Math.pow(p.width - resolution.width, 2) + Math.pow(p.height - resolution.height, 2));
+		const currentRatio = resolution.width / resolution.height;
+		const targetRatio = getAspectRatio(p.name);
+		// Apply a weighted penalty (x1000) for aspect ratio mismatch.
+		// This ensures that even if a resolution is close in size, it won't be chosen
+		// if its shape (e.g., UltraWide vs. Standard) is significantly different.
+		const ratioPenalty = Math.abs(currentRatio - targetRatio) * 1000;
+
+		return distance + ratioPenalty;
 	};
 
-	// Compares the calculated distances and returns the closest resolution type name that matches current resolution
+	// Compares the calculated distance scores and returns the closest resolution type name that matches the current resolution.
 	const {name} = types.reduce((prev, curr) => {
-		const distCurr = getDistance(curr, resolution);
-		const distPrev = getDistance(prev, resolution);
+		const currScore = getDistanceScore(curr);
+		const prevScore = getDistanceScore(prev);
 
-		return distCurr < distPrev ? curr : prev;
+		return currScore < prevScore ? curr : prev;
 	});
 
 	return name;
@@ -298,16 +330,13 @@ function calculateFontSize (type) {
 	}
 
 	const scrObj = getScreenTypeObject(type);
-	const shouldScaleFontSize = (config.fontSizeHandling === 'scale') && (workspaceBounds.width < scrObj.width || workspaceBounds.height < scrObj.height);
+	const shouldScaleFontSize = getShouldScale(scrObj);
 	let size;
 
-	if (orientation === 'portrait' && config.orientationHandling === 'scale') {
-		size = scrObj.height / scrObj.width * scrObj.pxPerRem;
+	if (shouldScaleFontSize) {
+		size = workspaceBounds.height * scrObj.pxPerRem / scrObj.height;
 	} else {
 		size = scrObj.pxPerRem;
-		if (orientation === 'landscape' && shouldScaleFontSize) {
-			size = workspaceBounds.height * scrObj.pxPerRem / scrObj.height;
-		}
 	}
 	return size + 'px';
 }
@@ -378,13 +407,10 @@ function getResolutionClasses (type = screenType) {
 function getRiRatio (type = screenType) {
 	if (type && baseScreen) {
 		let ratio = getUnitToPixelFactors(type) / getUnitToPixelFactors(baseScreen.name);
+		const {shouldScale, factor} = getScaleFactor(type);
 
-		if (orientation === 'landscape' && config.fontSizeHandling === 'scale') {
-			const {shouldScale, factor} = getLandscapeScaleFactor(type);
-
-			if (shouldScale) {
-				ratio *= factor;
-			}
+		if (shouldScale) {
+			ratio *= factor;
 		}
 
 		if (type === screenType) {
@@ -498,12 +524,10 @@ function unit (pixels, toUnit) {
 	if (typeof pixels === 'string' && pixels.substring(-2) === 'px') pixels = parseInt(pixels.substring(0, pixels.length - 2));
 	if (typeof pixels !== 'number') return;
 
-	if (screenType && orientation === 'landscape' && config.fontSizeHandling === 'scale') {
-		const {shouldScale, factor} = getLandscapeScaleFactor();
+	const {shouldScale, factor} = getScaleFactor();
 
-		if (shouldScale) {
-			return (pixels / factor / unitToPixelFactors[toUnit]) + '' + toUnit;
-		}
+	if (shouldScale) {
+		return (pixels / factor / unitToPixelFactors[toUnit]) + '' + toUnit;
 	}
 
 	return (pixels / unitToPixelFactors[toUnit]) + '' + toUnit;

--- a/packages/ui/resolution/resolution.js
+++ b/packages/ui/resolution/resolution.js
@@ -101,7 +101,9 @@ function getLinearSize () {
  * @returns {boolean}
  * @private
  */
-const getShouldScale = (scrObj) => {
+const getShouldScale = (scrObj = screenTypeObject) => {
+	if (!scrObj) return false;
+
 	const isPortrait = orientation === 'portrait';
 	const isLandscape = orientation === 'landscape';
 	const shouldScale = workspaceBounds.width < scrObj.width && workspaceBounds.height < scrObj.height;
@@ -124,6 +126,8 @@ const getShouldScale = (scrObj) => {
  * @private
  */
 const getScaleFactor = (type = screenType) => {
+	if (!type) return {shouldScale: false, factor: 1};
+
 	const scrObj = getScreenTypeObject(type);
 	const shouldScale = getShouldScale(scrObj);
 	return {shouldScale, factor: workspaceBounds.height / scrObj.height};

--- a/packages/ui/resolution/tests/resolution-specs.js
+++ b/packages/ui/resolution/tests/resolution-specs.js
@@ -52,7 +52,7 @@ describe('Resolution Specs', () => {
 			expect(getScreenType(UHD2)).toBe('uhd2');
 		});
 
-		test('should select screen type whose height and width are the closest to the screen', () => {
+		test('should select screen type whose height and width are the closest to the screen and have the same aspect ratio', () => {
 			screenTypes.forEach((type) => {
 				expect(getScreenType({width: type.width, height: type.height})).toBe(type.name);
 
@@ -60,28 +60,28 @@ describe('Resolution Specs', () => {
 				expect(getScreenType({width: type.width + 1, height: type.height + 1})).toBe(type.name);
 			});
 
-			for (let i = 0; i < screenTypes.length - 1; i++) {
-				const current = screenTypes[i];
-				const next = screenTypes[i + 1];
+			screenTypes.slice(0, -1)
+				.map((current, i) => [current, screenTypes[i + 1]])
+				.filter(([current, next]) => current.aspectRatioName === next.aspectRatioName)
+				.forEach(([current, next]) => {
+					const midPoint = {
+						width: (current.width + next.width) / 2,
+						height: (current.height + next.height) / 2
+					};
 
-				const midPoint = {
-					width: (current.width + next.width) / 2,
-					height: (current.height + next.height) / 2
-				};
+					const justBeforeMid = {
+						width: Math.floor(midPoint.width - 0.1),
+						height: Math.floor(midPoint.height - 0.1)
+					};
 
-				const justBeforeMid = {
-					width: Math.floor(midPoint.width - 0.1),
-					height: Math.floor(midPoint.height - 0.1)
-				};
+					const justAfterMid = {
+						width: Math.ceil(midPoint.width + 0.1),
+						height: Math.ceil(midPoint.height + 0.1)
+					};
 
-				const justAfterMid = {
-					width: Math.ceil(midPoint.width + 0.1),
-					height: Math.ceil(midPoint.height + 0.1)
-				};
-
-				expect(getScreenType(justBeforeMid)).toBe(current.name);
-				expect(getScreenType(justAfterMid)).toBe(next.name);
-			}
+					expect(getScreenType(justBeforeMid)).toBe(current.name);
+					expect(getScreenType(justAfterMid)).toBe(next.name);
+				});
 
 			const firstScreenType = screenTypes.at(0);
 			expect(getScreenType({width: 1, height: 1})).toBe(firstScreenType.name);
@@ -150,7 +150,7 @@ describe('Resolution Specs', () => {
 	});
 
 	test('should convert pixels to units in landscape and fontSizeHandling is "scale"', () => {
-		const closestResolution = {...XGA};
+		const closestResolution = {...HD};
 		const wideResolution = {innerWidth: 1024, innerHeight: 480};
 		init({measurementNode: wideResolution});
 
@@ -180,7 +180,7 @@ describe('Resolution Specs', () => {
 		// XGA
 		measurementNode = {innerWidth: XGA.width, innerHeight: XGA.height};
 		init({measurementNode});
-		expect(selectSrc(src)).toBe(src.hd);
+		expect(selectSrc(src)).toBe(src.vga);
 
 		// HD
 		measurementNode = {innerWidth: HD.width, innerHeight: HD.height};
@@ -226,6 +226,18 @@ describe('Resolution Specs', () => {
 		measurementNode = {innerWidth: UHD2.width, innerHeight: UHD2.height};
 		init({measurementNode});
 		expect(selectSrc(src)).toBe(src.uhd);
+	});
+
+	test('should calculate font size with orientationHandling="scale" in portrait', () => {
+		config.orientationHandling = 'scale';
+		const portraitWidth = 540;
+		const portraitHeight = 960;
+		init({measurementNode: {innerWidth: portraitWidth, innerHeight: portraitHeight}});
+
+		const expectedSize = (portraitWidth * 16 / HD.height) + 'px';
+		expect(calculateFontSize()).toBe(expectedSize);
+
+		config.orientationHandling = 'normal';
 	});
 
 	test('should calculate linearly scaled font size based on workspace bounds and current screen', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Modified `resolution` behavior

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Added a new function `getShouldScale` which determines if the font size should be scaled 
- Modified `getClosestResolutionType` function, so now the algorithm will also consider and the aspect ratio ratio of the screen, not only the spatial distance between resolutions
- Modified the behavior for the scaling in the `portrait` mode. Now the content will be scaled based on the current resolution size (only if `orientationHandling` is set to `scale`), as it already happens and in `landscape` mode.
- Changed the scale condition so scaling now applies only when the workspace is smaller than the matched screen type in both dimensions (previously either), to avoid over-scaling at intermediate resolutions.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-13084

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com