### PR TITLE
NXT-13028: Converted i18n/Text to functional component and fixed some root causes of unit tests console.error

### DIFF
--- a/packages/i18n/I18nDecorator/I18n.js
+++ b/packages/i18n/I18nDecorator/I18n.js
@@ -26,6 +26,7 @@ class I18n {
 	}) {
 		this._locale = null;
 		this._ready = sync;
+		this._updatingFromRender = false;
 		this.loadResourceJob = new Job(state => this._updateSnapshot(state));
 		this._listeners = new Set();
 		this._snapshot = {
@@ -97,12 +98,17 @@ class I18n {
 	 * construction, so updates notify immediately; `useSyncExternalStore` is
 	 * responsible for the tearing check under concurrent rendering.
 	 *
+	 * `_updatingFromRender` guards the render-phase `setContext` path: in sync mode
+	 * that updates the snapshot synchronously, and notifying subscribers there would
+	 * schedule a React update while rendering. The current render reads the fresh
+	 * snapshot via `getSnapshot`, so no notification is needed.
+	 *
 	 * @param {Object} newState New snapshot values
 	 * @private
 	 */
 	_updateSnapshot (newState) {
 		this._snapshot = newState;
-		if (this._ready) {
+		if (this._ready && !this._updatingFromRender) {
 			this._notifyListeners();
 		}
 	}
@@ -118,7 +124,16 @@ class I18n {
 	setContext (locale) {
 		if (this._locale !== locale) {
 			this._locale = locale;
-			this.loadResources(locale);
+
+			// `setContext` is invoked during render by `useI18n`. Suppress listener
+			// notification for this synchronous update so we don't schedule a
+			// React update while rendering;
+			this._updatingFromRender = true;
+			try {
+				this.loadResources(locale);
+			} finally {
+				this._updatingFromRender = false;
+			}
 		}
 	}
 

--- a/packages/i18n/I18nDecorator/tests/useI18n-specs.js
+++ b/packages/i18n/I18nDecorator/tests/useI18n-specs.js
@@ -107,18 +107,12 @@ describe('useI18n', () => {
 			);
 		}
 
-		test('should start with loaded=false', () => {
+		test('should start with loaded=false and then set loaded=true after resources resolve', async () => {
 			render(<AsyncComponent />);
 
 			const i18nDiv = screen.getByTestId('i18nDiv');
 
 			expect(i18nDiv).toHaveAttribute('data-loaded', 'false');
-		});
-
-		test('should set loaded=true after resources resolve', async () => {
-			render(<AsyncComponent />);
-
-			const i18nDiv = screen.getByTestId('i18nDiv');
 
 			await waitFor(() => {
 				expect(i18nDiv).toHaveAttribute('data-loaded', 'true');
@@ -211,6 +205,24 @@ describe('useI18n', () => {
 			});
 
 			expect(i18nDiv).toHaveTextContent('rtl');
+		});
+
+		// Regression guard for the render-phase `setContext` path. `useI18n` calls `setContext`
+		// during render, so in sync mode the locale-change snapshot update must NOT notify
+		// subscribers.
+		test('should not notify subscribers when setContext changes locale in sync mode', () => {
+			const i18n = new I18n({sync: true});
+			i18n.setContext('en-US');
+
+			const listener = jest.fn();
+			i18n.subscribe(listener);
+
+			// Simulates the render-phase locale change driven by `updateLocale`.
+			i18n.setContext('ar-SA');
+
+			expect(listener).not.toHaveBeenCalled();
+			// The snapshot is still updated so the in-progress render reads the new locale.
+			expect(i18n.getSnapshot().locale).toBe('ar-SA');
 		});
 	});
 

--- a/packages/i18n/Text/Text.js
+++ b/packages/i18n/Text/Text.js
@@ -11,7 +11,7 @@ import {checkPropTypes} from '@enact/core/util';
 import ilib from 'ilib';
 import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
-import {Component} from 'react';
+import {useEffect, useState} from 'react';
 
 import {I18nContextDecorator} from '../I18nDecorator';
 import {createResBundle, getIStringFromBundle, getResBundle} from '../src/resBundle';
@@ -111,137 +111,110 @@ const defaultConfig = {
 const TextDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {mapPropsToText} = config;
 
-	const Decorator = class extends Component {
-		static displayName = 'TextDecorator';
+	function Decorator (props) {
+		checkPropTypes(Decorator, props);
 
-		static propTypes = /** @lends i18n/Text.TextDecorator.prototype */ {
-			/**
-			 * Passed to the wrapped component.
-			 *
-			 * If `mapPropsToText` is `null` and `children` is a string, the string will be
-			 * translated before being passed to the wrapped component.
-			 *
-			 * @type {*}
-			 * @public
-			 */
-			children: PropTypes.any,
+		const {locale} = props;
+		const [map, setMap] = useState(() => getTextMap(mapPropsToText, props));
 
-			/**
-			 * The locale for translation.
-			 *
-			 * If not supplied, the current locale is used.
-			 *
-			 * @type {String}
-			 * @public
-			 */
-			locale: PropTypes.string
-		};
+		const shouldTranslate = mapPropsToText || typeof props.children === 'string';
 
-		constructor (props) {
-			super(props);
-			checkPropTypes(this, props);
+		// Translate on mount and whenever the locale changes. The cleanup flag prevents a
+		// pending translation from committing after the locale changes again or the component
+		// unmounts.
+		useEffect(() => {
+			if (!shouldTranslate || !map) return;
 
-			this.state = {
-				map: getTextMap(mapPropsToText, props)
-			};
-		}
-
-		componentDidMount () {
-			if (this.shouldTranslate()) {
-				this.translate(this.props.locale);
-			}
-		}
-
-		componentDidUpdate (prevProps) {
-			checkPropTypes(this, this.props, prevProps);
-			if (this.props.locale !== prevProps.locale) {
-				this.translate(this.props.locale);
-			}
-		}
-
-		shouldTranslate () {
-			return mapPropsToText || typeof this.props.children === 'string';
-		}
-
-		translate (locale = ilib.getLocale()) {
-			const {map} = this.state;
+			let active = true;
+			const targetLocale = locale != null ? locale : ilib.getLocale();
 			const bundle = getResBundle();
-
-			if (!map) return;
-
-			const props = Object.keys(map);
 
 			Promise.all([
 				new Promise((resolve) => {
 					if (bundle) {
 						resolve(bundle);
 					}
-					createResBundle({locale, sync: false, onLoad: resolve});
+					createResBundle({locale: targetLocale, sync: false, onLoad: resolve});
 				}),
 				// ResBundle.getString will try to synchronously fetch the plurals resource so need
 				// to proactively fetch it to avoid the sync XHR
 				new Promise(resolve => IString.loadPlurals(false, null, null, resolve))
 			]).then(([resBundle]) => {
-				if (!resBundle) return;
+				if (!active || !resBundle) return;
 
-				const translated = props.reduce((obj, prop) => {
+				setMap(prevMap => Object.keys(prevMap).reduce((obj, prop) => {
 					obj[prop].translated = String(getIStringFromBundle(obj[prop].text, resBundle));
 					return obj;
-				}, {...map});
-
-				this.setState({
-					map: translated
-				});
+				}, {...prevMap}));
 			});
-		}
 
-		canRender () {
-			const entries = Object.values(this.state.map);
-			for (const entry of entries) {
-				if (entry.translated === false && entry.defaultText === false) {
-					return false;
-				}
-			}
+			return () => {
+				active = false;
+			};
+		}, [locale, shouldTranslate]); // eslint-disable-line react-hooks/exhaustive-deps
 
-			return true;
-		}
-
-		getTextForProp (prop) {
-			const {defaultText = '', translated} = this.state.map[prop];
-
-			return translated === false ? defaultText : translated;
-		}
-
-		render () {
-			if (!this.shouldTranslate()) {
-				const passThrough = {...this.props};
-
-				delete passThrough.locale;
-
-				return (
-					<Wrapped {...passThrough} />
-				);
-			}
-
-			if (!this.canRender()) {
-				return null;
-			}
-
-			if (Wrapped === STRING_ONLY) {
-				return this.getTextForProp('children');
-			}
-
-			const props = {...this.props};
-			delete props.locale;
-
-			Object.keys(this.state.map).forEach(prop => {
-				props[prop] = this.getTextForProp(prop);
-			});
+		if (!shouldTranslate) {
+			const passThrough = {...props};
+			delete passThrough.locale;
 
 			return (
-				<Wrapped {...props} />
+				<Wrapped {...passThrough} />
 			);
 		}
+
+		const canRender = Object.values(map).every(
+			entry => !(entry.translated === false && entry.defaultText === false)
+		);
+
+		if (!canRender) {
+			return null;
+		}
+
+		const getTextForProp = (prop) => {
+			const {defaultText = '', translated} = map[prop];
+
+			return translated === false ? defaultText : translated;
+		};
+
+		if (Wrapped === STRING_ONLY) {
+			return getTextForProp('children');
+		}
+
+		const outProps = {...props};
+		delete outProps.locale;
+
+		Object.keys(map).forEach(prop => {
+			outProps[prop] = getTextForProp(prop);
+		});
+
+		return (
+			<Wrapped {...outProps} />
+		);
+	}
+
+	Decorator.displayName = 'TextDecorator';
+
+	Decorator.propTypes = /** @lends i18n/Text.TextDecorator.prototype */ {
+		/**
+		 * Passed to the wrapped component.
+		 *
+		 * If `mapPropsToText` is `null` and `children` is a string, the string will be
+		 * translated before being passed to the wrapped component.
+		 *
+		 * @type {*}
+		 * @public
+		 */
+		children: PropTypes.any,
+
+		/**
+		 * The locale for translation.
+		 *
+		 * If not supplied, the current locale is used.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		locale: PropTypes.string
 	};
 
 	return I18nContextDecorator(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
1. There were console.error while running unit tests, althought the tests did pass
2. Text component is class component. Need to modernize it

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Text.js:
  - class extends Component → function Decorator(props).
  - constructor + this.state.map → useState(() => getTextMap(...)) with a lazy initializer (map is still derived once from initial props, then only updated with translations — same as before).
  - componentDidMount + componentDidUpdate (translate on mount / on locale change) -> a single useEffect keyed on [locale, shouldTranslate].
  - checkPropTypes(this, ...) -> checkPropTypes(Decorator, ...) per render
  - Instance methods shouldTranslate/canRender/getTextForProp/translate -> migrated to local consts or inline logic in the render body.
  - setState({map}) -> functional setMap(prev => …), so the effect doesn't need map in its deps (which would otherwise loop).
 
i18n.js: Fixed the root cause of console.error in the unit tests "Cannot update a component (`I18nDecorator`) while rendering a different component (`I18nDecorator`). To locate the bad setState() call inside `I18nDecorator`, follow the stack trace as described in "

- The warning was a real render-purity bug. useI18n calls setContext(locale) during render; in sync mode that synchronously ran loadResources --> _updateSnapshot --> _notifyListeners(), firing the useSyncExternalStore subscriber and scheduling a React update mid-render. Async mode already dodged this because _ready starts false.
-  The fix gives sync mode the same suppression, scoped precisely to the render-phase path:
        - Added this._updatingFromRender = false to the constructor.
        - setContext now sets that flag (in a try/finally) around its loadResources call.
        - _updateSnapshot only notifies when this._ready && !this._updatingFromRender.

use18n-specs.js : 
a) Merge two unit test, because, the first one drives the I18n store directly: subscribe a listener, then call setContext('ar-SA') (the render-phase path useI18n triggers), and assert the listener is not notified while the snapshot is updated (getSnapshot().locale === 'ar-SA').
b) Added test for the scenario covered in i18n.js


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-13028

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))