### PR TITLE
NXT-12133: Fixed native scroll animation exactly on target instead of clipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The following is a curated list of changes in the Enact project, newest changes 
 - `ui/resolution` to not resize too often for some intermediate resolutions
 - `ui/Transition` to remove static `will-change` declarations, reducing persistent GPU layer promotion and memory usage on TV targets
 
+### Fixed
+
+- `ui/Scroller` native scroll animation to land exactly on the target position instead of overshooting by up to one animation step
+- `ui/VirtualList` native scroll animation to land exactly on the target position instead of overshooting by up to one animation step
+
 ## [5.5.1] - 2026-06-01
 
 ### Changed

--- a/packages/ui/Scroller/ScrollerBasic.js
+++ b/packages/ui/Scroller/ScrollerBasic.js
@@ -166,8 +166,13 @@ class ScrollerBasic extends Component {
 				return;
 			}
 
-			const horizontalScrollFactor = Math.max(Math.abs(left - node.scrollLeft) * 0.1, 8);
-			const verticalScrollFactor = Math.max(Math.abs(top - node.scrollTop) * 0.1, 8);
+			// Clamp the step to the remaining distance so the final frame lands exactly on the target
+			// instead of overshooting by up to the minimum step (8px), which would push a focused item
+			// anchored to the start edge (e.g. `stickTo="start"`) past that edge and clip it.
+			const remainingX = Math.abs(left - node.scrollLeft);
+			const remainingY = Math.abs(top - node.scrollTop);
+			const horizontalScrollFactor = Math.min(Math.max(remainingX * 0.1, 8), remainingX);
+			const verticalScrollFactor = Math.min(Math.max(remainingY * 0.1, 8), remainingY);
 
 			node.scrollBy({top: directionY * verticalScrollFactor, left: directionX * horizontalScrollFactor, behavior: 'instant'});
 			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);

--- a/packages/ui/VirtualList/VirtualListBasic.js
+++ b/packages/ui/VirtualList/VirtualListBasic.js
@@ -938,7 +938,13 @@ class VirtualListBasic extends Component {
 		const animateScroll = (currentTime) => {
 			const elapsed = (currentTime - startTime) / 500;
 
-			node.scrollBy({top: directionY * scrollFactor, left: directionX * scrollFactor, behavior: 'instant'});
+			// Clamp each step to the remaining distance so the final frame lands exactly on the target
+			// instead of overshooting by up to `scrollFactor`. Overshooting would push a focused item
+			// anchored to the start edge (e.g. `stickTo="start"`) past that edge and clip it.
+			const stepX = directionX === 0 ? 0 : directionX * Math.min(scrollFactor, Math.abs(left - node.scrollLeft));
+			const stepY = directionY === 0 ? 0 : directionY * Math.min(scrollFactor, Math.abs(top - node.scrollTop));
+
+			node.scrollBy({top: stepY, left: stepX, behavior: 'instant'});
 			this.scrollAnimationId = window.requestAnimationFrame(animateScroll);
 			this.scrolling = true;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using stickTo = start for limestone scroller or VirtualList, some focused items were clipped

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The native-mode `animateScroll` in both `ScrollerBasic` and `VirtualListBasic` advanced the scroll position by a fixed step each frame (`scrollFactor`, ~gridSize/12  for VirtualList; max(remaining*0.1, 8) for Scroller) and stopped on the first frame that reached or passed the target, without clamping the final step.
The overshoot was usually invisible because it landed within the same item. But when a focused item is anchored to the start edge (e.g. `stickTo="start"`), the overshoot pushed the item's leading edge past the viewport's start edge, clipping it. 
Clamp each frame's step to the remaining distance so the final frame lands exactly on the target, eliminating the overshoot.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-12133

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)