### PR TITLE
NXT-13025: enabled viewport addon for storybook

### DIFF
--- a/packages/sampler/.storybook/main.js
+++ b/packages/sampler/.storybook/main.js
@@ -18,7 +18,7 @@ export default {
 		backgrounds: false,
 		interactions: false,
 		postcss: false,
-		viewport: false,
+		viewport: true,
 		warnOnLegacyHierarchySeparator: false
 	},
 	framework: {

--- a/packages/sampler/.storybook/manager-head.html
+++ b/packages/sampler/.storybook/manager-head.html
@@ -1,0 +1,9 @@
+<style>
+	/*
+	 * Viewport tool: keep BOTH scrollbars pinned to the visible edges of the preview.
+	 */
+	#storybook-preview-wrapper,
+	div:has(> #storybook-preview-wrapper) {
+		overflow: visible !important;
+	}
+</style>

--- a/packages/sampler/.storybook/preview.js
+++ b/packages/sampler/.storybook/preview.js
@@ -3,6 +3,14 @@ import {getBooleanType, getObjectType} from '@enact/storybook-utils/addons/contr
 
 import Environment from '../src/Environment';
 
+const tvViewports = {
+	tvHD: {name: 'TV 720p (HD)', type: 'desktop', styles: {width: '1280px', height: '720px'}},
+	tvFHD: {name: 'TV 1080p (FHD)', type: 'desktop', styles: {width: '1920px', height: '1080px'}},
+	tvUHD: {name: 'TV 2160p (UHD / 4K)', type: 'desktop', styles: {width: '3840px', height: '2160px'}},
+	portraitFHD: {name: 'Portrait 1080p (FHD)', type: 'mobile', styles: {width: '1080px', height: '1920px'}},
+	portraitUHD: {name: 'Portrait 2160p (UHD / 4K)', type: 'mobile', styles: {width: '2160px', height: '3840px'}}
+};
+
 // NOTE: Locales taken from strawman. Might need to add more in the future.
 const locales = {
 	'local':                                                             '',
@@ -40,6 +48,11 @@ export const parameters = {
 	options: {
 		storySort: {
 			method: 'alphabetical'
+		}
+	},
+	viewport: {
+		options: {
+			...tvViewports
 		}
 	}
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Adopts 1 Storybook addons in the Limestone sampler: viewport.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Viewport (Storybook 10 core feature)
Enabled via features.viewport 
Added TV and portrait presets via parameters.viewport.options: 720p / 1080p / 4K landscape and 1080p / 4K portrait.
Added manager-head.html CSS so that when a viewport larger than the preview area is selected, both scrollbars stay pinned to the visible edges 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
NXT-13025

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))