### PR TITLE
NXT-10275: Added prerender support for ui/FloatingLayer

### DIFF
--- a/packages/ui/FloatingLayer/FloatingLayer.js
+++ b/packages/ui/FloatingLayer/FloatingLayer.js
@@ -99,6 +99,25 @@ class FloatingLayerBase extends Component {
 		open: PropTypes.bool,
 
 		/**
+		 * Enables prerendering support.
+		 *
+		 * When `true`, the floating layer renders its content inline on the first render (the
+		 * server prerender pass and the initial client render) instead of returning `null`, then
+		 * relocates the content into the floating layer via a portal once mounted on the client.
+		 * This allows modal content (e.g. popups) to be captured by `renderToString` during a
+		 * prerender pass and to hydrate without a mismatch.
+		 *
+		 * Because portals are not supported by the server renderer, this is the only way to include
+		 * floating-layer content in prerendered HTML. Leave `false` (default) for the standard
+		 * client-only portal behavior.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		prerender: PropTypes.bool,
+
+		/**
 		 * The scrim type that overlays FloatingLayer.
 		 *
 		 * It can be either `'transparent'`, `'translucent'`, or `'none'`.
@@ -117,6 +136,7 @@ class FloatingLayerBase extends Component {
 		floatLayerId: 'floatLayer',
 		noAutoDismiss: false,
 		open: false,
+		prerender: false,
 		scrimType: 'translucent'
 	};
 
@@ -238,7 +258,7 @@ class FloatingLayerBase extends Component {
 	}
 
 	render () {
-		const {children, className, floatLayerClassName, open, scrimType, ...rest} = this.props;
+		const {children, className, floatLayerClassName, open, prerender, scrimType, ...rest} = this.props;
 		const mergedClassName = classNames(floatLayerClassName, css.floatingLayer, className);
 
 		delete rest.floatLayerId;
@@ -247,14 +267,25 @@ class FloatingLayerBase extends Component {
 		delete rest.onDismiss;
 		delete rest.onOpen;
 
-		if (open && this.state.readyToRender) {
-			return ReactDOM.createPortal(
+		// When prerendering is enabled, render the content inline on the first render (the server
+		// prerender pass and the initial client render, both before `readyToRender` flips) so it is
+		// captured by `renderToString` and matches during hydration. The portal is unavailable until
+		// after mount, when `readyToRender` becomes true and the content is relocated into it.
+		const renderInline = prerender && !this.state.readyToRender;
+
+		if (open && (this.state.readyToRender || renderInline)) {
+			const content = (
 				<div className={mergedClassName} {...rest}>
 					{scrimType !== 'none' ? <Scrim type={scrimType} onClick={this.handleClick} /> : null}
 					{cloneElement(children, {onClick: this.stopPropagation})}
-				</div>,
-				this.floatingLayer
+				</div>
 			);
+
+			// Use the portal once the floating layer node is available on the client; otherwise
+			// (prerender pass / pre-mount) render inline.
+			return (this.state.readyToRender && this.floatingLayer) ?
+				ReactDOM.createPortal(content, this.floatingLayer) :
+				content;
 		}
 
 		return null;

--- a/packages/ui/FloatingLayer/tests/FloatingLayer-prerender-specs.js
+++ b/packages/ui/FloatingLayer/tests/FloatingLayer-prerender-specs.js
@@ -1,0 +1,67 @@
+/*
+ * Prerendering support for FloatingLayer.
+ *
+ * Portals are not supported by the server renderer, so, by default, a FloatingLayer renders `null`
+ * during a `renderToString` prerender pass. The `prerender` prop opts into rendering the content
+ * inline on the first render (server pass + initial client render) and relocating it into the
+ * floating layer via a portal once mounted on the client
+ */
+
+/* eslint-disable testing-library/render-result-naming-convention */
+import '@testing-library/jest-dom';
+import {act} from '@testing-library/react';
+import {hydrateRoot} from 'react-dom/client';
+import {renderToString} from 'react-dom/server';
+
+import {FloatingLayerBase} from '../FloatingLayer';
+import FloatingLayerDecorator from '../FloatingLayerDecorator';
+
+describe('FloatingLayer prerender support', () => {
+	const Root = FloatingLayerDecorator('div');
+
+	const tree = (props) => (
+		<Root>
+			<FloatingLayerBase open {...props}><p>Prerendered popup</p></FloatingLayerBase>
+		</Root>
+	);
+
+	test('should NOT prerender content without the prerender prop (server portal yields null)', () => {
+		const html = renderToString(tree());
+
+		expect(html).not.toContain('Prerendered popup');
+	});
+
+	test('should prerender content inline when prerender is enabled', () => {
+		const html = renderToString(tree({prerender: true}));
+
+		expect(html).toContain('Prerendered popup');
+	});
+
+	test('should hydrate prerendered content without mismatch and relocate it into the floating layer', async () => {
+		const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		// 1. Server prerender pass -> inline content captured in HTML.
+		const html = renderToString(tree({prerender: true}));
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+
+		// 2. Client hydration. The first client render is also inline (readyToRender is still false),
+		// so it matches the server markup; the portal move happens later, after mount.
+		await act(async () => {
+			hydrateRoot(container, tree({prerender: true}));
+		});
+
+		// No hydration mismatch was reported.
+		const hydrationErrors = errorSpy.mock.calls.filter(([msg]) => typeof msg === 'string' && /hydrat/i.test(msg));
+		expect(hydrationErrors).toEqual([]);
+
+		// 3. After mounting, the content has been relocated into the floating layer node via the portal.
+		const floatLayer = container.querySelector('#floatLayer');
+		expect(floatLayer).toBeInTheDocument();
+		expect(floatLayer).toHaveTextContent('Prerendered popup');
+
+		errorSpy.mockRestore();
+		document.body.removeChild(container);
+	});
+});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Portals are not supported by React's server renderer, so FloatingLayer renders null during a renderToString prerender pass and its content never appears in prerendered HTML. This adds an opt-in prerender prop that lets floating-layer content be prerendered.

When prerender is true, the content is rendered inline on the first render (the server prerender pass and the initial client render) and then relocated into the floating layer via createPortal once mounted. The inline first render matches the server markup, so hydration succeeds without a mismatch; the portal move happens in a post-mount commit.

When prerender is false (default), behavior is unchanged. Existing popups are unaffected.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-10275

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))